### PR TITLE
Log with ANSI colors in Beaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Also added lower-level methods for converting state between the formats.
 - Undo a fix applied to `olmo_core.data.numpy_dataset.NumpyFSLDatasetMixture` that was generating a mismatch between the shape of instances in the dataset and the shape of instances in the data loader.
 - Made the 1B and 7B scripts more similar to each other.
 - Changed underlying logic and top-level arguments of `convert_checkpoint_from_hf.py` and `convert_checkpoint_to_hf.py`.
+- Beaker experiments launched with the `BeakerLaunchConfig` will now log with ANSI colors enabled.
 
 ### Fixed
 

--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -244,6 +244,7 @@ class BeakerLaunchConfig(Config):
             ("WEKA_PROFILE", "WEKA"),
             ("NUM_NODES", str(self.num_nodes)),
             ("OLMO_CORE_VERSION", VERSION),
+            ("FORCE_COLOR", "1"),
         ]
         if self.shared_filesystem:
             env_vars.append((OLMO_SHARED_FS_ENV_VAR, "1"))

--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -244,7 +244,7 @@ class BeakerLaunchConfig(Config):
             ("WEKA_PROFILE", "WEKA"),
             ("NUM_NODES", str(self.num_nodes)),
             ("OLMO_CORE_VERSION", VERSION),
-            ("FORCE_COLOR", "1"),
+            ("FORCE_COLOR", "1"),  # for 'rich' because Beaker supports ANSI colors in logs
         ]
         if self.shared_filesystem:
             env_vars.append((OLMO_SHARED_FS_ENV_VAR, "1"))

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -277,10 +277,9 @@ def setup_logging(
     logging.setLogRecordFactory(log_record_factory)
 
     handler: logging.Handler
-    if (
-        os.environ.get("OLMo_NONINTERACTIVE", False)
-        or os.environ.get("DEBIAN_FRONTEND", None) == "noninteractive"
-        or not sys.stdout.isatty()
+    # NOTE: Beaker supports rich logging now.
+    if os.environ.get("BEAKER_EXPERIMENT_ID") is not None and (
+        os.environ.get("DEBIAN_FRONTEND", None) == "noninteractive" or not sys.stdout.isatty()
     ):
         handler = logging.StreamHandler(sys.stdout)
         formatter = logging.Formatter(

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -278,7 +278,7 @@ def setup_logging(
 
     handler: logging.Handler
     # NOTE: Beaker supports rich logging now.
-    if os.environ.get("BEAKER_EXPERIMENT_ID") is not None and (
+    if os.environ.get("BEAKER_EXPERIMENT_ID") is None and (
         os.environ.get("DEBIAN_FRONTEND", None) == "noninteractive" or not sys.stdout.isatty()
     ):
         handler = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
Beaker now supports logging with ANSI colors.

Test run: https://beaker.org/ex/01JRKJKK8FVJNQX9CY25PP3EB1