### PR TITLE
Add more options to the `unshard_checkpoint` function to help scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SkipStepAdamW` optimizer.
 - The trainer can load model-only checkpoints now.
 - Added the option to throttle checkpoint uploads to one rank from each node at a time.
+- Added `unshard_strategy` parameter to `unshard_checkpoint()` function in `olmo_coer.distributed.checkpoint`.
+- Added function `load_keys()` to `olmo_core.distributed.checkpoint`.
 
 ### Changed
 

--- a/src/olmo_core/distributed/checkpoint/__init__.py
+++ b/src/olmo_core/distributed/checkpoint/__init__.py
@@ -471,9 +471,9 @@ def unshard_checkpoint(
         elif unshard_strategy.name == UnshardStrategyType.one_file_per_tensor:
             path = target_dir / prefix
             chunks = []
-            for chunk_num, key in enumerate(metadata.state_dict_metadata.keys()):
+            for key in metadata.state_dict_metadata.keys():
                 if key.startswith(f"{prefix}."):
-                    chunks.append((path / f"chunk-{chunk_num:05d}.{ext}", [key]))
+                    chunks.append((path / f"{key.replace('.', '-')}.{ext}", [key]))
             return path, chunks
         elif unshard_strategy.name == UnshardStrategyType.chunks:
             assert unshard_strategy.chunk_size_bytes is not None

--- a/src/olmo_core/distributed/checkpoint/__init__.py
+++ b/src/olmo_core/distributed/checkpoint/__init__.py
@@ -459,6 +459,8 @@ def unshard_checkpoint(
 
     def get_chunks(prefix: str) -> Tuple[Path, List[Tuple[Path, List[str]]]]:
         assert unshard_strategy is not None
+        assert isinstance(target_dir, Path)
+
         if unshard_strategy.name == UnshardStrategyType.one_file:
             path = target_dir / f"{prefix}.{ext}"
             return path, [(path, [prefix])]

--- a/src/olmo_core/distributed/checkpoint/__init__.py
+++ b/src/olmo_core/distributed/checkpoint/__init__.py
@@ -581,12 +581,12 @@ def get_checkpoint_metadata(dir: PathOrStr) -> Metadata:
     dir = normalize_path(dir)
     try:
         storage_reader = RemoteFileSystemReader(dir)
+        return storage_reader.read_metadata()
     except FileNotFoundError as exc:
         msg = f"'{dir}' does not appear to contain a state dict checkpoint."
         if file_exists((suggested_path := join_path(dir, "model_and_optim/.metadata"))):
             msg += f" Did you mean to use '{suggested_path}'?"
         raise FileNotFoundError(msg) from exc
-    return storage_reader.read_metadata()
 
 
 def _prepare_env_for_save(

--- a/src/olmo_core/distributed/checkpoint/__init__.py
+++ b/src/olmo_core/distributed/checkpoint/__init__.py
@@ -584,8 +584,9 @@ def get_checkpoint_metadata(dir: PathOrStr) -> Metadata:
         return storage_reader.read_metadata()
     except FileNotFoundError as exc:
         msg = f"'{dir}' does not appear to contain a state dict checkpoint."
-        if file_exists((suggested_path := join_path(dir, "model_and_optim/.metadata"))):
-            msg += f" Did you mean to use '{suggested_path}'?"
+        suggested_dir = join_path(dir, "model_and_optim")
+        if file_exists(join_path(suggested_dir, ".metadata")):
+            msg += f" Did you mean to use '{suggested_dir}'?"
         raise FileNotFoundError(msg) from exc
 
 

--- a/src/olmo_core/distributed/checkpoint/filesystem.py
+++ b/src/olmo_core/distributed/checkpoint/filesystem.py
@@ -37,7 +37,7 @@ from olmo_core.io import (
     resource_path,
     upload,
 )
-from olmo_core.utils import generate_uuid, get_default_thread_count
+from olmo_core.utils import generate_uuid, get_default_thread_count, get_element_size
 
 log = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ def _item_size(item: WriteItem) -> int:
         size *= s
 
     dtype = item.tensor_data.properties.dtype
-    return size * torch._utils._element_size(dtype)
+    return size * get_element_size(dtype)
 
 
 def _split_by_size_and_type(bins: int, items: List[WriteItem]) -> List[List[WriteItem]]:

--- a/src/olmo_core/distributed/checkpoint/filesystem.py
+++ b/src/olmo_core/distributed/checkpoint/filesystem.py
@@ -386,7 +386,9 @@ class RemoteFileSystemReader(dist_cp.StorageReader):
                 ) as metadata_file:
                     metadata = pickle.load(metadata_file)
             except FileNotFoundError as exc:
-                msg = f"'{dir}' does not appear to contain a distributed state dict/checkpoint."
+                msg = (
+                    f"'{self.path}' does not appear to contain a distributed state dict/checkpoint."
+                )
                 suggested_dir = join_path(self.path, "model_and_optim")
                 if file_exists(join_path(suggested_dir, ".metadata")):
                     msg += f" Did you mean to use '{suggested_dir}'?"

--- a/src/olmo_core/distributed/checkpoint/filesystem.py
+++ b/src/olmo_core/distributed/checkpoint/filesystem.py
@@ -386,9 +386,7 @@ class RemoteFileSystemReader(dist_cp.StorageReader):
                 ) as metadata_file:
                     metadata = pickle.load(metadata_file)
             except FileNotFoundError as exc:
-                msg = (
-                    f"'{self.path}' does not appear to contain a distributed state dict/checkpoint."
-                )
+                msg = f"'{self.path}' is not a distributed checkpoint folder."
                 suggested_dir = join_path(self.path, "model_and_optim")
                 if file_exists(join_path(suggested_dir, ".metadata")):
                     msg += f" Did you mean to use '{suggested_dir}'?"

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -644,3 +644,10 @@ def cuda_sync_debug_mode(debug_mode: Union[int, str]):
     finally:
         if current_mode is not None:
             torch.cuda.set_sync_debug_mode(current_mode)
+
+
+def get_element_size(dtype: torch.dtype) -> int:
+    """
+    Get the size in bytes of element of the given PyTorch dtype.
+    """
+    return torch._utils._element_size(dtype)  # type: ignore


### PR DESCRIPTION
I was getting worried about unsharding really big checkpoints like for the 32B, which we'll need to do soon. The main issue at the moment is that in order to unshard we need to load the entire model (or optimizer state) in memory, which clearly isn't scalable. So I've added an option to unshard the checkpoint into chunks of a given size which helps scale because only a single chunk (which could be as small as a single tensor) needs to load into memory at a time. Each chunk gets written to a unique file. I think HuggingFace does something similar.

Note: this is not supported for optimizer state yet. But, speaking of optimizer state, this PR also adds a function called `load_keys()` for loading (and unsharding) specific keys from a checkpoint. So if you want to inspect part of the optimizer state, you could use that function without having to unshard the whole optimizer state.