### PR TITLE
Save metadata to Beaker results dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added sliding window attention as a feature
 - Added `BatchSizeSchedulerCallback` for setting a batch size schedule over the course of a training run.
 - The `BeakerCallback` will save the config and Python requirements to the results dataset.
+- Added `from_file` method to `Config` class.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a "interleaved" numpy FSL variant that interleaves several documents into sequences following the work from [LongSkywork: A Training Recipe for Efficiently Extending Context Length in Large Language Models](https://arxiv.org/pdf/2406.00605).
 - Added sliding window attention as a feature
 - Added `BatchSizeSchedulerCallback` for setting a batch size schedule over the course of a training run.
+- The `BeakerCallback` will save the config and Python requirements to the results dataset.
 
 ### Changed
 
 - Output of `LMHead` when `labels` is passed as input is now a 4-tuple instead of a 3-tuple, with `(logits, loss, ce_loss, z_loss)`, where `loss` is the combined loss (`ce_loss + z_loss`).
+- The `ConfigSaver` callback will automatically set the config to save for other callbacks (`WandBCallback`, `CometCallback`, and `BeakerCallback` as of now).
 
 ### Fixed
 

--- a/src/examples/llama/train.py
+++ b/src/examples/llama/train.py
@@ -197,8 +197,6 @@ def main(run_name: str, overrides: List[str]):
 
     # Save config to W&B and each checkpoint dir.
     config_dict = config.as_config_dict()
-    cast(CometCallback, trainer.callbacks["comet"]).config = config_dict
-    cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict
     cast(ConfigSaverCallback, trainer.callbacks["config_saver"]).config = config_dict
 
     # Train.

--- a/src/examples/moe/train.py
+++ b/src/examples/moe/train.py
@@ -195,8 +195,6 @@ def main(run_name: str, overrides: List[str]):
 
     # Save config to W&B and each checkpoint dir.
     config_dict = config.as_config_dict()
-    cast(CometCallback, trainer.callbacks["comet"]).config = config_dict
-    cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict
     cast(ConfigSaverCallback, trainer.callbacks["config_saver"]).config = config_dict
 
     # Train.

--- a/src/examples/ngpt/train.py
+++ b/src/examples/ngpt/train.py
@@ -173,8 +173,6 @@ def main(run_name: str, overrides: List[str]):
 
     # Save config to W&B and each checkpoint dir.
     config_dict = config.as_config_dict()
-    cast(CometCallback, trainer.callbacks["comet"]).config = config_dict
-    cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict
     cast(ConfigSaverCallback, trainer.callbacks["config_saver"]).config = config_dict
 
     # Train.

--- a/src/olmo_core/config.py
+++ b/src/olmo_core/config.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass, fields, is_dataclass, replace
 from enum import Enum
 from typing import (
@@ -14,10 +15,12 @@ from typing import (
 )
 
 import torch
+from cached_path import cached_path
 from omegaconf import OmegaConf as om
 from omegaconf.errors import OmegaConfBaseException
 from typing_extensions import Self
 
+from .aliases import PathOrStr
 from .exceptions import OLMoConfigurationError
 
 
@@ -255,6 +258,12 @@ class Config:
             return cast(C, om.to_object(conf))
         except OmegaConfBaseException as e:
             raise OLMoConfigurationError(str(e))
+
+    @classmethod
+    def from_file(cls: Type[C], path: PathOrStr, overrides: Optional[List[str]] = None) -> C:
+        with cached_path(path).open() as f:
+            config_dict = json.load(f)
+        return cls.from_dict(config_dict, overrides=overrides)
 
 
 def _clean_opts(opts: List[str]) -> List[str]:

--- a/src/olmo_core/internal/experiment.py
+++ b/src/olmo_core/internal/experiment.py
@@ -28,7 +28,6 @@ from olmo_core.train import (
 from olmo_core.train.callbacks import (
     BeakerCallback,
     Callback,
-    CometCallback,
     ConfigSaverCallback,
     DownstreamEvaluatorCallbackConfig,
     GarbageCollectorCallback,
@@ -36,7 +35,6 @@ from olmo_core.train.callbacks import (
     LMEvaluatorCallbackConfig,
     ProfilerCallback,
     SlackNotifierCallback,
-    WandBCallback,
 )
 from olmo_core.train.train_module import TransformerTrainModuleConfig
 from olmo_core.utils import prepare_cli_environment, seed_all
@@ -312,8 +310,6 @@ def train(config: ExperimentConfig):
 
     # Record the config to W&B/Comet and each checkpoint dir.
     config_dict = config.as_config_dict()
-    cast(CometCallback, trainer.callbacks["comet"]).config = config_dict
-    cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict
     cast(ConfigSaverCallback, trainer.callbacks["config_saver"]).config = config_dict
 
     # Train.

--- a/src/olmo_core/internal/model_ladder.py
+++ b/src/olmo_core/internal/model_ladder.py
@@ -16,7 +16,7 @@ from olmo_core.train import (
     prepare_training_environment,
     teardown_training_environment,
 )
-from olmo_core.train.callbacks import CometCallback, ConfigSaverCallback, WandBCallback
+from olmo_core.train.callbacks import ConfigSaverCallback
 from olmo_core.train.train_module import TransformerTrainModuleConfig
 from olmo_core.utils import get_default_device, prepare_cli_environment, seed_all
 
@@ -90,8 +90,6 @@ class SubCmd(StrEnum):
 
                 # Record the config to W&B/Comet and each checkpoint dir.
                 config_dict = config.as_config_dict()
-                cast(CometCallback, trainer.callbacks["comet"]).config = config_dict
-                cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict
                 cast(ConfigSaverCallback, trainer.callbacks["config_saver"]).config = config_dict
 
                 # Train.

--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -30,6 +30,7 @@ from rich.prompt import Confirm
 from ..config import Config, StrEnum
 from ..distributed.utils import OLMO_SHARED_FS_ENV_VAR
 from ..exceptions import BeakerExperimentFailedError, OLMoConfigurationError
+from ..train.callbacks.beaker import BEAKER_RESULT_DIR
 from ..utils import LOG_FILTER_TYPE_ENV_VAR, LogFilterType
 from ..version import VERSION
 from .utils import GIT_BRANCH_ENV_VAR, GIT_REF_ENV_VAR, GIT_REPO_URL_ENV_VAR, GitConfig
@@ -233,6 +234,11 @@ class BeakerLaunchConfig(Config):
     If not set, this will be initialized automatically from your working directory.
     """
 
+    result_dir: str = BEAKER_RESULT_DIR
+    """
+    The directory of the Beaker results dataset.
+    """
+
     # NOTE: don't assign a type here because omegaconf can't validate arbitrary classes
     #  _beaker: Optional[Beaker] = None
     _beaker = None
@@ -416,6 +422,7 @@ class BeakerLaunchConfig(Config):
                 propagate_preemption=True if self.num_nodes > 1 else None,
                 synchronized_start_timeout="90m" if self.num_nodes > 1 else None,
                 resources=TaskResources(gpu_count=self.num_gpus, shared_memory=self.shared_memory),
+                result_path=self.result_dir,
             )
             .with_dataset("/olmo-core", beaker=entrypoint_dataset.id)
             .with_constraint(cluster=self.clusters)

--- a/src/olmo_core/train/callbacks/beaker.py
+++ b/src/olmo_core/train/callbacks/beaker.py
@@ -93,6 +93,7 @@ class BeakerCallback(Callback):
             try:
                 with requirements_path.open("w") as requirements_file:
                     requirements_file.write(f"# python={platform.python_version()}\n")
+                with requirements_path.open("a") as requirements_file:
                     subprocess.call(
                         ["pip", "freeze"],
                         stdout=requirements_file,

--- a/src/olmo_core/train/callbacks/beaker.py
+++ b/src/olmo_core/train/callbacks/beaker.py
@@ -1,8 +1,12 @@
+import json
 import logging
 import os
+import platform
+import subprocess
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Optional
 
 from olmo_core.distributed.utils import get_rank
 from olmo_core.exceptions import OLMoEnvironmentError
@@ -19,6 +23,7 @@ log = logging.getLogger(__name__)
 
 
 BEAKER_EXPERIMENT_ID_ENV_VAR = "BEAKER_EXPERIMENT_ID"
+BEAKER_RESULT_DIR = "/results"
 
 
 @dataclass
@@ -32,6 +37,14 @@ class BeakerCallback(Callback):
     update_interval: Optional[int] = None
     description: Optional[str] = None
     enabled: Optional[bool] = None
+    config: Optional[Dict[str, Any]] = None
+    """
+    A JSON-serializable config to save to the results dataset as ``config.json``.
+    """
+    result_dir: str = BEAKER_RESULT_DIR
+    """
+    The directory of the Beaker results dataset where the config and other data will be saved.
+    """
 
     _client = None
     _url = None
@@ -63,6 +76,31 @@ class BeakerCallback(Callback):
             log.info(
                 f"Running in Beaker experiment {self.client.experiment.url(self.experiment_id)}"
             )
+
+            # Ensure result dataset directory exists.
+            result_dir = Path(self.result_dir) / "olmo-core"
+            result_dir.mkdir(parents=True, exist_ok=True)
+
+            # Save config to result dir.
+            if self.config is not None:
+                config_path = result_dir / "config.json"
+                with config_path.open("w") as config_file:
+                    log.info(f"Saving config to '{config_path}'")
+                    json.dump(self.config, config_file)
+
+            # Try saving Python requirements.
+            requirements_path = result_dir / "requirements.txt"
+            try:
+                with requirements_path.open("w") as requirements_file:
+                    requirements_file.write(f"# python={platform.python_version()}\n")
+                    subprocess.call(
+                        ["pip", "freeze"],
+                        stdout=requirements_file,
+                        stderr=subprocess.DEVNULL,
+                        timeout=10,
+                    )
+            except Exception as e:
+                log.exception(f"Error saving Python packages: {e}")
 
             # Try to get W&B/Comet URL of experiment.
             for callback in self.trainer.callbacks.values():

--- a/src/scripts/official/OLMo-2-0325-32B-anneal.py
+++ b/src/scripts/official/OLMo-2-0325-32B-anneal.py
@@ -323,8 +323,6 @@ def train(checkpoint: str, config: AnnealingConfig):
 
     # Record the config to W&B/Comet and each checkpoint dir.
     config_dict = config.as_config_dict()
-    cast(CometCallback, trainer.callbacks["comet"]).config = config_dict
-    cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict
     cast(ConfigSaverCallback, trainer.callbacks["config_saver"]).config = config_dict
 
     # Try loading a checkpoint from the save folder, otherwise start from the pretraining checkpoint.

--- a/src/scripts/official/OLMo-2-0325-32B-train.py
+++ b/src/scripts/official/OLMo-2-0325-32B-train.py
@@ -271,8 +271,6 @@ def main(run_name: str, overrides: List[str]):
 
     # Save config to W&B and each checkpoint dir.
     config_dict = config.as_config_dict()
-    cast(CometCallback, trainer.callbacks["comet"]).config = config_dict
-    cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict
     cast(ConfigSaverCallback, trainer.callbacks["config_saver"]).config = config_dict
 
     # Train.

--- a/src/scripts/train/template.py
+++ b/src/scripts/train/template.py
@@ -212,8 +212,6 @@ def train(config: ExperimentConfig):
 
     # Save config to W&B and each checkpoint dir.
     config_dict = config.as_config_dict()
-    cast(CometCallback, trainer.callbacks["comet"]).config = config_dict
-    cast(WandBCallback, trainer.callbacks["wandb"]).config = config_dict
     cast(ConfigSaverCallback, trainer.callbacks["config_saver"]).config = config_dict
 
     # Maybe load from existing checkpoint.


### PR DESCRIPTION
Changes:
- The `ConfigSaver` callback will automatically set the config to save for other callbacks.
- The Beaker callback will save the config and Python requirements to the Beaker results dataset.
- Adds a `Config.from_file()` convenience method.

Example run here: https://beaker.allen.ai/orgs/ai2/workspaces/OLMo-pretraining-stability/work/01JV58EEGHW87ETE470FKFZEQQ?taskId=01JV58EEHKN7WH9NSE5WV9PQHE&jobId=01JV58EEN499SASASGQPHBHNPB

Then, given the result dataset ID, the config can easily be loaded like this:

```python
from olmo_core.internal.experiment import ExperimentConfig
from olmo_core.utils import prepare_cli_environment

prepare_cli_environment()

result_dataset = "01JV58EEHQ4F43E3S9AHDYT6DV"
config = ExperimentConfig.from_file(f"beaker://{result_dataset}/olmo-core/config.json")
```

Or, given the experiment name or ID, you could do this:

```python
from beaker import Beaker
from olmo_core.internal.experiment import ExperimentConfig
from olmo_core.utils import prepare_cli_environment

prepare_cli_environment()

beaker = Beaker.from_env()
dataset = beaker.experiment.results("petew/testing123-train-43ce019a")
config = ExperimentConfig.from_file(f"beaker://{dataset.id}/olmo-core/config.json")
```