### PR TITLE
Log in-loop eval throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `instance_filter_config` field to `NumpyDatasetConfig`.
 - Added conversion script for OLMo 2 checkpoints to Huggingface format.
 - Added `BeakerCallback`.
+- Added logging for in-loop eval throughput
 
 ### Fixed
 

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -65,6 +65,10 @@ class EvaluatorCallback(Callback):
         self.trainer.model.eval()
         dp_world_size = get_world_size(self.trainer.dp_process_group)
 
+        evaluator_times = []
+        evaluator_names = []
+        evaluator_bs = []
+
         for evaluator in self.evaluators:
             log.info(f"Running {evaluator.name} evals...")
             start_time = time.monotonic()
@@ -99,15 +103,39 @@ class EvaluatorCallback(Callback):
             # NOTE: going to have a host-device sync here but that's okay. It's only once
             # per evaluator.
             metrics = []
+            evaluation_names = []
             with cuda_sync_debug_mode(0):
                 for name, value in evaluator.compute_metrics().items():
+                    evaluation_names.append(name)
                     metrics.append(f"    {name}={format_float(value.item())}")
                     self.trainer.record_metric(f"eval/{evaluator.name}/{name}", value)
+
+            evaluator_times.append(time.monotonic() - start_time)
+            evaluator_names.append(evaluation_names)
+            evaluator_bs.append(evaluator.total_batches)
+            
             log.info(
                 f"Finished {evaluator.name} evals in {time.monotonic() - start_time:.1f} seconds. Metrics:\n"
                 + "\n".join(metrics)
             )
 
+        # Sort by evaluator_times in ascending order
+        sorted_evaluators = sorted(zip(evaluator_names, evaluator_bs, evaluator_times), key=lambda x: x[2])
+
+        # Record evaluation speed
+        log.info("Evaluation speed:")
+        max_time_width = max(len(f"{t:.1f}") for t in evaluator_times)
+        max_batch_width = max(len(str(bs)) for bs in evaluator_bs)
+        for names, bs, t in sorted_evaluators:
+            name = names[0] # only use the name of the first metric for each downstream task
+            log.info(f"    {t:>{max_time_width}.1f} sec ({bs:>{max_batch_width}} batches): {name} (+ variants)")
+        total_time = sum(evaluator_times)
+        total_bs = sum(evaluator_bs)
+        log.info(f"    Total evaluation time: {total_time:.1f} seconds ({total_bs} batches)")
+
+        self.trainer.record_metric(f"throughput/in-loop eval time (s)", total_time)
+        self.trainer.record_metric(f"throughput/in-loop eval batches", total_bs)
+        
         # Restore model to train mode.
         self.trainer.model.train()
 


### PR DESCRIPTION
Simple change to log the timing of the in-loop evals, so we can identify slow evals if they need to be disabled:

- `throughput/in-loop eval time (s)`
- `throughput/in-loop eval batches`

### Example
Here's an example of our run-time with the current in-loop evals:

```
Evaluation Set 1 speed (tested on 1B, 4 L40s):
     0.1 sec (  2 batches): codex_humaneval_gold_bpb_0shot (BPB) (+ variants)
     0.3 sec ( 13 batches): mbpp_gold_bpb_0shot (BPB) (+ variants)
     0.4 sec (  4 batches): copycolors_10way (accuracy) (+ variants)
     0.7 sec ( 15 batches): minerva_math_counting_and_probability_gold_bpb_0shot (BPB) (+ variants)
     0.7 sec ( 11 batches): mmlu_social_sciences_val_rc_5shot (length-normalized accuracy) (+ variants)
     0.7 sec ( 15 batches): minerva_math_number_theory_gold_bpb_0shot (BPB) (+ variants)
     0.8 sec ( 16 batches): mmlu_stem_val_rc_5shot (length-normalized accuracy) (+ variants)
     0.9 sec ( 15 batches): minerva_math_geometry_gold_bpb_0shot (BPB) (+ variants)
     0.9 sec ( 26 batches): mmlu_other_val_rc_5shot (length-normalized accuracy) (+ variants)
     0.9 sec ( 10 batches): winogrande_val_rc_5shot (length-normalized accuracy) (+ variants)
     1.0 sec ( 18 batches): minerva_math_precalculus_gold_bpb_0shot (BPB) (+ variants)
     1.1 sec ( 25 batches): minerva_math_prealgebra_gold_bpb_0shot (BPB) (+ variants)
     1.4 sec ( 24 batches): gsm8k_gold_bpb_5shot (BPB) (+ variants)
     1.6 sec ( 29 batches): minerva_math_intermediate_algebra_gold_bpb_0shot (BPB) (+ variants)
     1.6 sec ( 38 batches): minerva_math_algebra_gold_bpb_0shot (BPB) (+ variants)
     1.7 sec ( 29 batches): piqa_val_rc_5shot (length-normalized accuracy) (+ variants)
     2.1 sec ( 23 batches): socialiqa_val_rc_5shot (length-normalized accuracy) (+ variants)
     2.1 sec ( 24 batches): csqa_val_rc_5shot (length-normalized accuracy) (+ variants)
     2.2 sec ( 65 batches): mmlu_humanities_val_rc_5shot (length-normalized accuracy) (+ variants)
     2.4 sec ( 32 batches): hellaswag_rc_5shot (length-normalized accuracy) (+ variants)
     2.7 sec ( 28 batches): arc_challenge_test_rc_5shot (length-normalized accuracy) (+ variants)
     3.6 sec ( 57 batches): arc_easy_test_rc_5shot (length-normalized accuracy) (+ variants)
     5.9 sec (124 batches): mmlu_social_sciences_test_rc_5shot (length-normalized accuracy) (+ variants)
     6.9 sec (168 batches): mmlu_stem_test_rc_5shot (length-normalized accuracy) (+ variants)
     7.4 sec (232 batches): mmlu_other_test_rc_5shot (length-normalized accuracy) (+ variants)
    20.4 sec (589 batches): mmlu_humanities_test_rc_5shot (length-normalized accuracy) (+ variants)
    Total evaluation time: 70.7 seconds (1632 batches)

Evaluation Set 2 speed (tested on 1B, 4 L40s):
     0.1 sec (  2 batches): codex_humaneval_gold_bpb_0shot (BPB) (+ variants)
     0.3 sec ( 13 batches): mbpp_gold_bpb_0shot (BPB) (+ variants)
     0.3 sec (  4 batches): copycolors_10way (accuracy) (+ variants)
     0.7 sec ( 15 batches): minerva_math_counting_and_probability_gold_bpb_0shot (BPB) (+ variants)
     0.7 sec ( 15 batches): minerva_math_number_theory_gold_bpb_0shot (BPB) (+ variants)
     0.8 sec ( 15 batches): minerva_math_geometry_gold_bpb_0shot (BPB) (+ variants)
     0.9 sec ( 10 batches): winogrande_val_rc_5shot (length-normalized accuracy) (+ variants)
     1.0 sec ( 18 batches): minerva_math_precalculus_gold_bpb_0shot (BPB) (+ variants)
     1.0 sec ( 31 batches): mmlu_social_sciences_val_mc_5shot (length-normalized accuracy) (+ variants)
     1.1 sec ( 30 batches): mmlu_other_val_mc_5shot (length-normalized accuracy) (+ variants)
     1.1 sec ( 25 batches): minerva_math_prealgebra_gold_bpb_0shot (BPB) (+ variants)
     1.4 sec ( 24 batches): gsm8k_gold_bpb_5shot (BPB) (+ variants)
     1.5 sec ( 29 batches): minerva_math_intermediate_algebra_gold_bpb_0shot (BPB) (+ variants)
     1.6 sec ( 38 batches): minerva_math_algebra_gold_bpb_0shot (BPB) (+ variants)
     2.3 sec ( 32 batches): hellaswag_rc_5shot (length-normalized accuracy) (+ variants)
     2.3 sec ( 44 batches): piqa_val_mc_5shot (accuracy) (+ variants)
     2.7 sec ( 35 batches): socialiqa_val_mc_5shot (accuracy) (+ variants)
     2.7 sec ( 65 batches): mmlu_humanities_val_mc_5shot (length-normalized accuracy) (+ variants)
     2.8 sec ( 37 batches): csqa_val_mc_5shot (accuracy) (+ variants)
     3.2 sec ( 21 batches): mmlu_stem_val_mc_5shot (length-normalized accuracy) (+ variants)
     4.7 sec ( 75 batches): arc_easy_test_mc_5shot (accuracy) (+ variants)
     5.0 sec ( 37 batches): arc_challenge_test_mc_5shot (accuracy) (+ variants)
     9.1 sec (216 batches): mmlu_stem_test_mc_5shot (length-normalized accuracy) (+ variants)
     9.3 sec (280 batches): mmlu_social_sciences_test_mc_5shot (length-normalized accuracy) (+ variants)
     9.5 sec (295 batches): mmlu_other_test_mc_5shot (length-normalized accuracy) (+ variants)
    24.2 sec (589 batches): mmlu_humanities_test_mc_5shot (length-normalized accuracy) (+ variants)
    Total evaluation time: 90.4 seconds (1995 batches)
```