### PR TITLE
Bump ai2-olmo-eval==0.7.2 (in-loop Basic Skills)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `BatchSizeSchedulerCallback` for setting a batch size schedule over the course of a training run.
 - The `BeakerCallback` will save the config and Python requirements to the results dataset.
 - Added `from_file` method to `Config` class.
+- Added in-loop evals for OLMES basic skills eval
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "omegaconf",
     "safetensors",
     "importlib_resources",
-    "ai2-olmo-eval==0.7.1",
+    "ai2-olmo-eval==0.7.2",
 ]
 
 [project.urls]

--- a/src/olmo_core/train/config.py
+++ b/src/olmo_core/train/config.py
@@ -114,6 +114,13 @@ class TrainerConfig(Config):
             "codex_mbpp_gold_bpb_0shot",
             # Sanity check for MCQA ability
             "copycolors_10way",
+            # Basic Skills
+            "basic_skills_arithmetic_rc_5shot",
+            "basic_skills_coding_rc_5shot",
+            "basic_skills_common_knowledge_rc_5shot",
+            "basic_skills_logical_reasoning_rc_5shot",
+            "basic_skills_pattern_rc_5shot",
+            "basic_skills_string_operations_rc_5shot",
         ]
 
         # For training runs where we expect the model to acquire MC
@@ -151,6 +158,13 @@ class TrainerConfig(Config):
             "codex_mbpp_gold_bpb_0shot",
             # Sanity check for MCQA ability
             "copycolors_10way",
+            # Basic Skills
+            "basic_skills_arithmetic_rc_5shot",
+            "basic_skills_coding_rc_5shot",
+            "basic_skills_common_knowledge_rc_5shot",
+            "basic_skills_logical_reasoning_rc_5shot",
+            "basic_skills_pattern_rc_5shot",
+            "basic_skills_string_operations_rc_5shot",
         ]
         # Unfortunately we need the same metrics for everything, so we run them all.
         tasks = list(set(tasks_small_compute + tasks_large_compute))


### PR DESCRIPTION
Increment ai2-olmo-eval==0.7.2: https://github.com/allenai/OLMo-in-loop-evals/releases/tag/v0.7.2

This allows us to use the following new in-loop eval config options:

```python
DownstreamEvaluatorCallbackConfig(
  tasks=[
    "basic_skills_arithmetic_rc_5shot",
    "basic_skills_coding_rc_5shot",
    "basic_skills_common_knowledge_rc_5shot",
    "basic_skills_logical_reasoning_rc_5shot",
    "basic_skills_pattern_rc_5shot",
    "basic_skills_string_operations_rc_5shot",
    ...
```

To run a quick test:
```sh
torchrun --nproc-per-node=1 src/scripts/train/OLMo2-ladder.py train 1B 5xC ai2/jupiter-cirrascale-2 \
    --trainer.callbacks.downstream_evaluator.eval_on_startup=true \
    --trainer.callbacks.downstream_evaluator.cancel_after_first_eval=true \
    --launch.num_gpus=1 \
    --ladder.save_folder=/tmp/debug \
    --trainer.save_folder=/tmp/debug \
    --launch.allow_dirty=True \
    --trainer.callbacks.downstream_evaluator.tasks=[basic_skills_arithmetic_rc_5shot,basic_skills_coding_rc_5shot,basic_skills_common_knowledge_rc_5shot,basic_skills_logical_reasoning_rc_5shot,basic_skills_pattern_rc_5shot,basic_skills_string_operations_rc_5shot]
```