### PR TITLE
Add "fast" in-loop task set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added in-loop evals for OLMES basic skills eval
 - Added in-loop fast MCQA for in-loop evals and translated MBPP tasks
 - Added in-loop few-shot HumanEval BPB
+- Added `fast` and `full` in-loop recommendations, where `fast` is a roughly 2-3x faster subset of `full`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `from_file` method to `Config` class.
 - Added in-loop evals for OLMES basic skills eval
 - Added in-loop fast MCQA for in-loop evals and translated MBPP tasks
+- Added in-loop few-shot HumanEval BPB
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "omegaconf",
     "safetensors",
     "importlib_resources",
-    "ai2-olmo-eval==0.8.1",
+    "ai2-olmo-eval==0.8.2",
 ]
 
 [project.urls]

--- a/src/olmo_core/train/config.py
+++ b/src/olmo_core/train/config.py
@@ -110,8 +110,8 @@ class TrainerConfig(Config):
             "minerva_math_number_theory_gold_bpb_0shot",
             "minerva_math_prealgebra_gold_bpb_0shot",
             "minerva_math_precalculus_gold_bpb_0shot",
-            "codex_humaneval_gold_bpb_0shot",
-            "codex_mbpp_gold_bpb_0shot",
+            "codex_humaneval_gold_bpb_3shot",
+            "codex_mbpp_gold_bpb_3shot",
             # MT MBPP tasks
             "mt_mbpp_rust_gold_bpb_3shot",
             "mt_mbpp_java_gold_bpb_3shot",
@@ -158,8 +158,8 @@ class TrainerConfig(Config):
             "minerva_math_number_theory_gold_bpb_0shot",
             "minerva_math_prealgebra_gold_bpb_0shot",
             "minerva_math_precalculus_gold_bpb_0shot",
-            "codex_humaneval_gold_bpb_0shot",
-            "codex_mbpp_gold_bpb_0shot",
+            "codex_humaneval_gold_bpb_3shot",
+            "codex_mbpp_gold_bpb_3shot",
             # MT MBPP tasks
             "mt_mbpp_rust_gold_bpb_3shot",
             "mt_mbpp_java_gold_bpb_3shot",

--- a/src/olmo_core/train/config.py
+++ b/src/olmo_core/train/config.py
@@ -67,7 +67,7 @@ class TrainerConfig(Config):
         return out
 
     def with_recommended_evals(
-        self, tokenizer: TokenizerConfig, sequence_length: int, cluster: str
+        self, tokenizer: TokenizerConfig, sequence_length: int, cluster: str, task_set: str = "full"
     ) -> "TrainerConfig":
         """
         Return a new trainer config with added callbacks for downstream evaluation and validation sets.
@@ -79,103 +79,141 @@ class TrainerConfig(Config):
             LMEvaluatorCallbackConfig,
         )
 
-        # For training runs where we don't expect the model to acquire MC (e.g., 1B-5xC, short 7B training runs)
-        tasks_small_compute = [
-            # OLMES Core 9(-ish) RC
-            "arc_challenge_test_rc_5shot",
-            "arc_easy_test_rc_5shot",
-            "hellaswag_rc_5shot",  # 1K subset of HellaSwag
-            "winogrande_val_rc_5shot",  # Helpful after 750M-5xC scale
-            "csqa_val_rc_5shot",
-            "piqa_val_rc_5shot",
-            "socialiqa_val_rc_5shot",
-            # Too noisy to be worth tracking
-            # "boolq_val_rc_5shot",
-            # "openbookqa_test_rc_5shot",
-            # MMLU RC
-            "mmlu_stem_val_rc_5shot",
-            "mmlu_humanities_val_rc_5shot",
-            "mmlu_social_sciences_val_rc_5shot",
-            "mmlu_other_val_rc_5shot",
-            "mmlu_stem_test_rc_5shot",
-            "mmlu_humanities_test_rc_5shot",
-            "mmlu_social_sciences_test_rc_5shot",
-            "mmlu_other_test_rc_5shot",
-            # Gen tasks BPB
-            "gsm8k_gold_bpb_5shot",
-            "minerva_math_algebra_gold_bpb_0shot",
-            "minerva_math_counting_and_probability_gold_bpb_0shot",
-            "minerva_math_geometry_gold_bpb_0shot",
-            "minerva_math_intermediate_algebra_gold_bpb_0shot",
-            "minerva_math_number_theory_gold_bpb_0shot",
-            "minerva_math_prealgebra_gold_bpb_0shot",
-            "minerva_math_precalculus_gold_bpb_0shot",
-            "codex_humaneval_gold_bpb_3shot",
-            "codex_mbpp_gold_bpb_3shot",
-            # MT MBPP tasks
-            "mt_mbpp_rust_gold_bpb_3shot",
-            "mt_mbpp_java_gold_bpb_3shot",
-            "mt_mbpp_cpp_gold_bpb_3shot",
-            # Sanity check for MCQA ability
-            "copycolors_10way_fast",
-            # Basic Skills
-            "basic_skills_arithmetic_rc_5shot",
-            "basic_skills_coding_rc_5shot",
-            "basic_skills_common_knowledge_rc_5shot",
-            "basic_skills_logical_reasoning_rc_5shot",
-            "basic_skills_pattern_rc_5shot",
-            "basic_skills_string_operations_rc_5shot",
-        ]
+        if task_set == "full":
+            # For training runs where we don't expect the model to acquire MC (e.g., 1B-5xC, short 7B training runs)
+            tasks_small_compute = [
+                # OLMES Core 9(-ish) RC
+                "arc_challenge_test_rc_5shot",
+                "arc_easy_test_rc_5shot",
+                "hellaswag_rc_5shot",  # 1K subset of HellaSwag
+                "winogrande_val_rc_5shot",  # Helpful after 750M-5xC scale
+                "csqa_val_rc_5shot",
+                "piqa_val_rc_5shot",
+                "socialiqa_val_rc_5shot",
+                # Too noisy to be worth tracking
+                # "boolq_val_rc_5shot",
+                # "openbookqa_test_rc_5shot",
+                # MMLU RC
+                "mmlu_stem_val_rc_5shot",
+                "mmlu_humanities_val_rc_5shot",
+                "mmlu_social_sciences_val_rc_5shot",
+                "mmlu_other_val_rc_5shot",
+                "mmlu_stem_test_rc_5shot",
+                "mmlu_humanities_test_rc_5shot",
+                "mmlu_social_sciences_test_rc_5shot",
+                "mmlu_other_test_rc_5shot",
+                # Gen tasks BPB
+                "gsm8k_gold_bpb_5shot",
+                "minerva_math_algebra_gold_bpb_0shot",
+                "minerva_math_counting_and_probability_gold_bpb_0shot",
+                "minerva_math_geometry_gold_bpb_0shot",
+                "minerva_math_intermediate_algebra_gold_bpb_0shot",
+                "minerva_math_number_theory_gold_bpb_0shot",
+                "minerva_math_prealgebra_gold_bpb_0shot",
+                "minerva_math_precalculus_gold_bpb_0shot",
+                "codex_humaneval_gold_bpb_3shot",
+                "codex_mbpp_gold_bpb_3shot",
+                # MT MBPP tasks
+                "mt_mbpp_rust_gold_bpb_3shot",
+                "mt_mbpp_java_gold_bpb_3shot",
+                "mt_mbpp_cpp_gold_bpb_3shot",
+                # Sanity check for MCQA ability
+                "copycolors_10way_fast",
+                # Basic Skills
+                "basic_skills_arithmetic_rc_5shot",
+                "basic_skills_coding_rc_5shot",
+                "basic_skills_common_knowledge_rc_5shot",
+                "basic_skills_logical_reasoning_rc_5shot",
+                "basic_skills_pattern_rc_5shot",
+                "basic_skills_string_operations_rc_5shot",
+            ]
 
-        # For training runs where we expect the model to acquire MC
-        tasks_large_compute = [
-            # OLMES Core 9(-ish) MC
-            "arc_challenge_test_mc_5shot_fast",
-            "arc_easy_test_mc_5shot_fast",
-            "hellaswag_rc_5shot",  # 1K subset of HellaSwag
-            "csqa_val_mc_5shot_fast",
-            "piqa_val_mc_5shot_fast",
-            "socialiqa_val_mc_5shot_fast",
-            "winogrande_val_rc_5shot",
-            # Too noisy to be worth tracking
-            # "boolq_val_mc_5shot_fast",
-            # "openbookqa_test_mc_5shot_fast",
-            # MMLU MC BPB
-            "mmlu_stem_val_mc_5shot_fast",
-            "mmlu_humanities_val_mc_5shot_fast",
-            "mmlu_social_sciences_val_mc_5shot_fast",
-            "mmlu_other_val_mc_5shot_fast",
-            "mmlu_stem_test_mc_5shot_fast",
-            "mmlu_humanities_test_mc_5shot_fast",
-            "mmlu_social_sciences_test_mc_5shot_fast",
-            "mmlu_other_test_mc_5shot_fast",
-            # Gen tasks BPB
-            "gsm8k_gold_bpb_5shot",
-            "minerva_math_algebra_gold_bpb_0shot",
-            "minerva_math_counting_and_probability_gold_bpb_0shot",
-            "minerva_math_geometry_gold_bpb_0shot",
-            "minerva_math_intermediate_algebra_gold_bpb_0shot",
-            "minerva_math_number_theory_gold_bpb_0shot",
-            "minerva_math_prealgebra_gold_bpb_0shot",
-            "minerva_math_precalculus_gold_bpb_0shot",
-            "codex_humaneval_gold_bpb_3shot",
-            "codex_mbpp_gold_bpb_3shot",
-            # MT MBPP tasks
-            "mt_mbpp_rust_gold_bpb_3shot",
-            "mt_mbpp_java_gold_bpb_3shot",
-            "mt_mbpp_cpp_gold_bpb_3shot",
-            # Sanity check for MCQA ability
-            "copycolors_10way_fast",
-            # Basic Skills
-            "basic_skills_arithmetic_rc_5shot",
-            "basic_skills_coding_rc_5shot",
-            "basic_skills_common_knowledge_rc_5shot",
-            "basic_skills_logical_reasoning_rc_5shot",
-            "basic_skills_pattern_rc_5shot",
-            "basic_skills_string_operations_rc_5shot",
-        ]
-        # Unfortunately we need the same metrics for everything, so we run them all.
-        tasks = list(set(tasks_small_compute + tasks_large_compute))
+            # For training runs where we expect the model to acquire MC
+            tasks_large_compute = [
+                # OLMES Core 9(-ish) MC
+                "arc_challenge_test_mc_5shot_fast",
+                "arc_easy_test_mc_5shot_fast",
+                "hellaswag_rc_5shot",  # 1K subset of HellaSwag
+                "csqa_val_mc_5shot_fast",
+                "piqa_val_mc_5shot_fast",
+                "socialiqa_val_mc_5shot_fast",
+                "winogrande_val_rc_5shot",
+                # Too noisy to be worth tracking
+                # "boolq_val_mc_5shot_fast",
+                # "openbookqa_test_mc_5shot_fast",
+                # MMLU MC BPB
+                "mmlu_stem_val_mc_5shot_fast",
+                "mmlu_humanities_val_mc_5shot_fast",
+                "mmlu_social_sciences_val_mc_5shot_fast",
+                "mmlu_other_val_mc_5shot_fast",
+                "mmlu_stem_test_mc_5shot_fast",
+                "mmlu_humanities_test_mc_5shot_fast",
+                "mmlu_social_sciences_test_mc_5shot_fast",
+                "mmlu_other_test_mc_5shot_fast",
+                # Gen tasks BPB
+                "gsm8k_gold_bpb_5shot",
+                "minerva_math_algebra_gold_bpb_0shot",
+                "minerva_math_counting_and_probability_gold_bpb_0shot",
+                "minerva_math_geometry_gold_bpb_0shot",
+                "minerva_math_intermediate_algebra_gold_bpb_0shot",
+                "minerva_math_number_theory_gold_bpb_0shot",
+                "minerva_math_prealgebra_gold_bpb_0shot",
+                "minerva_math_precalculus_gold_bpb_0shot",
+                "codex_humaneval_gold_bpb_3shot",
+                "codex_mbpp_gold_bpb_3shot",
+                # MT MBPP tasks
+                "mt_mbpp_rust_gold_bpb_3shot",
+                "mt_mbpp_java_gold_bpb_3shot",
+                "mt_mbpp_cpp_gold_bpb_3shot",
+                # Sanity check for MCQA ability
+                "copycolors_10way_fast",
+                # Basic Skills
+                "basic_skills_arithmetic_rc_5shot",
+                "basic_skills_coding_rc_5shot",
+                "basic_skills_common_knowledge_rc_5shot",
+                "basic_skills_logical_reasoning_rc_5shot",
+                "basic_skills_pattern_rc_5shot",
+                "basic_skills_string_operations_rc_5shot",
+            ]
+            # Unfortunately we need the same metrics for everything, so we run them all.
+            tasks = list(set(tasks_small_compute + tasks_large_compute))
+        elif task_set == "fast":
+            # Subset of "full" task set that is roughly 2-3x faster
+            tasks = [
+                # Subset of OLMES
+                "arc_challenge_test_bpb_5shot",
+                "arc_challenge_test_mc_5shot_fast",
+                "arc_easy_test_bpb_5shot",
+                "arc_easy_test_mc_5shot_fast",
+                "hellaswag_bpb_5shot",
+                "mmlu_humanities_test_bpb_5shot",
+                "mmlu_humanities_test_mc_5shot_fast",
+                "mmlu_other_test_bpb_5shot",
+                "mmlu_other_test_mc_5shot_fast",
+                "mmlu_social_sciences_test_bpb_5shot",
+                "mmlu_social_sciences_test_mc_5shot_fast",
+                "mmlu_stem_test_bpb_5shot",
+                "mmlu_stem_test_mc_5shot_fast",
+                # Basic Skills
+                "basic_skills_arithmetic_rc_5shot",
+                "basic_skills_coding_rc_5shot",
+                "basic_skills_common_knowledge_rc_5shot",
+                "basic_skills_logical_reasoning_rc_5shot",
+                "basic_skills_pattern_rc_5shot",
+                "basic_skills_string_operations_rc_5shot",
+                # Gen tasks BPB
+                "codex_humaneval_gold_bpb_3shot",
+                "codex_mbpp_gold_bpb_3shot",
+                "minerva_math_500_gold_bpb_0shot",
+                "mt_mbpp_cpp_gold_bpb_3shot",
+                "mt_mbpp_java_gold_bpb_3shot",
+                "mt_mbpp_rust_gold_bpb_3shot",
+                # Sanity check for MCQA ability
+                "copycolors_10way_fast",
+            ]
+        else:
+            raise ValueError(f"Task set not recognized: {task_set}")
+
         tasks.sort()
 
         return self.with_callback(


### PR DESCRIPTION
This adds a new `task_set` argument to `with_recommended_evals` and adds a `full` and `fast` task set. The full task set is the existing in-loop evals, and the fast task set is the fast in-loop evals.

```python
TrainerConfig(...).with_recommended_evals(..., task_set=[fast,full])
```

Here are the changes to both sets from our old in-loop evals:
- Added 3 of the translated MBPP tasks (C++, Java, Rust)
- Changed 0-shot HumanEval BPB to 3-shot HumanEval BPB
- Changed 0-shot MBPP to 3-shot MBPP
- Implemented fast MCQA (so MCQA tasks are 1 forward pass)
- Added RC for Ronan's Basic Skills

Here are the differences between `full` and `fast`:
- Swapped out full Minerva (n=5000) for Minerva 500 (n=500)
- Swapped out RC tasks for BPB tasks (except for Basic Skills)
- Removed PiQA, CSQA, WinoGrande, SocialIQA

Looking at the logs of Shane's integration test 2, the `full` set of in-loop evals runs at around [**81.4 sec**](https://beaker.allen.ai/orgs/ai2/workspaces/OLMo_3/work/01JVN1N4T1J70EV5B0T7A3AHCV?) (7B on 32 nodes), the `fast` set runs at [**35.1 sec**](https://beaker.allen.ai/orgs/ai2/workspaces/OLMo_3/work/01JVN58DJ4PCJTNPGSNN8K9Z15?taskId=01JVN58DJFRJA90GJPVW52D1RV&jobId=01JVN58DP3K32TJR2JDCZ9C53Z) (7B on 32 nodes) (note, that set uses 0-shot HE and MBPP instead of 3-shot in this set)