### PR TITLE
Do a dry-run batch before starting training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `CometCallback` for logging training runs to Comet.ml.
 - Added `DataMixBase` class, to allow extending to new data mix groups.
-- Trainer now starts with a dry-run of a fake batch.
+- Added method `DataLoaderBase.get_mock_batch()`.
+- Trainer now starts with a dry-run of a fake batch created by `DataLoaderBase.get_mock_batch()`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `CometCallback` for logging training runs to Comet.ml.
 - Added `DataMixBase` class, to allow extending to new data mix groups.
+- Trainer now starts with a dry-run of a fake batch.
 
 ### Changed
 

--- a/src/olmo_core/data/data_loader.py
+++ b/src/olmo_core/data/data_loader.py
@@ -209,11 +209,10 @@ class DataLoaderBase(ABC):
         self.tokens_processed = 0
 
     @abstractmethod
-    def get_test_batch(self) -> Dict[str, Any]:
+    def get_mock_batch(self) -> Dict[str, Any]:
         """
         Return a batch with arbitrary data. This can just be random data as it's only used by the
-        trainer to check for OOMs and potentially to compile the model. The resulting gradients are
-        thrown away.
+        trainer to do a dry-run of the forward and backward pass before training officially starts.
         """
         raise NotImplementedError
 
@@ -430,7 +429,7 @@ class NumpyDataLoaderBase(DataLoaderBase):
         self._epoch = epoch
         self.build_and_save_global_indices(in_memory=in_memory)
 
-    def get_test_batch(self) -> Dict[str, Any]:
+    def get_mock_batch(self) -> Dict[str, Any]:
         num_instances = self.rank_batch_size // self.dataset.max_sequence_length
         input_ids = torch.randint(
             0, self.dataset.vocab_size, (num_instances, self.dataset.max_sequence_length)

--- a/src/olmo_core/data/data_loader.py
+++ b/src/olmo_core/data/data_loader.py
@@ -208,6 +208,15 @@ class DataLoaderBase(ABC):
         self.batches_processed = 0
         self.tokens_processed = 0
 
+    @abstractmethod
+    def get_test_batch(self) -> Dict[str, Any]:
+        """
+        Return a batch with arbitrary data. This can just be random data as it's only used by the
+        trainer to check for OOMs and potentially to compile the model. The resulting gradients are
+        thrown away.
+        """
+        raise NotImplementedError
+
 
 class NumpyDataLoaderBase(DataLoaderBase):
     """
@@ -420,6 +429,13 @@ class NumpyDataLoaderBase(DataLoaderBase):
             raise ValueError(f"'epoch' must be at least 1, got {epoch}")
         self._epoch = epoch
         self.build_and_save_global_indices(in_memory=in_memory)
+
+    def get_test_batch(self) -> Dict[str, Any]:
+        num_instances = self.rank_batch_size // self.dataset.max_sequence_length
+        input_ids = torch.randint(
+            0, self.dataset.vocab_size, (num_instances, self.dataset.max_sequence_length)
+        )
+        return {"input_ids": input_ids}
 
     def _iter_batches(self) -> Iterable[Dict[str, Any]]:
         return torch.utils.data.DataLoader(

--- a/src/test/data/custom_data_loader.py
+++ b/src/test/data/custom_data_loader.py
@@ -76,6 +76,11 @@ class CustomDataLoader(DataLoaderBase):
             )
         ]
 
+    def get_test_batch(self) -> Dict[str, Any]:
+        num_instances = self.rank_batch_size // self.sequence_length
+        input_ids = torch.randint(0, self.vocab_size, (num_instances, self.sequence_length))
+        return {"input_ids": input_ids}
+
     def _iter_batches(self) -> Iterable[Dict[str, Any]]:
         assert self._dataset is not None, "did you forget to call 'reshuffle()'?"
 

--- a/src/test/data/custom_data_loader.py
+++ b/src/test/data/custom_data_loader.py
@@ -76,7 +76,7 @@ class CustomDataLoader(DataLoaderBase):
             )
         ]
 
-    def get_test_batch(self) -> Dict[str, Any]:
+    def get_mock_batch(self) -> Dict[str, Any]:
         num_instances = self.rank_batch_size // self.sequence_length
         input_ids = torch.randint(0, self.vocab_size, (num_instances, self.sequence_length))
         return {"input_ids": input_ids}

--- a/src/test/data/data_loader_test.py
+++ b/src/test/data/data_loader_test.py
@@ -49,6 +49,7 @@ def test_fsl_data_loader(
             sequence_length=sequence_length,
             pad_token_id=-1,
             eos_token_id=-1,
+            vocab_size=32_000,
         )
         for rank in range(world_size):
             data_loader = NumpyFSLDataLoader(
@@ -107,6 +108,7 @@ def test_fsl_data_loader_multiple_epochs(
         sequence_length=sequence_length,
         pad_token_id=-1,
         eos_token_id=-1,
+        vocab_size=32_000,
     )
     data_loader = NumpyFSLDataLoader(
         dataset,
@@ -204,6 +206,7 @@ def test_fsl_data_loader_with_seq_len_warmup(tmp_path: Path, shuffle: bool):
             sequence_length=seq_len,
             pad_token_id=-1,
             eos_token_id=-1,
+            vocab_size=32_000,
             max_target_sequence_length=max_target_sequence_length,
         )
         data_loader = NumpyFSLDataLoader(
@@ -261,6 +264,7 @@ def test_vsl_data_loader(
         tmp_path / "tokens2.npy",
         pad_token_id=0,
         eos_token_id=0,
+        vocab_size=32_000,
         min_sequence_length=2,
         max_sequence_length=4,
         dtype=np.uint16,

--- a/src/test/data/numpy_dataset_test.py
+++ b/src/test/data/numpy_dataset_test.py
@@ -28,6 +28,7 @@ def test_numpy_fsl_dataset(tmp_path: Path):
         sequence_length=4,
         pad_token_id=-1,
         eos_token_id=-1,
+        vocab_size=32_000,
     )
     assert ds[0]["input_ids"].tolist() == [0, 1, 2, 3]
     assert ds[1]["input_ids"].tolist() == [4, 5, 6, 7]
@@ -52,6 +53,7 @@ def test_numpy_padded_fsl_dataset(tmp_path: Path):
         sequence_length=8,
         pad_token_id=0,
         eos_token_id=0,
+        vocab_size=32_000,
     )
     ds.prepare()
     assert ds[0]["input_ids"].tolist() == [1, 2, 3, 4, 5, 6, 7, 0]
@@ -92,6 +94,7 @@ def test_numpy_vsl_dataset(tmp_path: Path):
         data2_path,
         pad_token_id=pad_token_id,
         eos_token_id=eos_token_id,
+        vocab_size=32_000,
         max_sequence_length=8,
         min_sequence_length=2,
         dtype=dtype,


### PR DESCRIPTION
Fixes a discrepancy after restarts caused by compiling on the first batch.