### PR TITLE
More trainer / launch improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `Trainer.hard_stop` field.
+- The trainer now catches `SIGTERM` and marks the run as canceled.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add `Trainer.hard_stop` field.
+
 ### Fixed
 
 - Fixed bug with how command arguments were expanded by `BeakerLaunchConfig`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed bug with how command arguments were expanded by `BeakerLaunchConfig`.
+
 ## [v1.0.2](https://github.com/allenai/OLMo-core/releases/tag/v1.0.2) - 2024-08-29
 
 ### Added

--- a/src/examples/train.py
+++ b/src/examples/train.py
@@ -7,6 +7,7 @@ Launch this with torchrun:
 """
 
 import json
+from typing import cast
 
 from olmo_core.config import DType
 from olmo_core.data import MemMapDatasetConfig, TokenizerConfig
@@ -29,7 +30,6 @@ from olmo_core.train.callbacks import (
 )
 from olmo_core.utils import get_default_device
 
-LOAD_PATH = None  # path to a checkpoint folder
 WANDB_RUN = None  # name of W&B run
 SAVE_FOLDER = "/tmp/run01"
 DATA_FILES = ["/net/nfs/allennlp/llm-data/c4/en/c4-train.*.npy"]  # can be globs
@@ -75,13 +75,20 @@ TRAINER_CONFIG = (
             save_interval=1000,
             ephemeral_save_interval=50,
             save_async=True,
-            pre_train_checkpoint=LOAD_PATH is None,
         ),
     )
     .with_callback(
         "speed_monitor",
         SpeedMonitorCallback(
             num_flops_per_token=MODEL_CONFIG.num_flops_per_token(DATASET_CONFIG.sequence_length)
+        ),
+    )
+    .with_callback(
+        "wandb",
+        WandBCallback(
+            name=WANDB_RUN,
+            cancel_check_interval=10,
+            enabled=WANDB_RUN is not None,
         ),
     )
 )
@@ -92,19 +99,7 @@ def main():
         model=MODEL_CONFIG.as_config_dict(),
         optim=OPTIM_CONFIG.as_config_dict(),
         trainer=TRAINER_CONFIG.as_config_dict(),
-        load_path=LOAD_PATH,
     )
-
-    # Maybe add W&B callback.
-    if WANDB_RUN is not None:
-        TRAINER_CONFIG.with_callback(
-            "wandb",
-            WandBCallback(
-                name=WANDB_RUN,
-                config=config_dict,
-                cancel_check_interval=10,
-            ),
-        )
 
     # Build components.
     model = MODEL_CONFIG.build(
@@ -116,15 +111,12 @@ def main():
     dataset = DATASET_CONFIG.build()
     trainer = TRAINER_CONFIG.build(model, optim, dataset)
 
-    # Save config to file.
+    # Save config to W&B and file.
     if get_rank() == 0:
+        cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict
         trainer.checkpointer.write_file(
             SAVE_FOLDER, "config.json", json.dumps(config_dict, indent=2)
         )
-
-    # Maybe load a checkpoint.
-    if LOAD_PATH is not None:
-        trainer.load_checkpoint(LOAD_PATH)
 
     # Train.
     trainer.fit()

--- a/src/examples/train.py
+++ b/src/examples/train.py
@@ -64,6 +64,7 @@ TRAINER_CONFIG = (
         data_seed=SEED,
         data_loader_workers=4,
         metrics_collect_interval=5,
+        cancel_check_interval=5,
     )
     .with_callback("lr_scheduler", SchedulerCallback(scheduler=CosWithWarmup(warmup_steps=100)))
     .with_callback("gpu_monitor", GPUMemoryMonitorCallback())
@@ -101,6 +102,7 @@ def main():
             WandBCallback(
                 name=WANDB_RUN,
                 config=config_dict,
+                cancel_check_interval=10,
             ),
         )
 

--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -311,7 +311,7 @@ class BeakerLaunchConfig(Config):
             'git checkout "${GIT_REF}"',
             "git submodule update --init --recursive",
             *self.setup_steps,
-            " ".join(self._get_torchrun_cmd()) + " $@",
+            " ".join(self._get_torchrun_cmd()) + ' "$@"',
         ]
 
         entrypoint_dataset = self._create_script_dataset("entrypoint.sh", entrypoint_script)

--- a/src/olmo_core/train/callbacks/checkpointer.py
+++ b/src/olmo_core/train/callbacks/checkpointer.py
@@ -90,12 +90,13 @@ class CheckpointerCallback(Callback):
                 return fut
         return None
 
-    def _save_checkpoint(self) -> str:
+    def _save_checkpoint(self, save_async: Optional[bool] = None) -> str:
+        save_async = save_async if save_async is not None else self.save_async
         self._await_last_checkpoint()
         self._latest_checkpoint = self.step
         dirname = self.checkpointer.checkpoint_dirname(self.step)
         path = f"{self.save_folder}/{dirname}"
-        if self.save_async:
+        if save_async:
             log.info(f"Saving checkpoint for step {self.step} to '{path}' asynchronously...")
             self._future = self.checkpointer.save_async(
                 path,
@@ -174,5 +175,5 @@ class CheckpointerCallback(Callback):
 
     def post_train(self):
         if self.step > self._latest_checkpoint:
-            self._checkpoints.append(self._save_checkpoint())
+            self._checkpoints.append(self._save_checkpoint(save_async=False))
         self._await_last_checkpoint()

--- a/src/olmo_core/train/callbacks/wandb.py
+++ b/src/olmo_core/train/callbacks/wandb.py
@@ -71,6 +71,12 @@ class WandBCallback(Callback):
     Defaults to ``["cancel", "canceled", "cancelled"]``.
     """
 
+    cancel_check_interval: Optional[int] = None
+    """
+    Check for cancel tags every this many steps. Defaults to
+    :data:`olmo_core.train.Trainer.cancel_check_interval`.
+    """
+
     _wandb = None
     _run_path = None
 
@@ -114,7 +120,8 @@ class WandBCallback(Callback):
             self.wandb.log(metrics, step=step)
 
     def post_step(self):
-        if self.enabled and get_rank() == 0 and self.step % self.trainer.cancel_check_interval == 0:
+        cancel_check_interval = self.cancel_check_interval or self.trainer.cancel_check_interval
+        if self.enabled and get_rank() == 0 and self.step % cancel_check_interval == 0:
             self.trainer.thread_pool.submit(self.check_if_canceled)
 
     def post_train(self):

--- a/src/olmo_core/train/config.py
+++ b/src/olmo_core/train/config.py
@@ -35,6 +35,7 @@ class TrainerConfig(Config):
     max_duration: Duration = field(
         default_factory=lambda: Duration(value=1, unit=DurationUnit.epochs)
     )
+    cancel_check_interval: int = 25
     hard_stop: Optional[Duration] = None
     metrics_collect_interval: int = 5
     callbacks: Dict[str, Callback] = field(default_factory=dict)

--- a/src/olmo_core/train/config.py
+++ b/src/olmo_core/train/config.py
@@ -35,6 +35,7 @@ class TrainerConfig(Config):
     max_duration: Duration = field(
         default_factory=lambda: Duration(value=1, unit=DurationUnit.epochs)
     )
+    hard_stop: Optional[Duration] = None
     metrics_collect_interval: int = 5
     callbacks: Dict[str, Callback] = field(default_factory=dict)
     fused_loss: bool = False

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -256,6 +256,13 @@ class Trainer:
     The interval (in steps) to check if the run is canceled. Checking requires distributed comms.
     """
 
+    hard_stop: Optional[Duration] = None
+    """
+    Set a hard stopping point for the trainer. This is useful for ablations when you you don't
+    want to do a complete training run, but you don't want to change :data:`max_duration` as to
+    not affect the learning rate schedule.
+    """
+
     _metrics: Dict[int, Dict[str, torch.Tensor]] = field(default_factory=OrderedDict)
     _metrics_reduce_type: Dict[str, Optional[ReduceType]] = field(default_factory=dict)
     _canceled: bool = False
@@ -368,6 +375,8 @@ class Trainer:
         if self._canceled:
             return True
         elif self._duration_due(self.max_duration):
+            return True
+        elif self.hard_stop is not None and self._duration_due(self.hard_stop):
             return True
         else:
             return False

--- a/src/scripts/train/OLMo-7B.py
+++ b/src/scripts/train/OLMo-7B.py
@@ -140,6 +140,7 @@ def build_config(run_name: str, cluster: str, overrides: List[str]) -> Experimen
             data_seed=34521,
             data_loader_workers=4,
             metrics_collect_interval=10,
+            cancel_check_interval=1,
         )
         .with_callback(
             "lr_scheduler", SchedulerCallback(scheduler=CosWithWarmup(warmup_steps=2000))
@@ -167,6 +168,7 @@ def build_config(run_name: str, cluster: str, overrides: List[str]) -> Experimen
                 entity="ai2-llm",
                 project="OLMo-core-testing",
                 enabled=True,
+                cancel_check_interval=10,
             ),
         )
     )

--- a/src/scripts/train/OLMo-7B.py
+++ b/src/scripts/train/OLMo-7B.py
@@ -73,7 +73,6 @@ def build_config(run_name: str, cluster: str, overrides: List[str]) -> Experimen
         cmd=["src/scripts/train/OLMo-7B.py", SubCmd.train, run_name, cluster, *overrides],
         task_name="train",
         workspace="ai2/OLMo-core",
-        description="Testing OLMo-core launch utilities",
         clusters=[cluster],
         weka_buckets=weka_buckets,
         beaker_image=OLMoCoreBeakerImage.nightly,  # some features require nightly at the moment

--- a/src/scripts/train/OLMo-7B.py
+++ b/src/scripts/train/OLMo-7B.py
@@ -166,7 +166,7 @@ def build_config(run_name: str, cluster: str, overrides: List[str]) -> Experimen
             WandBCallback(
                 name=run_name,
                 entity="ai2-llm",
-                project="ai2/OLMo-core-doc-masking",
+                project="OLMo-core-testing",
                 enabled=True,
             ),
         )


### PR DESCRIPTION
- Fix how launch overrides arguments are passed to the entrypoint script.
- Catch SIGTERM in the trainer and mark the run as canceled. This allows us to detect when a job is preempted in Beaker and save a checkpoint before the run is killed.
- Always save the final checkpoint synchronously. That might be a little faster.