### PR TITLE
clone single branch when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Also added lower-level methods for converting state between the formats.
 - Fixed a bug where the trainer might try to save a duplicate final checkpoint if the run that already completed was restarted.
 - When submitting a Beaker job from a branch that's tracking a GitHub fork, OLMo-core now instructs Beaker to pull from the fork instead of from the main repo.
 - Made Beaker image resolution more robust.
+- Beaker launcher will only clone a single branch at runtime when possible, which can be much faster.
 
 ## [v2.0.1](https://github.com/allenai/OLMo-core/releases/tag/v2.0.1) - 2025-03-18
 


### PR DESCRIPTION
As we're accumulating more and more branches, clone time is getting proportionately slower. This PR makes it so we only clone a single branch at a runtime on Beaker when possible, which is must faster.

- Test run: https://beaker.org/ex/01JRK5BR70QFZG4RGZYQV1XDSN
- References:
  - https://stackoverflow.com/questions/4811434/clone-only-one-branch