### PR TITLE
Fix bug when restarting a completed run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TransformerTrainModuleConfig` can now be used to build a `TransformerPipelineTrainModule` by adding a `pp_config` spec. This makes the `TransformerPipelineTrainModuleConfig` redundant, but it will be kept around for backwards compatibility until the next major release.
 - Several state dict methods in `TrainModule` now take an `optim` option, which can disable the use of optimizer state.
 
+### Fixed
+
+- Fixed a bug where the trainer might try to save a duplicate final checkpoint if the run that already completed was restarted.
+
 ## [v2.0.1](https://github.com/allenai/OLMo-core/releases/tag/v2.0.1) - 2025-03-18
 
 ### Added

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -583,6 +583,13 @@ class Trainer:
 
         barrier()
 
+        # It's possible that we tried restarting a run that had already finished.
+        if self.training_complete:
+            log.warning("Training already complete, ending run now")
+            self._shutdown_bookkeeping()
+            gc_cuda()
+            return
+
         log.info("Callback order:")
         for i, callback_name in enumerate(self.callbacks.keys()):
             log.info(f"  - Callback {i+1}: {callback_name}")
@@ -618,13 +625,14 @@ class Trainer:
             callback.post_train()
 
         # Wait for any bookkeeping tasks to finish.
+        self._shutdown_bookkeeping()
+        gc_cuda()
+        log.info("Training complete")
+
+    def _shutdown_bookkeeping(self):
         self.thread_pool.shutdown(wait=True, cancel_futures=False)
         self._thread_pool = None
-
         barrier()
-        gc_cuda()
-
-        log.info("Training complete")
 
     def state_dict(self) -> TrainerStateDict:
         """


### PR DESCRIPTION
Fixes a bug where the trainer might try to save a duplicate final checkpoint when restarting from a run that already completed. See https://beaker.allen.ai/orgs/ai2/workspaces/OLMo-core/work/01JPTRNMGVV756C3X3J5G0WZMM/logs?jobId=01JPTRNMPB4TT6HDW8AEBT8ER3, for example.