### PR TITLE
Increment torch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.8"
 license = { file = "LICENSE" }
 dependencies = [
     "numpy",
-    "torch>=2.0",
+    "torch>=2.1",
     "safetensors",
     "pydantic>=2.0,<3.0",
     "cached-path",


### PR DESCRIPTION
The `_all_handles` attribute used [here](https://github.com/allenai/OLMo-core/blob/1847b8e8734e41d229a09bbac7f2de2e56c7403a/src/olmo_core/distributed/checkpoint.py#L983) is not present in `2.0.1+rocm5.4.2` but is present in `2.1.0+rocm5.6`