### PR TITLE
make LB loss with sigmoid more robust

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,7 +196,6 @@ jobs:
                     - ai2/jupiter-cirrascale-2
                     - ai2/augusta-google-1
                     - ai2/ceres-cirrascale
-                    - ai2/test-h100
                     # A100 clusters
                     - ai2/saturn-cirrascale
                     # - ai2/allennlp-elanding-a100-40g

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
 - Modify `TokenizerConfig.from_hf()` to fallback to tokenizer_config.json if config.json is not found.
+- Made MoE load balancing loss more robust.
 
 ## [v2.1.0](https://github.com/allenai/OLMo-core/releases/tag/v2.1.0) - 2025-04-14
 

--- a/src/olmo_core/nn/moe/router.py
+++ b/src/olmo_core/nn/moe/router.py
@@ -59,9 +59,6 @@ _uniform_expert_assignment: Callable[
 ] = _UniformExpertAssignment.apply  # type: ignore
 
 
-_EPSILON = torch.finfo(torch.float32).tiny  # = smallest normal value ~= 1.175e-38
-
-
 class MoERouterType(StrEnum):
     """
     An enumeration of the different MoE router implementations.
@@ -460,7 +457,7 @@ class MoERouter(nn.Module):
 
         # Make sure scores are normalized, otherwise load balancing loss doesn't work.
         if self.gating_function == MoERouterGatingFunction.sigmoid:
-            scores = scores / (scores.sum(dim=-1, keepdim=True) + _EPSILON)
+            scores = scores / scores.sum(dim=-1, keepdim=True)
 
         with torch.no_grad():
             # Histogram the expert ids to identify the number of items/tokens routed to each expert.

--- a/src/olmo_core/ops/moe.py
+++ b/src/olmo_core/ops/moe.py
@@ -3,8 +3,6 @@ from typing import Any, List, Optional, Tuple, Union
 import torch
 import torch.distributed as dist
 
-from olmo_core.utils import move_to_device
-
 try:
     from olmo_core.kernels import moe as kernels
 except (ImportError, RuntimeError):
@@ -292,9 +290,9 @@ def batched_histc(x: torch.Tensor, num_classes: int) -> torch.Tensor:
     """
     A batched version of ``torch.histc``.
     """
-    hist = move_to_device(torch.zeros((*x.shape[:-1], num_classes), dtype=x.dtype), x.device)
-    ones = move_to_device(torch.tensor(1, dtype=x.dtype), x.device).expand_as(x)
-    hist.scatter_add_(-1, ((x * num_classes) // (x.max() + 1)).long(), ones)
+    hist = torch.zeros((*x.shape[:-1], num_classes), dtype=x.dtype, device=x.device)
+    ones = torch.ones_like(x)
+    hist.scatter_add_(-1, x, ones)
     return hist
 
 

--- a/src/test/ops/moe_test.py
+++ b/src/test/ops/moe_test.py
@@ -159,5 +159,7 @@ def test_binned_scatter(sl: int, hs: int, ne: int, top_k: int):
 @pytest.mark.parametrize("device", DEVICES)
 def test_batched_histc(device: torch.device):
     x = torch.tensor([[0, 1, 1], [2, 0, 0]], device=device)
-    hist = ops.batched_histc(x, 3)
-    torch.testing.assert_close(hist, torch.tensor([[1, 2, 0], [2, 0, 1]], device=device))
+    hist = ops.batched_histc(x, 5)
+    torch.testing.assert_close(
+        hist, torch.tensor([[1, 2, 0, 0, 0], [2, 0, 1, 0, 0]], device=device)
+    )


### PR DESCRIPTION
The epsilon we used in the denominator when normalizing the sigmoid scores for the LB loss was too big (1e-20, which we took from [Megatron-LM](https://github.com/NVIDIA/Megatron-LM/blob/55c968dabb6d32cf8c21b1e3fadeea47e2ceb78d/megatron/core/transformer/moe/router.py#L195-L199)), allowing the model to hack the LB loss function by pushing sigmoid scores below epsilon.

![image](https://github.com/user-attachments/assets/498ecfa1-48b4-48b8-89b7-196e38889d4b)
