### PR TITLE
More fixes for `LMHead` with TP

### DIFF
--- a/src/olmo_core/nn/lm_head.py
+++ b/src/olmo_core/nn/lm_head.py
@@ -350,12 +350,12 @@ class LMHead(nn.Module):
                 parallelize_plan=SequenceParallel(),
             )
 
-        #  if self.loss_implementation != LMLossImplementation.fused_linear:
-        parallelize_module(
-            module=self.w_out,
-            device_mesh=tp_mesh,
-            parallelize_plan=ColwiseParallel(output_layouts=Shard(1), use_local_output=False),
-        )
+        if self.loss_implementation != LMLossImplementation.fused_linear:
+            parallelize_module(
+                module=self.w_out,
+                device_mesh=tp_mesh,
+                parallelize_plan=ColwiseParallel(output_layouts=Shard(1), use_local_output=False),
+            )
 
         self._tp_mesh = tp_mesh
 

--- a/src/olmo_core/nn/lm_head.py
+++ b/src/olmo_core/nn/lm_head.py
@@ -254,13 +254,7 @@ class LMHead(nn.Module):
                 compute_z_loss=z_loss_multiplier is not None,
                 z_loss_multiplier=z_loss_multiplier or 1e-4,
             )
-            #  loss = self._finalize_loss(
-            #      loss, B, loss_reduction=loss_reduction, loss_div_factor=loss_div_factor
-            #  )
             if z_loss is not None:
-                #  z_loss = self._finalize_loss(
-                #      z_loss, B, loss_reduction=loss_reduction, loss_div_factor=loss_div_factor
-                #  )
                 ce_loss = loss - z_loss
             else:
                 ce_loss = loss

--- a/src/olmo_core/nn/lm_head.py
+++ b/src/olmo_core/nn/lm_head.py
@@ -331,13 +331,12 @@ class LMHead(nn.Module):
             device_mesh=tp_mesh,
             parallelize_plan=PrepareModuleInput(
                 input_layouts=None if input_layouts is None else input_layouts[0],
-                desired_input_layouts=Shard(1) if self.norm is not None else Replicate(),
-                #  desired_input_layouts=Shard(1)
-                #  if (
-                #      self.loss_implementation == LMLossImplementation.fused_linear
-                #      or self.norm is not None
-                #  )
-                #  else Replicate(),
+                desired_input_layouts=Shard(1)
+                if (
+                    self.loss_implementation == LMLossImplementation.fused_linear
+                    or self.norm is not None
+                )
+                else Replicate(),
                 input_kwarg_layouts=None if input_layouts is None else {"labels": input_layouts[1]},
                 desired_input_kwarg_layouts={"labels": Shard(1)},
             ),

--- a/src/olmo_core/nn/lm_head.py
+++ b/src/olmo_core/nn/lm_head.py
@@ -368,7 +368,13 @@ class LMHead(nn.Module):
                 parallelize_plan=SequenceParallel(),
             )
 
-        if self.loss_implementation != LMLossImplementation.fused_linear:
+        if self.loss_implementation == LMLossImplementation.fused_linear:
+            parallelize_module(
+                module=self.w_out,
+                device_mesh=tp_mesh,
+                parallelize_plan=SequenceParallel(),
+            )
+        else:
             parallelize_module(
                 module=self.w_out,
                 device_mesh=tp_mesh,

--- a/src/olmo_core/nn/lm_head.py
+++ b/src/olmo_core/nn/lm_head.py
@@ -234,6 +234,13 @@ class LMHead(nn.Module):
                 compute_z_loss=z_loss_multiplier is not None,
                 z_loss_multiplier=z_loss_multiplier or 1e-4,
             )
+            ce_loss = self._finalize_loss(
+                ce_loss, B, loss_reduction=loss_reduction, loss_div_factor=loss_div_factor
+            )
+            if z_loss is not None:
+                z_loss = self._finalize_loss(
+                    z_loss, B, loss_reduction=loss_reduction, loss_div_factor=loss_div_factor
+                )
         elif self.loss_implementation == LMLossImplementation.fused_linear:
             logits = None
             loss, z_loss = fused_linear_cross_entropy_loss(
@@ -266,14 +273,6 @@ class LMHead(nn.Module):
         elif return_logits is True and logits is None:
             raise RuntimeError(
                 f"'return_logits=True' is not compatible '{self.loss_implementation}' loss implementation"
-            )
-
-        ce_loss = self._finalize_loss(
-            ce_loss, B, loss_reduction=loss_reduction, loss_div_factor=loss_div_factor
-        )
-        if z_loss is not None:
-            z_loss = self._finalize_loss(
-                z_loss, B, loss_reduction=loss_reduction, loss_div_factor=loss_div_factor
             )
 
         return LMOutputWithLoss(logits=logits, loss=None, ce_loss=ce_loss, z_loss=z_loss)

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -358,9 +358,6 @@ class TransformerTrainModule(TrainModule):
                     return_logits=False,
                     **model_kwargs,
                 )
-                #  loss = ce_loss
-                #  if z_loss is not None:
-                #      loss += z_loss
 
                 # Update total batch CE and Z loss.
                 ce_batch_loss += get_local_tensor(ce_loss.detach())

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -358,6 +358,7 @@ class TransformerTrainModule(TrainModule):
                     return_logits=False,
                     **model_kwargs,
                 )
+                log.info(f"{loss=}, {ce_loss=}, {z_loss=}")
 
                 # Update total batch CE and Z loss.
                 ce_batch_loss += get_local_tensor(ce_loss.detach())

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -358,9 +358,9 @@ class TransformerTrainModule(TrainModule):
                     return_logits=False,
                     **model_kwargs,
                 )
-                loss = ce_loss
-                if z_loss is not None:
-                    loss += z_loss
+                #  loss = ce_loss
+                #  if z_loss is not None:
+                #      loss += z_loss
 
                 # Update total batch CE and Z loss.
                 ce_batch_loss += get_local_tensor(ce_loss.detach())

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -358,7 +358,9 @@ class TransformerTrainModule(TrainModule):
                     return_logits=False,
                     **model_kwargs,
                 )
-                log.info(f"{loss=}, {ce_loss=}, {z_loss=}")
+                loss = ce_loss
+                if z_loss is not None:
+                    loss += z_loss
 
                 # Update total batch CE and Z loss.
                 ce_batch_loss += get_local_tensor(ce_loss.detach())

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -856,7 +856,7 @@ class Trainer:
         if not isinstance(value, torch.Tensor):
             value = torch.tensor(value)
         else:
-            value = get_local_tensor(value).float()
+            value = get_local_tensor(value.detach()).float()
 
         if self.global_step not in self._metrics:
             self._metrics[self.global_step] = OrderedDict()

--- a/src/test/nn/lm_head_test.py
+++ b/src/test/nn/lm_head_test.py
@@ -119,8 +119,8 @@ def run_lm_head_tp(
     )
     _, local_loss, local_ce_loss, local_z_loss = local_output
 
-    # The loss for optimizing ('local_loss') will have been reduced across the TP group, but not losses
-    # logging ('local_ce_loss' and 'local_z_loss').
+    # The loss for optimizing ('local_loss') will have been reduced across the TP group, but not the losses
+    # for logging ('local_ce_loss' and 'local_z_loss').
     dist.all_reduce(local_ce_loss)
     local_ce_loss.div_(get_world_size())
     dist.all_reduce(local_z_loss)

--- a/src/test/nn/lm_head_test.py
+++ b/src/test/nn/lm_head_test.py
@@ -118,6 +118,14 @@ def run_lm_head_tp(
         z_loss_multiplier=z_loss_multiplier,
     )
     _, local_loss, local_ce_loss, local_z_loss = local_output
+
+    # The loss for optimizing ('local_loss') will have been reduced across the TP group, but not losses
+    # logging ('local_ce_loss' and 'local_z_loss').
+    dist.all_reduce(local_ce_loss)
+    local_ce_loss.div_(get_world_size())
+    dist.all_reduce(local_z_loss)
+    local_z_loss.div_(get_world_size())
+
     local_loss.backward()
     assert local_inputs.grad is not None
 


### PR DESCRIPTION
There were 2 more issues with the `LMHead` when TP is enabled:

1. An unexpected bug with the default loss implementation introduced by #261. I don't completely understand the issue, but it had to do with combining CE loss and Z loss as `DTensors` across the TP group within the `LMHead` module. When I changed that to combine them as local, non-distributed tensors, everything worked again. See [this beaker run](https://beaker.allen.ai/orgs/ai2/workspaces/long-contexts/work/01JSWWW8YSE524MRSFNQYNQTP3?taskId=01JSWWW8YZB1KE7NG5ZSPHXCDJ&jobId=01JSWWW93H0MW7NVHXJBJ7BCXQ).
2. An issue with the fused-linear loss implementation that existed prior to #261. The problem was that the `w_out` linear module wasn't treated with any TP wrapper, so FSDP would complain that the parameters of `w_out` were only placed across the DP dimension of the device mesh, while every other parameter was placed across both DP and TP dimensions. See [this beaker run](https://beaker.allen.ai/orgs/ai2/workspaces/long-contexts/work/01JSX066ZAMZEZCKH5499ZSFEV?taskId=01JSX066ZG5DPGKX0XXYBSCVSX&jobId=01JSX0672ZV9QBEWFPTPDTAXN1). This was an easy fix: https://github.com/allenai/OLMo-core/pull/264#discussion_r2064063805