### PR TITLE
Bump ai2-olmo-eval==0.8.3 (RC/BPB speed fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Output of `LMHead` when `labels` is passed as input is now a 4-tuple instead of a 3-tuple, with `(logits, loss, ce_loss, z_loss)`, where `loss` is the combined loss (`ce_loss + z_loss`).
 - The `ConfigSaver` callback will automatically set the config to save for other callbacks (`WandBCallback`, `CometCallback`, and `BeakerCallback` as of now).
+- Fixed bug causing slow evals in BPB/RC in-loop evals due to fast MC
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "omegaconf",
     "safetensors",
     "importlib_resources",
-    "ai2-olmo-eval==0.8.2",
+    "ai2-olmo-eval==0.8.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
Incorporate this one-line PR: https://github.com/allenai/OLMo-in-loop-evals/pull/12

TL;DR: https://github.com/allenai/OLMo-core/pull/281 made in-loop RC and BPB slower, this fixes that bug. **The RC/BPB in-loop evals run with `ai2-olmo-eval~=0.8.0` are correct evals, just slower.**