### PR TITLE
Add option to cancel run after first evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `auto_resume` option to `CometCallback` for resume an existing run.
 - (BETA) Added methods `load_hf_model` and `save_hf_model` for saving supported OLMo Core models to HF transformers format.
 Also added lower-level methods for converting state between the formats.
-- Added the ability to run an eval at startup
+- Added the ability to run the evaluator callback on `.pre_train()` by setting `eval_on_startup=True`, and to cancel the run after the first time evals run by setting `cancel_after_first_eval=True`.
 - Added support for label mask files with numpy FSL datasets.
 
 ### Changed

--- a/src/examples/llama/train.py
+++ b/src/examples/llama/train.py
@@ -160,7 +160,7 @@ def build_config(run_name: str, overrides: List[str]) -> ExperimentConfig:
                     work_dir=DATA_WORK_DIR,
                 ),
                 eval_interval=250,
-                eval_duration=Duration.steps(10),
+                eval_duration=Duration.steps(50),
             ),
         )
         .with_callback(

--- a/src/olmo_core/train/__init__.py
+++ b/src/olmo_core/train/__init__.py
@@ -51,7 +51,13 @@ from ..distributed.utils import init_distributed, is_distributed
 from ..io import add_cached_path_clients
 from ..utils import LogFilterType, get_default_device, prepare_cli_environment, seed_all
 from .checkpoint import Checkpointer, CheckpointerConfig
-from .common import Duration, DurationUnit, LoadStrategy, ReduceType
+from .common import (
+    Duration,
+    DurationUnit,
+    LoadStrategy,
+    MetricMergeStrategy,
+    ReduceType,
+)
 from .config import TrainerConfig
 from .trainer import Trainer
 
@@ -66,6 +72,7 @@ __all__ = [
     "Duration",
     "DurationUnit",
     "ReduceType",
+    "MetricMergeStrategy",
 ]
 
 

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -126,13 +126,6 @@ class EvaluatorCallback(Callback):
                     with cuda_sync_debug_mode(0):
                         evaluator.update_metrics(batch, ce_loss, logits)
 
-                if (
-                    not self.cancel_after_first_eval
-                ):  # guard here in case we have multiple evaluators doing this
-                    if self.trainer.is_canceled:
-                        self._log_progress(evaluator, eval_step)
-                        return
-
                 if self.eval_duration.due(step=eval_step, tokens=eval_tokens, epoch=1):
                     self._log_progress(evaluator, eval_step)
                     break

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -152,7 +152,7 @@ class EvaluatorCallback(Callback):
                     self.trainer.record_metric(f"eval/{evaluator.name}/{name}", value)
 
             evaluator_times.append(time.monotonic() - start_time)
-            evaluator_names.append(evaluation_names)
+            evaluator_names.append(evaluator.name)
             evaluator_bs.append(eval_step)
 
             log.info(
@@ -169,10 +169,9 @@ class EvaluatorCallback(Callback):
         eval_speeds = []
         max_time_width = max(len(f"{t:.1f}") for t in evaluator_times)
         max_batch_width = max(len(str(bs)) for bs in evaluator_bs)
-        for names, bs, t in sorted_evaluators:
-            name = names[0]  # only use the name of the first metric for each downstream task
+        for name, bs, t in sorted_evaluators:
             eval_speeds.append(
-                f"    {t:>{max_time_width}.1f} sec ({bs:>{max_batch_width}} batches): {name} (+ variants)"
+                f"    {name}: {t:>{max_time_width}.1f} sec ({bs:>{max_batch_width}} batches)"
             )
         total_time = sum(evaluator_times)
         total_bs = sum(int(bs) if bs is not None else 0 for bs in evaluator_bs)

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -63,7 +63,7 @@ class EvaluatorCallback(Callback):
     cancel_after_first_eval: bool = False
     """
     If ``True``, cancel the run after running evals for the first time. 
-    This combiend with ``eval_on_startup=True`` is useful if you just want to run in-loop evals
+    This combined with ``eval_on_startup=True`` is useful if you just want to run in-loop evals
     without training any longer.
     """
 
@@ -165,18 +165,21 @@ class EvaluatorCallback(Callback):
             zip(evaluator_names, evaluator_bs, evaluator_times), key=lambda x: x[2]
         )
 
-        # Record evaluation speed
-        log.info("Evaluation speed:")
+        # Record evaluation speed.
+        eval_speeds = []
         max_time_width = max(len(f"{t:.1f}") for t in evaluator_times)
         max_batch_width = max(len(str(bs)) for bs in evaluator_bs)
         for names, bs, t in sorted_evaluators:
             name = names[0]  # only use the name of the first metric for each downstream task
-            log.info(
+            eval_speeds.append(
                 f"    {t:>{max_time_width}.1f} sec ({bs:>{max_batch_width}} batches): {name} (+ variants)"
             )
         total_time = sum(evaluator_times)
         total_bs = sum(int(bs) if bs is not None else 0 for bs in evaluator_bs)
-        log.info(f"    Total evaluation time: {total_time:.1f} seconds ({total_bs} batches)")
+        eval_speeds.append(
+            f"    Total evaluation time: {total_time:.1f} seconds ({total_bs} batches)"
+        )
+        log.info("Evaluation speed:\n" + "\n".join(eval_speeds))
 
         self.trainer.record_metric("throughput/in-loop eval time (s)", total_time)
         self.trainer.record_metric("throughput/in-loop eval batches", total_bs)

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -167,13 +167,9 @@ class EvaluatorCallback(Callback):
 
         # Record evaluation speed.
         eval_speeds = []
-        max_time_width = max(len(f"{t:.1f}") for t in evaluator_times)
-        max_batch_width = max(len(str(bs)) for bs in evaluator_bs)
         for names, bs, t in sorted_evaluators:
             name = names[0]
-            eval_speeds.append(
-                f"    {name} (+variants): {t:>{max_time_width}.1f} sec ({bs:>{max_batch_width}} batches)"
-            )
+            eval_speeds.append(f"    {name} (+variants): {t:.1f} sec ({bs} batches)")
         total_time = sum(evaluator_times)
         total_bs = sum(int(bs) if bs is not None else 0 for bs in evaluator_bs)
         eval_speeds.append(

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -60,6 +60,13 @@ class EvaluatorCallback(Callback):
     Whether to run an evaluation when the trainer starts up.
     """
 
+    cancel_after_first_eval: bool = False
+    """
+    If ``True``, cancel the run after running evals for the first time. 
+    This combiend with ``eval_on_startup=True`` is useful if you just want to run in-loop evals
+    without training any longer.
+    """
+
     eval_duration: Duration = field(default_factory=lambda: Duration.epochs(1))
     """
     The duration to run each evaluator for.
@@ -171,6 +178,9 @@ class EvaluatorCallback(Callback):
 
         self.trainer.record_metric("throughput/in-loop eval time (s)", total_time)
         self.trainer.record_metric("throughput/in-loop eval batches", total_bs)
+
+        if self.cancel_after_first_eval:
+            self.trainer.cancel_run("canceled from evaluator callback", no_sync=True)
 
     def _log_progress(self, evaluator: Evaluator, eval_step: int):
         if evaluator.total_batches is not None:

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -26,7 +26,7 @@ from olmo_core.utils import (
     move_to_device,
 )
 
-from ..common import Duration
+from ..common import Duration, MetricMergeStrategy
 from ..train_module import EvalBatchSizeUnit, EvalBatchSpec, TransformerTrainModule
 from .callback import Callback, CallbackConfig
 
@@ -177,8 +177,12 @@ class EvaluatorCallback(Callback):
         )
         log.info("Evaluation speed:\n" + "\n".join(eval_speeds))
 
-        self.trainer.record_metric("throughput/in-loop eval time (s)", total_time)
-        self.trainer.record_metric("throughput/in-loop eval batches", total_bs)
+        self.trainer.record_metric(
+            "throughput/in-loop eval time (s)", total_time, merge_strategy=MetricMergeStrategy.sum
+        )
+        self.trainer.record_metric(
+            "throughput/in-loop eval batches", total_bs, merge_strategy=MetricMergeStrategy.sum
+        )
 
         if self.cancel_after_first_eval:
             self.trainer.cancel_run(

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -152,7 +152,7 @@ class EvaluatorCallback(Callback):
                     self.trainer.record_metric(f"eval/{evaluator.name}/{name}", value)
 
             evaluator_times.append(time.monotonic() - start_time)
-            evaluator_names.append(evaluator_names)
+            evaluator_names.append(evaluation_names)
             evaluator_bs.append(eval_step)
 
             log.info(

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -152,7 +152,7 @@ class EvaluatorCallback(Callback):
                     self.trainer.record_metric(f"eval/{evaluator.name}/{name}", value)
 
             evaluator_times.append(time.monotonic() - start_time)
-            evaluator_names.append(evaluator.name)
+            evaluator_names.append(evaluator_names)
             evaluator_bs.append(eval_step)
 
             log.info(
@@ -169,9 +169,10 @@ class EvaluatorCallback(Callback):
         eval_speeds = []
         max_time_width = max(len(f"{t:.1f}") for t in evaluator_times)
         max_batch_width = max(len(str(bs)) for bs in evaluator_bs)
-        for name, bs, t in sorted_evaluators:
+        for names, bs, t in sorted_evaluators:
+            name = names[0]
             eval_speeds.append(
-                f"    {name}: {t:>{max_time_width}.1f} sec ({bs:>{max_batch_width}} batches)"
+                f"    {name} (+variants): {t:>{max_time_width}.1f} sec ({bs:>{max_batch_width}} batches)"
             )
         total_time = sum(evaluator_times)
         total_bs = sum(int(bs) if bs is not None else 0 for bs in evaluator_bs)

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -153,7 +153,7 @@ class EvaluatorCallback(Callback):
 
             evaluator_times.append(time.monotonic() - start_time)
             evaluator_names.append(evaluation_names)
-            evaluator_bs.append(evaluator.total_batches)
+            evaluator_bs.append(eval_step)
 
             log.info(
                 f"Finished {evaluator.name} evals in {time.monotonic() - start_time:.1f} seconds. Metrics:\n"

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -194,6 +194,7 @@ class LMEvaluatorCallbackConfig(CallbackConfig):
     eval_dataset: NumpyDatasetConfig
     eval_interval: int = 1000
     eval_on_startup: bool = False
+    cancel_after_first_eval: bool = False
     eval_duration: Duration = field(default_factory=lambda: Duration.epochs(1))
     log_interval: int = 5
     enabled: bool = True
@@ -250,6 +251,7 @@ class LMEvaluatorCallbackConfig(CallbackConfig):
             eval_interval=self.eval_interval,
             log_interval=self.log_interval,
             eval_on_startup=self.eval_on_startup,
+            cancel_after_first_eval=self.cancel_after_first_eval,
             eval_duration=self.eval_duration,
         )
 
@@ -376,6 +378,7 @@ class DownstreamEvaluatorCallbackConfig(CallbackConfig):
     eval_interval: int = 1000
     eval_duration: Duration = field(default_factory=lambda: Duration.epochs(1))
     eval_on_startup: bool = False
+    cancel_after_first_eval: bool = False
     log_interval: int = 5
     enabled: bool = True
 
@@ -414,6 +417,7 @@ class DownstreamEvaluatorCallbackConfig(CallbackConfig):
             evaluators=evaluators,
             eval_interval=self.eval_interval,
             eval_on_startup=self.eval_on_startup,
+            cancel_after_first_eval=self.cancel_after_first_eval,
             log_interval=self.log_interval,
             eval_duration=self.eval_duration,
         )

--- a/src/olmo_core/train/common.py
+++ b/src/olmo_core/train/common.py
@@ -153,6 +153,11 @@ class MetricMergeStrategy(StrEnum):
     When a duplicate is logged we take the average with the last value.
     """
 
+    warn = "warn"
+    """
+    Warn when a duplicate is logged, keeping the current value.
+    """
+
 
 def reshape_inputs_for_loss(
     logits: torch.Tensor, labels: torch.Tensor

--- a/src/olmo_core/train/common.py
+++ b/src/olmo_core/train/common.py
@@ -128,6 +128,32 @@ class ReduceType(StrEnum):
     """
 
 
+class MetricMergeStrategy(StrEnum):
+    """
+    Determines how duplicate metrics are merged.
+    """
+
+    latest = "latest"
+    """
+    The latest is used.
+    """
+
+    oldest = "oldest"
+    """
+    The oldest (first logged) is used.
+    """
+
+    sum = "sum"
+    """
+    The sum of the duplicates is used.
+    """
+
+    mean = "mean"
+    """
+    When a duplicate is logged we take the average with the last value.
+    """
+
+
 def reshape_inputs_for_loss(
     logits: torch.Tensor, labels: torch.Tensor
 ) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/src/olmo_core/train/common.py
+++ b/src/olmo_core/train/common.py
@@ -133,6 +133,11 @@ class MetricMergeStrategy(StrEnum):
     Determines how duplicate metrics are merged.
     """
 
+    warn = "warn"
+    """
+    Warn when a duplicate is logged, keeping the current value.
+    """
+
     latest = "latest"
     """
     The latest is used.
@@ -143,19 +148,24 @@ class MetricMergeStrategy(StrEnum):
     The oldest (first logged) is used.
     """
 
-    sum = "sum"
-    """
-    The sum of the duplicates is used.
-    """
-
     mean = "mean"
     """
     When a duplicate is logged we take the average with the last value.
     """
 
-    warn = "warn"
+    sum = "sum"
     """
-    Warn when a duplicate is logged, keeping the current value.
+    The sum of the duplicates is used.
+    """
+
+    max = "max"
+    """
+    Take the maximum value of the duplicates.
+    """
+
+    min = "min"
+    """
+    Take the minimum value of the duplicates.
     """
 
 

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -936,7 +936,7 @@ class Trainer:
                 (k, cb)
                 for _, (k, cb) in sorted(
                     enumerate(self.callbacks.items()),
-                    key=lambda x: (x[1][1].priority, x[0]),
+                    key=lambda x: (x[1][1].priority, -1 * x[0]),
                     reverse=True,
                 )
             )

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -545,6 +545,7 @@ class Trainer:
         if no_sync:
             self._canceled = True
             log.warning(f"Run canceled from all ranks. Reason: {reason}")
+            barrier()
 
     def check_if_canceled(self):
         """

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -615,6 +615,8 @@ class Trainer:
 
         # Quick check if the run has already been canceled.
         if self.is_canceled:
+            self._shutdown_bookkeeping()
+            gc_cuda()
             return
 
         # Install SIGTERM + SIGINT handlers.

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -537,6 +537,9 @@ class Trainer:
         :param no_sync: Set this to ``True`` only if you're calling this from all ranks at the same
             time, otherwise you'll get a distributed deadlock.
         """
+        if self.is_canceled:
+            return
+
         self._canceling_rank = get_rank()
         self._cancel_reason = reason
         if no_sync:

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -540,9 +540,7 @@ class Trainer:
         self._canceling_rank = get_rank()
         self._cancel_reason = reason
         if no_sync:
-            self._canceled = (
-                True  # NOTE: important not to set this otherwise!! Leads to distributed hang.
-            )
+            self._canceled = True
             log.warning(f"Run canceled from all ranks. Reason: {reason}")
 
     def check_if_canceled(self):

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -819,7 +819,7 @@ class Trainer:
         value: Union[float, torch.Tensor],
         reduce_type: Optional[ReduceType] = None,
         namespace: Optional[str] = None,
-        merge_strategy: MetricMergeStrategy = MetricMergeStrategy.latest,
+        merge_strategy: MetricMergeStrategy = MetricMergeStrategy.warn,
     ):
         """
         Record a new metric for the current step.
@@ -853,6 +853,11 @@ class Trainer:
             step_metrics[name] = step_metrics[name] + value
         elif merge_strategy == MetricMergeStrategy.mean:
             step_metrics[name] = (step_metrics[name] + value) / 2
+        elif merge_strategy == MetricMergeStrategy.warn:
+            log.warning(
+                f"Attempting to log duplicate metric '{name}' for step {(self.global_step)}. "
+                "The latest value will be ignored."
+            )
         elif merge_strategy == MetricMergeStrategy.oldest:
             pass
         else:

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -853,6 +853,10 @@ class Trainer:
             step_metrics[name] = step_metrics[name] + value
         elif merge_strategy == MetricMergeStrategy.mean:
             step_metrics[name] = (step_metrics[name] + value) / 2
+        elif merge_strategy == MetricMergeStrategy.max:
+            step_metrics[name] = torch.max(step_metrics[name], value.to(step_metrics[name].device))
+        elif merge_strategy == MetricMergeStrategy.min:
+            step_metrics[name] = torch.min(step_metrics[name], value.to(step_metrics[name].device))
         elif merge_strategy == MetricMergeStrategy.warn:
             log.warning(
                 f"Attempting to log duplicate metric '{name}' for step {(self.global_step)}. "


### PR DESCRIPTION
You can use this feature to only run in-loop evals without training any longer. For example, add these flags to your launch command:

```bash
  --trainer.callbacks.lm_evaluator.eval_on_startup=true \
  --trainer.callbacks.lm_evaluator.cancel_after_first_eval=true \
  --trainer.callbacks.downstream_evaluator.eval_on_startup=true \
  --trainer.callbacks.downstream_evaluator.cancel_after_first_eval=true
```

This also includes some minor fixes to how we log the speed of in-loop evals.