### PR TITLE
FSDP optimizations

### DIFF
--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -589,11 +589,14 @@ class Transformer(nn.Module):
                 **fsdp_config,
             )
 
-        if (
-            wrapping_strategy == TransformerDataParallelWrappingStrategy.fine_grained
-            and self.embeddings is not None
-        ):
+        #  if (
+        #      wrapping_strategy == TransformerDataParallelWrappingStrategy.fine_grained
+        #      and self.embeddings is not None
+        #  ):
+        if self.embeddings is not None:
             fully_shard(self.embeddings, reshard_after_forward=reshard_after_forward, **fsdp_config)
+            # Embedding params are not needed for backwards computation.
+            cast(FSDPModule, self.embeddings).set_unshard_in_backward(False)
 
         if (
             wrapping_strategy != TransformerDataParallelWrappingStrategy.blocks

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -589,10 +589,6 @@ class Transformer(nn.Module):
                 **fsdp_config,
             )
 
-        #  if (
-        #      wrapping_strategy == TransformerDataParallelWrappingStrategy.fine_grained
-        #      and self.embeddings is not None
-        #  ):
         if self.embeddings is not None:
             fully_shard(self.embeddings, reshard_after_forward=reshard_after_forward, **fsdp_config)
             # Embedding params are not needed for backwards computation.


### PR DESCRIPTION
- Improve FSDP settings for gradient accumulation. For example, with HSDP we delay the gradient all-reduce until the final micro-batch. 
- Always wrap the embeddings separately but don't unshard them in the backwards pass since embedding params aren't needed for the gradient computation.