### PR TITLE
Add a `BeakerCallback`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added conversion script for OLMo 2 checkpoints to Huggingface format.
+- Added `BeakerCallback`.
 
 ### Fixed
 

--- a/src/olmo_core/internal/experiment.py
+++ b/src/olmo_core/internal/experiment.py
@@ -27,6 +27,7 @@ from olmo_core.train import (
     teardown_training_environment,
 )
 from olmo_core.train.callbacks import (
+    BeakerCallback,
     Callback,
     CometCallback,
     ConfigSaverCallback,
@@ -194,6 +195,7 @@ def build_common_components(
             eval_interval=1000,
         ),
         "slack_notifier": SlackNotifierCallback(name=run_name, enabled=False),
+        "beaker": BeakerCallback(),
     }
     if torch.cuda.is_available():
         callbacks["gpu_monitor"] = GPUMemoryMonitorCallback()

--- a/src/olmo_core/train/callbacks/__init__.py
+++ b/src/olmo_core/train/callbacks/__init__.py
@@ -2,6 +2,7 @@
 Trainer :class:`Callback` implementations.
 """
 
+from .beaker import BeakerCallback
 from .callback import Callback, CallbackConfig
 from .checkpointer import CheckpointerCallback, CheckpointRemovalStrategy
 from .comet import CometCallback, CometNotificationSetting
@@ -50,6 +51,7 @@ __all__ = [
     "SequenceLengthSchedulerCallback",
     "SpeedMonitorCallback",
     "WandBCallback",
+    "BeakerCallback",
 ]
 
 __doc__ += "\n"

--- a/src/olmo_core/train/callbacks/beaker.py
+++ b/src/olmo_core/train/callbacks/beaker.py
@@ -1,0 +1,107 @@
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar, Optional
+
+from olmo_core.distributed.utils import get_rank
+from olmo_core.exceptions import OLMoEnvironmentError
+
+from .callback import Callback
+from .comet import CometCallback
+from .wandb import WandBCallback
+
+if TYPE_CHECKING:
+    from beaker import Beaker
+
+log = logging.getLogger(__name__)
+
+
+BEAKER_EXPERIMENT_ID_ENV_VAR = "BEAKER_EXPERIMENT_ID"
+
+
+@dataclass
+class BeakerCallback(Callback):
+    """
+    Adds metadata to the Beaker experiment description when running as a Beaker batch job.
+    """
+
+    priority: ClassVar[int] = min(CometCallback.priority - 1, WandBCallback.priority - 1)
+    enabled: bool = True
+    experiment_id: Optional[str] = None
+    update_interval: Optional[int] = None
+    description: Optional[str] = None
+
+    _client = None
+    _url = None
+
+    @property
+    def client(self) -> "Beaker":
+        return self._client  # type: ignore
+
+    @client.setter
+    def client(self, client: "Beaker"):
+        self._client = client
+
+    def pre_train(self):
+        if self.enabled and get_rank() == 0:
+            if self.experiment_id is None:
+                if BEAKER_EXPERIMENT_ID_ENV_VAR not in os.environ:
+                    raise OLMoEnvironmentError(f"missing env var '{BEAKER_EXPERIMENT_ID_ENV_VAR}'")
+                else:
+                    self.experiment_id = os.environ[BEAKER_EXPERIMENT_ID_ENV_VAR]
+
+            from beaker import Beaker
+
+            self.client = Beaker.from_env()
+
+            for callback in self.trainer.callbacks.values():
+                if isinstance(callback, WandBCallback) and callback.enabled:
+                    if (url := callback.run.get_url()) is not None:
+                        self._url = url
+                    break
+                elif isinstance(callback, CometCallback) and callback.enabled:
+                    if (url := callback.exp.url) is not None:
+                        self._url = url
+                    break
+
+    def post_step(self):
+        update_interval = self.update_interval or self.trainer.metrics_collect_interval
+        if self.enabled and get_rank() == 0 and self.step % update_interval == 0:
+            self.trainer.thread_pool.submit(
+                self._set_description,
+                step=self.step,
+                max_steps=self.trainer.max_steps,
+                msg=self.description,
+            )
+
+    def post_train(self):
+        if self.enabled and get_rank() == 0:
+            self.trainer.thread_pool.submit(
+                self._set_description,
+                step=self.step,
+                max_steps=self.trainer.max_steps,
+                msg=self.description,
+            )
+
+    def _set_description(self, *, step: int, max_steps: Optional[int], msg: Optional[str]):
+        from beaker import BeakerError, HTTPError
+        from requests.exceptions import RequestException
+
+        assert self.experiment_id is not None
+        progress: str
+        if max_steps is not None:
+            perc = max(100, int(100 * step / max_steps))
+            progress = f"{perc}%, {step}/{max_steps}"
+        else:
+            progress = f"{step}/??"
+
+        description = f"[{progress}]"
+        if msg is not None:
+            description = f"{description} {msg}"
+        if self._url is not None:
+            description = f"{description} {self._url}"
+
+        try:
+            self.client.experiment.set_description(self.experiment_id, description)
+        except (RequestException, BeakerError, HTTPError) as e:
+            log.warning(f"Failed to communicate with Beaker server: {e}")

--- a/src/olmo_core/train/callbacks/beaker.py
+++ b/src/olmo_core/train/callbacks/beaker.py
@@ -107,7 +107,7 @@ class BeakerCallback(Callback):
             description = f"[{progress}] "
 
         if self.description is not None:
-            description = f"{description}{self.description} "
+            description = f"{description}{self.description}\n"
 
         if self._url is not None:
             description = f"{description}{self._url} "

--- a/src/olmo_core/train/callbacks/beaker.py
+++ b/src/olmo_core/train/callbacks/beaker.py
@@ -26,10 +26,10 @@ class BeakerCallback(Callback):
     """
 
     priority: ClassVar[int] = min(CometCallback.priority - 1, WandBCallback.priority - 1)
-    enabled: bool = True
     experiment_id: Optional[str] = None
     update_interval: Optional[int] = None
     description: Optional[str] = None
+    enabled: Optional[bool] = None
 
     _client = None
     _url = None
@@ -41,6 +41,10 @@ class BeakerCallback(Callback):
     @client.setter
     def client(self, client: "Beaker"):
         self._client = client
+
+    def post_attach(self):
+        if self.enabled is None and BEAKER_EXPERIMENT_ID_ENV_VAR in os.environ:
+            self.enabled = True
 
     def pre_train(self):
         if self.enabled and get_rank() == 0:
@@ -104,4 +108,4 @@ class BeakerCallback(Callback):
         try:
             self.client.experiment.set_description(self.experiment_id, description)
         except (RequestException, BeakerError, HTTPError) as e:
-            log.warning(f"Failed to communicate with Beaker server: {e}")
+            log.warning(f"Failed to update Beaker experiment description: {e}")

--- a/src/olmo_core/train/callbacks/beaker.py
+++ b/src/olmo_core/train/callbacks/beaker.py
@@ -103,7 +103,7 @@ class BeakerCallback(Callback):
                 perc = min(100, int(100 * step / max_steps))
                 progress = f"{perc}%, {step:,d}/{max_steps:,d}"
             else:
-                progress = f"{step}/??"
+                progress = f"{step:,d}/??"
             description = f"[{progress}] "
 
         if self.description is not None:

--- a/src/olmo_core/train/callbacks/wandb.py
+++ b/src/olmo_core/train/callbacks/wandb.py
@@ -2,12 +2,15 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from olmo_core.distributed.utils import get_rank
 from olmo_core.exceptions import OLMoEnvironmentError
 
 from .callback import Callback
+
+if TYPE_CHECKING:
+    from wandb.sdk.wandb_run import Run
 
 log = logging.getLogger(__name__)
 
@@ -94,7 +97,7 @@ class WandBCallback(Callback):
         return self._wandb
 
     @property
-    def run(self):
+    def run(self) -> "Run":
         return self.wandb.run
 
     @property


### PR DESCRIPTION
Adds a callback that updates the description of the corresponding beaker experiment with a progress indicator and a URL to the experiment on W&B or Comet.

![image](https://github.com/user-attachments/assets/2c297d7c-73b2-4d60-884f-756cd89cf50f)
