### PR TITLE
Pre-download only relevant files per rank.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "numpy<2.0",
     "torch>=2.5.1",
-    "cached-path",
+    "cached-path@git+https://github.com/allenai/cached_path@shanea/cache-gs-client",
     "requests",
     "packaging",
     "rich",

--- a/src/olmo_core/distributed/checkpoint/filesystem.py
+++ b/src/olmo_core/distributed/checkpoint/filesystem.py
@@ -272,18 +272,25 @@ class RemoteFileSystemReader(dist_cp.StorageReader):
     that can read data directly from cloud storage as well as a local directory.
     """
 
-    def __init__(self, path: PathOrStr, *, thread_count: Optional[int] = None):
+    def __init__(
+        self, path: PathOrStr, *, thread_count: Optional[int] = None, pre_download: bool = False
+    ):
         super().__init__()
         if thread_count is not None and thread_count <= 0:
             raise ValueError("thread count must be at least 1")
         self.path = normalize_path(path)
         self.thread_count = thread_count or get_default_thread_count()
+        self.pre_download = pre_download
         self.storage_data: Dict[MetadataIndex, _StorageInfo] = dict()
         self.load_id = generate_uuid()
         self._metadata: Optional[Metadata] = None
 
     def _get_bytes(self, relative_path: str, offset: int, length: int) -> bytes:
-        return get_bytes_range(f"{self.path}/{relative_path}", offset, length)
+        if self.pre_download:
+            full_path = str(resource_path(self.path, relative_path))
+        else:
+            full_path = f"{self.path}/{relative_path}"
+        return get_bytes_range(full_path, offset, length)
 
     def _get_content_for_read(self, read_item: ReadItem) -> Tuple[ReadItem, bytes]:
         sinfo = self.storage_data[read_item.storage_index]

--- a/src/olmo_core/train/checkpoint.py
+++ b/src/olmo_core/train/checkpoint.py
@@ -157,21 +157,6 @@ class Checkpointer:
         """
         dir = normalize_path(dir)
 
-        if is_url(dir) and self.pre_download:
-            target = self.work_dir / "load" / os.path.basename(dir)
-            log.info(f"Pre-downloading checkpoint from '{dir}' to '{target}'...")
-            if get_fs_local_rank() == 0:
-                copy_dir(dir, target, save_overwrite=self.save_overwrite)
-            barrier(self.process_group)
-            return self.load(
-                target,
-                model,
-                optim,
-                load_optimizer_state=load_optimizer_state,
-                load_trainer_state=load_trainer_state,
-                key_mapping=key_mapping,
-            )
-
         # Maybe load trainer state.
         trainer_state: Optional[Dict[str, Any]] = None
         if load_trainer_state:
@@ -193,6 +178,7 @@ class Checkpointer:
             optim if load_optimizer_state else None,
             process_group=self.process_group,
             key_mapping=key_mapping,
+            pre_download=is_url(dir) and self.pre_download,
         )
 
         return trainer_state


### PR DESCRIPTION
This builds on #123 and tries to change it in ways listed below. Completely untested and just an idea.

- Instead of pre-downloading the whole checkpoint, download a checkpoint file when a range query is about to made on it for the first time. `resource_path` will (hopefully) prevent any concurrency issues. As a bonus, this also splits up the work between the various processes.
- Instead of saving each non-sharded data item on the rank with the smallest save payload (thus spreading the items out across a bunch of files/ranks), save them all to the lowest rank (empirically, rank 0). This will limit how many files we have to download/read from, but makes rank 0 bigger (I think only by like 1 MB though).
  - This is the solution for https://github.com/pytorch/pytorch/issues/125740