### PR TITLE
Fix issue loading checkpoints with missing keys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,7 +196,6 @@ jobs:
                     - ai2/jupiter-cirrascale-2
                     - ai2/augusta-google-1
                     - ai2/ceres-cirrascale
-                    - ai2/test-h100
                     # A100 clusters
                     - ai2/saturn-cirrascale
                     # - ai2/allennlp-elanding-a100-40g

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
 - Modify `TokenizerConfig.from_hf()` to fallback to tokenizer_config.json if config.json is not found.
+- Fixed loading checkpoints with missing keys from transformer train modules using torch 2.7.
 
 ## [v2.1.0](https://github.com/allenai/OLMo-core/releases/tag/v2.1.0) - 2025-04-14
 

--- a/src/olmo_core/distributed/checkpoint/__init__.py
+++ b/src/olmo_core/distributed/checkpoint/__init__.py
@@ -61,6 +61,7 @@ __all__ = [
     "UnshardStrategy",
     "UnshardStrategyType",
     "prune_state_dict",
+    "merge_state_dicts",
 ]
 
 log = logging.getLogger(__name__)
@@ -800,3 +801,12 @@ def prune_state_dict(state_dict: Dict[str, Any], allowed_keys: Set[str]) -> Set[
             _get_key(state_dict, key, pop=True)
             pruned_keys.add(key)
     return pruned_keys
+
+
+def merge_state_dicts(lhs: Dict[str, Any], rhs: Dict[str, Any]):
+    """
+    Merge ``rhs`` state dict into ``lhs``.
+    """
+    keys_to_set = set(_iter_flat_keys(rhs)) - set(_iter_flat_keys(lhs))
+    for key in keys_to_set:
+        _set_key(lhs, key, _get_key(rhs, key))

--- a/src/olmo_core/distributed/checkpoint/__init__.py
+++ b/src/olmo_core/distributed/checkpoint/__init__.py
@@ -60,6 +60,7 @@ __all__ = [
     "get_checkpoint_metadata",
     "UnshardStrategy",
     "UnshardStrategyType",
+    "swap_param_keys",
     "prune_state_dict",
     "merge_state_dicts",
 ]
@@ -335,7 +336,7 @@ def load_model_and_optim_state(
     metadata = reader.read_metadata()
 
     if key_mapping is not None:
-        _swap_param_keys(state_dict, key_mapping, metadata=metadata)
+        swap_param_keys(state_dict, key_mapping, metadata=metadata)
 
     dist_cp.load(
         state_dict,
@@ -345,7 +346,7 @@ def load_model_and_optim_state(
     )
 
     if key_mapping is not None:
-        _swap_param_keys(state_dict, key_mapping, reverse=True, quiet=True)
+        swap_param_keys(state_dict, key_mapping, reverse=True, quiet=True)
 
     dist_cp_sd.set_model_state_dict(
         model, state_dict["model"], options=dist_cp_sd.StateDictOptions(strict=strict)
@@ -685,7 +686,7 @@ def _prepare_state_dict(
     return state_dict
 
 
-def _swap_param_keys(
+def swap_param_keys(
     state_dict: Dict[str, Any],
     key_mapping: Dict[str, str],
     metadata: Optional[Metadata] = None,

--- a/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
@@ -16,9 +16,9 @@ from torch.optim import Optimizer
 
 from olmo_core.data.utils import get_labels
 from olmo_core.distributed.checkpoint import (
-    _swap_param_keys,
     merge_state_dicts,
     prune_state_dict,
+    swap_param_keys,
 )
 from olmo_core.distributed.parallel import (
     PipelineSchedule,
@@ -306,7 +306,7 @@ class TransformerPipelineTrainModule(TrainModule):
 
         state_dict = self._get_state_dict(load_opts, optim=optim)
         if self.load_key_mapping is not None:
-            _swap_param_keys(state_dict, self.load_key_mapping, metadata=metadata)
+            swap_param_keys(state_dict, self.load_key_mapping, metadata=metadata)
 
         if not load_opts.strict:
             # Remove any keys in the 'state_dict' that are not present in the checkpoint.
@@ -323,7 +323,7 @@ class TransformerPipelineTrainModule(TrainModule):
         load_optim = "optim" in state_dict
 
         if self.load_key_mapping is not None:
-            _swap_param_keys(state_dict, self.load_key_mapping, reverse=True, quiet=True)
+            swap_param_keys(state_dict, self.load_key_mapping, reverse=True, quiet=True)
 
         # NOTE: `dist_cp_sd.set_(model|optimizer)_state_dict()` doesn't respect `strict=False`
         # option, so we have to handle that on our own.

--- a/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
@@ -15,7 +15,7 @@ from torch.distributed.tensor import DTensor
 from torch.optim import Optimizer
 
 from olmo_core.data.utils import get_labels
-from olmo_core.distributed.checkpoint import _swap_param_keys
+from olmo_core.distributed.checkpoint import _swap_param_keys, prune_state_dict
 from olmo_core.distributed.parallel import (
     PipelineSchedule,
     build_world_mesh,
@@ -303,6 +303,12 @@ class TransformerPipelineTrainModule(TrainModule):
         state_dict = self._get_state_dict(load_opts, optim=optim)
         if self.load_key_mapping is not None:
             _swap_param_keys(state_dict, self.load_key_mapping, metadata=metadata)
+
+        if not load_opts.strict:
+            # Remove any keys in the 'state_dict' that are not present in the checkpoint.
+            pruned_keys = prune_state_dict(state_dict, set(metadata.state_dict_metadata.keys()))
+            if pruned_keys:
+                log.warning(f"Checkpoint is missing the following keys: {pruned_keys}")
 
         return state_dict
 

--- a/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
@@ -326,7 +326,7 @@ class TransformerPipelineTrainModule(TrainModule):
             swap_param_keys(state_dict, self.load_key_mapping, reverse=True, quiet=True)
 
         # NOTE: `dist_cp_sd.set_(model|optimizer)_state_dict()` doesn't respect `strict=False`
-        # option, so we have to handle that on our own.
+        # option with missing keys, so we have to handle that on our own.
         if not self.state_dict_load_opts.strict:
             flatten_optimizer_state_dict = (
                 False if not load_optim else ("state" not in state_dict["optim"])

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -18,9 +18,9 @@ from torch.optim import Optimizer
 
 from olmo_core.data.utils import get_labels, split_batch
 from olmo_core.distributed.checkpoint import (
-    _swap_param_keys,
     merge_state_dicts,
     prune_state_dict,
+    swap_param_keys,
 )
 from olmo_core.distributed.parallel import (
     DataParallelType,
@@ -263,7 +263,7 @@ class TransformerTrainModule(TrainModule):
 
         state_dict = self._get_state_dict(load_opts, optim=optim)
         if self.load_key_mapping is not None:
-            _swap_param_keys(state_dict, self.load_key_mapping, metadata=metadata)
+            swap_param_keys(state_dict, self.load_key_mapping, metadata=metadata)
 
         if not load_opts.strict:
             # Remove any keys in the 'state_dict' that are not present in the checkpoint.
@@ -280,7 +280,7 @@ class TransformerTrainModule(TrainModule):
         load_optim = "optim" in state_dict
 
         if self.load_key_mapping is not None:
-            _swap_param_keys(state_dict, self.load_key_mapping, reverse=True, quiet=True)
+            swap_param_keys(state_dict, self.load_key_mapping, reverse=True, quiet=True)
 
         # NOTE: `dist_cp_sd.set_(model|optimizer)_state_dict()` doesn't respect `strict=False`
         # option, so we have to handle that on our own.

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -17,7 +17,11 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import Optimizer
 
 from olmo_core.data.utils import get_labels, split_batch
-from olmo_core.distributed.checkpoint import _swap_param_keys, prune_state_dict
+from olmo_core.distributed.checkpoint import (
+    _swap_param_keys,
+    merge_state_dicts,
+    prune_state_dict,
+)
 from olmo_core.distributed.parallel import (
     DataParallelType,
     build_world_mesh,
@@ -273,15 +277,30 @@ class TransformerTrainModule(TrainModule):
         return self._get_state_dict(self.state_dict_save_opts, optim=optim)
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        load_optim = "optim" in state_dict
+
         if self.load_key_mapping is not None:
             _swap_param_keys(state_dict, self.load_key_mapping, reverse=True, quiet=True)
+
+        # NOTE: `dist_cp_sd.set_(model|optimizer)_state_dict()` doesn't respect `strict=False`
+        # option, so we have to handle that on our own.
+        if not self.state_dict_load_opts.strict:
+            flatten_optimizer_state_dict = (
+                False if not load_optim else ("state" not in state_dict["optim"])
+            )
+            load_opts = replace(
+                self.state_dict_load_opts, flatten_optimizer_state_dict=flatten_optimizer_state_dict
+            )
+            full_state_dict = self._get_state_dict(load_opts, optim=load_optim)
+            merge_state_dicts(state_dict, full_state_dict)
+
         dist_cp_sd.set_model_state_dict(
             self.model,
             state_dict["model"],
             options=self.state_dict_load_opts,
         )
         gc_cuda()
-        if "optim" in state_dict:
+        if load_optim:
             dist_cp_sd.set_optimizer_state_dict(
                 self.model,
                 self.optim,

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -283,7 +283,7 @@ class TransformerTrainModule(TrainModule):
             swap_param_keys(state_dict, self.load_key_mapping, reverse=True, quiet=True)
 
         # NOTE: `dist_cp_sd.set_(model|optimizer)_state_dict()` doesn't respect `strict=False`
-        # option, so we have to handle that on our own.
+        # option with missing keys, so we have to handle that on our own.
         if not self.state_dict_load_opts.strict:
             flatten_optimizer_state_dict = (
                 False if not load_optim else ("state" not in state_dict["optim"])

--- a/src/test/distributed/checkpoint_test.py
+++ b/src/test/distributed/checkpoint_test.py
@@ -13,7 +13,6 @@ from torch.distributed.tensor.parallel import (
 
 from olmo_core.distributed.checkpoint import (
     UnshardStrategy,
-    _iter_flat_keys,
     async_save_model_and_optim_state,
     load_keys,
     load_model_and_optim_state,

--- a/src/test/distributed/checkpoint_test.py
+++ b/src/test/distributed/checkpoint_test.py
@@ -16,6 +16,7 @@ from olmo_core.distributed.checkpoint import (
     async_save_model_and_optim_state,
     load_keys,
     load_model_and_optim_state,
+    merge_state_dicts,
     prune_state_dict,
     save_model_and_optim_state,
     save_state_dict,
@@ -482,3 +483,18 @@ def test_prune_state_dict():
             "c": 1,
         },
     }
+
+
+def test_merge_state_dicts():
+    state_dict = {
+        "model": {
+            "a": 1,
+            "b": 2,
+        },
+        "optim": {
+            "c": 1,
+            "d": 2,
+        },
+    }
+    merge_state_dicts(state_dict, {"model": {"e": 3}})
+    assert state_dict["model"]["e"] == 3


### PR DESCRIPTION
Somethings changed in the recent RC of torch 2.7 that broke this. 