### PR TITLE
catch other types of error when importing liger-kernel

### DIFF
--- a/src/olmo_core/nn/functional/cross_entropy_loss.py
+++ b/src/olmo_core/nn/functional/cross_entropy_loss.py
@@ -1,9 +1,12 @@
+import logging
 from typing import Callable, Literal, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
 
 __all__ = ["cross_entropy_loss", "fused_linear_cross_entropy_loss"]
+
+log = logging.getLogger(__name__)
 
 
 def cross_entropy_loss(
@@ -57,6 +60,8 @@ try:
     _fused_linear_cross_entropy_loss = LigerFusedLinearCrossEntropyFunction.apply
 except ImportError:
     pass
+except Exception:
+    log.exception("Error importing liger-kernel")
 
 
 @torch._dynamo.disable()


### PR DESCRIPTION
@2015aroras ran into issue where importing liger-kernel from a newly-spawned data loading working in the middle of a training run would raise an exception.
With this change we catch non-`ImportError` exceptions when importing `liger-kernel` and log them.