### PR TITLE
Add support for label masks with numpy datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `auto_resume` option to `CometCallback` for resume an existing run.
 - (BETA) Added methods `load_hf_model` and `save_hf_model` for saving supported OLMo Core models to HF transformers format.
 Also added lower-level methods for converting state between the formats.
-- Added support for label mask files with numpy datasets.
+- Added support for label mask files with numpy FSL datasets.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `auto_resume` option to `CometCallback` for resume an existing run.
 - (BETA) Added methods `load_hf_model` and `save_hf_model` for saving supported OLMo Core models to HF transformers format.
 Also added lower-level methods for converting state between the formats.
+- Added support for label mask files with numpy datasets.
 
 ### Changed
 

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -823,6 +823,9 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
         return data
 
     def _get_instance_indices_path(self, path: PathOrStr) -> Path:
+        # NOTE: the instance indices file names are based on the corresponding source (token IDs) file name,
+        # so to get the right instance indices file name for a label mask file, we need to map
+        # the label mask file name to its corresponding source file name.
         if path in self._label_mask_path_to_source_path:
             path = self._label_mask_path_to_source_path[path]
         sha256_hash = hashlib.sha256()

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -9,6 +9,7 @@ import tempfile
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import (
     Any,
@@ -22,6 +23,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
 import numpy as np
@@ -373,6 +375,7 @@ class NumpyFSLDataset(NumpyDatasetBase, Dataset[Dict[str, Any]]):
         generate_doc_lengths: bool = False,
         max_target_sequence_length: Optional[int] = None,
         instance_filter_config: Optional[InstanceFilterConfig] = None,
+        label_mask_paths: Optional[List[PathOrStr]] = None,
     ):
         if max_target_sequence_length is not None and (
             max_target_sequence_length < sequence_length
@@ -393,6 +396,11 @@ class NumpyFSLDataset(NumpyDatasetBase, Dataset[Dict[str, Any]]):
         else:
             metadata = [metadata or {}] * len(paths)
 
+        if label_mask_paths is not None and len(label_mask_paths) != len(paths):
+            raise OLMoConfigurationError(
+                "There must be the same number of 'label_mask_paths' as there are 'paths'"
+            )
+
         super().__init__(
             *paths,
             pad_token_id=pad_token_id,
@@ -401,6 +409,7 @@ class NumpyFSLDataset(NumpyDatasetBase, Dataset[Dict[str, Any]]):
             dtype=dtype,
         )
         self._metadata = tuple(metadata)
+        self._label_mask_paths = label_mask_paths
         self._sequence_length = sequence_length
         self._max_target_sequence_length = max_target_sequence_length
         self._array_offsets: Optional[Tuple[Tuple[int, int], ...]] = None
@@ -472,6 +481,12 @@ class NumpyFSLDataset(NumpyDatasetBase, Dataset[Dict[str, Any]]):
         input_ids = self._read_chunk_from_array(self.paths[array_index], array_local_index)
         out: Dict[str, Any] = {"input_ids": input_ids}
 
+        if self._label_mask_paths is not None:
+            label_mask = self._read_chunk_from_array(
+                self._label_mask_paths[array_index], array_local_index, dtype=np.bool_
+            )
+            out["label_mask"] = label_mask
+
         if self.instance_filter_config is not None:
             out["instance_mask"] = self._validate_instance(input_ids, self.instance_filter_config)
 
@@ -487,11 +502,13 @@ class NumpyFSLDataset(NumpyDatasetBase, Dataset[Dict[str, Any]]):
     @property
     def _sizes_and_offsets(self) -> Tuple[Tuple[int, ...], Tuple[Tuple[int, int], ...]]:
         if self._array_offsets is None or self._array_file_sizes is None:
+            array_lengths: List[int] = []
             array_offsets: List[Tuple[int, int]] = []
             array_file_sizes: List[int] = []
 
             start_offset = 0
             for size, length in self.map(self._get_file_size_and_length):
+                array_lengths.append(length)
                 end_offset = start_offset + length
                 array_offsets.append((start_offset, end_offset))
                 array_file_sizes.append(size)
@@ -500,17 +517,31 @@ class NumpyFSLDataset(NumpyDatasetBase, Dataset[Dict[str, Any]]):
             self._array_offsets = tuple(array_offsets)
             self._array_file_sizes = tuple(array_file_sizes)
 
+            if self._label_mask_paths is not None:
+                for i, (_, length) in enumerate(
+                    self.map(
+                        partial(self._get_file_size_and_length, dtype=np.bool_),
+                        _paths=self._label_mask_paths,
+                    )
+                ):
+                    if array_lengths[i] != length:
+                        raise RuntimeError(
+                            f"mismatch between length of source file '{self._array_paths[i]}' and "
+                            f"length of corresponding label mask file '{self._label_mask_paths[i]}'"
+                        )
+
         return self._array_file_sizes, self._array_offsets
 
-    def _read_chunk_from_array(self, path: PathOrStr, index: int) -> torch.Tensor:
+    def _read_chunk_from_array(self, path: PathOrStr, index: int, dtype=None) -> torch.Tensor:
         start_idx = index * self.sequence_length
         return load_array_slice_into_tensor(
-            path, start_idx, start_idx + self.sequence_length, self.dtype
+            path,
+            start_idx,
+            start_idx + self.sequence_length,
+            dtype or self.dtype,
         )
 
-    def _get_file_size_and_length(
-        self, path: PathOrStr, idx: int, dtype: Optional[NumpyUIntTypes] = None
-    ) -> Tuple[int, int]:
+    def _get_file_size_and_length(self, path: PathOrStr, idx: int, dtype=None) -> Tuple[int, int]:
         del idx
         dtype = dtype or self.dtype
         item_size = dtype(0).itemsize
@@ -673,9 +704,7 @@ class NumpyFSLDatasetMixture(NumpyFSLDataset):
     #     data = load_array_slice_into_tensor(path, int(start_idx), int(end_idx), self.dtype)
     #     return data
 
-    def _get_file_size_and_length(
-        self, path: PathOrStr, idx: int, dtype: Optional[NumpyUIntTypes] = None
-    ) -> Tuple[int, int]:
+    def _get_file_size_and_length(self, path: PathOrStr, idx: int, dtype=None) -> Tuple[int, int]:
         dtype = dtype or self.dtype
         item_size = dtype(0).itemsize
         file_size = self._get_size_from_offset_index((path, idx))
@@ -720,6 +749,7 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
         metadata: Optional[Union[List[Dict[str, Any]], Dict[str, Any]]] = None,
         include_instance_metadata: Optional[bool] = None,
         instance_filter_config: Optional[InstanceFilterConfig] = None,
+        label_mask_paths: Optional[List[PathOrStr]] = None,
     ):
         super().__init__(
             *paths,
@@ -731,6 +761,7 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
             metadata=metadata,
             include_instance_metadata=include_instance_metadata,
             instance_filter_config=instance_filter_config,
+            label_mask_paths=label_mask_paths,
         )
         self._array_instance_offsets: Optional[Tuple[Tuple[int, int], ...]] = None
 
@@ -766,19 +797,22 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
     def __getitem__(self, index: int) -> Dict[str, Any]:
         item = super().__getitem__(index)
         pad_shape = (0, self.sequence_length - len(item["input_ids"]))
-        item["label_mask"] = F.pad(
-            torch.ones_like(item["input_ids"], dtype=torch.bool), pad_shape, value=False
-        )
+        if "label_mask" in item:
+            item["label_mask"] = F.pad(item["label_mask"], pad_shape, value=False)
+        else:
+            item["label_mask"] = F.pad(
+                torch.ones_like(item["input_ids"], dtype=torch.bool), pad_shape, value=False
+            )
         item["input_ids"] = F.pad(item["input_ids"], pad_shape, value=self.pad_token_id)
         return item
 
-    def _read_chunk_from_array(self, path: PathOrStr, index: int) -> torch.Tensor:
+    def _read_chunk_from_array(self, path: PathOrStr, index: int, dtype=None) -> torch.Tensor:
         indices_path = self._get_instance_indices_path(path)
         indices = load_array_slice_into_tensor(
             indices_path, index * 2, index * 2 + 2, self.indices_dtype
         )
         start_idx, end_idx = indices
-        data = load_array_slice_into_tensor(path, int(start_idx), int(end_idx), self.dtype)
+        data = load_array_slice_into_tensor(path, int(start_idx), int(end_idx), dtype or self.dtype)
         return data
 
     def _get_instance_indices_path(self, path: PathOrStr) -> Path:
@@ -1607,6 +1641,10 @@ class NumpyDatasetConfig(Config):
         all of you runs.
     """
     instance_filter_config: Optional[InstanceFilterConfig] = None
+    label_mask_paths: Optional[List[str]] = None
+    """
+    The paths/URLs to numpy bool files indicating which tokens should be masked.
+    """
 
     def validate(self):
         if self.name in (NumpyDatasetType.fsl, NumpyDatasetType.padded_fsl):
@@ -1747,8 +1785,12 @@ class NumpyDatasetConfig(Config):
                     "'vsl_curriculum' is only a valid field for VSL datasets"
                 )
             if self.source_mixture_config:
+                if self.label_mask_paths is not None:
+                    raise OLMoConfigurationError(
+                        "'label_mask_paths' is not supported for mixture datasets"
+                    )
                 mixture = self.source_mixture_config.build()
-                return NumpyFSLDatasetMixture(
+                dataset = NumpyFSLDatasetMixture(
                     *mixture.to_paths(),
                     seed=mixture.seed,
                     sequence_length=self.sequence_length,
@@ -1776,6 +1818,7 @@ class NumpyDatasetConfig(Config):
                     include_instance_metadata=self.include_instance_metadata,
                     generate_doc_lengths=self.generate_doc_lengths,
                     instance_filter_config=self.instance_filter_config,
+                    label_mask_paths=cast(Optional[List[PathOrStr]], self.label_mask_paths),
                 )
         elif self.name == NumpyDatasetType.padded_fsl:
             if self.sequence_length is None:
@@ -1816,6 +1859,7 @@ class NumpyDatasetConfig(Config):
                 metadata=metadata,
                 include_instance_metadata=self.include_instance_metadata,
                 instance_filter_config=self.instance_filter_config,
+                label_mask_paths=cast(Optional[List[PathOrStr]], self.label_mask_paths),
             )
         elif self.name == NumpyDatasetType.vsl:
             if self.max_sequence_length is None:
@@ -1830,6 +1874,8 @@ class NumpyDatasetConfig(Config):
                 raise OLMoConfigurationError(
                     "'generate_doc_lengths' is only valid for FSL datasets"
                 )
+            if self.label_mask_paths is not None:
+                raise OLMoConfigurationError("'label_mask_paths' is not supported for VSL datasets")
             dataset = NumpyVSLDataset(
                 *paths,
                 max_sequence_length=self.max_sequence_length,

--- a/src/test/data/numpy_dataset_test.py
+++ b/src/test/data/numpy_dataset_test.py
@@ -43,6 +43,49 @@ def test_numpy_fsl_dataset(tmp_path: Path):
     assert len(ds) == 8
 
 
+def test_numpy_fsl_dataset_with_label_mask(tmp_path: Path):
+    mmap1 = np.memmap(tmp_path / "mmap1.npy", mode="w+", dtype=np.uint16, shape=(16,))
+    mmap1[:] = list(range(16))
+    mmap1.flush()
+
+    mmap1_mask = np.memmap(tmp_path / "mmap1_mask.npy", mode="w+", dtype=np.bool_, shape=(16,))
+    mmap1_mask[:] = True
+    mmap1_mask[7] = False
+    mmap1_mask.flush()
+
+    mmap2 = np.memmap(tmp_path / "mmap2.npy", mode="w+", dtype=np.uint16, shape=(16,))
+    mmap2[:] = list(range(16, 32))
+    mmap2.flush()
+
+    mmap2_mask = np.memmap(tmp_path / "mmap2_mask.npy", mode="w+", dtype=np.bool_, shape=(16,))
+    mmap2_mask[:] = True
+    mmap2_mask[0:3] = False
+    mmap2_mask.flush()
+
+    ds = NumpyFSLDataset(
+        tmp_path / "mmap1.npy",
+        tmp_path / "mmap2.npy",
+        sequence_length=4,
+        pad_token_id=-1,
+        eos_token_id=-1,
+        vocab_size=32_000,
+        label_mask_paths=[tmp_path / "mmap1_mask.npy", tmp_path / "mmap2_mask.npy"],
+    )
+    assert len(ds) == 8
+
+    assert ds[0]["input_ids"].tolist() == [0, 1, 2, 3]
+    assert ds[0]["label_mask"].tolist() == [True, True, True, True]
+
+    assert ds[1]["input_ids"].tolist() == [4, 5, 6, 7]
+    assert ds[1]["label_mask"].tolist() == [True, True, True, False]
+
+    assert ds[4]["input_ids"].tolist() == [16, 17, 18, 19]
+    assert ds[4]["label_mask"].tolist() == [False, False, False, True]
+
+    assert ds[7]["input_ids"].tolist() == [28, 29, 30, 31]
+    assert ds[7]["label_mask"].tolist() == [True, True, True, True]
+
+
 def test_numpy_padded_fsl_dataset(tmp_path: Path):
     data1 = [1, 2, 3, 4, 5, 6, 7, 0, 8, 9, 10, 0]
     mmap1 = np.memmap(tmp_path / "mmap1.npy", mode="w+", dtype=np.uint16, shape=(len(data1),))
@@ -70,6 +113,58 @@ def test_numpy_padded_fsl_dataset(tmp_path: Path):
     assert ds[2]["input_ids"].tolist() == [11, 12, 13, 14, 15, 16, 17, 18]
     assert ds[3]["input_ids"].tolist() == [21, 22, 0, 0, 0, 0, 0, 0]
     assert len(ds) == 4
+
+
+def test_numpy_padded_fsl_dataset_with_label_mask(tmp_path: Path):
+    data1 = [1, 2, 3, 4, 5, 6, 7, 0, 8, 9, 10, 0]
+    mmap1 = np.memmap(tmp_path / "mmap1.npy", mode="w+", dtype=np.uint16, shape=(len(data1),))
+    mmap1[:] = data1
+    mmap1.flush()
+
+    data1_mask = [False, True, True, True, True, True, True, True] + [True, True, True, True]
+    mmap1_mask = np.memmap(
+        tmp_path / "mmap1_mask.npy", mode="w+", dtype=np.bool_, shape=(len(data1_mask),)
+    )
+    mmap1_mask[:] = data1_mask
+    mmap1_mask.flush()
+
+    data2 = [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 0, 21, 22, 0]
+    mmap2 = np.memmap(tmp_path / "mmap2.npy", mode="w+", dtype=np.uint16, shape=(len(data2),))
+    mmap2[:] = data2
+    mmap2.flush()
+
+    data2_mask = [True, True, True, True, True, True, True, True, True, True, True] + [
+        True,
+        True,
+        True,
+    ]
+    mmap2_mask = np.memmap(
+        tmp_path / "mmap2_mask.npy", mode="w+", dtype=np.bool_, shape=(len(data2_mask),)
+    )
+    mmap2_mask[:] = data2_mask
+    mmap2_mask.flush()
+
+    ds = NumpyPaddedFSLDataset(
+        tmp_path / "mmap1.npy",
+        tmp_path / "mmap2.npy",
+        sequence_length=8,
+        pad_token_id=0,
+        eos_token_id=0,
+        vocab_size=32_000,
+        label_mask_paths=[tmp_path / "mmap1_mask.npy", tmp_path / "mmap2_mask.npy"],
+    )
+
+    ds.prepare()
+    assert len(ds) == 4
+
+    assert ds[0]["input_ids"].tolist() == [1, 2, 3, 4, 5, 6, 7, 0]
+    assert ds[0]["label_mask"].tolist() == [False] + [True] * 7
+
+    assert ds[1]["input_ids"].tolist() == [8, 9, 10, 0, 0, 0, 0, 0]
+    assert ds[1]["label_mask"].tolist() == [True] * 4 + [False] * 4
+
+    assert ds[2]["input_ids"].tolist() == [11, 12, 13, 14, 15, 16, 17, 18]
+    assert ds[3]["input_ids"].tolist() == [21, 22, 0, 0, 0, 0, 0, 0]
 
 
 def test_numpy_fsl_mixture_dataset(tmp_path: Path):


### PR DESCRIPTION
Ports over support for custom label masks from old OLMo. You can enable this by setting `label_mask_paths` to a list of paths/URLs to numpy bool files in your `NumpyDatasetConfig`. Currently only FSL and padded FSL datasets support this.