### PR TITLE
Allow train modules to not load/save optimizer state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added automatic support for LL128 when running on Augusta.
 - Added information about 32B training logs.
 
+### Changed
+
+- Several state dict methods in `TrainModule` now take an `optim` option, which can disable the use of optimizer state.
+
 ### Fixed
 
 - The official config for the 32B had unrealistic batch size settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added automatic support for LL128 when running on Augusta.
 - Added information about 32B training logs.
 
-### Changed
-
-- Several state dict methods in `TrainModule` now take an `optim` option, which can disable the use of optimizer state.
-
 ### Fixed
 
 - The official config for the 32B had unrealistic batch size settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `TransformerTrainModuleConfig` can now be used to build a `TransformerPipelineTrainModule` by adding a `pp_config` spec. This makes the `TransformerPipelineTrainModuleConfig` redundant, but it will be kept around for backwards compatibility until the next major release.
+- Several state dict methods in `TrainModule` now take an `optim` option, which can disable the use of optimizer state.
 
 ## [v2.0.1](https://github.com/allenai/OLMo-core/releases/tag/v2.0.1) - 2025-03-18
 

--- a/src/olmo_core/train/train_module/train_module.py
+++ b/src/olmo_core/train/train_module/train_module.py
@@ -122,26 +122,32 @@ class TrainModule(Stateful, metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def state_dict(self) -> Dict[str, Any]:
+    def state_dict(self, *, optim: bool = True) -> Dict[str, Any]:
         """
         Get the state dict to save or load.
+
+        :param optim: If set to ``False``, optimizer state is not returned in the state dict.
         """
         raise NotImplementedError
 
-    def state_dict_to_save(self) -> Dict[str, Any]:
+    def state_dict_to_save(self, *, optim: bool = True) -> Dict[str, Any]:
         """
         Can be overridden if the state dict to save should be different from the state dict to load.
         By default just returns :func:`state_dict()`.
-        """
-        return self.state_dict()
 
-    def state_dict_to_load(self, metadata: Metadata) -> Dict[str, Any]:
+        :param optim: If set to ``False``, optimizer state is not returned in the state dict.
+        """
+        return self.state_dict(optim=optim)
+
+    def state_dict_to_load(self, metadata: Metadata, *, optim: bool = True) -> Dict[str, Any]:
         """
         Can be overridden if the state dict to load should be different from the state dict to save.
         By default just returns :func:`state_dict()`.
+
+        :param optim: If set to ``False``, optimizer state is not returned in the state dict.
         """
         del metadata
-        return self.state_dict()
+        return self.state_dict(optim=optim)
 
     @abstractmethod
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:

--- a/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
@@ -270,10 +270,10 @@ class TransformerPipelineTrainModule(TrainModule):
             num_microbatches=num_microbatches,
         )
 
-    def state_dict(self) -> Dict[str, Any]:
-        return self._get_state_dict(self.state_dict_save_opts)
+    def state_dict(self, *, optim: bool = True) -> Dict[str, Any]:
+        return self._get_state_dict(self.state_dict_save_opts, optim=optim)
 
-    def state_dict_to_load(self, metadata: Metadata) -> Dict[str, Any]:
+    def state_dict_to_load(self, metadata: Metadata, *, optim: bool = True) -> Dict[str, Any]:
         load_opts = self.state_dict_load_opts
 
         if "optim.param_groups.0.params" in metadata.state_dict_metadata:
@@ -295,24 +295,24 @@ class TransformerPipelineTrainModule(TrainModule):
                 )
                 load_opts = replace(load_opts, flatten_optimizer_state_dict=True)
 
-        state_dict = self._get_state_dict(load_opts)
-        if self.load_key_mapping is not None:
-            _swap_param_keys(state_dict, self.load_key_mapping, metadata=metadata)
-
         has_optim_state: bool = False
         for key in metadata.state_dict_metadata.keys():
             if key.startswith("optim."):
                 has_optim_state = True
                 break
 
-        if not has_optim_state:
-            del state_dict["optim"]
+        if optim and not has_optim_state:
             log.warning("No optimizer state found in checkpoint")
+            optim = False
+
+        state_dict = self._get_state_dict(load_opts, optim=optim)
+        if self.load_key_mapping is not None:
+            _swap_param_keys(state_dict, self.load_key_mapping, metadata=metadata)
 
         return state_dict
 
-    def state_dict_to_save(self) -> Dict[str, Any]:
-        return self._get_state_dict(self.state_dict_save_opts)
+    def state_dict_to_save(self, *, optim: bool = True) -> Dict[str, Any]:
+        return self._get_state_dict(self.state_dict_save_opts, optim=optim)
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         if self.load_key_mapping is not None:
@@ -638,16 +638,20 @@ class TransformerPipelineTrainModule(TrainModule):
                 stack.enter_context(torch.autocast(self.device.type, dtype=self.autocast_precision))
             yield
 
-    def _get_state_dict(self, sd_options: dist_cp_sd.StateDictOptions) -> Dict[str, Any]:
-        return {
+    def _get_state_dict(
+        self, sd_options: dist_cp_sd.StateDictOptions, optim: bool = True
+    ) -> Dict[str, Any]:
+        state_dict: Dict[str, Any] = {
             "model": {
                 k: v
                 for sd in map(
                     partial(dist_cp_sd.get_model_state_dict, options=sd_options), self.model_parts
                 )
                 for k, v in sd.items()
-            },
-            "optim": {
+            }
+        }
+        if optim:
+            state_dict["optim"] = {
                 k: v
                 for sd in map(
                     partial(dist_cp_sd.get_optimizer_state_dict, options=sd_options),
@@ -655,8 +659,9 @@ class TransformerPipelineTrainModule(TrainModule):
                     self.optimizers,
                 )
                 for k, v in sd.items()
-            },
-        }
+            }
+
+        return state_dict
 
     def _clip_grad_norm(
         self, max_grad_norm: float, norm_type: float = 2.0, foreach: Optional[bool] = None

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -227,10 +227,10 @@ class TransformerTrainModule(TrainModule):
                 f"micro-batch size ({self.rank_microbatch_size:,d}) x DP world size ({dp_ws})"
             )
 
-    def state_dict(self) -> Dict[str, Any]:
-        return self._get_state_dict(self.state_dict_save_opts)
+    def state_dict(self, *, optim: bool = True) -> Dict[str, Any]:
+        return self._get_state_dict(self.state_dict_save_opts, optim=optim)
 
-    def state_dict_to_load(self, metadata: Metadata) -> Dict[str, Any]:
+    def state_dict_to_load(self, metadata: Metadata, *, optim: bool = True) -> Dict[str, Any]:
         load_opts = self.state_dict_load_opts
 
         if "optim.param_groups.0.params" in metadata.state_dict_metadata:
@@ -252,24 +252,24 @@ class TransformerTrainModule(TrainModule):
                 )
                 load_opts = replace(load_opts, flatten_optimizer_state_dict=True)
 
-        state_dict = self._get_state_dict(load_opts)
-        if self.load_key_mapping is not None:
-            _swap_param_keys(state_dict, self.load_key_mapping, metadata=metadata)
-
         has_optim_state: bool = False
         for key in metadata.state_dict_metadata.keys():
             if key.startswith("optim."):
                 has_optim_state = True
                 break
 
-        if not has_optim_state:
-            del state_dict["optim"]
+        if optim and not has_optim_state:
             log.warning("No optimizer state found in checkpoint")
+            optim = False
+
+        state_dict = self._get_state_dict(load_opts, optim=optim)
+        if self.load_key_mapping is not None:
+            _swap_param_keys(state_dict, self.load_key_mapping, metadata=metadata)
 
         return state_dict
 
-    def state_dict_to_save(self) -> Dict[str, Any]:
-        return self._get_state_dict(self.state_dict_save_opts)
+    def state_dict_to_save(self, *, optim: bool = True) -> Dict[str, Any]:
+        return self._get_state_dict(self.state_dict_save_opts, optim=optim)
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         if self.load_key_mapping is not None:
@@ -565,13 +565,17 @@ class TransformerTrainModule(TrainModule):
                 stack.enter_context(torch.autocast(self.device.type, dtype=self.autocast_precision))
             yield
 
-    def _get_state_dict(self, sd_options: dist_cp_sd.StateDictOptions) -> Dict[str, Any]:
-        return {
+    def _get_state_dict(
+        self, sd_options: dist_cp_sd.StateDictOptions, optim: bool = True
+    ) -> Dict[str, Any]:
+        state_dict: Dict[str, Any] = {
             "model": dist_cp_sd.get_model_state_dict(self.model, options=sd_options),
-            "optim": dist_cp_sd.get_optimizer_state_dict(
-                self.model, self.optim, options=sd_options
-            ),
         }
+        if optim:
+            state_dict["optim"] = dist_cp_sd.get_optimizer_state_dict(
+                self.model, self.optim, options=sd_options
+            )
+        return state_dict
 
     def _clip_grad_norm(
         self, max_grad_norm: float, norm_type: float = 2.0, foreach: Optional[bool] = None


### PR DESCRIPTION
This PR allows train modules to not load/save optimizer state by adding a boolean `optim` option to various state-related methods. Being able to disable loading/saving optimizer state is a perf/memory boost when converting a model to/from HF format.