### PR TITLE
Fix device in mock batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added missing `weights_only=False` argument to fix loading train checkpoints with newer versions of PyTorch.
 - Fixed bug where GCS upload does not retry on transient failures.
+- Fixed bug in `get_mock_batch()` by adding `non_cuda` option so that mock batches can be loaded on cuda devices in addition to MPS devices.
 
 ## [v1.7.0](https://github.com/allenai/OLMo-core/releases/tag/v1.7.0) - 2024-11-27
 

--- a/src/olmo_core/data/data_loader.py
+++ b/src/olmo_core/data/data_loader.py
@@ -434,7 +434,7 @@ class NumpyDataLoaderBase(DataLoaderBase):
         self.build_and_save_global_indices(in_memory=in_memory)
 
     def get_mock_batch(self) -> Dict[str, Any]:
-        rng = torch.Generator(device=get_default_device())
+        rng = torch.Generator(device=get_default_device(non_cuda=True))
         rng.manual_seed(self.seed + self.dp_rank)
         num_instances = self.rank_batch_size // self.dataset.max_sequence_length
         input_ids = torch.randint(

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -118,12 +118,15 @@ def mark_dynamic(x: torch.Tensor, dim: Union[int, Sequence[int]]):
     torch._dynamo.mark_dynamic(x, dim)
 
 
-def get_default_device() -> torch.device:
+def get_default_device(non_cuda: bool = False) -> torch.device:
     """
     Get the default device.
     """
     if torch.cuda.is_available() and torch.cuda.is_initialized():
-        return torch.device("cuda")
+        if non_cuda:
+            return torch.device("cpu")
+        else:
+            return torch.device("cuda")
     elif torch.mps.is_available():
         return torch.device("mps")
     else:


### PR DESCRIPTION
Fixed bug in `get_mock_batch()` by adding `non_cuda` option so that mock batches can be loaded on cuda devices in addition to MPS devices.