### PR TITLE
Skip step AdamW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new LR schedulers: `LinearWithWarmup`, `InvSqrtWithWarmup`, `ConstantWithWarmup`, `SequentialScheduler`.
 - Added option to pre-download checkpoint files from remote storage before trying to load a checkpoint.
 - Added a callback for sending Slack notifications.
+- Added `SkipStepAdamW` optimizer.
 
 ### Changed
 
 - Changed storage of shared shard state in sharded checkpoints from smallest shard to lowest rank (normally 0).
+- Changed underlying AdamW implementation.
 
 ### Fixed
 

--- a/src/olmo_core/optim/__init__.py
+++ b/src/olmo_core/optim/__init__.py
@@ -1,5 +1,5 @@
 from .adam import AdamConfig
-from .adamw import AdamWConfig, SkipStepAdamW, SkipStepAdamWConfig
+from .adamw import AdamW, AdamWConfig, SkipStepAdamW, SkipStepAdamWConfig
 from .config import OptimConfig, OptimGroupOverride
 from .lion import Lion, LionConfig, SkipStepLion, SkipStepLionConfig
 from .scheduler import (
@@ -19,6 +19,7 @@ __all__ = [
     "SkipStepOptimizer",
     "AdamWConfig",
     "AdamConfig",
+    "AdamW",
     "SkipStepAdamWConfig",
     "SkipStepAdamW",
     "LionConfig",

--- a/src/olmo_core/optim/__init__.py
+++ b/src/olmo_core/optim/__init__.py
@@ -1,5 +1,5 @@
 from .adam import AdamConfig
-from .adamw import AdamWConfig
+from .adamw import AdamWConfig, SkipStepAdamW, SkipStepAdamWConfig
 from .config import OptimConfig, OptimGroupOverride
 from .lion import Lion, LionConfig, SkipStepLion, SkipStepLionConfig
 from .scheduler import (
@@ -19,6 +19,8 @@ __all__ = [
     "SkipStepOptimizer",
     "AdamWConfig",
     "AdamConfig",
+    "SkipStepAdamWConfig",
+    "SkipStepAdamW",
     "LionConfig",
     "Lion",
     "SkipStepLionConfig",

--- a/src/olmo_core/optim/adamw.py
+++ b/src/olmo_core/optim/adamw.py
@@ -4,11 +4,12 @@ from typing import Optional, Tuple, Type
 
 import torch
 import torch.nn as nn
+from torch.optim.optimizer import Optimizer
 
 from .config import OptimConfig
+from .skip_step_optimizer import SkipStepOptimizer
 
 
-# TODO: use this when we implement a "skip step" version of AdamW.
 def adamw_step(
     p: nn.Parameter,
     *,
@@ -47,6 +48,129 @@ def adamw_step(
     p.add_(update)
 
 
+class AdamW(Optimizer):
+    """
+    An implementation of the AdamW optimizer.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 1e-3,
+        betas: Tuple[float, float] = (0.9, 0.999),
+        eps: float = 1e-8,
+        weight_decay: float = 1e-2,
+        foreach: Optional[bool] = None,
+        fused: Optional[bool] = None,
+    ):
+        assert lr > 0.0
+        assert all([0.0 <= beta <= 1.0 for beta in betas])
+        defaults = dict(
+            lr=lr, betas=betas, eps=eps, weight_decay=weight_decay, foreach=foreach, fused=fused
+        )
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None) -> None:
+        if closure is not None:
+            with torch.enable_grad():
+                closure()
+
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+
+                state = self.state[p]
+                if len(state) == 0:
+                    state["step"] = torch.tensor(0.0, dtype=torch.float32, device=p.device)
+                    state["exp_avg"] = torch.zeros_like(p)
+                    state["exp_avg_sq"] = torch.zeros_like(p)
+                    state["step_factor"] = torch.tensor(1.0, device=p.device)
+
+                adamw_step(
+                    p,
+                    lr=group["lr"],
+                    betas=group["betas"],
+                    eps=group["eps"],
+                    weight_decay=group["weight_decay"],
+                    exp_avg=state["exp_avg"],
+                    exp_avg_sq=state["exp_avg_sq"],
+                    step=state["step"],
+                    step_factor=state["step_factor"],
+                )
+
+
+class SkipStepAdamW(SkipStepOptimizer):
+    """
+    A "skip step" version of :class:`AdamW`.
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float = 1e-3,
+        betas: Tuple[float, float] = (0.9, 0.999),
+        eps: float = 1e-8,
+        weight_decay: float = 1e-2,
+        foreach: Optional[bool] = None,
+        fused: Optional[bool] = None,
+        rolling_interval_length: int = 128,
+        sigma_factor: int = 6,
+    ) -> None:
+        assert lr > 0.0
+        assert all([0.0 <= beta <= 1.0 for beta in betas])
+        defaults = dict(
+            lr=lr, betas=betas, eps=eps, weight_decay=weight_decay, foreach=foreach, fused=fused
+        )
+        super().__init__(
+            params,
+            defaults,
+            rolling_interval_length=rolling_interval_length,
+            sigma_factor=sigma_factor,
+        )
+        self._step_skipped: Optional[torch.Tensor] = None
+
+    @property
+    def step_skipped(self) -> torch.Tensor:
+        if self._step_skipped is not None:
+            return self._step_skipped
+        else:
+            return torch.tensor(0.0)
+
+    @torch.no_grad()
+    def step(self, closure=None) -> None:
+        if closure is not None:
+            with torch.enable_grad():
+                closure()
+
+        step_factor = self.get_step_factor()
+        self._step_skipped = 1 - step_factor
+        for group in self.param_groups:
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+
+                state = self.state[p]
+                if len(state) == 0:
+                    state["step"] = torch.tensor(0.0, dtype=torch.float32, device=p.device)
+                    state["exp_avg"] = torch.zeros_like(p)
+                    state["exp_avg_sq"] = torch.zeros_like(p)
+                    state["step_factor"] = torch.tensor(1.0, device=p.device)
+
+                adamw_step(
+                    p,
+                    lr=group["lr"],
+                    betas=group["betas"],
+                    eps=group["eps"],
+                    weight_decay=group["weight_decay"],
+                    exp_avg=state["exp_avg"],
+                    exp_avg_sq=state["exp_avg_sq"],
+                    step=state["step"],
+                    step_factor=state["step_factor"],
+                )
+
+
 @dataclass
 class AdamWConfig(OptimConfig):  # NOTE: omagaconf doesn't like "OptimConfig[torch.optim.AdamW]"
     """
@@ -61,5 +185,23 @@ class AdamWConfig(OptimConfig):  # NOTE: omagaconf doesn't like "OptimConfig[tor
     fused: Optional[bool] = None
 
     @classmethod
-    def optimizer(cls) -> Type[torch.optim.AdamW]:
-        return torch.optim.AdamW
+    def optimizer(cls) -> Type[AdamW]:
+        return AdamW
+
+
+@dataclass
+class SkipStepAdamWConfig(OptimConfig):
+    """
+    Configuration class for building a :class:`SkipStepAdamW` optimizer.
+    """
+
+    lr: float = 1e-3
+    betas: Tuple[float, float] = (0.9, 0.999)
+    eps: float = 1e-8
+    weight_decay: float = 1e-2
+    rolling_interval_length: int = 128
+    sigma_factor: int = 6
+
+    @classmethod
+    def optimizer(cls) -> Type[SkipStepAdamW]:
+        return SkipStepAdamW

--- a/src/olmo_core/optim/adamw.py
+++ b/src/olmo_core/optim/adamw.py
@@ -199,6 +199,8 @@ class SkipStepAdamWConfig(OptimConfig):
     betas: Tuple[float, float] = (0.9, 0.999)
     eps: float = 1e-8
     weight_decay: float = 1e-2
+    foreach: Optional[bool] = None
+    fused: Optional[bool] = None
     rolling_interval_length: int = 128
     sigma_factor: int = 6
 

--- a/src/test/optim/adamw_test.py
+++ b/src/test/optim/adamw_test.py
@@ -1,7 +1,9 @@
+import pytest
 import torch
 import torch.nn as nn
 
-from olmo_core.optim import AdamWConfig, OptimGroupOverride
+from olmo_core.optim import AdamWConfig, OptimGroupOverride, SkipStepAdamWConfig
+from test.utils import DEVICES
 
 
 class MyModel(nn.Module):
@@ -43,3 +45,33 @@ def test_adamw_config_to_optim_with_group_overrides():
 
     for group in optim.param_groups:
         assert "initial_lr" in group
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_adamw(device: torch.device):
+    config = AdamWConfig()
+    model = MyModel().train().to(device)
+    optim = config.build(model)
+
+    for group in optim.param_groups:
+        assert "initial_lr" in group
+
+    # Take a step.
+    optim.zero_grad(set_to_none=True)
+    model(torch.randint(0, 1024, (2, 8), device=device).int()).sum().backward()
+    optim.step()
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_skip_step_adamw(device: torch.device):
+    config = SkipStepAdamWConfig()
+    model = MyModel().train().to(device)
+    optim = config.build(model)
+
+    for group in optim.param_groups:
+        assert "initial_lr" in group
+
+    # Take a step.
+    optim.zero_grad(set_to_none=True)
+    model(torch.randint(0, 1024, (2, 8), device=device).int()).sum().backward()
+    optim.step()

--- a/src/test/optim/adamw_test.py
+++ b/src/test/optim/adamw_test.py
@@ -1,9 +1,10 @@
+from test.utils import DEVICES
+
 import pytest
 import torch
 import torch.nn as nn
 
 from olmo_core.optim import AdamWConfig, OptimGroupOverride, SkipStepAdamWConfig
-from test.utils import DEVICES
 
 
 class MyModel(nn.Module):

--- a/src/test/optim/adamw_test.py
+++ b/src/test/optim/adamw_test.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 import torch.nn as nn
 
-from olmo_core.optim import AdamWConfig, OptimGroupOverride, SkipStepAdamWConfig
+from olmo_core.optim import AdamW, AdamWConfig, OptimGroupOverride, SkipStepAdamWConfig
 
 
 class MyModel(nn.Module):
@@ -23,7 +23,7 @@ def test_adamw_config_to_optim():
     model = MyModel()
     optim = config.build(model)
 
-    assert isinstance(optim, torch.optim.AdamW)
+    assert isinstance(optim, AdamW)
     assert len(optim.param_groups) == 1
 
     assert config.merge(["lr=1e-1"]).lr == 0.1
@@ -36,7 +36,7 @@ def test_adamw_config_to_optim_with_group_overrides():
 
     model = MyModel()
     optim = config.build(model)
-    assert isinstance(optim, torch.optim.AdamW)
+    assert isinstance(optim, AdamW)
     assert len(optim.param_groups) == 2
     assert optim.param_groups[0]["weight_decay"] == 0.0
     assert len(optim.param_groups[0]["params"]) == 1


### PR DESCRIPTION
This PR implements `SkipStepAdamW`. It's not ideal since it doesn't support fused ops or similar at present. I changed default AdamW to also use the same underlying implementation