### PR TITLE
Add learning rate schedulers

### DIFF
--- a/src/olmo_core/optim/__init__.py
+++ b/src/olmo_core/optim/__init__.py
@@ -2,7 +2,15 @@ from .adam import AdamConfig
 from .adamw import AdamWConfig
 from .config import OptimConfig, OptimGroupOverride
 from .lion import Lion, LionConfig, SkipStepLion, SkipStepLionConfig
-from .scheduler import ConstantScheduler, CosWithWarmup, Scheduler
+from .scheduler import (
+    ConstantScheduler,
+    CosWithWarmup,
+    InvSqrtScheduler,
+    LinearWarmupDecoratorScheduler,
+    LinearScheduler,
+    Scheduler,
+    SequentialScheduler,
+)
 from .skip_step_optimizer import SkipStepOptimizer
 
 __all__ = [
@@ -18,4 +26,8 @@ __all__ = [
     "Scheduler",
     "CosWithWarmup",
     "ConstantScheduler",
+    "InvSqrtScheduler",
+    "LinearScheduler",
+    "LinearWarmupDecoratorScheduler",
+    "SequentialScheduler",
 ]

--- a/src/olmo_core/optim/scheduler.py
+++ b/src/olmo_core/optim/scheduler.py
@@ -42,7 +42,7 @@ class ConstantScheduler(Scheduler):
     ) -> Union[float, torch.Tensor]:
         del step, max_steps
         return initial_lr
-    
+
 
 @dataclass
 class LinearWarmupDecoratorScheduler(Scheduler):
@@ -54,7 +54,9 @@ class LinearWarmupDecoratorScheduler(Scheduler):
     warmup_steps: int = 2000
     warmup_min_lr: float = 0.0
 
-    def get_lr(self, initial_lr: Union[float, torch.Tensor], step: int, max_steps: int) -> Union[float, torch.Tensor]:
+    def get_lr(
+        self, initial_lr: Union[float, torch.Tensor], step: int, max_steps: int
+    ) -> Union[float, torch.Tensor]:
         if step <= self.warmup_steps:
             lr_at_intercept = self.inner.get_lr(initial_lr, 1, max_steps - self.warmup_steps)
             return self.warmup_min_lr + (lr_at_intercept - self.warmup_min_lr) * (step / self.warmup_steps)
@@ -87,7 +89,7 @@ class LinearScheduler(Scheduler):
 class InvSqrtScheduler(Scheduler):
     """
     Inverse square root learning rate (LR) schedule.
-    
+
     To enable having a customizable LR warmup (or no warmup), this schedule removes
     the LR warmup that is part of traditional formulations of the inverse square
     root scheduler. Instead, it supports skipping the beginning of the inverse square

--- a/src/olmo_core/optim/scheduler.py
+++ b/src/olmo_core/optim/scheduler.py
@@ -86,17 +86,20 @@ class LinearScheduler(Scheduler):
 @dataclass
 class InvSqrtScheduler(Scheduler):
     """
-    Inverse square root learning rate schedule.
+    Inverse square root learning rate (LR) schedule.
     
-    Rather than including warmup (to avoid dividing by 0 at step 0), the schedule
-    allows skipping the first `step_offset` steps of the schedule.
+    To enable having a customizable LR warmup (or no warmup), this schedule removes
+    the LR warmup that is part of traditional formulations of the inverse square
+    root scheduler. Instead, it supports skipping the beginning of the inverse square
+    root using `step_offset`.
     """
 
     alpha_f: float = 0.1
-    step_offset: int = 0
+    step_offset: int = 1
     """
     Step provided is increased by the given offset for inverse square root calculations.
-    Largers offsets give less steep LR decay.
+    Largers offsets give less steep LR decay, since `get_lr` is normalized to
+    give the initial learning rate at step 0.
     """
 
     def get_lr(

--- a/src/test/optim/scheduler_test.py
+++ b/src/test/optim/scheduler_test.py
@@ -1,0 +1,90 @@
+import math
+
+from olmo_core.optim import (
+    CosWithWarmup,
+    ConstantScheduler,
+    LinearScheduler,
+    LinearWarmupDecoratorScheduler,
+    InvSqrtScheduler,
+    SequentialScheduler,
+)
+
+
+def test_constant_scheduler():
+    initial_lr = 10.0
+    max_steps = 10_000
+    scheduler = ConstantScheduler()
+    assert scheduler.get_lr(initial_lr, 0, max_steps) == 10.0
+    assert scheduler.get_lr(initial_lr, 2_000, max_steps) == 10.0
+    assert scheduler.get_lr(initial_lr, 10_000, max_steps) == 10.0
+
+
+def test_linear_scheduler():
+    initial_lr = 10.0
+    max_steps = 10_000
+    alpha_f = 0.2
+    scheduler = LinearScheduler(alpha_f=alpha_f)
+    assert scheduler.get_lr(initial_lr, 0, max_steps) == 10.0
+    assert scheduler.get_lr(initial_lr, 2_000, max_steps) == 8.4
+    assert scheduler.get_lr(initial_lr, 10_000, max_steps) == 2.0
+    assert scheduler.get_lr(initial_lr, 3_000, max_steps) > scheduler.get_lr(initial_lr, 5_000, max_steps)
+
+
+def test_inv_sqrt_scheduler():
+    initial_lr = 10.0
+    max_steps = 10_000
+    alpha_f = 0.2
+    step_offset = 1_000
+    scheduler = InvSqrtScheduler(alpha_f=alpha_f, step_offset=step_offset)
+    assert scheduler.get_lr(initial_lr, 1, max_steps) == 2.0 + 8.0 * math.sqrt(1_000.0 / 1_001.0)
+    assert scheduler.get_lr(initial_lr, 2_000, max_steps) == 2.0 + 8.0 * math.sqrt(1_000.0 / 3_000.0)
+    assert scheduler.get_lr(initial_lr, 3_000, max_steps) == scheduler.get_lr(initial_lr, 3_000, 10 * max_steps)
+
+
+def test_linear_warmup_decorator_scheduler():
+    initial_lr = 10.0
+    warmup_min_lr = 4.0
+    warmup_steps = 3_000
+    max_steps = 10_000
+    inner_scheduler = ConstantScheduler()
+    scheduler = LinearWarmupDecoratorScheduler(
+        inner=inner_scheduler, warmup_steps=warmup_steps, warmup_min_lr=warmup_min_lr
+    )
+    assert scheduler.get_lr(initial_lr, 0, max_steps) == 4.0
+    assert scheduler.get_lr(initial_lr, 1_000, max_steps) == 6.0
+    assert scheduler.get_lr(initial_lr, 3_000, max_steps) == 10.0
+    assert scheduler.get_lr(initial_lr, 10_000, max_steps) == 10.0
+
+
+def test_cos_with_warmup_scheduler():
+    initial_lr = 10.0
+    warmup_min_lr = 4.0
+    warmup_steps = 3_000
+    max_steps = 10_000
+    alpha_f = 0.2
+    scheduler = CosWithWarmup(warmup_steps=warmup_steps, alpha_f=alpha_f, warmup_min_lr=warmup_min_lr)
+    assert scheduler.get_lr(initial_lr, 0, max_steps) == 4.0
+    assert scheduler.get_lr(initial_lr, 1_000, max_steps) == 6.0
+    assert scheduler.get_lr(initial_lr, 3_000, max_steps) == 10.0
+    assert scheduler.get_lr(initial_lr, 5_000, max_steps) == 2.0 + 8.0 * (1 + math.cos(math.pi * 2_000 / 7_000)) / 2
+    assert scheduler.get_lr(initial_lr, 10_000, max_steps) == 2.0
+
+
+def test_sequential_scheduler():
+    initial_lr = 10.0
+    max_steps = 20_000
+
+    first_scheduler = InvSqrtScheduler(alpha_f=0.5, step_offset=1_000)
+    second_scheduler = CosWithWarmup()
+    third_scheduler = LinearScheduler(t_max=3_000)
+    schedulers_max_steps = [2_500, 4_000]
+    scheduler = SequentialScheduler(
+        schedulers=[first_scheduler, second_scheduler, third_scheduler], schedulers_max_steps=schedulers_max_steps
+    )
+
+    first_scheduler_final_lr = first_scheduler.get_lr(initial_lr, 2_500, 2_500)
+    second_scheduler_final_lr = second_scheduler.get_lr(first_scheduler_final_lr, 4_000, 4_000)
+
+    assert scheduler.get_lr(initial_lr, 1_000, max_steps) == first_scheduler.get_lr(initial_lr, 1_000, 2_500)
+    assert scheduler.get_lr(initial_lr, 4_000, max_steps) == second_scheduler.get_lr(first_scheduler_final_lr, 1_500, 4_000)
+    assert scheduler.get_lr(initial_lr, 7_500, max_steps) == third_scheduler.get_lr(second_scheduler_final_lr, 1_000, max_steps - 6_500)


### PR DESCRIPTION
This PR adds a few standard LR schedulers. Unlike in the original OLMo, these do not have warmup inbuilt.

- `LinearScheduler` - Standard linear LR schedule. LR is kept constant once the end of the decay is reached.
- `InvSqrtScheduler` - Inverse square root LR schedule.

I have also added some schedulers that I think are convenient.

- `LinearWarmupDecoratorScheduler` - Wraps an existing scheduler, adding linear warmup to it.
- `SequentialScheduler` - Allows you to chain schedules sequentially, so that one is called after another. The initial LR of a scheduler is that final LR of the previous scheduler. Last scheduler is assumed to run indefinitely.

As an example, the following scheduler warms up for 100 steps, then does inverse square root to 1/2 max LR for 150 steps, then linear decay to 0 for 200 steps, and then constant forever after (since linear schedule is constant after decay is done).
```
SequentialScheduler(
    schedulers=[
        LinearWarmupDecoratorScheduler(
            warmup_steps=100,
            inner=InvSqrtScheduler(
                alpha_f=0.5,
                step_offset=100,
            ),
        ),
        LinearScheduler(alpha_f=0, t_max=200),
    ],
    schedulers_max_steps=[250],
)
```