### PR TITLE
Bump pytorch, ring-flash-attn, and liger-kernel versions

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -43,7 +43,7 @@ RUN chmod +x ~/miniconda.sh && \
 
 # Install PyTorch core ecosystem.
 ARG CUDA_VERSION_PATH
-ARG TORCH_VERSION=2.7.0
+ARG TORCH_VERSION=2.7.1
 ARG INSTALL_CHANNEL=whl
 RUN pip install --no-cache-dir --index-url https://download.pytorch.org/${INSTALL_CHANNEL}/${CUDA_VERSION_PATH}/ \
     torch==${TORCH_VERSION} torchao torchvision torchaudio
@@ -62,11 +62,11 @@ ARG FLASH_ATTN_VERSION=2.7.4.post1
 RUN pip install --no-build-isolation --no-cache-dir flash-attn==${FLASH_ATTN_VERSION}
 
 # Install ring-flash-attn.
-ARG RING_FLASH_ATTN_VERSION=0.1.4
+ARG RING_FLASH_ATTN_VERSION=0.1.5
 RUN pip install --no-build-isolation --no-cache-dir ring-flash-attn==${RING_FLASH_ATTN_VERSION}
 
 # Install liger-kernel.
-ARG LIGER_KERNEL_VERSION=0.5.4
+ARG LIGER_KERNEL_VERSION=0.5.10
 RUN pip install --no-build-isolation --no-cache-dir liger-kernel==${LIGER_KERNEL_VERSION}
 
 # Install direct dependencies, but not source code.


### PR DESCRIPTION
Based on the changelogs these are mostly under the hood bugfixes.