### PR TITLE
Add BaseDataMix class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `BaseDataMix` class, to allow extending to new data mix groups.
+
 ### Changed
 
 - `BeakerLaunchConfig.setup_steps` should now include steps to clone your repo (which it will by default). This change allows support for private repos.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `BaseDataMix` class, to allow extending to new data mix groups.
+- Added `DataMixBase` class, to allow extending to new data mix groups.
 
 ### Changed
 

--- a/src/olmo_core/data/__init__.py
+++ b/src/olmo_core/data/__init__.py
@@ -20,7 +20,7 @@ from .data_loader import (
     NumpyFSLDataLoader,
     NumpyVSLDataLoader,
 )
-from .mixes import DataMix
+from .mixes import DataMix, DataMixBase
 from .numpy_dataset import (
     NumpyDatasetBase,
     NumpyDatasetConfig,
@@ -56,7 +56,7 @@ __all__ = [
     "NumpyDatasetDType",
     "TokenizerConfig",
     "TokenizerName",
-    "BaseDataMix",
+    "DataMixBase",
     "DataMix",
     "DataCollator",
     "PaddingDirection",

--- a/src/olmo_core/data/__init__.py
+++ b/src/olmo_core/data/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "NumpyDatasetDType",
     "TokenizerConfig",
     "TokenizerName",
+    "BaseDataMix",
     "DataMix",
     "DataCollator",
     "PaddingDirection",

--- a/src/olmo_core/data/mixes/__init__.py
+++ b/src/olmo_core/data/mixes/__init__.py
@@ -16,6 +16,15 @@ class BaseDataMix(StrEnum):
     """
 
     def build(self, base_dir: str, tokenizer: TokenizerName) -> Tuple[List[str], List[str]]:
+        """
+        Construct the data mix.
+
+        :param base_dir: Where the mix is stored, e.g. "s3://ai2-llm" or "/weka/oe-training-default/ai2-llm".
+        :param tokenizer: The tokenizer identifier.
+
+        :returns: A list of paths/URLs to the tokenized numpy data files in the mix and list
+            of corresponding labels.
+        """
         raise NotImplementedError
 
 
@@ -29,15 +38,6 @@ class DataMix(BaseDataMix):
     v3_small_ppl_validation = "v3-small-ppl-validation"
 
     def build(self, base_dir: str, tokenizer: TokenizerName) -> Tuple[List[str], List[str]]:
-        """
-        Construct the data mix.
-
-        :param base_dir: Where the mix is stored, e.g. "s3://ai2-llm" or "/weka/oe-training-default/ai2-llm".
-        :param tokenizer: The tokenizer identifier.
-
-        :returns: A list of paths/URLs to the tokenized numpy data files in the mix and list
-            of corresponding labels.
-        """
         if not base_dir.endswith("/"):
             base_dir = base_dir + "/"
 

--- a/src/olmo_core/data/mixes/__init__.py
+++ b/src/olmo_core/data/mixes/__init__.py
@@ -7,10 +7,10 @@ from olmo_core.config import StrEnum
 
 from ..tokenizer import TokenizerName
 
-__all__ = ["BaseDataMix", "DataMix"]
+__all__ = ["DataMixBase", "DataMix"]
 
 
-class BaseDataMix(StrEnum):
+class DataMixBase(StrEnum):
     """
     Base class for enumeration of data mixes.
     """
@@ -28,7 +28,7 @@ class BaseDataMix(StrEnum):
         raise NotImplementedError
 
 
-class DataMix(BaseDataMix):
+class DataMix(DataMixBase):
     """
     An enumeration of data mix names.
     """

--- a/src/olmo_core/data/mixes/__init__.py
+++ b/src/olmo_core/data/mixes/__init__.py
@@ -14,6 +14,7 @@ class BaseDataMix(StrEnum):
     """
     Base class for enumeration of data mixes.
     """
+
     def build(self, base_dir: str, tokenizer: TokenizerName) -> Tuple[List[str], List[str]]:
         raise NotImplementedError
 

--- a/src/olmo_core/data/mixes/__init__.py
+++ b/src/olmo_core/data/mixes/__init__.py
@@ -7,10 +7,18 @@ from olmo_core.config import StrEnum
 
 from ..tokenizer import TokenizerName
 
-__all__ = ["DataMix"]
+__all__ = ["BaseDataMix", "DataMix"]
 
 
-class DataMix(StrEnum):
+class BaseDataMix(StrEnum):
+    """
+    Base class for enumeration of data mixes.
+    """
+    def build(self, base_dir: str, tokenizer: TokenizerName) -> Tuple[List[str], List[str]]:
+        raise NotImplementedError
+
+
+class DataMix(BaseDataMix):
     """
     An enumeration of data mix names.
     """

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -35,7 +35,7 @@ from ..aliases import PathOrStr
 from ..config import Config, StrEnum
 from ..distributed.utils import barrier, get_fs_local_rank
 from ..io import _get_s3_client, get_file_size
-from .mixes import DataMix
+from .mixes import BaseDataMix
 from .tokenizer import TokenizerConfig
 from .utils import (
     bucket_documents,
@@ -1366,7 +1366,7 @@ class NumpyDatasetConfig(Config):
     """
     The paths/URLs to the numpy token ID arrays.
     """
-    mix: Optional[DataMix] = None
+    mix: Optional[BaseDataMix] = None
     """
     The name of a data mix.
     """
@@ -1440,7 +1440,7 @@ class NumpyDatasetConfig(Config):
 
     @classmethod
     def from_data_mix(
-        cls, mix: DataMix, *, tokenizer: TokenizerConfig, **kwargs
+        cls, mix: BaseDataMix, *, tokenizer: TokenizerConfig, **kwargs
     ) -> "NumpyDatasetConfig":
         """
         Initialize a dataset config from an official data mix.

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -35,7 +35,7 @@ from ..aliases import PathOrStr
 from ..config import Config, StrEnum
 from ..distributed.utils import barrier, get_fs_local_rank
 from ..io import _get_s3_client, get_file_size
-from .mixes import BaseDataMix
+from .mixes import DataMixBase
 from .tokenizer import TokenizerConfig
 from .utils import (
     bucket_documents,
@@ -1366,7 +1366,7 @@ class NumpyDatasetConfig(Config):
     """
     The paths/URLs to the numpy token ID arrays.
     """
-    mix: Optional[BaseDataMix] = None
+    mix: Optional[DataMixBase] = None
     """
     The name of a data mix.
     """
@@ -1440,7 +1440,7 @@ class NumpyDatasetConfig(Config):
 
     @classmethod
     def from_data_mix(
-        cls, mix: BaseDataMix, *, tokenizer: TokenizerConfig, **kwargs
+        cls, mix: DataMixBase, *, tokenizer: TokenizerConfig, **kwargs
     ) -> "NumpyDatasetConfig":
         """
         Initialize a dataset config from an official data mix.


### PR DESCRIPTION
This allows extending the class to specify new mixes in projects using `olmo_core`.