### PR TITLE
OLMo Core to HF conversion refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- (BETA) Added methods `load_hf_model` and `save_hf_model` for saving supported OLMo Core models to HF transformers format.
+Also added lower-level methods for converting state between the formats.
+
 ### Changed
 
 - `TransformerTrainModuleConfig` can now be used to build a `TransformerPipelineTrainModule` by adding a `pp_config` spec. This makes the `TransformerPipelineTrainModuleConfig` redundant, but it will be kept around for backwards compatibility until the next major release.
 - Several state dict methods in `TrainModule` now take an `optim` option, which can disable the use of optimizer state.
+- Changed underlying logic and top-level arguments of `convert_checkpoint_from_hf.py` and `convert_checkpoint_to_hf.py`.
 
 ## [v2.0.1](https://github.com/allenai/OLMo-core/releases/tag/v2.0.1) - 2025-03-18
 

--- a/src/examples/huggingface/convert_checkpoint_from_hf.py
+++ b/src/examples/huggingface/convert_checkpoint_from_hf.py
@@ -8,165 +8,368 @@ HuggingFace.
 
 import json
 import logging
-import os
+import types
+from argparse import ArgumentParser
+from functools import partial
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, Optional
 
 import torch
+from cached_path import cached_path
+from torch.distributed import DeviceMesh
 from transformers import AutoModelForCausalLM
 
+from olmo_core.aliases import PathOrStr
 from olmo_core.data.tokenizer import TokenizerConfig
-from olmo_core.distributed.checkpoint import load_model_and_optim_state, save_state_dict
-from olmo_core.io import clear_directory, dir_is_empty
-from olmo_core.nn.rope import RoPEScalingConfig
-from olmo_core.nn.transformer import TransformerConfig
+from olmo_core.io import file_exists
+from olmo_core.nn.conversion.state_mapping import TemplatePlaceholder
+from olmo_core.nn.hf.checkpoint import load_hf_model
+from olmo_core.nn.hf.convert import get_converter_from_hf
+from olmo_core.nn.transformer.config import TransformerConfig
+from olmo_core.nn.transformer.model import Transformer
+from olmo_core.optim.adamw import AdamWConfig
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.train_module.transformer import TransformerTrainModuleConfig
 from olmo_core.utils import get_default_device, prepare_cli_environment
 
 log = logging.getLogger(__name__)
 
-HF_MODEL = "allenai/OLMo-2-1124-7B"
-# HF_MODEL = "allenai/OLMo-2-1124-7B-Instruct"
-# HF_MODEL = "allenai/OLMo-2-1124-13B-Instruct"
-# HF_MODEL = "meta-llama/Llama-3.2-1B"
-# HF_MODEL = "meta-llama/Llama-3.2-8B"
 
-SAVE_PATH = f"/tmp/checkpoints/{HF_MODEL}"
-SAVE_OVERWRITE = False
-
-TOKENIZER_CONFIG = TokenizerConfig.from_hf(HF_MODEL)
-MODEL_CONFIG: TransformerConfig
-if HF_MODEL == "meta-llama/Llama-3.2-1B":
-    MODEL_CONFIG = TransformerConfig.llama3_1B(
-        TOKENIZER_CONFIG.vocab_size,
-        fused_ops=False,
-        use_flash=False,
-        rope_scaling=RoPEScalingConfig(),
-    )
-elif HF_MODEL.startswith("allenai/OLMo-2-1124-7B"):
-    MODEL_CONFIG = TransformerConfig.olmo2_7B(
-        TOKENIZER_CONFIG.vocab_size,
-        fused_ops=False,
-        use_flash=False,
-    )
-elif HF_MODEL.startswith("allenai/OLMo-2-1124-13B"):
-    MODEL_CONFIG = TransformerConfig.olmo2_13B(
-        TOKENIZER_CONFIG.vocab_size,
-        fused_ops=False,
-        use_flash=False,
-    )
-else:
-    raise NotImplementedError(HF_MODEL)
-
-
-def convert_checkpoint() -> AutoModelForCausalLM:
-    log.info(f"Loading HF checkpoint '{HF_MODEL}'")
-    hf_model = AutoModelForCausalLM.from_pretrained(HF_MODEL)
-    print(hf_model)
-
-    if not dir_is_empty(SAVE_PATH):
-        if SAVE_OVERWRITE:
-            log.warning(f"Clearing existing checkpoint at '{SAVE_PATH}'")
-            clear_directory(SAVE_PATH)
-        else:
-            log.warning(f"Using existing checkpoint at '{SAVE_PATH}'")
-            return hf_model
-
-    n_layers = len(hf_model.model.layers)
-    state_dict = hf_model.state_dict()
-
-    # Map old keys to OLMo-core keys.
-    new_state_dict = {
-        "embeddings.weight": state_dict.pop("model.embed_tokens.weight"),
-        "lm_head.norm.weight": state_dict.pop("model.norm.weight"),
-        "lm_head.w_out.weight": state_dict.pop("lm_head.weight"),
+def _get_transformer_config(model_arch: str, vocab_size: int) -> TransformerConfig:
+    transformer_configs = {
+        "olmo2_190m": TransformerConfig.olmo2_190M,
+        "olmo2_370m": TransformerConfig.olmo2_370M,
+        "olmo2_600m": TransformerConfig.olmo2_600M,
+        "olmo2_760m": TransformerConfig.olmo2_760M,
+        "olmo2_1b": TransformerConfig.olmo2_1B,
+        "olmo2_3b": TransformerConfig.olmo2_3B,
+        "olmo2_7b": TransformerConfig.olmo2_7B,
+        "olmo2_13b": TransformerConfig.olmo2_13B,
+        "olmo2_32b": TransformerConfig.olmo2_32B,
+        "smallmoe": TransformerConfig.smallmoe,
+        "olmoe_1b_7b": TransformerConfig.olmoe_1B_7B,
+        "olmoe_4x7b": TransformerConfig.olmoe_4X7B,
+        "olmoe_tiny_test": TransformerConfig.olmoe_tiny_test,
+        "ngpt_271m": TransformerConfig.ngpt_271M,
+        "ngpt_1b": TransformerConfig.ngpt_1B,
+        "llama2_271m": TransformerConfig.llama2_271M,
+        "llama2_1b": TransformerConfig.llama2_1B,
+        "llama2_7b": TransformerConfig.llama2_7B,
+        "llama2_13b": TransformerConfig.llama2_13B,
+        "llama2_26b": TransformerConfig.llama2_26B,
+        "llama2_70b": TransformerConfig.llama2_70B,
+        "llama3_1b": TransformerConfig.llama3_1B,
+        "llama3_8b": TransformerConfig.llama3_8B,
+        "llama3_70b": TransformerConfig.llama3_70B,
+        "llama3_405b": TransformerConfig.llama3_405B,
     }
-    for block in range(n_layers):
-        # Attention.
-        new_state_dict[f"blocks.{block}.attention.w_q.weight"] = state_dict.pop(
-            f"model.layers.{block}.self_attn.q_proj.weight"
+
+    return transformer_configs[model_arch.lower()](vocab_size)
+
+
+def _get_tokenizer_config(tokenizer_id: str) -> TokenizerConfig:
+    tokenizer_configs = {
+        "dolma2": TokenizerConfig.dolma2,
+        "gpt_neox_olmo_dolma_v1_5": TokenizerConfig.gpt_neox_olmo_dolma_v1_5,
+        "gpt2": TokenizerConfig.gpt2,
+    }
+
+    return tokenizer_configs[tokenizer_id.lower()]()
+
+
+def convert_checkpoint_from_hf(
+    hf_checkpoint_path: str | Path,
+    output_path: str | Path,
+    transformer_config_dict: Dict[str, Any],
+    tokenizer_config_dict: Dict[str, Any],
+    *,
+    max_sequence_length: int = -1,
+    validate: bool = True,
+    debug: bool = False,
+    device: torch.device | None = None,
+) -> None:
+    """
+    Convert a HF checkpoint to an OLMo core checkpoint.
+
+    Args:
+        hf_checkpoint_path: Path to the original HF checkpoint
+        output_path: Where to save the converted model
+        transformer_config_dict: Dictionary form of OLMo core model config
+        tokenizer_config_dict: Dictionary form of OLMo core tokenizer config
+    """
+    if max_sequence_length <= 0:
+        raise ValueError(f"Missing or invalid sequence length: {max_sequence_length}")
+
+    # Remove deprecated transformer config options
+    if "compile" in transformer_config_dict:
+        del transformer_config_dict["compile"]
+    if "dp_config" in transformer_config_dict:
+        del transformer_config_dict["dp_config"]
+    if "tp_config" in transformer_config_dict:
+        del transformer_config_dict["tp_config"]
+    if "float8_config" in transformer_config_dict:
+        del transformer_config_dict["float8_config"]
+
+    model = TransformerConfig.from_dict(transformer_config_dict).build()
+
+    # Replace weight init with an efficient alternative that just allocates memory
+    @torch.no_grad()
+    def init_weights(
+        self: Transformer,
+        *,
+        max_seq_len: Optional[int] = None,
+        max_local_microbatch_size: Optional[int] = None,
+        device: Optional[torch.device] = None,
+        pp_mesh: Optional[DeviceMesh] = None,
+    ) -> torch.Generator:
+        """
+        Initialize the model weights.
+
+        :param max_seq_len: The maximum sequence length expected. This is used
+            to warm up the RoPE cache.
+        :param max_local_microbatch_size: The maximum local (rank) micro-batch size (in tokens)
+            expected. This is used to warm-up some MoE cache.
+        :param device: The device the local copy of the model will be trained on.
+        :param pp_mesh: Pipeline parallel mesh. Pass this when using pipeline parallelism
+            to ensure the weights are initialized differently for different stages.
+        """
+        device = device or self.device
+        self.to_empty(device=device)
+
+        for module in self.modules():
+            if hasattr(module, "reset_parameters"):
+                module.to_empty(device=device)  # type: ignore
+
+        seed = self.init_seed
+        if pp_mesh is not None:
+            seed += pp_mesh.get_local_rank()
+        return torch.Generator(device).manual_seed(seed)
+
+    model.init_weights = types.MethodType(init_weights, model)
+
+    device = device or get_default_device()
+
+    train_module = TransformerTrainModuleConfig(
+        rank_microbatch_size=max_sequence_length,
+        max_sequence_length=max_sequence_length,
+        optim=AdamWConfig(),
+    ).build(model, device=device)
+
+    tokenizer_config = TokenizerConfig.from_dict(tokenizer_config_dict)
+
+    with TemporaryDirectory() as work_dir:
+        checkpointer_config = CheckpointerConfig(work_dir=work_dir, save_overwrite=True)
+        checkpointer = checkpointer_config.build()
+
+        log.info(f"Loading HF checkpoint from '{hf_checkpoint_path}'")
+        model_state_dict = train_module.state_dict_to_save(optim=False)["model"]
+        load_hf_model(
+            hf_checkpoint_path,
+            model_state_dict,
+            process_group=checkpointer.process_group,
+            work_dir=checkpointer.work_dir,
         )
-        new_state_dict[f"blocks.{block}.attention.w_k.weight"] = state_dict.pop(
-            f"model.layers.{block}.self_attn.k_proj.weight"
+        model.load_state_dict(model_state_dict)
+        log.info(f"Saving OLMo core checkpoint to '{output_path}'")
+        checkpointer.save(output_path, train_module, train_state={})
+        log.info(f"Successfully saved converted model to '{output_path}'")
+
+        log.info(f"Writing partial experiment config to '{output_path}'")
+        experiment_config_dict = {
+            "model": transformer_config_dict,
+            "dataset": {
+                "tokenizer": tokenizer_config_dict,
+            },
+        }
+        log.info(f"Successfully wrote partial experiment config to '{output_path}'")
+
+        checkpointer.write_file(output_path, "config.json", json.dumps(experiment_config_dict))
+
+    if validate:
+        log.info("Validating converted model")
+        validate_conversion(
+            hf_checkpoint_path, model, tokenizer_config.vocab_size, debug=debug, device=device
         )
-        new_state_dict[f"blocks.{block}.attention.w_v.weight"] = state_dict.pop(
-            f"model.layers.{block}.self_attn.v_proj.weight"
-        )
-        new_state_dict[f"blocks.{block}.attention.w_out.weight"] = state_dict.pop(
-            f"model.layers.{block}.self_attn.o_proj.weight"
-        )
-
-        # MLP.
-        new_state_dict[f"blocks.{block}.feed_forward.w1.weight"] = state_dict.pop(
-            f"model.layers.{block}.mlp.gate_proj.weight"
-        )
-        new_state_dict[f"blocks.{block}.feed_forward.w2.weight"] = state_dict.pop(
-            f"model.layers.{block}.mlp.down_proj.weight"
-        )
-        new_state_dict[f"blocks.{block}.feed_forward.w3.weight"] = state_dict.pop(
-            f"model.layers.{block}.mlp.up_proj.weight"
-        )
-
-        # Layer norms.
-        if "Llama" in HF_MODEL:
-            new_state_dict[f"blocks.{block}.feed_forward_norm.weight"] = state_dict.pop(
-                f"model.layers.{block}.post_attention_layernorm.weight"
-            )
-            new_state_dict[f"blocks.{block}.attention_norm.weight"] = state_dict.pop(
-                f"model.layers.{block}.input_layernorm.weight"
-            )
-        else:
-            new_state_dict[f"blocks.{block}.attention_norm.weight"] = state_dict.pop(
-                f"model.layers.{block}.post_attention_layernorm.weight"
-            )
-            new_state_dict[f"blocks.{block}.feed_forward_norm.weight"] = state_dict.pop(
-                f"model.layers.{block}.post_feedforward_layernorm.weight"
-            )
-            new_state_dict[f"blocks.{block}.attention.q_norm.weight"] = state_dict.pop(
-                f"model.layers.{block}.self_attn.q_norm.weight"
-            )
-            new_state_dict[f"blocks.{block}.attention.k_norm.weight"] = state_dict.pop(
-                f"model.layers.{block}.self_attn.k_norm.weight"
-            )
-
-    assert len(state_dict) == 0
-
-    log.info(f"Saving converted model checkpoint '{SAVE_PATH}'...")
-    save_state_dict(os.path.join(SAVE_PATH, "model_and_optim"), {"model": new_state_dict})
-
-    with open(os.path.join(SAVE_PATH, "config.json"), "w") as f:
-        json.dump({"model": MODEL_CONFIG.as_dict()}, f)
-
-    return hf_model
+        log.info("Validation completed successful")
 
 
-def validate_conversion(hf_model):
-    device = get_default_device()
+def _register_debug_hooks(hf_model: torch.nn.Module, model: Transformer):
+    MAX_DIM_SIZE = 100_000
+
+    olmo_core_state = {}
+    hf_state = {}
+
+    def module_hook(state: Dict, name: str, _: torch.nn.Module, args, output):
+        if len(args) >= 1 and isinstance(args[0], torch.Tensor):
+            state_name = f"{name}|input"
+            input = args[0].detach()
+            for i, size in enumerate(input.shape):
+                input = input.narrow(i, 0, min(size, MAX_DIM_SIZE))
+            state[state_name] = (len(state), input.float())
+        if isinstance(output, torch.Tensor):
+            state_name = f"{name}|output"
+            output = output.detach()
+            for i, size in enumerate(output.shape):
+                output = output.narrow(i, 0, min(size, MAX_DIM_SIZE))
+            state[state_name] = (len(state), output.float())
+
+    for name, module in model.named_modules():
+        module.register_forward_hook(partial(module_hook, olmo_core_state, name))
+    for name, module in hf_model.named_modules():
+        module.register_forward_hook(partial(module_hook, hf_state, name))
+
+    return olmo_core_state, hf_state
+
+
+def validate_conversion(
+    hf_path: str | Path,
+    model: Transformer,
+    vocab_size: int,
+    debug: bool = False,
+    device: torch.device | None = None,
+):
+    if torch.cuda.is_available():
+        torch.cuda.init()
+
+    device = device or get_default_device()
 
     B, T = 1, 120
-    input_ids = torch.randint(0, TOKENIZER_CONFIG.vocab_size, (B, T)).to(device)
+    input_ids = torch.randint(0, vocab_size, (B, T)).to(device)
 
-    hf_model = hf_model.to(device).eval()
+    log.info("Loading converted checkpoint for validation...")
+    hf_model = AutoModelForCausalLM.from_pretrained(hf_path).to(device).eval()
+
+    olmo_core_state, hf_state = {}, {}
+    state_mapping = None
+    if debug:
+        olmo_core_state, hf_state = _register_debug_hooks(hf_model, model)
+        state_converter = get_converter_from_hf()
+
+        if not hasattr(hf_model.config, "num_hidden_layers"):
+            raise ValueError(f"Number of hidden layers missing in HF config: {hf_model.config}")
+        n_layers: int = hf_model.config.num_hidden_layers
+        n_experts: int | None = getattr(hf_model.config, "num_experts", None)
+
+        placeholder_bounds = {
+            TemplatePlaceholder.LAYER: n_layers,
+        }
+        if n_experts:
+            placeholder_bounds[TemplatePlaceholder.EXPERT] = n_experts
+
+        state_mapping = state_converter.get_mappings(hf_model.state_dict(), placeholder_bounds)
+
+    log.info("Running OLMo core and HF models for validation...")
     with torch.no_grad():
         hf_logits, *_ = hf_model(input_ids=input_ids, return_dict=False)
 
     del hf_model
 
-    model = MODEL_CONFIG.build()
-    model.init_weights(device=device, max_seq_len=131072)
-    model.eval()
-
-    log.info("Loading converted checkpoint for validation...")
-    load_model_and_optim_state(SAVE_PATH, model)
-
+    model = model.to(device).eval()
     with torch.no_grad():
         logits = model(input_ids=input_ids)
 
+    if debug:
+        assert state_mapping is not None
+
+        simple_key_mapping = {
+            mapping.source_keys[0]
+            .replace(".weight", ""): mapping.dest_keys[0]
+            .replace(".weight", "")
+            for mapping in state_mapping
+            if len(mapping.source_keys) == 1
+            and len(mapping.dest_keys) == 1
+            and mapping.source_keys[0].endswith(".weight")
+            and mapping.dest_keys[0].endswith(".weight")
+        }
+
+        log.info(f"mapping: {simple_key_mapping}")
+        log.info(f"hf_state keys: {hf_state.keys()}")
+        log.info(f"olmo_core_state keys: {olmo_core_state.keys()}")
+
+        for hf_state_name, (_, hf_tensor) in sorted(hf_state.items(), key=lambda item: item[1][0]):
+            hf_key, state_type = hf_state_name.split("|")
+            if hf_key not in simple_key_mapping:
+                continue
+
+            olmo_state_name = f"{simple_key_mapping[hf_key]}|{state_type}"
+            if olmo_state_name not in olmo_core_state:
+                continue
+
+            _, olmo_core_tensor = olmo_core_state[olmo_state_name]
+
+            log.info(
+                f"{hf_state_name}, {olmo_state_name} norm diff: {torch.norm(hf_tensor - olmo_core_tensor)}"
+            )
+
     torch.testing.assert_close(hf_logits, logits)
 
-    log.info("Conversion successful")
+
+def load_config(checkpoint_input_dir: PathOrStr) -> Optional[dict]:
+    if not file_exists(f"{checkpoint_input_dir}/config.json"):
+        log.warning(f"Config file not found at {checkpoint_input_dir}")
+        return None
+
+    with cached_path(f"{checkpoint_input_dir}/config.json").open("r", encoding="utf-8") as f:
+        config_dict = json.load(f)
+
+    if "model" not in config_dict:
+        log.warning(
+            f"Config file at {checkpoint_input_dir} is not an OLMo core experiment config, ignoring"
+        )
+        return None
+
+    return config_dict
+
+
+def parse_args():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("-i", "--checkpoint-input-path", type=str, required=True)
+
+    parser.add_argument("-c", "--config-path", type=str, default=None)
+    parser.add_argument("-m", "--model-arch")
+    parser.add_argument("-t", "--tokenizer", type=str, default="dolma2")
+
+    parser.add_argument("-o", "--huggingface-output-dir", type=Path, required=True)
+    parser.add_argument("-s", "--max-sequence-length", type=int, required=True)
+    parser.add_argument("--skip-validation", dest="validate", action="store_false")
+    parser.add_argument("--debug", dest="debug", action="store_true")
+    parser.add_argument("--device", type=torch.device)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    experiment_config = load_config(args.config_path or args.checkpoint_input_path)
+    transformer_config_dict = None
+    if experiment_config is not None:
+        transformer_config_dict = experiment_config["model"]
+        tokenizer_config_dict = experiment_config.get("dataset", {}).get("tokenizer")
+    else:
+        assert args.model_arch is not None
+        assert args.tokenizer is not None
+        tokenizer_config = _get_tokenizer_config(args.tokenizer)
+        transformer_config_dict = _get_transformer_config(
+            args.model_arch, tokenizer_config.padded_vocab_size()
+        ).as_config_dict()
+        tokenizer_config_dict = tokenizer_config.as_config_dict()
+
+    assert transformer_config_dict is not None
+    assert tokenizer_config_dict is not None
+
+    convert_checkpoint_from_hf(
+        hf_checkpoint_path=args.checkpoint_input_path,
+        output_path=args.huggingface_output_dir,
+        transformer_config_dict=transformer_config_dict,
+        tokenizer_config_dict=tokenizer_config_dict,
+        max_sequence_length=args.max_sequence_length,
+        validate=args.validate,
+        debug=args.debug,
+        device=args.device,
+    )
 
 
 if __name__ == "__main__":
     prepare_cli_environment()
-
-    config = MODEL_CONFIG.as_dict()
-    hf_model = convert_checkpoint()
-    validate_conversion(hf_model)
+    main()

--- a/src/examples/huggingface/convert_checkpoint_to_hf.py
+++ b/src/examples/huggingface/convert_checkpoint_to_hf.py
@@ -1,301 +1,315 @@
 """
 Example script to convert a OLMo Core model checkpoint to a HuggingFace model checkpoint.
+
+Note that this script is architecture-dependent, meaning it may only work for OLMo Core models that
+have support in the `transformers` library.
 """
 
 import json
 import logging
-import re
-import shutil
+import types
 from argparse import ArgumentParser
-from contextlib import contextmanager
+from functools import partial
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Generator
+from typing import Any, Dict, Optional
 
 import torch
-from safetensors.torch import load_file
-from transformers import AutoModelForCausalLM, AutoTokenizer, GPT2Tokenizer, Olmo2Config
+from cached_path import cached_path
+from torch.distributed import DeviceMesh
+from transformers import AutoConfig, AutoModelForCausalLM
 
-from olmo_core.distributed.checkpoint import unshard_checkpoint
-from olmo_core.utils import prepare_cli_environment
+from olmo_core.aliases import PathOrStr
+from olmo_core.data.tokenizer import TokenizerConfig
+from olmo_core.io import file_exists
+from olmo_core.nn.conversion.state_mapping import TemplatePlaceholder
+from olmo_core.nn.hf.checkpoint import save_hf_model
+from olmo_core.nn.hf.convert import get_converter_to_hf
+from olmo_core.nn.transformer.config import TransformerConfig
+from olmo_core.nn.transformer.model import Transformer
+from olmo_core.optim.adamw import AdamWConfig
+from olmo_core.train.checkpoint import CheckpointerConfig
+from olmo_core.train.train_module.transformer import TransformerTrainModuleConfig
+from olmo_core.utils import get_default_device, prepare_cli_environment
 
 log = logging.getLogger(__name__)
 
 
-try:
-    from accelerate import init_empty_weights
-except ImportError:
-    pass
-
-    @contextmanager
-    def init_empty_weights(include_buffers: bool = False) -> Generator[None, None, None]:
-        log.warning("accelerate not installed, will initialize weights.")
-        yield None
-
-
-def load_state_dict(checkpoint_path: str | Path) -> dict[str, torch.Tensor]:
-    """
-    Load a state dict from either a PyTorch checkpoint or safetensors file.
-
-    Args:
-        checkpoint_path: Path to checkpoint file (.pt, .pth, .bin, or .safetensors)
-
-    Returns:
-        Dictionary containing model state dict
-    """
-    checkpoint_path = Path(checkpoint_path)
-
-    if checkpoint_path.suffix == ".safetensors":
-        # Load safetensors format
-        state_dict = load_file(checkpoint_path)
-    else:
-        # Load PyTorch format (.pt, .pth, .bin)
-        state_dict = torch.load(checkpoint_path, map_location="cpu")
-
-        # Handle both cases:
-        # 1. Direct state dict
-        # 2. Nested state dict under 'model' or 'state_dict' key
-        if "model" in state_dict:
-            state_dict = state_dict["model"]
-        elif "state_dict" in state_dict:
-            state_dict = state_dict["state_dict"]
-
-    return state_dict
-
-
-def convert_to_hf_checkpoint(
-    olmo_checkpoint_path: str | Path,
+def convert_checkpoint_to_hf(
+    original_checkpoint_path: str | Path,
     output_path: str | Path,
-    olmo_core_config: dict,
-    tokenizer: GPT2Tokenizer,
+    transformer_config_dict: Dict[str, Any],
+    tokenizer_config_dict: Dict[str, Any],
+    *,
     max_sequence_length: int = -1,
+    validate: bool = True,
+    debug: bool = False,
+    device: torch.device | None = None,
 ) -> None:
     """
-    Convert an OLMo core checkpoint to Hugging Face format.
+    Convert a checkpoint to a different OLMo core compatible format.
 
     Args:
-        olmo_checkpoint_path: Path to the OLMo core checkpoint
-        output_path: Where to save the converted HF model
-        olmo_core_config: OLMo core configuration dictionary
-        tokenizer: HuggingFace tokenizer instance
+        original_checkpoint_path: Path to the original checkpoint
+        output_format: Format of converted checkpoint
+        output_path: Where to save the converted model
+        transformer_config_dict: Dictionary form of OLMo core model config
+        tokenizer_config_dict: Dictionary form of OLMo core tokenizer config
     """
-    log.info(f"Loading OLMo core checkpoint from '{olmo_checkpoint_path}'")
-    olmo_state_dict = load_state_dict(olmo_checkpoint_path)
-
-    # Initialize new state dict for HF format
-    hf_state_dict = {}
-
-    # Map OLMo-core keys to HF keys
-    hf_state_dict["model.embed_tokens.weight"] = olmo_state_dict.pop("embeddings.weight")  # ok
-
-    if "norm.weight" in olmo_state_dict:
-        log.info("Using norm.weight as model.norm.weight")
-        hf_state_dict["model.norm.weight"] = olmo_state_dict.pop("norm.weight")
-    elif "lm_head.norm.weight" in olmo_state_dict:
-        log.info("Using lm_head.norm.weight as model.norm.weight")
-        hf_state_dict["model.norm.weight"] = olmo_state_dict.pop("lm_head.norm.weight")
-    else:
-        raise ValueError("No norm.weight or lm_head.norm.weight found in the state dict")
-
-    if "w_out.weight" in olmo_state_dict:
-        log.info("Using w_out.weight as lm_head.weight")
-        hf_state_dict["lm_head.weight"] = olmo_state_dict.pop("w_out.weight")
-    elif "lm_head.w_out.weight" in olmo_state_dict:
-        log.info("Using lm_head.w_out.weight as lm_head.weight")
-        hf_state_dict["lm_head.weight"] = olmo_state_dict.pop("lm_head.w_out.weight")
-    else:
-        raise ValueError("No w_out.weight or lm_head.w_out.weight found in the state dict")
-
-    # Count number of layers from the state dict keys
-    layer_ids = [
-        match.group(1)
-        for key in olmo_state_dict.keys()
-        if (match := re.match(r"blocks\.(\d+)\.", key))
-    ]
-    assert layer_ids, "No layer IDs found in the state dict keys"
-    n_layers = max(map(int, layer_ids)) + 1
-
-    for block in range(n_layers):
-        # Attention
-        hf_state_dict[f"model.layers.{block}.self_attn.q_proj.weight"] = olmo_state_dict.pop(
-            f"blocks.{block}.attention.w_q.weight"
-        )
-        hf_state_dict[f"model.layers.{block}.self_attn.k_proj.weight"] = olmo_state_dict.pop(
-            f"blocks.{block}.attention.w_k.weight"
-        )
-        hf_state_dict[f"model.layers.{block}.self_attn.v_proj.weight"] = olmo_state_dict.pop(
-            f"blocks.{block}.attention.w_v.weight"
-        )
-        hf_state_dict[f"model.layers.{block}.self_attn.o_proj.weight"] = olmo_state_dict.pop(
-            f"blocks.{block}.attention.w_out.weight"
-        )
-
-        # MLP
-        hf_state_dict[f"model.layers.{block}.mlp.gate_proj.weight"] = olmo_state_dict.pop(
-            f"blocks.{block}.feed_forward.w1.weight"
-        )
-        hf_state_dict[f"model.layers.{block}.mlp.down_proj.weight"] = olmo_state_dict.pop(
-            f"blocks.{block}.feed_forward.w2.weight"
-        )
-        hf_state_dict[f"model.layers.{block}.mlp.up_proj.weight"] = olmo_state_dict.pop(
-            f"blocks.{block}.feed_forward.w3.weight"
-        )
-
-        # Check if we have q_norm and k_norm (non-Llama model)
-        has_qk_norm = f"blocks.{block}.attention.q_norm.weight" in olmo_state_dict
-
-        if has_qk_norm:
-            # Non-Llama model
-            hf_state_dict[
-                f"model.layers.{block}.post_attention_layernorm.weight"
-            ] = olmo_state_dict.pop(f"blocks.{block}.attention_norm.weight")
-            hf_state_dict[
-                f"model.layers.{block}.post_feedforward_layernorm.weight"
-            ] = olmo_state_dict.pop(f"blocks.{block}.feed_forward_norm.weight")
-            hf_state_dict[f"model.layers.{block}.self_attn.q_norm.weight"] = olmo_state_dict.pop(
-                f"blocks.{block}.attention.q_norm.weight"
-            )
-            hf_state_dict[f"model.layers.{block}.self_attn.k_norm.weight"] = olmo_state_dict.pop(
-                f"blocks.{block}.attention.k_norm.weight"
-            )
-        else:
-            # Llama model
-            hf_state_dict[
-                f"model.layers.{block}.post_attention_layernorm.weight"
-            ] = olmo_state_dict.pop(f"blocks.{block}.feed_forward_norm.weight")
-            hf_state_dict[f"model.layers.{block}.input_layernorm.weight"] = olmo_state_dict.pop(
-                f"blocks.{block}.attention_norm.weight"
-            )
-
-    # Verify we used all keys
-    if len(olmo_state_dict) > 0:
-        _unused_keys = "\n".join(f"\t-{k}" for k in olmo_state_dict.keys())
-        raise ValueError(f"Unused keys in the state dict:\n{_unused_keys}")
-
-    if not hasattr(tokenizer, "vocab") or not isinstance(tokenizer.vocab, dict):
-        raise ValueError("Tokenizer must have a vocab dictionary")
-
-    if (
-        k := olmo_core_config.get("model", {})
-        .get("block", {})
-        .get("layer_norm", {})
-        .get("name", None)
-    ) != "rms":
-        raise ValueError(f"Only RMSNorm is supported, found {k}")
-
-    if max_sequence_length <= 0:
-        dataset_config = olmo_core_config["dataset"]
-        if "max_sequence_length" in dataset_config:
-            max_sequence_length = int(dataset_config["max_sequence_length"])
-        elif "sequence_length" in dataset_config:
-            max_sequence_length = int(dataset_config["sequence_length"])
-        else:
-            max_sequence_length = tokenizer.model_max_length
-
     if max_sequence_length <= 0:
         raise ValueError(f"Missing or invalid sequence length: {max_sequence_length}")
 
-    # Create HF model instance and load state dict
-    huggingface_config = Olmo2Config(
-        vocab_size=olmo_core_config["model"]["vocab_size"],
-        hidden_size=olmo_core_config["model"]["d_model"],
-        intermediate_size=olmo_core_config["model"]["block"]["feed_forward"]["hidden_size"],
-        num_hidden_layers=olmo_core_config["model"]["n_layers"],
-        num_attention_heads=(n_heads := olmo_core_config["model"]["block"]["attention"]["n_heads"]),
-        num_key_value_heads=(
-            olmo_core_config["model"]["block"]["attention"].get("n_kv_heads") or n_heads
-        ),
-        hidden_act="silu",
-        max_position_embeddings=max_sequence_length,
-        rope_theta=olmo_core_config["model"]["block"]["attention"]["rope"]["theta"],
-        attention_bias=olmo_core_config["model"]["block"]["attention"].get("bias") or False,
-        pad_token_id=tokenizer.vocab.get(tokenizer.pad_token, None),
-        bos_token_id=tokenizer.vocab.get(tokenizer.bos_token, None),
-        eos_token_id=tokenizer.vocab.get(tokenizer.eos_token, None),
-        rms_norm_eps=olmo_core_config["model"]["block"]["layer_norm"]["eps"],
-        tie_word_embeddings=False,
-    )
+    # Remove deprecated transformer config options
+    if "compile" in transformer_config_dict:
+        del transformer_config_dict["compile"]
+    if "dp_config" in transformer_config_dict:
+        del transformer_config_dict["dp_config"]
+    if "tp_config" in transformer_config_dict:
+        del transformer_config_dict["tp_config"]
+    if "float8_config" in transformer_config_dict:
+        del transformer_config_dict["float8_config"]
 
-    with init_empty_weights():
-        log.info("Initializing HF model with empty weights...")
-        model = AutoModelForCausalLM.from_config(huggingface_config)
+    model = TransformerConfig.from_dict(transformer_config_dict).build()
 
-    log.info("Loading state dict into HF model...")
-    model.load_state_dict(hf_state_dict, assign=True)
+    # Replace weight init with an efficient alternative that just allocates memory
+    @torch.no_grad()
+    def init_weights(
+        self: Transformer,
+        *,
+        max_seq_len: Optional[int] = None,
+        max_local_microbatch_size: Optional[int] = None,
+        device: Optional[torch.device] = None,
+        pp_mesh: Optional[DeviceMesh] = None,
+    ) -> torch.Generator:
+        """
+        Initialize the model weights.
 
-    # Save the model in HF format
-    log.info(f"Saving HF model checkpoint to {output_path}...")
-    model.save_pretrained(output_path)
-    log.info(f"Successfully saved HF model to '{output_path}'")
+        :param max_seq_len: The maximum sequence length expected. This is used
+            to warm up the RoPE cache.
+        :param max_local_microbatch_size: The maximum local (rank) micro-batch size (in tokens)
+            expected. This is used to warm-up some MoE cache.
+        :param device: The device the local copy of the model will be trained on.
+        :param pp_mesh: Pipeline parallel mesh. Pass this when using pipeline parallelism
+            to ensure the weights are initialized differently for different stages.
+        """
+        device = device or self.device
+        self.to_empty(device=device)
 
-    # Save the tokenizer in HF format
-    tokenizer.save_pretrained(output_path)
-    log.info(f"Successfully saved HF tokenizer to '{output_path}'")
+        for module in self.modules():
+            if hasattr(module, "reset_parameters"):
+                module.to_empty(device=device)  # type: ignore
+
+        seed = self.init_seed
+        if pp_mesh is not None:
+            seed += pp_mesh.get_local_rank()
+        return torch.Generator(device).manual_seed(seed)
+
+    model.init_weights = types.MethodType(init_weights, model)
+
+    device = device or get_default_device()
+    train_module = TransformerTrainModuleConfig(
+        rank_microbatch_size=max_sequence_length,
+        max_sequence_length=max_sequence_length,
+        optim=AdamWConfig(),
+    ).build(model, device=device)
+
+    tokenizer_config = TokenizerConfig.from_dict(tokenizer_config_dict)
+
+    with TemporaryDirectory() as work_dir:
+        checkpointer_config = CheckpointerConfig(work_dir=work_dir, save_overwrite=True)
+        checkpointer = checkpointer_config.build()
+
+        log.info(f"Loading checkpoint from '{original_checkpoint_path}'")
+        checkpointer.load(original_checkpoint_path, train_module, load_trainer_state=False)
+        log.info(f"Saving checkpoint to '{output_path}'")
+        save_hf_model(
+            output_path,
+            train_module.state_dict_to_save(optim=False)["model"],
+            train_module.model,
+            process_group=checkpointer.process_group,
+            work_dir=checkpointer.work_dir,
+            save_overwrite=checkpointer.save_overwrite,
+        )
+        # checkpointer.save(output_path, train_module, train_state={}, format=output_format)
+        log.info(f"Successfully saved converted model to '{output_path}'")
+
+    log.info("Fixing HF config using tokenizer config data and script arguments")
+    huggingface_config = AutoConfig.from_pretrained(output_path)
+    huggingface_config.max_position_embeddings = max_sequence_length
+    huggingface_config.pad_token_id = tokenizer_config.pad_token_id
+    huggingface_config.bos_token_id = tokenizer_config.bos_token_id
+    huggingface_config.eos_token_id = tokenizer_config.eos_token_id
+    huggingface_config.save_pretrained(output_path)
+    log.info("Successfully fixed config using tokenizer config data and script arguments")
+
+    if validate:
+        log.info("Validating converted model")
+        validate_conversion(
+            output_path, model, tokenizer_config.vocab_size, debug=debug, device=device
+        )
+        log.info("Validation completed successful")
 
 
-def load_config(checkpoint_input_dir: Path) -> dict:
-    assert (
-        checkpoint_input_dir / "config.json"
-    ).exists(), f"Config file not found at {checkpoint_input_dir}"
+def _register_debug_hooks(hf_model: torch.nn.Module, model: Transformer):
+    MAX_DIM_SIZE = 100_000
 
-    with open(checkpoint_input_dir / "config.json", "r", encoding="utf-8") as f:
+    olmo_core_state = {}
+    hf_state = {}
+
+    def module_hook(state: Dict, name: str, _: torch.nn.Module, args, output):
+        if len(args) >= 1 and isinstance(args[0], torch.Tensor):
+            state_name = f"{name}|input"
+            input = args[0].detach()
+            for i, size in enumerate(input.shape):
+                input = input.narrow(i, 0, min(size, MAX_DIM_SIZE))
+            state[state_name] = (len(state), input.float())
+        if isinstance(output, torch.Tensor):
+            state_name = f"{name}|output"
+            output = output.detach()
+            for i, size in enumerate(output.shape):
+                output = output.narrow(i, 0, min(size, MAX_DIM_SIZE))
+            state[state_name] = (len(state), output.float())
+
+    for name, module in model.named_modules():
+        module.register_forward_hook(partial(module_hook, olmo_core_state, name))
+    for name, module in hf_model.named_modules():
+        module.register_forward_hook(partial(module_hook, hf_state, name))
+
+    return olmo_core_state, hf_state
+
+
+def validate_conversion(
+    hf_path: str | Path,
+    model: Transformer,
+    vocab_size: int,
+    debug: bool = False,
+    device: torch.device | None = None,
+):
+    if torch.cuda.is_available():
+        torch.cuda.init()
+
+    device = device or get_default_device()
+
+    B, T = 1, 120
+    input_ids = torch.randint(0, vocab_size, (B, T)).to(device)
+
+    log.info("Loading converted checkpoint for validation...")
+    hf_model = AutoModelForCausalLM.from_pretrained(hf_path).to(device).eval()
+
+    olmo_core_state, hf_state = {}, {}
+    state_mapping = None
+    if debug:
+        olmo_core_state, hf_state = _register_debug_hooks(hf_model, model)
+        state_converter = get_converter_to_hf()
+
+        if not hasattr(hf_model.config, "num_hidden_layers"):
+            raise ValueError(f"Number of hidden layers missing in HF config: {hf_model.config}")
+        n_layers: int = hf_model.config.num_hidden_layers
+        n_experts: int | None = getattr(hf_model.config, "num_experts", None)
+
+        placeholder_bounds = {
+            TemplatePlaceholder.LAYER: n_layers,
+        }
+        if n_experts:
+            placeholder_bounds[TemplatePlaceholder.EXPERT] = n_experts
+
+        state_mapping = state_converter.get_mappings(model.state_dict(), placeholder_bounds)
+
+    log.info("Running OLMo core and HF models for validation...")
+    with torch.no_grad():
+        hf_logits, *_ = hf_model(input_ids=input_ids, return_dict=False)
+
+    del hf_model
+
+    model.eval()
+    with torch.no_grad():
+        logits = model(input_ids=input_ids)
+
+    if debug:
+        assert state_mapping is not None
+
+        simple_key_mapping = {
+            mapping.source_keys[0]
+            .replace(".weight", ""): mapping.dest_keys[0]
+            .replace(".weight", "")
+            for mapping in state_mapping
+            if len(mapping.source_keys) == 1 and len(mapping.dest_keys) == 1
+        }
+
+        log.info(f"simple mapping: {simple_key_mapping}")
+        log.info(f"hf_state keys: {hf_state.keys()}")
+        log.info(f"olmo_core_state keys: {olmo_core_state.keys()}")
+
+        for olmo_core_state_name, (_, olmo_core_tensor) in sorted(
+            olmo_core_state.items(), key=lambda item: item[1][0]
+        ):
+            olmo_core_key, state_type = olmo_core_state_name.split("|")
+            if olmo_core_key not in simple_key_mapping:
+                continue
+
+            hf_state_name = f"{simple_key_mapping[olmo_core_key]}|{state_type}"
+            if hf_state_name not in hf_state:
+                continue
+
+            _, hf_tensor = hf_state[hf_state_name]
+
+            log.info(
+                f"{olmo_core_state_name}, {hf_state_name} norm diff: {torch.norm(olmo_core_tensor - hf_tensor)}"
+            )
+
+    torch.testing.assert_close(hf_logits, logits)
+
+
+def load_config(checkpoint_input_dir: PathOrStr) -> Optional[dict]:
+    if not file_exists(f"{checkpoint_input_dir}/config.json"):
+        raise RuntimeError(f"Config file not found at {checkpoint_input_dir}")
+
+    with cached_path(f"{checkpoint_input_dir}/config.json").open("r", encoding="utf-8") as f:
         config_dict = json.load(f)
+
+    if "model" not in config_dict:
+        raise RuntimeError(
+            f"Config file at {checkpoint_input_dir} is not an OLMo core experiment config, ignoring"
+        )
 
     return config_dict
 
 
 def parse_args():
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument("-i", "--checkpoint-input-dir", type=Path, required=True)
-    parser.add_argument("-u", "--unsharded-output-dir", type=Path, default=None)
+    parser.add_argument("-i", "--checkpoint-input-path", type=str, required=True)
+
     parser.add_argument("-o", "--huggingface-output-dir", type=Path, required=True)
-    parser.add_argument("-t", "--tokenizer-name-or-path", type=str, default=None)
-    parser.add_argument("-s", "--max-sequence-length", type=int, default=-1)
+    parser.add_argument("-s", "--max-sequence-length", type=int, required=True)
+    parser.add_argument("--skip-validation", dest="validate", action="store_false")
+    parser.add_argument("--debug", dest="debug", action="store_true")
+    parser.add_argument("--device", type=torch.device)
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
-    experiment_config = load_config(args.checkpoint_input_dir)
 
-    if args.tokenizer_name_or_path is None:
-        args.tokenizer_name_or_path = (
-            experiment_config.get("dataset", {}).get("tokenizer", {}).get("identifier", None)
-        )
+    experiment_config = load_config(args.checkpoint_input_path)
+    if experiment_config is None:
+        raise RuntimeError("Experiment config not found, cannot convert to HF checkpoint")
 
-        if args.tokenizer_name_or_path is None:
-            raise ValueError(
-                "Tokenizer identifier not found in the config; please provide it manually"
-            )
+    transformer_config_dict = experiment_config["model"]
+    tokenizer_config_dict = experiment_config.get("dataset", {}).get("tokenizer")
 
-    tokenizer_config = AutoTokenizer.from_pretrained(args.tokenizer_name_or_path)
+    assert transformer_config_dict is not None
+    assert tokenizer_config_dict is not None
 
-    with TemporaryDirectory() as _unsharded_dir:
-        if args.unsharded_output_dir:
-            log.info(f"Using provided unsharded output directory: {args.unsharded_output_dir}")
-            _unsharded_dir = args.unsharded_output_dir
-
-        shards_dir = args.checkpoint_input_dir / "model_and_optim"
-        if shards_dir.exists() and shards_dir.is_dir():
-            logging.info(f"Unsharding checkpoint from {shards_dir} to {_unsharded_dir}")
-            (unsharded_dir := Path(_unsharded_dir)).mkdir(parents=True, exist_ok=True)
-            unshard_checkpoint(
-                dir=shards_dir, target_dir=unsharded_dir, optim=False, save_overwrite=True
-            )
-
-            logging.info("Copying config.json to unsharded directory")
-            shutil.copy(args.checkpoint_input_dir / "config.json", unsharded_dir / "config.json")
-        else:
-            logging.info("No sharded checkpoint found, using input directory as unsharded")
-            unsharded_dir = args.checkpoint_input_dir
-
-        convert_to_hf_checkpoint(
-            olmo_checkpoint_path=unsharded_dir / "model.pt",
-            output_path=args.huggingface_output_dir,
-            olmo_core_config=experiment_config,
-            max_sequence_length=args.max_sequence_length,
-            tokenizer=tokenizer_config,  # type: ignore
-        )
+    convert_checkpoint_to_hf(
+        original_checkpoint_path=args.checkpoint_input_path,
+        output_path=args.huggingface_output_dir,
+        transformer_config_dict=transformer_config_dict,
+        tokenizer_config_dict=tokenizer_config_dict,
+        max_sequence_length=args.max_sequence_length,
+        validate=args.validate,
+        debug=args.debug,
+        device=args.device,
+    )
 
 
 if __name__ == "__main__":

--- a/src/olmo_core/nn/conversion/__init__.py
+++ b/src/olmo_core/nn/conversion/__init__.py
@@ -1,0 +1,17 @@
+"""
+Common logic for converting OLMo Core `nn` features to/from other formats (like Hugging Face).
+"""
+
+from .state_mapping import (
+    StateConverter,
+    StateMapping,
+    StateMappingTemplate,
+    TemplatePlaceholder,
+)
+
+__all__ = [
+    "StateConverter",
+    "StateMapping",
+    "StateMappingTemplate",
+    "TemplatePlaceholder",
+]

--- a/src/olmo_core/nn/conversion/state_mapping.py
+++ b/src/olmo_core/nn/conversion/state_mapping.py
@@ -1,0 +1,362 @@
+import itertools
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import torch
+
+from olmo_core.config import StrEnum
+
+
+class TemplatePlaceholder(StrEnum):
+    LAYER = "[layer]"
+    EXPERT = "[expert]"
+
+
+@dataclass
+class StateMappingTemplate:
+    """
+    The template for a mapping from state from one format to another format (e.g. OLMo Core to HF).
+    These mappings are 'templates' since they support keys and other metadata having placeholders
+    for information like the layer number or number of MoE experts. This class can be converted
+    to a `StateMapping` by providing the placeholder information information.
+
+    The most standard mapping is a one-to-one state mapping, which corresponds to a single
+    string entry for both `source_template_keys` and `dest_template_keys`. The class also supports
+    more complicated mappings, like many-to-many mappings or mappings that also require further
+    manipulations of state like permuting dimensions.
+    """
+
+    source_template_keys: str | Tuple[str, ...]
+    """
+    The key or keys of the state(s) being mapping from.
+    """
+    dest_template_keys: str | Tuple[str, ...]
+    """
+    The key or keys of the state(s) being mapping to.
+    """
+
+    source_key_per_placeholder: TemplatePlaceholder | None = None
+    """
+    A placeholder in `source_template_keys` for which this mapping should map all valid placeholder
+    values, rather than 1 specific value. For example, this enables mapping states from all experts
+    (using `TemplatePlaceholder.EXPERT`) to a single state.
+
+    When provided, `source_template_keys` must be a string.
+    """
+    dest_key_per_placeholder: TemplatePlaceholder | None = None
+    """
+    A placeholder in `dest_template_keys` for which this mapping should map all valid placeholder
+    values, rather than 1 specific value. For example, this enables mapping from a single state to
+    states from all experts (using `TemplatePlaceholder.EXPERT`).
+
+    When provided, `dest_template_keys` must be a string.
+    """
+
+    source_concat_dim: int = 0
+    """
+    When many states are being mapping from, this specifies the dimension on which to combine them.
+    """
+    unflatten_dim: Tuple[int, Tuple[TemplatePlaceholder | int, ...]] | None = None
+    """
+    This specifies that the given dimension (`unflatten_dim[0]`) should be unflattened using the shape
+    given in `unflatten_dim[1]`. A placeholder can be given instead of a number, to represent its
+    corresponding upper bound (e.g. `TemplatePlaceholder.EXPERT` represents the number of experts). 
+    """
+    dims_permutation: Tuple[int, ...] | None = None
+    """
+    This specifies the permutation that should be applied to the dimensions of the state after any
+    unflattening from `unflatten_dim` has occurred.
+    """
+    flatten_dims: Tuple[int, int] | None = None
+    """
+    This specifies that all the dimensions between the 2 given dimensions (inclusive) should be flattened,
+    after any permutations from `dims_permutation` have been applied.
+    """
+    dest_chunk_dim: int = 0
+    """
+    When many states are being mapping to, this specifies the dimension on which to (evenly) chunk them.
+    """
+
+    def __post_init__(self):
+        if self.source_key_per_placeholder and isinstance(self.source_template_keys, tuple):
+            raise ValueError(
+                f"Having a key per {self.source_key_per_placeholder} is not supported with multiple template keys"
+            )
+
+        if self.dest_key_per_placeholder and isinstance(self.dest_template_keys, tuple):
+            raise ValueError(
+                f"Having a key per {self.dest_key_per_placeholder} is not supported with multiple template keys"
+            )
+
+    def _templates_to_keys(
+        self,
+        templates: str | Tuple[str, ...],
+        placeholder_values: Dict[TemplatePlaceholder, Any],
+        *,
+        key_per_placeholder: TemplatePlaceholder | None = None,
+        key_per_placeholder_values: List[Any] | None = None,
+    ) -> Tuple[str, ...] | None:
+        if key_per_placeholder:
+            if key_per_placeholder_values is None:
+                return None
+
+            assert isinstance(templates, str)
+            assert key_per_placeholder in templates
+            assert key_per_placeholder_values is not None
+            templates = tuple(
+                templates.replace(key_per_placeholder, str(value))
+                for value in key_per_placeholder_values
+            )
+        elif isinstance(templates, str):
+            templates = (templates,)
+
+        assert isinstance(templates, tuple)
+
+        keys = []
+        for template in templates:
+            key = template
+            for placeholder, value in placeholder_values.items():
+                if placeholder in template and value is not None:
+                    key = key.replace(placeholder, str(value))
+                elif placeholder not in template and value is None:
+                    pass
+                else:
+                    # If a placeholder is given a value but is not present,
+                    # we treat the placeholder values as invalid.
+                    # Similarly, if a placeholder is not given a value but is present,
+                    # we treat the placeholder values as invalid.
+                    return None
+
+            keys.append(key)
+
+        return tuple(keys)
+
+    def to_mapping(
+        self,
+        placeholder_values: Dict[TemplatePlaceholder, int | None],
+        placeholder_bounds: Dict[TemplatePlaceholder, int],
+    ) -> Optional["StateMapping"]:
+        required_placeholders: Set[TemplatePlaceholder | None] = set()
+        if self.source_key_per_placeholder:
+            required_placeholders.add(self.source_key_per_placeholder)
+        if self.dest_key_per_placeholder:
+            required_placeholders.add(self.dest_key_per_placeholder)
+        if self.unflatten_dim:
+            required_placeholders.update(
+                [dim for dim in self.unflatten_dim[1] if isinstance(dim, TemplatePlaceholder)]
+            )
+
+        missing_required_placeholders = required_placeholders.difference(placeholder_bounds.keys())
+        if missing_required_placeholders:
+            return None
+
+        source_keys = self._templates_to_keys(
+            self.source_template_keys,
+            placeholder_values,
+            key_per_placeholder=self.source_key_per_placeholder,
+            key_per_placeholder_values=list(
+                range(placeholder_bounds[self.source_key_per_placeholder])
+            )
+            if self.source_key_per_placeholder
+            and placeholder_values[self.source_key_per_placeholder] is None
+            else None,
+        )
+        dest_keys = self._templates_to_keys(
+            self.dest_template_keys,
+            placeholder_values,
+            key_per_placeholder=self.dest_key_per_placeholder,
+            key_per_placeholder_values=list(
+                range(placeholder_bounds[self.dest_key_per_placeholder])
+            )
+            if self.dest_key_per_placeholder
+            and placeholder_values[self.dest_key_per_placeholder] is None
+            else None,
+        )
+
+        if source_keys is None or dest_keys is None:
+            return None
+
+        unflatten_dim = None
+        if self.unflatten_dim is not None:
+            unflatten_dim_shape = tuple(
+                placeholder_bounds[dim] if isinstance(dim, TemplatePlaceholder) else int(dim)
+                for dim in self.unflatten_dim[1]
+            )
+            unflatten_dim = (self.unflatten_dim[0], unflatten_dim_shape)
+
+        return StateMapping(
+            source_keys,
+            dest_keys,
+            source_concat_dim=self.source_concat_dim,
+            unflatten_dim=unflatten_dim,
+            dims_permutation=self.dims_permutation,
+            flatten_dims=self.flatten_dims,
+            dest_chunk_dim=self.dest_chunk_dim,
+        )
+
+
+@dataclass
+class StateMapping:
+    """
+    A mapping from state from one format to another format (e.g. OLMo Core to HF).
+
+    The most standard mapping is a one-to-one state mapping, which corresponds to a single
+    string entry for both `source_template_keys` and `dest_template_keys`. The class also supports
+    more complicated mappings, like many-to-many mappings or mappings that also require further
+    manipulations of state like permuting dimensions.
+    """
+
+    source_keys: Tuple[str, ...]
+    """
+    The key(s) of the state(s) being mapping from.
+    """
+
+    dest_keys: Tuple[str, ...]
+    """
+    The key or keys of the state(s) being mapping to.
+    """
+
+    source_concat_dim: int = 0
+    """
+    When many states are being mapping from, this specifies the dimension on which to combine them.
+    """
+    unflatten_dim: Tuple[int, Tuple[int, ...]] | None = None
+    """
+    This specifies that the given dimension (`unflatten_dim[0]`) should be unflattened using the shape
+    given in `unflatten_dim[1]`.
+    """
+    dims_permutation: Tuple[int, ...] | None = None
+    """
+    This specifies the permutation that should be applied to the dimensions of the state after any
+    unflattening from `unflatten_dim` has occurred.
+    """
+    flatten_dims: Tuple[int, int] | None = None
+    """
+    This specifies that all the dimensions between the 2 given dimensions (inclusive) should be flattened,
+    after any permutations from `dims_permutation` have been applied.
+    """
+    dest_chunk_dim: int = 0
+    """
+    When many states are being mapping to, this specifies the dimension on which to (evenly) chunk them.
+    """
+
+
+class StateConverter:
+    """
+    A class for converting state from one format to another format (e.g. OLMo Core to HF).
+    """
+
+    def __init__(self, mapping_templates: List[StateMappingTemplate]) -> None:
+        self.mapping_templates = mapping_templates
+
+    def _fill_placeholders(
+        self,
+        mapping: StateMappingTemplate,
+        placeholder_values: Dict[TemplatePlaceholder, int | None],
+        placeholder_bounds: Dict[TemplatePlaceholder, int],
+    ) -> StateMapping | None:
+        return mapping.to_mapping(placeholder_values, placeholder_bounds)
+
+    def _get_mappings(
+        self, state_dict: Dict[str, Any], placeholder_bounds: Dict[TemplatePlaceholder, int]
+    ) -> List[StateMapping]:
+        # We consider all combinations of placeholders, including allowing each placeholder to not be set.
+        # If a placeholder is set when not need, the combination will be treated as invalid
+        # and so ignored.
+        placeholder_value_combinations: List[Dict[TemplatePlaceholder, int | None]] = list(
+            map(
+                dict,
+                itertools.product(
+                    *[
+                        [(placeholder, i) for i in range(bound)] + [(placeholder, None)]
+                        for placeholder, bound in placeholder_bounds.items()
+                    ]
+                ),
+            )
+        )
+
+        # Fill in the placeholders in the mapping templates
+        state_mappings = [
+            self._fill_placeholders(
+                mapping_template,
+                placeholder_value_combination,
+                placeholder_bounds,
+            )
+            for mapping_template in self.mapping_templates
+            for placeholder_value_combination in placeholder_value_combinations
+        ]
+        state_mappings = [mapping for mapping in state_mappings if mapping is not None]
+
+        # Filter for mappings that are relevant to the given state dict
+        state_keys = set(state_dict.keys())
+        state_mappings = [
+            mapping
+            for mapping in state_mappings
+            if mapping and all(k in state_keys for k in mapping.source_keys)
+        ]
+
+        return state_mappings
+
+    def get_mappings(
+        self, state_dict: Dict[str, Any], placeholder_bounds: Dict[TemplatePlaceholder, int]
+    ) -> List[StateMapping]:
+        """
+        Gets the state mapping from the given state dict to the converted format,
+        without performing conversion.
+
+        :param state_dict: The state dictionary in unconverted format.
+        :param placeholder_bounds: Upper bound values for any relevant placeholders
+            (e.g. for `TemplatePlaceholder.EXPERT`, the number of experts).
+        """
+
+        return self._get_mappings(state_dict, placeholder_bounds)
+
+    def convert(
+        self, state_dict: Dict[str, Any], placeholder_bounds: Dict[TemplatePlaceholder, int]
+    ) -> Dict[str, Any]:
+        """
+        Converts a state dict to another format.
+
+        :param state_dict: The state dictionary to convert.
+        :param placeholder_bounds: Upper bound values for any relevant placeholders
+            (e.g. for `TemplatePlaceholder.EXPERT`, the number of experts).
+        """
+
+        state_mappings = self._get_mappings(state_dict, placeholder_bounds)
+
+        unused_original_keys = set(state_dict.keys())
+        converted_state_dict = {}
+        for mapping in state_mappings:
+            original_keys = mapping.source_keys
+            converted_keys = mapping.dest_keys
+            if isinstance(state_dict[original_keys[0]], torch.Tensor):
+                original_state = torch.cat(
+                    [state_dict[key] for key in original_keys],
+                    dim=mapping.source_concat_dim,
+                )
+
+                if mapping.unflatten_dim is not None:
+                    original_state = original_state.unflatten(*mapping.unflatten_dim)
+                if mapping.dims_permutation is not None:
+                    original_state = original_state.permute(*mapping.dims_permutation)
+                if mapping.flatten_dims is not None:
+                    original_state = original_state.flatten(*mapping.flatten_dims)
+
+                state_chunks = torch.chunk(
+                    original_state, chunks=len(converted_keys), dim=mapping.dest_chunk_dim
+                )
+                for hf_key, state_chunk in zip(converted_keys, state_chunks):
+                    converted_state_dict[hf_key] = state_chunk.contiguous()
+            else:
+                raise RuntimeError(
+                    f"Attempting to map {len(original_keys)} non-tensor states to {len(converted_keys)} keys"
+                )
+
+            unused_original_keys -= set(original_keys)
+
+        if len(unused_original_keys) > 0:
+            raise RuntimeError(
+                f"Some state keys were not converted: {sorted(unused_original_keys)}"
+            )
+
+        return converted_state_dict

--- a/src/olmo_core/nn/hf/__init__.py
+++ b/src/olmo_core/nn/hf/__init__.py
@@ -1,0 +1,18 @@
+from .checkpoint import load_hf_model, save_hf_model
+from .config import get_hf_config
+from .convert import (
+    convert_state_from_hf,
+    convert_state_to_hf,
+    get_converter_from_hf,
+    get_converter_to_hf,
+)
+
+__all__ = [
+    "convert_state_from_hf",
+    "convert_state_to_hf",
+    "get_converter_from_hf",
+    "get_converter_to_hf",
+    "get_hf_config",
+    "load_hf_model",
+    "save_hf_model",
+]

--- a/src/olmo_core/nn/hf/checkpoint.py
+++ b/src/olmo_core/nn/hf/checkpoint.py
@@ -1,0 +1,159 @@
+import logging
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Generator, Optional
+
+import torch
+import torch.distributed as dist
+from huggingface_hub import repo_exists
+from torch.distributed.tensor import DTensor, distribute_tensor
+from transformers import AutoModelForCausalLM
+
+from olmo_core.aliases import PathOrStr
+from olmo_core.distributed.utils import barrier, get_fs_local_rank, get_full_tensor
+from olmo_core.doc_utils import beta_feature
+from olmo_core.io import clear_directory, copy_dir, file_exists, is_url, upload
+from olmo_core.nn.hf.config import get_hf_config
+from olmo_core.nn.hf.convert import convert_state_from_hf, convert_state_to_hf
+from olmo_core.nn.transformer.model import Transformer
+
+try:
+    from accelerate import init_empty_weights
+except ImportError:
+
+    @contextmanager
+    def init_empty_weights(include_buffers: bool = False) -> Generator[None, None, None]:
+        log.warning("accelerate not installed, will initialize weights.")
+        yield None
+
+
+log = logging.getLogger(__name__)
+
+
+@beta_feature
+def load_hf_model(
+    model_name_or_path: PathOrStr,
+    model_state_dict: Dict[str, Any],
+    *,
+    process_group: Optional[dist.ProcessGroup] = None,
+    work_dir: Optional[PathOrStr] = None,
+):
+    """
+    Loads an OLMo Core model state dict using a model in Hugging Face transformers format.
+
+    :param model_name_or_path: The name of a model in HF Hub or the path to a model saved in HF format.
+    :param model_state_dict: The OLMo Core model state dict in which to load HF state.
+    :param process_group: The process group to use for distributed communication.
+    :param work_dir: A local directory that can be used for holding temporary state. Required when
+        downloading a model from a cloud directory.
+    """
+
+    work_dir = f"{work_dir}/hf-tmp" if work_dir is not None else None
+
+    if is_url(model_name_or_path):
+        log.warning(
+            "Model id or path provided is a remote Hugging Face directory. This may not be suitable for unshared file systems."
+        )
+        assert work_dir is not None
+        assert (
+            file_exists(f"{model_name_or_path}/generation_config.json")
+            or file_exists(f"{model_name_or_path}/model.safetensors.index.json")
+            or file_exists(f"{model_name_or_path}/pytorch_model.bin")
+        )
+        model_id = None
+
+        # Download model to local FS
+        if get_fs_local_rank() == 0:
+            copy_dir(model_name_or_path, work_dir)
+        barrier(group=process_group)
+    elif Path(model_name_or_path).is_dir():
+        assert (
+            file_exists(f"{model_name_or_path}/generation_config.json")
+            or file_exists(f"{model_name_or_path}/model.safetensors.index.json")
+            or file_exists(f"{model_name_or_path}/pytorch_model.bin")
+        )
+        model_id = None
+    elif repo_exists(str(model_name_or_path)):
+        log.warning(
+            "Model id or path provided is a Hugging Face model id. This may not be suitable for unshared file systems."
+        )
+        model_id = str(model_name_or_path)
+    else:
+        raise NotImplementedError
+
+    # Warm up the HF local cache by downloading the model on just local rank 0
+    if get_fs_local_rank() == 0:
+        hf_model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
+        del hf_model
+    barrier(group=process_group)
+
+    hf_model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
+    log.info(f"Loaded hf model: {hf_model}")
+
+    converted_state_dict: Dict[str, torch.Tensor] = convert_state_from_hf(
+        hf_model.config, hf_model.state_dict(), model_id=model_id
+    )
+
+    for key, state in converted_state_dict.items():
+        olmo_core_state = model_state_dict[key]
+        if isinstance(olmo_core_state, DTensor):
+            olmo_core_state = distribute_tensor(
+                state, olmo_core_state.device_mesh, olmo_core_state.placements
+            )
+        else:
+            olmo_core_state = state
+
+        model_state_dict[key] = olmo_core_state
+
+    if work_dir:
+        clear_directory(work_dir)
+
+
+@beta_feature
+def save_hf_model(
+    save_dir: PathOrStr,
+    model_state_dict: Dict[str, Any],
+    model: Transformer,
+    *,
+    process_group: Optional[dist.ProcessGroup] = None,
+    work_dir: Optional[PathOrStr] = None,
+    save_overwrite: bool = False,
+):
+    """
+    Save an OLMo Core model state dict in Hugging Face transformers format.
+
+    :param save_dir: Directory in which to save model.
+    :param model_state_dict: The OLMo Core model state dict being saved in HF format.
+    :param process_group: The process group to use for distributed communication.
+    :param work_dir: A local directory that can be used for holding temporary state. Required when
+        downloading a model from a cloud directory.
+    :param save_overwrite: Overwrite existing files in `save_dir`.
+    """
+
+    hf_config = get_hf_config(model)
+
+    model_state_dict = {key: get_full_tensor(state) for key, state in model_state_dict.items()}
+    hf_state_dict: Dict[str, torch.Tensor] = convert_state_to_hf(hf_config, model_state_dict)
+
+    # model.save_pretrained fails says `tensor.reshape()` should be used instead of `tensor.view()`
+    # if we do not make the state contiguous. Unfortunately this is bad for perf.
+    hf_state_dict = {key: state.contiguous() for key, state in hf_state_dict.items()}
+
+    with init_empty_weights():
+        log.info("Initializing HF model with empty weights...")
+        hf_model = AutoModelForCausalLM.from_config(hf_config)
+
+    hf_model.load_state_dict(hf_state_dict, assign=True)
+
+    if get_fs_local_rank(process_group) == 0:
+        if is_url(save_dir):
+            assert work_dir is not None
+            hf_model.save_pretrained(work_dir)
+
+            upload(work_dir, str(save_dir), save_overwrite=save_overwrite)
+        else:
+            target = Path(save_dir)
+            if target.is_dir() and not save_overwrite:
+                raise FileExistsError(target)
+            target.parent.mkdir(exist_ok=True, parents=True)
+            hf_model.save_pretrained(target)

--- a/src/olmo_core/nn/hf/config.py
+++ b/src/olmo_core/nn/hf/config.py
@@ -1,0 +1,51 @@
+from transformers import Olmo2Config, PretrainedConfig
+
+from olmo_core.doc_utils import beta_feature
+from olmo_core.nn.attention import Attention
+from olmo_core.nn.transformer.block import ReorderedNormTransformerBlock
+from olmo_core.nn.transformer.model import (
+    MoETransformer,
+    NormalizedTransformer,
+    Transformer,
+)
+
+
+@beta_feature
+def get_hf_config(model: Transformer) -> PretrainedConfig:
+    if isinstance(model, (MoETransformer, NormalizedTransformer)):
+        raise NotImplementedError(
+            f"Building HF config not implemented for {model.__class__.__name__}"
+        )
+
+    block = next(iter(model.blocks.values()))
+    if not isinstance(block, ReorderedNormTransformerBlock):
+        raise NotImplementedError(
+            f"Block is not a {ReorderedNormTransformerBlock.__name__}, unable to build HF config for {model.__class__.__name__}"
+        )
+
+    if not isinstance(block.attention, Attention):
+        raise NotImplementedError(
+            f"Attention is not a {Attention.__name__}, unable to build HF config for {model.__class__.__name__}"
+        )
+    if block.attention.rope is None:
+        raise NotImplementedError(
+            f"Attention does not use rope, unable to build HF config for {model.__class__.__name__}"
+        )
+
+    return Olmo2Config(
+        vocab_size=model.vocab_size,
+        hidden_size=model.d_model,
+        intermediate_size=block.feed_forward.hidden_size,
+        num_hidden_layers=model.n_layers,
+        num_attention_heads=block.attention.n_heads,
+        num_key_value_heads=block.attention.n_kv_heads,
+        hidden_act="silu",
+        max_position_embeddings=-1,
+        attention_bias=block.attention.w_out.bias is not None,
+        rope_theta=block.attention.rope.theta,
+        pad_token_id=None,  # type: ignore
+        bos_token_id=None,
+        eos_token_id=None,  # type: ignore
+        rms_norm_eps=block.feed_forward_norm.eps,
+        tie_word_embeddings=False,
+    )

--- a/src/olmo_core/nn/hf/convert.py
+++ b/src/olmo_core/nn/hf/convert.py
@@ -1,0 +1,272 @@
+from typing import Any, Dict, List
+
+from transformers import PretrainedConfig
+
+from olmo_core.doc_utils import beta_feature
+from olmo_core.nn.conversion.state_mapping import (
+    StateConverter,
+    StateMappingTemplate,
+    TemplatePlaceholder,
+)
+
+LAYER = TemplatePlaceholder.LAYER
+EXPERT = TemplatePlaceholder.EXPERT
+
+
+# Map of Hugging Face keys to OLMo Core keys, that is used to determine how HF state
+# maps to OLMo Core state. Different HF models may use different names for a given OLMo
+# Core state.
+#
+# This map only captures one-to-one mappings from HF to OLMo Core. For many-to-many mappings
+# or mappings that require additional manipulation of state, see
+# `HF_TO_OLMO_CORE_TEMPLATE_MAPPING`. If a given HF key can refer to different OLMo Core
+# states depending on the HF model, see `MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS`.
+HF_TO_OLMO_CORE_MAPPINGS: Dict[str, str] = {
+    "model.embed_tokens.weight": "embeddings.weight",
+    "model.norm.weight": "lm_head.norm.weight",
+    "lm_head.weight": "lm_head.w_out.weight",
+    # Attention.
+    f"model.layers.{LAYER}.self_attn.q_proj.weight": f"blocks.{LAYER}.attention.w_q.weight",
+    f"model.layers.{LAYER}.self_attn.k_proj.weight": f"blocks.{LAYER}.attention.w_k.weight",
+    f"model.layers.{LAYER}.self_attn.v_proj.weight": f"blocks.{LAYER}.attention.w_v.weight",
+    f"model.layers.{LAYER}.self_attn.o_proj.weight": f"blocks.{LAYER}.attention.w_out.weight",
+    # MLP.
+    f"model.layers.{LAYER}.mlp.gate_proj.weight": f"blocks.{LAYER}.feed_forward.w1.weight",
+    f"model.layers.{LAYER}.mlp.down_proj.weight": f"blocks.{LAYER}.feed_forward.w2.weight",
+    f"model.layers.{LAYER}.mlp.up_proj.weight": f"blocks.{LAYER}.feed_forward.w3.weight",
+    # Layer norms.
+    f"model.layers.{LAYER}.input_layernorm.weight": f"blocks.{LAYER}.attention_norm.weight",
+    f"model.layers.{LAYER}.post_attention_layernorm.weight": f"blocks.{LAYER}.attention_norm.weight",
+    f"model.layers.{LAYER}.post_feedforward_layernorm.weight": f"blocks.{LAYER}.feed_forward_norm.weight",
+    f"model.layers.{LAYER}.self_attn.q_norm.weight": f"blocks.{LAYER}.attention.q_norm.weight",
+    f"model.layers.{LAYER}.self_attn.k_norm.weight": f"blocks.{LAYER}.attention.k_norm.weight",
+    # MoEMLP.
+    f"model.layers.{LAYER}.mlp.gate.weight": f"blocks.{LAYER}.feed_forward_moe.router.weight",
+    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight": f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
+    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight": f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
+    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight": f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
+}
+
+
+# Map of Hugging Face keys to OLMo Core keys. This map captures overrides of the standard
+# one-to-one mappings in `HF_TO_OLMO_CORE_MAPPINGS`, in case a given HF key can refer to
+# different OLMo Core states depending on the HF model.
+MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS: Dict[str, Dict[str, str]] = {
+    "meta-llama/Llama-3.2-1B": {
+        f"model.layers.{LAYER}.post_attention_layernorm.weight": f"blocks.{LAYER}.feed_forward_norm.weight"
+    }
+}
+
+
+# Map of Hugging Face keys to OLMo Core keys, that is used to determine how HF state
+# maps to OLMo Core state. Different HF models may use different names for a given OLMo
+# Core state.
+#
+# This map captures many-to-many mappings from HF to OLMo Core and mappings that require
+# additional manipulation of state (e.g. merging dimensions).
+# For simple one-to-one mappings from HF to OLMo Core, see
+# `HF_TO_OLMO_CORE_MAPPINGS`.
+HF_TO_OLMO_CORE_TEMPLATE_MAPPING: Dict[str, StateMappingTemplate] = {
+    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight",
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
+        source_key_per_placeholder=TemplatePlaceholder.EXPERT,
+        source_concat_dim=1,
+        dims_permutation=(1, 0),
+        dest_chunk_dim=0,
+    ),
+    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight",
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
+        source_key_per_placeholder=TemplatePlaceholder.EXPERT,
+        source_concat_dim=1,
+        dims_permutation=(1, 0),
+        dest_chunk_dim=0,
+    ),
+    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight",
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
+        source_key_per_placeholder=TemplatePlaceholder.EXPERT,
+        source_concat_dim=1,
+        dims_permutation=(1, 0),
+        dest_chunk_dim=0,
+    ),
+    f"model.layers.{LAYER}.mlp.gate.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.gate.weight",
+        f"blocks.{LAYER}.feed_forward_moe.router.weight",
+        flatten_dims=(0, 1),
+    ),
+}
+
+
+# Map of OLMo Core keys to Hugging Face keys, that is used to determine how OLMo Core state
+# maps to HF state.
+#
+# This map only captures one-to-one mappings from OLMo Core to HF. For many-to-many mappings
+# or mappings that require additional manipulation of state, see `OLMO_CORE_TO_HF_TEMPLATE_MAPPING`.
+OLMO_CORE_TO_HF_MAPPINGS: Dict[str, str] = {
+    "embeddings.weight": "model.embed_tokens.weight",
+    "lm_head.norm.weight": "model.norm.weight",
+    "lm_head.w_out.weight": "lm_head.weight",
+    # Attention.
+    f"blocks.{LAYER}.attention.w_q.weight": f"model.layers.{LAYER}.self_attn.q_proj.weight",
+    f"blocks.{LAYER}.attention.w_k.weight": f"model.layers.{LAYER}.self_attn.k_proj.weight",
+    f"blocks.{LAYER}.attention.w_v.weight": f"model.layers.{LAYER}.self_attn.v_proj.weight",
+    f"blocks.{LAYER}.attention.w_out.weight": f"model.layers.{LAYER}.self_attn.o_proj.weight",
+    # MLP.
+    f"blocks.{LAYER}.feed_forward.w1.weight": f"model.layers.{LAYER}.mlp.gate_proj.weight",
+    f"blocks.{LAYER}.feed_forward.w2.weight": f"model.layers.{LAYER}.mlp.down_proj.weight",
+    f"blocks.{LAYER}.feed_forward.w3.weight": f"model.layers.{LAYER}.mlp.up_proj.weight",
+    # Layer norms.
+    f"blocks.{LAYER}.attention_norm.weight": f"model.layers.{LAYER}.post_attention_layernorm.weight",
+    f"blocks.{LAYER}.feed_forward_norm.weight": f"model.layers.{LAYER}.post_feedforward_layernorm.weight",
+    f"blocks.{LAYER}.attention.q_norm.weight": f"model.layers.{LAYER}.self_attn.q_norm.weight",
+    f"blocks.{LAYER}.attention.k_norm.weight": f"model.layers.{LAYER}.self_attn.k_norm.weight",
+    # MoEMLP.
+    f"blocks.{LAYER}.feed_forward_moe.router.weight": f"model.layers.{LAYER}.mlp.gate.weight",
+    f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1": f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight",
+    f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2": f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight",
+    f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3": f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight",
+}
+
+
+# Map of OLMo Core keys to Hugging Face keys, that is used to determine how OLMo Core state
+# maps to HF state.
+#
+# This map captures many-to-many mappings from OLMo Core to HF and mappings that require
+# additional manipulation of state (e.g. merging dimensions).
+# For simple one-to-one mappings from OLMo Core to HF, see
+# `OLMO_CORE_TO_HF_MAPPINGS`.
+OLMO_CORE_TO_HF_TEMPLATE_MAPPING: Dict[str, StateMappingTemplate] = {
+    f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1": StateMappingTemplate(
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
+        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight",
+        dest_key_per_placeholder=TemplatePlaceholder.EXPERT,
+        source_concat_dim=0,
+        dims_permutation=(1, 0),
+        dest_chunk_dim=1,
+    ),
+    f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2": StateMappingTemplate(
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
+        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight",
+        dest_key_per_placeholder=TemplatePlaceholder.EXPERT,
+        source_concat_dim=0,
+        dims_permutation=(1, 0),
+        dest_chunk_dim=1,
+    ),
+    f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3": StateMappingTemplate(
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
+        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight",
+        dest_key_per_placeholder=TemplatePlaceholder.EXPERT,
+        source_concat_dim=0,
+        dims_permutation=(1, 0),
+        dest_chunk_dim=1,
+    ),
+    f"blocks.{LAYER}.feed_forward_moe.router.weight": StateMappingTemplate(
+        f"blocks.{LAYER}.feed_forward_moe.router.weight",
+        f"model.layers.{LAYER}.mlp.gate.weight",
+        unflatten_dim=(0, (TemplatePlaceholder.EXPERT, -1)),
+    ),
+}
+
+
+def _get_hf_model_to_olmo_core_one_to_one_templates(
+    model_id: str | None = None,
+) -> List[StateMappingTemplate]:
+    mapping_templates = {
+        hf_key: StateMappingTemplate(hf_key, olmo_core_key)
+        for hf_key, olmo_core_key in HF_TO_OLMO_CORE_MAPPINGS.items()
+    }
+    if model_id in MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS:
+        model_specific_mapping_templates = {
+            hf_key: StateMappingTemplate(hf_key, olmo_core_key)
+            for hf_key, olmo_core_key in MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS[model_id].items()
+        }
+        mapping_templates.update(model_specific_mapping_templates)
+
+    return list(mapping_templates.values())
+
+
+def _get_converter_from_hf(model_id: str | None = None) -> StateConverter:
+    mapping_templates = _get_hf_model_to_olmo_core_one_to_one_templates(model_id)
+    mapping_templates += list(HF_TO_OLMO_CORE_TEMPLATE_MAPPING.values())
+    return StateConverter(mapping_templates)
+
+
+@beta_feature
+def get_converter_from_hf(model_id: str | None = None) -> StateConverter:
+    return _get_converter_from_hf(model_id=model_id)
+
+
+@beta_feature
+def convert_state_from_hf(
+    config: PretrainedConfig,
+    hf_state: Dict[str, Any],
+    *,
+    model_id: str | None = None,
+) -> Dict[str, Any]:
+    """
+    Converts a model state dict in Hugging Face transformers format into an unsharded state dict of
+    OLMo Core format.
+
+    :param config: The Hugging Face config for the model
+    :param hf_state: A model state dict in HF format.
+    :param model_id: The model id of the HF model in HF Hub.
+    """
+
+    converter = _get_converter_from_hf(model_id=model_id)
+
+    if not hasattr(config, "num_hidden_layers"):
+        raise ValueError(f"Number of hidden layers missing in HF config: {config}")
+    n_layers: int = config.num_hidden_layers
+    n_experts: int | None = getattr(config, "num_experts", None)
+
+    placeholder_bounds = {
+        TemplatePlaceholder.LAYER: n_layers,
+    }
+    if n_experts:
+        placeholder_bounds[TemplatePlaceholder.EXPERT] = n_experts
+
+    return converter.convert(hf_state, placeholder_bounds)
+
+
+def _get_converter_to_hf() -> StateConverter:
+    mapping_templates = [
+        StateMappingTemplate(olmo_core_key, hf_key)
+        for olmo_core_key, hf_key in OLMO_CORE_TO_HF_MAPPINGS.items()
+    ]
+    mapping_templates += list(OLMO_CORE_TO_HF_TEMPLATE_MAPPING.values())
+    return StateConverter(mapping_templates)
+
+
+@beta_feature
+def get_converter_to_hf() -> StateConverter:
+    return _get_converter_to_hf()
+
+
+@beta_feature
+def convert_state_to_hf(
+    config: PretrainedConfig, olmo_core_state: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Converts an *unsharded* model state dict of OLMo Core format into Hugging Face transformers format.
+
+    :param config: The Hugging Face config for the model
+    :param olmo_core_state: An unsharded OLMo Core model state dict. None of the states can be
+        :class:`DTensor` or :class:`ShardedTensor`
+    """
+
+    converter = _get_converter_to_hf()
+
+    if not hasattr(config, "num_hidden_layers"):
+        raise ValueError(f"Number of hidden layers missing in HF config: {config}")
+    n_layers: int = config.num_hidden_layers
+    n_experts: int | None = getattr(config, "num_experts", None)
+
+    placeholder_bounds = {
+        TemplatePlaceholder.LAYER: n_layers,
+    }
+    if n_experts:
+        placeholder_bounds[TemplatePlaceholder.EXPERT] = n_experts
+
+    return converter.convert(olmo_core_state, placeholder_bounds)


### PR DESCRIPTION
Issue: Our conversion logic between OLMo Core and HF transformers formats is not very flexible. Every time we want to support a new architecture, we have to write new logic and test from scratch. The ideal is to have an easy way to specify how OLMo Core states maps to/from HF, and have our code use that mapping information to perform the conversion.

Fix: This PR refactors the logic around conversion to make it easier to convert between the formats. It enables us to specify mappings between states of the 2 formats that support placeholders for things like expert id and layer id (in `src/olmo_core/nn/hf/convert.py` using `StateMappingTemplate`s). The mappings can be many-to-many and allow us to specify some operations that need to be performed as part of conversion, like permuting dimensions or merging/unmerging layers. The operations currently supported are the minimum needed to support OLMo2 and the current MoE implementation.