### PR TITLE
Some HF tokenizers only use tokenizer_config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Modify `TokenizerConfig.from_hf()` to fallback to tokenizer_config.json if config.json is not found.
+
 ## [v2.1.0](https://github.com/allenai/OLMo-core/releases/tag/v2.1.0) - 2025-04-14
 
 ### Added

--- a/src/olmo_core/data/tokenizer.py
+++ b/src/olmo_core/data/tokenizer.py
@@ -118,13 +118,8 @@ class TokenizerConfig(Config):
 
         try:
             config_path = cached_path(f"hf://{identifier}/config.json")
-        except:
-            try:
-                config_path = cached_path(f"hf://{identifier}/tokenizer_config.json")
-            except Exception as e:
-                raise ValueError(
-                    f"Could not find config.json or tokenizer_config.json for {identifier}"
-                ) from e
+        except FileNotFoundError:
+            config_path = cached_path(f"hf://{identifier}/tokenizer_config.json")
 
         with config_path.open() as f:
             config = json.load(f)

--- a/src/olmo_core/data/tokenizer.py
+++ b/src/olmo_core/data/tokenizer.py
@@ -116,7 +116,17 @@ class TokenizerConfig(Config):
 
         from cached_path import cached_path
 
-        with cached_path(f"hf://{identifier}/config.json").open() as f:
+        try:
+            config_path = cached_path(f"hf://{identifier}/config.json")
+        except:
+            try:
+                config_path = cached_path(f"hf://{identifier}/tokenizer_config.json")
+            except Exception as e:
+                raise ValueError(
+                    f"Could not find config.json or tokenizer_config.json for {identifier}"
+                ) from e
+
+        with config_path.open() as f:
             config = json.load(f)
 
         return cls(


### PR DESCRIPTION
This change modifies `TokenizerConfig.from_hf()` to look for both config.json and tokenizer_config.json as a fallback.

A few examples where we only have `tokenizer_config.json`:
https://huggingface.co/allenai/dolma2-tokenizer/tree/main
https://huggingface.co/Xenova/gpt-4/tree/main
https://huggingface.co/allenai/superbpe-experimental_v0.1.0/tree/main