### PR TITLE
Add an API to get training ETA

### DIFF
--- a/src/olmo_core/data/utils.py
+++ b/src/olmo_core/data/utils.py
@@ -442,7 +442,7 @@ def segment_documents_into_instances(
         rng = get_rng(seed)
         indices = rng.choice(indices.reshape(-1, 2), size=max_instances).reshape(-1)
 
-    if not indices:
+    if indices.size == 0:
         raise RuntimeError(f"Failed to produce any documents from '{path}'")
 
     with memmap_to_write(target, dtype=indices_dtype, shape=(indices.size,)) as indices_mmap:

--- a/src/olmo_core/train/callbacks/speed_monitor.py
+++ b/src/olmo_core/train/callbacks/speed_monitor.py
@@ -36,6 +36,11 @@ class SpeedMonitorCallback(Callback):
     _step_tokens: int = 0
     _step_seq_len: int = 0
     _parallel_degree: int = 1
+    _bps_avg: Optional[float] = None
+
+    @property
+    def bps_avg(self) -> Optional[float]:
+        return self._bps_avg
 
     def _get_num_flops_per_token(self, seq_len: int) -> Optional[int]:
         if self.num_flops_per_token is not None:
@@ -114,6 +119,8 @@ class SpeedMonitorCallback(Callback):
         bps = 1 / step_time
         bps_avg = self._total_steps / total_time
         data_pct = 100 * self._batch_load_time / step_time
+
+        self._bps_avg = bps_avg
 
         self.trainer.record_metric("throughput/total tokens", self.trainer.global_train_tokens_seen)
         self.trainer.record_metric(

--- a/src/olmo_core/train/common.py
+++ b/src/olmo_core/train/common.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Tuple
+from datetime import timedelta
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 
 from ..config import StrEnum
 from ..data.utils import get_labels
+from ..utils import format_timedelta
 
 
 class DurationUnit(StrEnum):
@@ -138,3 +140,28 @@ def get_inputs_for_loss(
     return reshape_inputs_for_loss(
         logits, batch.get("labels", get_labels(batch, label_ignore_index=label_ignore_index))
     )
+
+
+@dataclass
+class TrainingProgress:
+    current_step: int
+    """
+    The current training step.
+    """
+    total_steps: int
+    """
+    The step that training will stop at.
+    """
+    time_remaining: Optional[timedelta] = None
+    """
+    Estimated time remaining.
+    """
+
+    def __str__(self) -> str:
+        progress_perc = min(100, int(100 * self.current_step / self.total_steps))
+        progress_str = (
+            f"{progress_perc}% complete (step {self.current_step:,d}/{self.total_steps:,d})"
+        )
+        if self.time_remaining is not None:
+            progress_str += f", eta {format_timedelta(self.time_remaining)}"
+        return progress_str

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -4,6 +4,7 @@ import signal
 from collections import OrderedDict
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
+from datetime import timedelta
 from pathlib import Path
 from typing import (
     Any,
@@ -47,7 +48,7 @@ from .callbacks import (
     SpeedMonitorCallback,
 )
 from .checkpoint import Checkpointer
-from .common import Duration, DurationUnit, LoadStrategy, ReduceType
+from .common import Duration, DurationUnit, LoadStrategy, ReduceType, TrainingProgress
 from .train_module import TrainModule
 from .utils import EnvRngStates, move_metrics, reduce_metrics
 
@@ -387,15 +388,18 @@ class Trainer:
         """
         The maximum number of steps to train for, as determined by :data:`max_duration`.
         """
-        if self.max_duration.unit == DurationUnit.steps:
-            return self.max_duration.value
-        elif self.max_duration.unit == DurationUnit.epochs:
+        return self._get_max_steps(self.max_duration)
+
+    def _get_max_steps(self, duration: Duration) -> int:
+        if duration.unit == DurationUnit.steps:
+            return duration.value
+        elif duration.unit == DurationUnit.epochs:
             if self.data_loader.total_batches is None:
                 raise RuntimeError(
                     "the number of steps cannot be determined from an 'epochs' duration since "
                     "the data loader's number of batches is unknown"
                 )
-            max_epochs = self.max_duration.value
+            max_epochs = duration.value
             complete_epochs_remaining = max(max_epochs - self.epoch, 0)
             steps_remaining_this_epoch = max(
                 self.data_loader.total_batches - self.data_loader.batches_processed, 0
@@ -405,9 +409,9 @@ class Trainer:
                 + steps_remaining_this_epoch
             )
             return self.global_step + steps_remaining
-        elif self.max_duration.unit == DurationUnit.tokens:
+        elif duration.unit == DurationUnit.tokens:
             # Need to account for a change in batch size.
-            max_tokens = self.max_duration.value
+            max_tokens = duration.value
             tokens_remaining = max(max_tokens - self.global_train_tokens_seen, 0)
             steps_remaining = math.ceil(tokens_remaining / self.tokens_per_batch)
             return self.global_step + steps_remaining
@@ -450,6 +454,35 @@ class Trainer:
         If a checkpoint has been loaded.
         """
         return self._checkpoint_loaded
+
+    @property
+    def training_progress(self) -> TrainingProgress:
+        # Calculate total steps.
+        total_steps = max(
+            self._get_max_steps(self.hard_stop) if self.hard_stop is not None else self.max_steps,
+            self.global_step,
+        )
+
+        # Get current speed in batches per second.
+        bps: Optional[float] = None
+        for callback in self.callbacks.values():
+            if isinstance(callback, SpeedMonitorCallback):
+                bps = callback.bps_avg
+                break
+
+        # Estimate the remaining time.
+        time_remaining: Optional[timedelta] = None
+        if bps is not None and (steps_remaining := (total_steps - self.global_step)) > 0:
+            seconds_remaining = steps_remaining / bps
+            # Round to nearest minute.
+            minutes_remaining = 1 + (seconds_remaining // 60)
+            time_remaining = timedelta(minutes=minutes_remaining)
+
+        return TrainingProgress(
+            current_step=self.global_step,
+            total_steps=total_steps,
+            time_remaining=time_remaining,
+        )
 
     def cancel_run(self, reason: str):
         """

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -9,7 +9,7 @@ import time
 import uuid
 import warnings
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timedelta
 from itertools import cycle, islice
 from queue import Queue
 from threading import Thread
@@ -609,6 +609,29 @@ def format_float(value: float) -> str:
         return f"{value:.3f}"
     else:
         return f"{value:.4f}"
+
+
+def format_timedelta(td: timedelta) -> str:
+    breakdown = []
+    if td.days > 0:
+        breakdown.append(f"{td.days}d")
+
+    hours = td.seconds // 3600
+    if hours > 0:
+        breakdown.append(f"{hours}h")
+
+    minutes = (td.seconds % 3600) // 60
+    if minutes > 0:
+        breakdown.append(f"{minutes}m")
+
+    seconds = td.seconds % 60
+    if seconds > 0:
+        breakdown.append(f"{seconds}s")
+
+    if breakdown:
+        return ", ".join(breakdown)
+    else:
+        return "0s"
 
 
 def flatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
ETA will be added to console logs and Beaker experiment descriptions (via the `BeakerCallback`).

![image](https://github.com/user-attachments/assets/cd7ee53d-7931-4614-9e0a-50973b3fd761)
