### PR TITLE
Add checkpointing support for DTensors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,14 +102,26 @@ jobs:
           . .venv/bin/activate
           pip uninstall -y ai2-olmo-core
 
-  gpu_tests:
-    name: GPU Tests
+  gpu_checks:
+    name: ${{ matrix.task.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 8
     env:
       BEAKER_TOKEN: ${{ secrets.BEAKER_TOKEN }}
       BEAKER_IMAGE: olmo-torch2-test
       BEAKER_WORKSPACE: ai2/llm-testing
+    strategy:
+      fail-fast: false
+      matrix:
+        task:
+          - name: Test (GPU)
+            run: pytest -v --color=yes --durations=3 -m gpu src/test/ --ignore-glob='src/test/distributed/fsdp*' --ignore-glob='src/test/distributed/checkpoint*'
+
+          - name: Test checkpoint (GPU)
+            run: pytest -v --color=yes --durations=3 -m gpu src/test/distributed/checkpoint*
+
+          - name: Test FSDP (GPU)
+            run: pytest -v --color=yes --durations=3 -m gpu src/test/distributed/fsdp/
     steps:
       - name: Determine current commit SHA (pull request)
         if: github.event_name == 'pull_request'
@@ -127,7 +139,7 @@ jobs:
         with:
           spec: |
             version: v2
-            description: GPU Tests
+            description: OLMo-core ${{ matrix.task.name }}
             budget: ai2/oe-training
             tasks:
               - name: tests
@@ -151,10 +163,14 @@ jobs:
                     value: ":16:8"
                   - name: TOKENIZERS_PARALLELISM
                     value: "false"
+                  - name: AWS_ACCESS_KEY_ID
+                    secret: AWS_ACCESS_KEY_ID
+                  - name: AWS_SECRET_ACCESS_KEY
+                    secret: AWS_SECRET_ACCESS_KEY
                 command:
                   - "bash"
                   - "-c"
-                  - "git clone https://github.com/allenai/OLMo-core.git && cd OLMo-core && git checkout ${{ env.COMMIT_SHA }} && pip install -e .[all] && pytest -v src/test -m gpu"
+                  - "git clone https://github.com/allenai/OLMo-core.git && cd OLMo-core && git checkout ${{ env.COMMIT_SHA }} && pip install -e .[all] && ${{ matrix.task.run }}"
                 result:
                   path: /unused
           token: ${{ env.BEAKER_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,3 +101,61 @@ jobs:
         run: |
           . .venv/bin/activate
           pip uninstall -y ai2-olmo-core
+
+  gpu_tests:
+    name: GPU Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    env:
+      BEAKER_TOKEN: ${{ secrets.BEAKER_TOKEN }}
+      BEAKER_IMAGE: olmo-torch2-test
+      BEAKER_WORKSPACE: ai2/llm-testing
+    steps:
+      - name: Determine current commit SHA (pull request)
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+
+      - name: Determine current commit SHA (push)
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
+
+      - name: GPU Tests
+        uses: allenai/beaker-run-action@v1.2
+        if: env.BEAKER_TOKEN != ''
+        with:
+          spec: |
+            version: v2
+            description: GPU Tests
+            budget: ai2/oe-training
+            tasks:
+              - name: tests
+                image:
+                  beaker: ${{ env.BEAKER_IMAGE }}
+                context:
+                  priority: normal
+                  preemptible: true
+                resources:
+                  gpuCount: 2
+                constraints:
+                  cluster:
+                    - ai2/general-cirrascale
+                    - ai2/general-cirrascale-a100-80g-ib
+                    - ai2/allennlp-cirrascale
+                    - ai2/allennlp-elanding-a100-40g
+                    - ai2/pluto-cirrascale
+                    - ai2/jupiter-cirrascale
+                envVars:
+                  - name: CUBLAS_WORKSPACE_CONFIG
+                    value: ":16:8"
+                  - name: TOKENIZERS_PARALLELISM
+                    value: "false"
+                command:
+                  - "bash"
+                  - "-c"
+                  - "git clone https://github.com/allenai/OLMo-core.git && cd OLMo-core && git checkout ${{ env.COMMIT_SHA }} && pip install -e .[all] && pytest -v src/test -m gpu"
+                result:
+                  path: /unused
+          token: ${{ env.BEAKER_TOKEN }}
+          workspace: ${{ env.BEAKER_WORKSPACE }}

--- a/docs/source/distributed/checkpoint.rst
+++ b/docs/source/distributed/checkpoint.rst
@@ -2,5 +2,5 @@
 ==========================
 
 .. automodule:: olmo_core.distributed.checkpoint
-   :members: save_model_and_optim_state, load_model_and_optim_state, unshard_model_state, unshard_optim_state, Checkpointer, StorageMetadata, TensorStorageMetadata
+   :members: save_model_and_optim_state, load_model_and_optim_state, unshard_model_state, unshard_optim_state, Checkpointer, StorageMetadata, TensorStorageMetadata, TensorShardSpec
    :member-order: bysource

--- a/docs/source/distributed/tensors.rst
+++ b/docs/source/distributed/tensors.rst
@@ -4,3 +4,7 @@
 .. automodule:: olmo_core.distributed.tensors
    :members:
    :member-order: bysource
+
+.. automodule:: olmo_core.distributed.tensors.dtensor_utils
+   :members:
+   :member-order: bysource

--- a/src/olmo_core/distributed/checkpoint.py
+++ b/src/olmo_core/distributed/checkpoint.py
@@ -495,7 +495,7 @@ class Checkpointer:
             if _check_for_nans:
                 # Check for NaNs which would indicate we didn't fill the state dict correctly.
                 if state_dict[key].isnan().any().item():
-                    raise RuntimeError(f"error loading {key} from checkpoint, nans encountered")
+                    raise RuntimeError(f"error loading '{key}' from checkpoint, nans encountered")
 
     @torch.no_grad()
     def unshard(

--- a/src/olmo_core/distributed/checkpoint.py
+++ b/src/olmo_core/distributed/checkpoint.py
@@ -1120,8 +1120,7 @@ def init_optimizer_state(optim: torch.optim.Optimizer):
             # Some parameters may be empty for sharded models, in which case the state does not need
             # to be initialized.
             if p.numel() > 0:
-                p.grad = p.data.new(p.size()).zero_()
-                p.grad.requires_grad_(False)
+                p.grad = torch.zeros_like(p, memory_format=torch.preserve_format)
     optim.step()
     optim.zero_grad()
 

--- a/src/olmo_core/distributed/checkpoint.py
+++ b/src/olmo_core/distributed/checkpoint.py
@@ -424,10 +424,7 @@ class Checkpointer:
                                 flat_tensor_start, flat_tensor_end = 0, flat_view_slice.numel()
                                 # Start and end index of the slice within `flat_tensor_to_load` that we're going
                                 # to load into the slice of `flat_tensor`.
-                                flat_tensor_to_load_start, flat_tensor_to_load_end = (
-                                    numel_in_file_so_far,
-                                    numel_in_file_so_far + numel_in_file_slice,
-                                )
+                                flat_tensor_to_load_start, flat_tensor_to_load_end = 0, numel_in_file_slice
                                 # There are 5 scenarios to consider in terms of where the tensors overlap.
                                 # Suppose the original flat tensor has 6 elements: 'x x x x x x'
                                 # -------------------------------------------
@@ -473,7 +470,9 @@ class Checkpointer:
 
                                 # Load the slice.
                                 flat_tensor_to_load = loader.get_flat_slice(
-                                    key, flat_tensor_to_load_start, flat_tensor_to_load_end
+                                    key,
+                                    numel_in_file_so_far + flat_tensor_to_load_start,
+                                    numel_in_file_so_far + flat_tensor_to_load_end,
                                 )
                                 if (
                                     load_shape := flat_view_slice[flat_tensor_start:flat_tensor_end].shape

--- a/src/olmo_core/distributed/checkpoint.py
+++ b/src/olmo_core/distributed/checkpoint.py
@@ -8,7 +8,8 @@ Features
 --------
 
 - Sharded distributed models, such OLMo-core's :class:`~olmo_core.distributed.fsdp.FSDP` or PyTorch's
-  :class:`~torch.distributed.fsdp.FullyShardedDataParallel` are supported out-of-the-box.
+  :class:`~torch.distributed.fsdp.FullyShardedDataParallel` (with ``use_orig_params=True``)
+  are supported out-of-the-box.
 - Utilizes `safetensors <https://huggingface.co/docs/safetensors/>`_ under the hood for fast, efficient, and
   safe serialization/deserialization.
 - Save with one distributed topology, seamlessly load with a different one. For example,

--- a/src/olmo_core/distributed/checkpoint.py
+++ b/src/olmo_core/distributed/checkpoint.py
@@ -608,8 +608,9 @@ class Checkpointer:
             full_shape = tuple(tensor.shape)
             is_sharded = True
             for global_rank in tensor.device_mesh.mesh.flatten():
+                global_rank = int(global_rank.item())
                 local_shape, global_offset = dtensor_utils.get_local_shape_and_global_offset(
-                    tensor, rank=int(global_rank.item())
+                    tensor, rank=global_rank
                 )
                 shard_spec_per_rank[global_rank] = TensorShardSpec(
                     local_shape=local_shape, global_offset=global_offset

--- a/src/olmo_core/distributed/checkpoint.py
+++ b/src/olmo_core/distributed/checkpoint.py
@@ -1319,6 +1319,9 @@ def _get_local_tensor_data(tensor: torch.Tensor) -> torch.Tensor:
 
 
 def _wrap_tensor_for_sharded_parameter(tensor: torch.Tensor, param: Optional[torch.Tensor]) -> torch.Tensor:
+    if isinstance(tensor, (ShardedFlatTensor, DTensor)):
+        return tensor
+
     if isinstance(param, ShardedFlatTensor):
         return param.wrap(tensor, requires_grad=False)
     elif isinstance(param, DTensor):

--- a/src/olmo_core/distributed/checkpoint.py
+++ b/src/olmo_core/distributed/checkpoint.py
@@ -789,7 +789,7 @@ class TensorShardSpec(BaseModel):
         else:
             raise ValueError("missing required fields to produce flattened offsets")
 
-    def get_merged_flattened_offsets(self, full_shape: Tuple[int, int]) -> Generator[Tuple[int, int], None, None]:
+    def get_merged_flattened_offsets(self, full_shape: Tuple[int, ...]) -> Generator[Tuple[int, int], None, None]:
         """
         Like :meth:`get_flattened_offset` but it merges consecutive offsets that are contiguous.
         """

--- a/src/olmo_core/distributed/checkpoint.py
+++ b/src/olmo_core/distributed/checkpoint.py
@@ -458,17 +458,6 @@ class Checkpointer:
                                     # Scenarios (A), (D)
                                     flat_tensor_end -= offsets[1] - offsets_in_file[1]
 
-                                log.debug(
-                                    "Loading '%s'\n  offsets: %s\n  offsets in file: %s\n  load into: (%s, %s)\n  load from: (%s, %s)",
-                                    key,
-                                    offsets,
-                                    offsets_in_file,
-                                    flat_tensor_start,
-                                    flat_tensor_end,
-                                    flat_tensor_to_load_start,
-                                    flat_tensor_to_load_end,
-                                )
-
                                 # Load the slice.
                                 if slice_in_file is not None:
                                     flat_tensor_to_load = slice_in_file[
@@ -487,9 +476,11 @@ class Checkpointer:
                                     load_shape := flat_view_slice[flat_tensor_start:flat_tensor_end].shape
                                 ) != flat_tensor_to_load.shape:
                                     raise RuntimeError(
-                                        f"error loading tensor '{key}' from file '{filename}' with offsets "
-                                        f"({flat_tensor_start}, {flat_tensor_end}), "
-                                        f"expected shape {tuple(load_shape)}, found {tuple(flat_tensor_to_load.shape)}"
+                                        f"Error loading tensor '{key}' with offsets {offsets} "
+                                        f"from file '{filename}' with offsets {offsets_in_file}.\n"
+                                        f"Loading into slice ({flat_tensor_start}, {flat_tensor_end}) from "
+                                        f"slice ({flat_tensor_to_load_start}, {flat_tensor_to_load_end}) failed, "
+                                        f"expected shape {tuple(load_shape)}, found {tuple(flat_tensor_to_load.shape)}."
                                     )
 
                                 flat_view_slice[flat_tensor_start:flat_tensor_end].copy_(flat_tensor_to_load)

--- a/src/olmo_core/distributed/tensors/dtensor_utils.py
+++ b/src/olmo_core/distributed/tensors/dtensor_utils.py
@@ -4,12 +4,24 @@ Helper functions for dealing with PyTorch's :class:`DTensor`.
 
 from typing import Optional, Sequence, Tuple
 
+from torch.distributed._tensor import DTensor
 from torch.distributed._tensor.placement_types import Placement, Shard
 from torch.distributed.device_mesh import DeviceMesh
 
 from olmo_core.utils import ShapeType
 
 from ..utils import get_mesh_coordinates
+
+
+def get_local_shape_and_global_offset(
+    dtensor: DTensor, rank: Optional[int] = None
+) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
+    global_shape = dtensor.shape
+    mesh = dtensor.device_mesh
+    placements = dtensor.placements
+    local_shape, global_offset = compute_local_shape_and_global_offset(global_shape, mesh, placements, rank=rank)
+    assert local_shape == dtensor.to_local().shape
+    return local_shape, global_offset
 
 
 # Adapted from `torch.distributed._tensor._utils.py`.

--- a/src/olmo_core/distributed/tensors/dtensor_utils.py
+++ b/src/olmo_core/distributed/tensors/dtensor_utils.py
@@ -1,0 +1,102 @@
+"""
+Helper functions for dealing with PyTorch's :class:`DTensor`.
+"""
+
+from typing import Optional, Sequence, Tuple
+
+from torch.distributed._tensor.placement_types import Placement, Shard
+from torch.distributed.device_mesh import DeviceMesh
+
+from olmo_core.utils import ShapeType
+
+from ..utils import get_mesh_coordinates
+
+
+# Adapted from `torch.distributed._tensor._utils.py`.
+def compute_local_shape_and_global_offset(
+    global_shape: ShapeType,
+    mesh: DeviceMesh,
+    placements: Sequence[Placement],
+    rank: Optional[int] = None,
+) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
+    """
+    Compute the local tensor shape and the global offsets into the original tensor
+    of a DTensor on its current global rank. This is useful for checkpointing purpose.
+
+    :param global_shape: The shape of the global unsharded tensor.
+    :param mesh: The device mesh.
+    :param placements: The placements of the :class:`DTensor`.
+    :param rank: The global rank to compute the local shape and global offsets for. If ``None``,
+        defaults to the current rank.
+
+    Example (2 host with 4GPUs each):
+
+        # Below is a DeviceMesh with mesh_shape of ``(2, 4)``
+        mesh = DeviceMesh(device_type="cuda", mesh=[
+            [0, 1, 2, 3],
+            [4, 5, 6, 7]
+        ])
+
+    Let's say we distribute a global_tensor of shape ``(8,4)`` over the above DeviceMesh
+    with a placements of ``[Shard(0), Shard(0)]``.
+
+    The local shape and global offset will be as follows:
+    rank0 -- local_shape:[1, 4], global_offset:[0, 0]
+    rank1 -- local_shape:[1, 4], global_offset:[1, 0]
+    rank2 -- local_shape:[1, 4], global_offset:[2, 0]
+    rank5 -- local_shape:[1, 4], global_offset:[5, 0]
+    rank3 -- local_shape:[1, 4], global_offset:[3, 0]
+    rank4 -- local_shape:[1, 4], global_offset:[4, 0]
+    rank6 -- local_shape:[1, 4], global_offset:[6, 0]
+    rank7 -- local_shape:[1, 4], global_offset:[7, 0]
+
+    Let's say we distribute a global_tensor of shape ``(2,)`` over the above DeviceMesh with
+    a placements of ``[Shard(0)]``. We will not have non-empty local tensor for all the ranks.
+
+    The local shape and global offset will be as follows:
+    rank0 -- local_shape:[1,], global_offset:[0,]
+    rank1 -- local_shape:[1,], global_offset:[1,]
+    rank2 -- local_shape:[0,], global_offset:[2,]
+    rank5 -- local_shape:[0,], global_offset:[2,]
+    rank3 -- local_shape:[0,], global_offset:[2,]
+    rank4 -- local_shape:[0,], global_offset:[2,]
+    rank6 -- local_shape:[0,], global_offset:[2,]
+    rank7 -- local_shape:[0,], global_offset:[2,]
+    """
+    my_coordinate = mesh.get_coordinate() if rank is None else get_mesh_coordinates(mesh, rank)
+
+    if my_coordinate is None:
+        # if rank not in the mesh, return empty offset
+        return ((), ())
+    else:
+        local_shape = list(global_shape)
+        global_offset = [0] * len(global_shape)
+
+        for idx, placement in enumerate(placements):
+            mesh_dim_size = mesh.size(idx)
+            if isinstance(placement, Shard):
+                shard_dim = placement.dim
+                local_offset = [0] * len(global_shape)
+                assert shard_dim < len(
+                    local_shape
+                ), f"Sharding dim {shard_dim} greater than tensor ndim {len(local_shape)}"
+                shard_size, shard_offset = placement._local_shard_size_on_dim(
+                    local_shape[shard_dim],
+                    mesh_dim_size,
+                    my_coordinate[idx],
+                    return_offset=True,
+                )
+
+                local_shape[shard_dim] = shard_size
+                local_offset[shard_dim] = shard_offset
+
+                # On a given dimension, if the local_offset[shard_dim] is smaller than global_offset[shard_dim],
+                # it means that this dimension has been already sharded in previous placement.
+                # Therefore, we cannot simply replace the global_offset[shard_dim] with local_offset[shard_dim].
+                # Instead, for the given shard_dim, we need to add local_offset[shard_dim] to existing global_offset[shard_dim].
+                if global_offset[shard_dim] <= local_offset[shard_dim]:
+                    global_offset[shard_dim] = local_offset[shard_dim]
+                else:
+                    global_offset[shard_dim] += local_offset[shard_dim]
+
+        return tuple(local_shape), tuple(global_offset)

--- a/src/olmo_core/distributed/tensors/dtensor_utils.py
+++ b/src/olmo_core/distributed/tensors/dtensor_utils.py
@@ -30,7 +30,6 @@ def get_local_shape_and_global_offset(
     mesh = dtensor.device_mesh
     placements = dtensor.placements
     local_shape, global_offset = compute_local_shape_and_global_offset(global_shape, mesh, placements, rank=rank)
-    assert local_shape == dtensor.to_local().shape
     return local_shape, global_offset
 
 

--- a/src/olmo_core/distributed/tensors/dtensor_utils.py
+++ b/src/olmo_core/distributed/tensors/dtensor_utils.py
@@ -16,6 +16,16 @@ from ..utils import get_mesh_coordinates
 def get_local_shape_and_global_offset(
     dtensor: DTensor, rank: Optional[int] = None
 ) -> Tuple[Tuple[int, ...], Tuple[int, ...]]:
+    """
+    Like :func:`compute_local_shape_and_global_offset`, but acts directly on a :class:`DTensor`
+    instance.
+
+    :param dtensor: A DTensor instance.
+    :param rank: The global rank to compute the local shape and global offsets for. If ``None``,
+        defaults to the current rank.
+
+    :returns: The local shape and global offset.
+    """
     global_shape = dtensor.shape
     mesh = dtensor.device_mesh
     placements = dtensor.placements
@@ -41,9 +51,11 @@ def compute_local_shape_and_global_offset(
     :param rank: The global rank to compute the local shape and global offsets for. If ``None``,
         defaults to the current rank.
 
-    Example (2 host with 4GPUs each):
+    :returns: The local shape and global offset.
 
-        # Below is a DeviceMesh with mesh_shape of ``(2, 4)``
+    Example (2 host with 4GPUs each)::
+
+        # Below is a DeviceMesh with mesh_shape of (2, 4)
         mesh = DeviceMesh(device_type="cuda", mesh=[
             [0, 1, 2, 3],
             [4, 5, 6, 7]
@@ -53,27 +65,29 @@ def compute_local_shape_and_global_offset(
     with a placements of ``[Shard(0), Shard(0)]``.
 
     The local shape and global offset will be as follows:
-    rank0 -- local_shape:[1, 4], global_offset:[0, 0]
-    rank1 -- local_shape:[1, 4], global_offset:[1, 0]
-    rank2 -- local_shape:[1, 4], global_offset:[2, 0]
-    rank5 -- local_shape:[1, 4], global_offset:[5, 0]
-    rank3 -- local_shape:[1, 4], global_offset:[3, 0]
-    rank4 -- local_shape:[1, 4], global_offset:[4, 0]
-    rank6 -- local_shape:[1, 4], global_offset:[6, 0]
-    rank7 -- local_shape:[1, 4], global_offset:[7, 0]
+
+    - ``rank0 -- local_shape:[1, 4], global_offset:[0, 0]``
+    - ``rank1 -- local_shape:[1, 4], global_offset:[1, 0]``
+    - ``rank2 -- local_shape:[1, 4], global_offset:[2, 0]``
+    - ``rank5 -- local_shape:[1, 4], global_offset:[5, 0]``
+    - ``rank3 -- local_shape:[1, 4], global_offset:[3, 0]``
+    - ``rank4 -- local_shape:[1, 4], global_offset:[4, 0]``
+    - ``rank6 -- local_shape:[1, 4], global_offset:[6, 0]``
+    - ``rank7 -- local_shape:[1, 4], global_offset:[7, 0]``
 
     Let's say we distribute a global_tensor of shape ``(2,)`` over the above DeviceMesh with
     a placements of ``[Shard(0)]``. We will not have non-empty local tensor for all the ranks.
 
     The local shape and global offset will be as follows:
-    rank0 -- local_shape:[1,], global_offset:[0,]
-    rank1 -- local_shape:[1,], global_offset:[1,]
-    rank2 -- local_shape:[0,], global_offset:[2,]
-    rank5 -- local_shape:[0,], global_offset:[2,]
-    rank3 -- local_shape:[0,], global_offset:[2,]
-    rank4 -- local_shape:[0,], global_offset:[2,]
-    rank6 -- local_shape:[0,], global_offset:[2,]
-    rank7 -- local_shape:[0,], global_offset:[2,]
+
+    - ``rank0 -- local_shape:[1,], global_offset:[0,]``
+    - ``rank1 -- local_shape:[1,], global_offset:[1,]``
+    - ``rank2 -- local_shape:[0,], global_offset:[2,]``
+    - ``rank5 -- local_shape:[0,], global_offset:[2,]``
+    - ``rank3 -- local_shape:[0,], global_offset:[2,]``
+    - ``rank4 -- local_shape:[0,], global_offset:[2,]``
+    - ``rank6 -- local_shape:[0,], global_offset:[2,]``
+    - ``rank7 -- local_shape:[0,], global_offset:[2,]``
     """
     my_coordinate = mesh.get_coordinate() if rank is None else get_mesh_coordinates(mesh, rank)
 

--- a/src/olmo_core/distributed/utils.py
+++ b/src/olmo_core/distributed/utils.py
@@ -3,6 +3,7 @@ from typing import List, Optional, TypeVar
 
 import torch
 import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
 
 
 def is_distributed() -> bool:
@@ -83,3 +84,18 @@ def get_gradient_divide_factor(world_size: int) -> float:
     while world_size % factor == 0 and world_size / factor > factor:
         factor *= 2
     return float(factor)
+
+
+def get_mesh_coordinates(mesh: DeviceMesh, rank: Optional[int] = 0) -> Optional[List[int]]:
+    """
+    Calculate the coordinates of a global rank on a device mesh.
+
+    :param mesh: The device mesh.
+    :param rank: The global rank. If ``None``, the current global rank is used.
+
+    :return: The coordinates or ``None`` if the rank is not part of the mesh.
+    """
+    rank = rank if rank is not None else get_rank()
+    rank_coords = (mesh.mesh == get_rank()).nonzero()
+    assert rank_coords.size(0) in (0, 1)
+    return rank_coords[0].tolist() if rank_coords.size(0) > 0 else None

--- a/src/olmo_core/distributed/utils.py
+++ b/src/olmo_core/distributed/utils.py
@@ -86,7 +86,7 @@ def get_gradient_divide_factor(world_size: int) -> float:
     return float(factor)
 
 
-def get_mesh_coordinates(mesh: DeviceMesh, rank: Optional[int] = 0) -> Optional[List[int]]:
+def get_mesh_coordinates(mesh: DeviceMesh, rank: Optional[int] = None) -> Optional[List[int]]:
     """
     Calculate the coordinates of a global rank on a device mesh.
 
@@ -96,6 +96,6 @@ def get_mesh_coordinates(mesh: DeviceMesh, rank: Optional[int] = 0) -> Optional[
     :return: The coordinates or ``None`` if the rank is not part of the mesh.
     """
     rank = rank if rank is not None else get_rank()
-    rank_coords = (mesh.mesh == get_rank()).nonzero()
+    rank_coords = (mesh.mesh == rank).nonzero()
     assert rank_coords.size(0) in (0, 1)
     return rank_coords[0].tolist() if rank_coords.size(0) > 0 else None

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -3,7 +3,7 @@ import gc
 import os
 import time
 from enum import Enum
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, List, Tuple, Union
 
 import numpy as np
 import torch
@@ -27,6 +27,8 @@ class StrEnum(str, Enum):
     def __repr__(self) -> str:
         return f"'{str(self)}'"
 
+
+ShapeType = Union[torch.Size, List[int], Tuple[int, ...]]
 
 # torch.float8 formats require 2.1; we do not support these dtypes on earlier versions
 _float8_e4m3fn = getattr(torch, "float8_e4m3fn", None)

--- a/src/test/distributed/checkpoint_test.py
+++ b/src/test/distributed/checkpoint_test.py
@@ -154,6 +154,7 @@ def save_and_load_checkpoint_with_dtensors(dir):
         "2d_rowwise": distribute_tensor(torch.randn(16, 8, device=get_default_device()), mesh, [Shard(dim=1)]),
     }
 
+    checkpointer.save(dir, state_dict_to_save)  # type: ignore[arg-type]
     checkpointer.load(dir, state_dict_to_load)  # type: ignore[arg-type]
 
     for key in state_dict_to_load:

--- a/src/test/distributed/checkpoint_test.py
+++ b/src/test/distributed/checkpoint_test.py
@@ -40,7 +40,7 @@ from .utils import (
 def test_tensor_shard_spec_for_dtensor_1D():
     full_shape = (16,)
     shard_spec = TensorShardSpec(local_shape=(8,), global_offset=(0,))
-    assert shard_spec.get_flattened_offsets(full_shape) == ((0, 8),)
+    assert list(shard_spec.get_flattened_offsets(full_shape)) == [(0, 8)]
 
 
 def test_tensor_shard_spec_for_dtensor_2D_colwise():
@@ -50,7 +50,7 @@ def test_tensor_shard_spec_for_dtensor_2D_colwise():
     #  distribute_tensor(torch.randn(16, 8), mesh, [Shard(dim=0)])
     full_shape = (16, 8)
     shard_spec = TensorShardSpec(local_shape=(4, 8), global_offset=(4, 0))
-    assert shard_spec.get_flattened_offsets(full_shape) == ((32, 40), (40, 48), (48, 56), (56, 64))
+    assert list(shard_spec.get_flattened_offsets(full_shape)) == [(32, 40), (40, 48), (48, 56), (56, 64)]
 
 
 def test_tensor_shard_spec_for_dtensor_2D_rowwise():
@@ -60,7 +60,7 @@ def test_tensor_shard_spec_for_dtensor_2D_rowwise():
     #  distribute_tensor(torch.randn(16, 8), mesh, [Shard(dim=1)])
     full_shape = (16, 8)
     shard_spec = TensorShardSpec(local_shape=(16, 2), global_offset=(0, 2))
-    assert shard_spec.get_flattened_offsets(full_shape) == (
+    assert list(shard_spec.get_flattened_offsets(full_shape)) == [
         (2, 4),  # row 0
         (10, 12),  # row 1
         (18, 20),  # row 2
@@ -77,7 +77,7 @@ def test_tensor_shard_spec_for_dtensor_2D_rowwise():
         (106, 108),  # row 13
         (114, 116),  # row 14
         (122, 124),  # row 15
-    )
+    ]
 
 
 def save_and_load_checkpoint_with_regular_and_sharded_tensors(dir):

--- a/src/test/distributed/checkpoint_test.py
+++ b/src/test/distributed/checkpoint_test.py
@@ -860,6 +860,11 @@ def run_save_and_load_tensor_parallel_model(dir, take_step_before_checkpoint):
     # Save checkpoint.
     save_model_and_optim_state(dir, feed_forward, optim)
 
+    # Now load the checkpoint with a different topology, in this case an unsharded model.
+    unsharded_feed_forward = FeedForward().cuda()
+    unsharded_optim = torch.optim.AdamW(unsharded_feed_forward.parameters())
+    load_model_and_optim_state(dir, unsharded_feed_forward, unsharded_optim)
+
 
 @requires_multi_gpu
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is important because it will allow us to use our new checkpointing functionality with models that have been sharded using PyTorch's tensor parallel wrappers or FSDP2, which both use `DTensor` under the hood.

Caveats: currently I've only implemented this for 1D and 2D DTensors. Supporting higher dimensional DTensors will require a more elegant solution.