### PR TITLE
Support lower precisions for conversion to HF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BatchSizeSchedulerCallback` for setting a batch size schedule over the course of a training run.
 - The `BeakerCallback` will save the config and Python requirements to the results dataset.
 - Added `from_file` method to `Config` class.
+- Added support for converting to HF models in lower precisions.
 
 ### Changed
 
 - Output of `LMHead` when `labels` is passed as input is now a 4-tuple instead of a 3-tuple, with `(logits, loss, ce_loss, z_loss)`, where `loss` is the combined loss (`ce_loss + z_loss`).
 - The `ConfigSaver` callback will automatically set the config to save for other callbacks (`WandBCallback`, `CometCallback`, and `BeakerCallback` as of now).
+- Changed default precision of converted HF models in `src/examples/huggingface/convert_checkpoint_to_hf.py` to bfloat16.
 
 ### Fixed
 

--- a/src/examples/huggingface/convert_checkpoint_from_hf.py
+++ b/src/examples/huggingface/convert_checkpoint_from_hf.py
@@ -252,13 +252,10 @@ def validate_conversion(
             .replace(".weight", ""): mapping.dest_keys[0]
             .replace(".weight", "")
             for mapping in state_mapping
-            if len(mapping.source_keys) == 1
-            and len(mapping.dest_keys) == 1
-            and mapping.source_keys[0].endswith(".weight")
-            and mapping.dest_keys[0].endswith(".weight")
+            if len(mapping.source_keys) == 1 and len(mapping.dest_keys) == 1
         }
 
-        log.info(f"mapping: {simple_key_mapping}")
+        log.info(f"simple mapping: {simple_key_mapping}")
         log.info(f"hf_state keys: {hf_state.keys()}")
         log.info(f"olmo_core_state keys: {olmo_core_state.keys()}")
 
@@ -277,9 +274,20 @@ def validate_conversion(
                 log.info(
                     f"{hf_state_name}, {olmo_core_state_name} shape mismatch: {hf_tensor.shape} {olmo_core_tensor.shape}"
                 )
-            else:
+            if olmo_core_tensor.dtype != hf_tensor.dtype:
                 log.info(
-                    f"{hf_state_name}, {olmo_core_state_name} norm diff: {torch.norm(olmo_core_tensor - hf_tensor)}"
+                    f"{hf_state_name}, {olmo_core_state_name} dtype mismatch: {hf_tensor.dtype} {olmo_core_tensor.dtype}"
+                )
+            if len(olmo_core_tensor.shape) == len(hf_tensor.shape):
+                common_shape = tuple(
+                    min(olmo_core_dim, hf_dim)
+                    for olmo_core_dim, hf_dim in zip(olmo_core_tensor.shape, hf_tensor.shape)
+                )
+                for i, dim in enumerate(common_shape):
+                    olmo_core_tensor = olmo_core_tensor.narrow(i, 0, dim)
+                    hf_tensor = hf_tensor.narrow(i, 0, dim)
+                log.info(
+                    f"{hf_state_name}, {olmo_core_state_name} element diff abs mean: {(olmo_core_tensor - hf_tensor).float().abs().mean()}"
                 )
 
     torch.testing.assert_close(hf_logits[..., :vocab_size], logits[..., :vocab_size])

--- a/src/examples/huggingface/convert_checkpoint_to_hf.py
+++ b/src/examples/huggingface/convert_checkpoint_to_hf.py
@@ -239,7 +239,10 @@ def validate_conversion(
                     f"{olmo_core_state_name}, {hf_state_name} dtype mismatch: {olmo_core_tensor.dtype} {hf_tensor.dtype}"
                 )
             if len(olmo_core_tensor.shape) == len(hf_tensor.shape):
-                common_shape = tuple(min(olmo_core_dim, hf_dim) for olmo_core_dim, hf_dim in zip(olmo_core_tensor.shape, hf_tensor.shape))
+                common_shape = tuple(
+                    min(olmo_core_dim, hf_dim)
+                    for olmo_core_dim, hf_dim in zip(olmo_core_tensor.shape, hf_tensor.shape)
+                )
                 for i, dim in enumerate(common_shape):
                     olmo_core_tensor = olmo_core_tensor.narrow(i, 0, dim)
                     hf_tensor = hf_tensor.narrow(i, 0, dim)
@@ -247,7 +250,9 @@ def validate_conversion(
                     f"{olmo_core_state_name}, {hf_state_name} element diff abs mean: {(olmo_core_tensor - hf_tensor).float().abs().mean()}"
                 )
 
-    torch.testing.assert_close(hf_logits[..., :vocab_size].float(), logits[..., :vocab_size].float(), rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(
+        hf_logits[..., :vocab_size].float(), logits[..., :vocab_size].float(), rtol=1e-4, atol=1e-4
+    )
 
 
 def load_config(checkpoint_input_dir: PathOrStr) -> Optional[dict]:

--- a/src/examples/huggingface/convert_checkpoint_to_hf.py
+++ b/src/examples/huggingface/convert_checkpoint_to_hf.py
@@ -19,6 +19,7 @@ from cached_path import cached_path
 from transformers import AutoConfig, AutoModelForCausalLM
 
 from olmo_core.aliases import PathOrStr
+from olmo_core.config import DType
 from olmo_core.data.tokenizer import TokenizerConfig
 from olmo_core.distributed.checkpoint import load_model_and_optim_state
 from olmo_core.io import file_exists, join_path
@@ -38,6 +39,7 @@ def convert_checkpoint_to_hf(
     transformer_config_dict: Dict[str, Any],
     tokenizer_config_dict: Dict[str, Any],
     *,
+    dtype: Optional[DType] = None,
     max_sequence_length: int = -1,
     validate: bool = True,
     debug: bool = False,
@@ -91,6 +93,7 @@ def convert_checkpoint_to_hf(
             output_path,
             model_state_dict,
             model,
+            dtype=dtype,
             vocab_size=vocab_size,
             work_dir=work_dir,
             save_overwrite=True,
@@ -110,7 +113,7 @@ def convert_checkpoint_to_hf(
     if validate:
         log.info("Validating converted model")
         validate_conversion(
-            output_path, model, tokenizer_config.vocab_size, debug=debug, device=device
+            output_path, model, tokenizer_config.vocab_size, debug=debug, dtype=dtype, device=device
         )
         log.info("Validation completed successful")
 
@@ -133,13 +136,13 @@ def _register_debug_hooks(hf_model: torch.nn.Module, model: Transformer):
             input = args[0].detach()
             for i, size in enumerate(input.shape):
                 input = input.narrow(i, 0, min(size, MAX_DIM_SIZE))
-            debug_state[state_name] = (len(debug_state), input.float())
+            debug_state[state_name] = (len(debug_state), input)
         if isinstance(output, torch.Tensor):
             state_name = f"{name}|output"
             output = output.detach()
             for i, size in enumerate(output.shape):
                 output = output.narrow(i, 0, min(size, MAX_DIM_SIZE))
-            debug_state[state_name] = (len(debug_state), output.float())
+            debug_state[state_name] = (len(debug_state), output)
 
     for name, module in model.named_modules():
         module.register_forward_hook(partial(module_hook, olmo_core_debug_state, name))
@@ -154,6 +157,7 @@ def validate_conversion(
     model: Transformer,
     vocab_size: int,
     debug: bool = False,
+    dtype: DType | None = None,
     device: torch.device | None = None,
 ):
     if torch.cuda.is_available():
@@ -165,7 +169,7 @@ def validate_conversion(
     input_ids = torch.randint(0, vocab_size, (B, T)).to(device)
 
     log.info("Loading converted checkpoint for validation...")
-    hf_model = AutoModelForCausalLM.from_pretrained(hf_path).to(device).eval()
+    hf_model = AutoModelForCausalLM.from_pretrained(hf_path, torch_dtype="auto").to(device).eval()
 
     olmo_core_state, hf_state = {}, {}
     state_mapping = None
@@ -192,6 +196,8 @@ def validate_conversion(
 
     del hf_model
 
+    if dtype:
+        model = model.to(dtype.as_pt())
     model.eval()
     with torch.no_grad():
         logits = model(input_ids=input_ids)
@@ -228,12 +234,20 @@ def validate_conversion(
                 log.info(
                     f"{olmo_core_state_name}, {hf_state_name} shape mismatch: {olmo_core_tensor.shape} {hf_tensor.shape}"
                 )
-            else:
+            if olmo_core_tensor.dtype != hf_tensor.dtype:
                 log.info(
-                    f"{olmo_core_state_name}, {hf_state_name} norm diff: {torch.norm(olmo_core_tensor - hf_tensor)}"
+                    f"{olmo_core_state_name}, {hf_state_name} dtype mismatch: {olmo_core_tensor.dtype} {hf_tensor.dtype}"
+                )
+            if len(olmo_core_tensor.shape) == len(hf_tensor.shape):
+                common_shape = tuple(min(olmo_core_dim, hf_dim) for olmo_core_dim, hf_dim in zip(olmo_core_tensor.shape, hf_tensor.shape))
+                for i, dim in enumerate(common_shape):
+                    olmo_core_tensor = olmo_core_tensor.narrow(i, 0, dim)
+                    hf_tensor = hf_tensor.narrow(i, 0, dim)
+                log.info(
+                    f"{olmo_core_state_name}, {hf_state_name} element diff abs mean: {(olmo_core_tensor - hf_tensor).float().abs().mean()}"
                 )
 
-    torch.testing.assert_close(hf_logits[..., :vocab_size], logits[..., :vocab_size])
+    torch.testing.assert_close(hf_logits[..., :vocab_size].float(), logits[..., :vocab_size].float(), rtol=1e-4, atol=1e-4)
 
 
 def load_config(checkpoint_input_dir: PathOrStr) -> Optional[dict]:
@@ -292,6 +306,12 @@ def parse_args():
         type=torch.device,
         help="The device on which conversion and validation occurs. Defaults to CUDA or MPS if available and initialized.",
     )
+    parser.add_argument(
+        "--dtype",
+        help="The torch dtype that model weights should be saved as. Defaults to bfloat16 due to https://github.com/allenai/olmo-cookbook/issues/60.",
+        type=DType,
+        default=DType.bfloat16,
+    )
     return parser.parse_args()
 
 
@@ -313,6 +333,7 @@ def main():
         output_path=args.huggingface_output_dir,
         transformer_config_dict=transformer_config_dict,
         tokenizer_config_dict=tokenizer_config_dict,
+        dtype=args.dtype,
         max_sequence_length=args.max_sequence_length,
         validate=args.validate,
         debug=args.debug,

--- a/src/olmo_core/config.py
+++ b/src/olmo_core/config.py
@@ -285,6 +285,7 @@ class DType(StrEnum):
 
     float32 = "float32"
     bfloat16 = "bfloat16"
+    float16 = "float16"
 
     @classmethod
     def from_pt(cls, dtype: torch.dtype) -> "DType":
@@ -292,6 +293,8 @@ class DType(StrEnum):
             return DType.float32
         elif dtype == torch.bfloat16:
             return DType.bfloat16
+        elif dtype == torch.float16:
+            return DType.float16
         else:
             raise NotImplementedError(dtype)
 

--- a/src/olmo_core/nn/hf/checkpoint.py
+++ b/src/olmo_core/nn/hf/checkpoint.py
@@ -145,7 +145,9 @@ def save_hf_model(
 
     model_state_dict = {key: get_full_tensor(state) for key, state in model_state_dict.items()}
     if dtype is not None:
-        model_state_dict = {key: state.to(dtype=dtype.as_pt()) for key, state in model_state_dict.items()}
+        model_state_dict = {
+            key: state.to(dtype=dtype.as_pt()) for key, state in model_state_dict.items()
+        }
 
     hf_state_dict: Dict[str, torch.Tensor] = convert_state_to_hf(hf_config, model_state_dict)
 

--- a/src/olmo_core/nn/hf/checkpoint.py
+++ b/src/olmo_core/nn/hf/checkpoint.py
@@ -10,6 +10,7 @@ from torch.distributed.tensor import DTensor, distribute_tensor
 from transformers import AutoModelForCausalLM
 
 from olmo_core.aliases import PathOrStr
+from olmo_core.config import DType
 from olmo_core.distributed.utils import barrier, get_fs_local_rank, get_full_tensor
 from olmo_core.doc_utils import beta_feature
 from olmo_core.io import clear_directory, copy_dir, file_exists, is_url, upload
@@ -121,6 +122,7 @@ def save_hf_model(
     model_state_dict: Dict[str, Any],
     model: Transformer,
     *,
+    dtype: Optional[DType] = None,
     vocab_size: Optional[int] = None,
     process_group: Optional[dist.ProcessGroup] = None,
     work_dir: Optional[PathOrStr] = None,
@@ -131,6 +133,7 @@ def save_hf_model(
 
     :param save_dir: Directory in which to save model.
     :param model_state_dict: The OLMo Core model state dict being saved in HF format.
+    :param dtype: The torch dtype that model weights should be saved as.
     :param vocab_size: The size of the vocab, defaults to the number of embeddings in the OLMo Core model.
     :param process_group: The process group to use for distributed communication.
     :param work_dir: A local directory that can be used for holding temporary state. Required when
@@ -141,6 +144,9 @@ def save_hf_model(
     hf_config = get_hf_config(model)
 
     model_state_dict = {key: get_full_tensor(state) for key, state in model_state_dict.items()}
+    if dtype is not None:
+        model_state_dict = {key: state.to(dtype=dtype.as_pt()) for key, state in model_state_dict.items()}
+
     hf_state_dict: Dict[str, torch.Tensor] = convert_state_to_hf(hf_config, model_state_dict)
 
     # model.save_pretrained fails says `tensor.reshape()` should be used instead of `tensor.view()`


### PR DESCRIPTION
This PR adds support for converting models to HF in lower precisions. Due to https://github.com/allenai/olmo-cookbook/issues/60, it also changes the default HF precision to bf16 (so that vllm is less likely to be broken).