### PR TITLE
fix in-loop normalization with v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Also added lower-level methods for converting state between the formats.
 
 - The official config for the 32B had unrealistic batch size settings.
 - Ignore `group_overrides` for frozen parameters instead of throwing an error.
+- Bump `ai2-olmo-eval==0.7.1`, which fixes makes the in-loop evaluation consistent with OLMES by removing [a bias](https://github.com/allenai/OLMo-in-loop-evals/pull/6)
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "omegaconf",
     "safetensors",
     "importlib_resources",
-    "ai2-olmo-eval==0.7.0",
+    "ai2-olmo-eval==0.7.1",
 ]
 
 [project.urls]

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -246,14 +246,23 @@ class LMEvaluatorCallbackConfig(CallbackConfig):
 
 class DownstreamEvaluator(Evaluator):
     metric_type_to_label = {
-        "f1": "F1 score",
-        "acc": "accuracy",
-        "len_norm": "length-normalized accuracy",
-        "pmi_dc": "PMI-DC accuracy",
-        "ce_loss": "CE loss",
-        "bpb": "BPB",
-        "soft": "soft loss",
-        "soft_log": "log soft loss",
+        "f1_v1": "F1 score v1",
+        "acc_v1": "accuracy v1",
+        "len_norm_v1": "length-normalized accuracy v1",
+        "pmi_dc_v1": "PMI-DC accuracy v1",
+        "ce_loss_v1": "CE loss v1",
+        "bpb_v1": "BPB v1",
+        "soft_v1": "soft loss v1",
+        "soft_log_v1": "log soft loss v1",
+
+        "f1_v2": "F1 score v2",
+        "acc_v2": "accuracy v2",
+        "len_norm_v2": "length-normalized accuracy v2",
+        "pmi_dc_v2": "PMI-DC accuracy v2",
+        "ce_loss_v2": "CE loss v2",
+        "bpb_v2": "BPB v2",
+        "soft_v2": "soft loss v2",
+        "soft_log_v2": "log soft loss v2",
     }
 
     def __init__(

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -246,14 +246,14 @@ class LMEvaluatorCallbackConfig(CallbackConfig):
 
 class DownstreamEvaluator(Evaluator):
     metric_type_to_label = {
-        "f1_v1": "F1 score v1",
-        "acc_v1": "accuracy v1",
-        "len_norm_v1": "length-normalized accuracy v1",
-        "pmi_dc_v1": "PMI-DC accuracy v1",
-        "ce_loss_v1": "CE loss v1",
-        "bpb_v1": "BPB v1",
-        "soft_v1": "soft loss v1",
-        "soft_log_v1": "log soft loss v1",
+        "f1_v1": "F1 score",
+        "acc_v1": "accuracy",
+        "len_norm_v1": "length-normalized accuracy",
+        "pmi_dc_v1": "PMI-DC accuracy",
+        "ce_loss_v1": "CE loss",
+        "bpb_v1": "BPB",
+        "soft_v1": "soft loss",
+        "soft_log_v1": "log soft loss",
         "f1_v2": "F1 score v2",
         "acc_v2": "accuracy v2",
         "len_norm_v2": "length-normalized accuracy v2",

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -254,7 +254,6 @@ class DownstreamEvaluator(Evaluator):
         "bpb_v1": "BPB v1",
         "soft_v1": "soft loss v1",
         "soft_log_v1": "log soft loss v1",
-
         "f1_v2": "F1 score v2",
         "acc_v2": "accuracy v2",
         "len_norm_v2": "length-normalized accuracy v2",


### PR DESCRIPTION
Merge and update in-loop evals to match https://github.com/allenai/OLMo-in-loop-evals/pull/6

Description from the `ai2-olmo-eval==0.7.1` PR:
> our current in-loop does not match the OLMES standard (in our downstream evals), [the downstream normalization is here](https://github.com/allenai/oe-eval-internal/blob/main/oe_eval/metrics/metric.py#L229-L231). It appears the -1 term is an artifact from when we originally implemented in-loop evals.

This will keep the original version of the metrics (`_v1`) and the version with the fixed normalization (`_v2`)