### PR TITLE
Add option to auto resume Comet experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for auxiliary-loss-free MoE load-balancing, similar to DeepSeek-v3. You can activate this by setting `bias_gamma` to a non-zero float in your `MoERouter` config.
 - Compatibility with B200s.
 - Added support for `warmup_fraction` as an alternative to `warmup_steps` in all schedulers, allowing warmup to be specified as a fraction of total training steps.
+- Added `auto_resume` option to `CometCallback` for resume an existing run.
 - (BETA) Added methods `load_hf_model` and `save_hf_model` for saving supported OLMo Core models to HF transformers format.
 Also added lower-level methods for converting state between the formats.
 

--- a/src/olmo_core/train/callbacks/comet.py
+++ b/src/olmo_core/train/callbacks/comet.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from olmo_core.config import StrEnum
 from olmo_core.distributed.utils import get_rank
@@ -111,7 +111,13 @@ class CometCallback(Callback):
     The tag to assign to failed experiments.
     """
 
+    auto_resume: bool = False
+    """
+    If ``True``, an existing experiment will be resumed from a checkpoint.
+    """
+
     _exp = None
+    _exp_key: Optional[str] = None
     _finalized: bool = False
 
     @property
@@ -125,6 +131,13 @@ class CometCallback(Callback):
     @property
     def finalized(self) -> bool:
         return self._finalized
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {"experiment_key": self._exp_key}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]):
+        if self.auto_resume:
+            self._exp_key = state_dict.get("experiment_key")
 
     def finalize(self):
         if not self.finalized:
@@ -140,22 +153,33 @@ class CometCallback(Callback):
             if COMET_API_KEY_ENV_VAR not in os.environ:
                 raise OLMoEnvironmentError(f"missing env var '{COMET_API_KEY_ENV_VAR}'")
 
-            self.exp = comet.Experiment(
-                api_key=os.environ[COMET_API_KEY_ENV_VAR],
-                project_name=self.project,
-                workspace=self.workspace,
-                auto_output_logging="simple",
-                display_summary_level=0,
-            )
+            if self.auto_resume and self._exp_key is not None:
+                self.exp = cast(
+                    "Experiment",
+                    comet.start(
+                        api_key=os.environ[COMET_API_KEY_ENV_VAR],
+                        mode="get",
+                        experiment_key=self._exp_key,
+                    ),
+                )
+            else:
+                self.exp = comet.Experiment(
+                    api_key=os.environ[COMET_API_KEY_ENV_VAR],
+                    project_name=self.project,
+                    workspace=self.workspace,
+                    auto_output_logging="simple",
+                    display_summary_level=0,
+                )
+                self._exp_key = self.exp.get_key()
 
-            if self.name is not None:
-                self.exp.set_name(self.name)
+                if self.name is not None:
+                    self.exp.set_name(self.name)
 
-            if self.tags:
-                self.exp.add_tags(self.tags)
+                if self.tags:
+                    self.exp.add_tags(self.tags)
 
-            if self.config is not None:
-                self.exp.log_parameters(self.config)
+                if self.config is not None:
+                    self.exp.log_parameters(self.config)
 
             if self.notifications == CometNotificationSetting.all:
                 self.exp.send_notification(

--- a/src/olmo_core/train/callbacks/comet.py
+++ b/src/olmo_core/train/callbacks/comet.py
@@ -154,6 +154,7 @@ class CometCallback(Callback):
                 raise OLMoEnvironmentError(f"missing env var '{COMET_API_KEY_ENV_VAR}'")
 
             if self.auto_resume and self._exp_key is not None:
+                log.info(f"Resuming Comet logging from existing experiment '{self._exp_key}'")
                 self.exp = cast(
                     "Experiment",
                     comet.start(

--- a/src/olmo_core/train/callbacks/comet.py
+++ b/src/olmo_core/train/callbacks/comet.py
@@ -161,10 +161,12 @@ class CometCallback(Callback):
                         api_key=os.environ[COMET_API_KEY_ENV_VAR],
                         mode="get",
                         experiment_key=self._exp_key,
+                        experiment_config=comet.ExperimentConfig(
+                            auto_output_logging="simple",
+                            display_summary_level=0,
+                        ),
                     ),
                 )
-                self.exp.auto_output_logging = "simple"
-                self.exp.display_summary_level = 0
             else:
                 self.exp = comet.Experiment(
                     api_key=os.environ[COMET_API_KEY_ENV_VAR],

--- a/src/olmo_core/train/callbacks/comet.py
+++ b/src/olmo_core/train/callbacks/comet.py
@@ -163,6 +163,8 @@ class CometCallback(Callback):
                         experiment_key=self._exp_key,
                     ),
                 )
+                self.exp.auto_output_logging = "simple"
+                self.exp.display_summary_level = 0
             else:
                 self.exp = comet.Experiment(
                     api_key=os.environ[COMET_API_KEY_ENV_VAR],


### PR DESCRIPTION
Default behavior of the Comet callback is unchanged, but now if you set `auto_resume=True` in your `CometCallback`, you'll keep logging to the same experiment on Comet when resuming from a checkpoint.

See https://www.comet.com/docs/v2/guides/experiment-management/resume-experiment/ for reference.