### PR TITLE
Allow profiler to record on multiple ranks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
   checks:
     name: ${{ matrix.task.name }}
     runs-on: [ubuntu-latest]
-    timeout-minutes: 8
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for headwise QK norm.
 - Add BOS token in in-loop evals, when specified by the tokenizer (`ai2-olmo-eval==0.8.4`)
 - Add support for BOS token matching EOS token for intra-document masking in FSL numpy datasets.
+- Added option to allow profiler to record on multiple ranks.
 
 ### Changed
 

--- a/src/olmo_core/train/callbacks/profiler.py
+++ b/src/olmo_core/train/callbacks/profiler.py
@@ -2,6 +2,14 @@ import logging
 from contextlib import ExitStack
 from dataclasses import dataclass
 
+from olmo_core.distributed.parallel import (
+    get_cp_mesh,
+    get_dp_mesh,
+    get_ep_mesh,
+    get_pp_mesh,
+    get_tp_mesh,
+    get_world_mesh,
+)
 from olmo_core.distributed.utils import get_rank
 
 from .callback import Callback
@@ -36,17 +44,83 @@ class ProfilerCallback(Callback):
     """
     Repeat the cycle start at ``wait`` steps.
     """
+    with_stack: bool = True
+    """
+    Whether to record source information (file and line number) for the ops.
+    """
+    profile_memory: bool = False
+    """
+    Whether to track tensor memory allocation/deallocation
+    """
     enabled: bool = True
     """
     Set to ``False`` to disable profiling.
+    """
+    ranks: list[int] | str | None = None
+    """
+    Ranks to profile. Can be:
+    - ``None``: Only rank 0 is profiled
+    - List of integers: Specific ranks to profile
+    - String shortcuts:
+      - ``"dp"``: Profile one rank (rank 0) in each data parallel group
+      - ``"tp"``: Profile one rank (rank 0) in each tensor parallel group
+      - ``"cp"``: Profile one rank (rank 0) in each context parallel group
+      - ``"pp"``: Profile one rank (rank 0) in each pipeline parallel group
+      - ``"ep"``: Profile one rank (rank 0) in each expert parallel group
+      - ``"all"``: Profile all ranks
+
+    Useful in conjunction with https://github.com/facebookresearch/HolisticTraceAnalysis
+      to analyze traces from a distributed training job.
     """
 
     _exit_stack = None
     _profiler = None
     _first_batch: bool = True
 
+    def _should_profile_rank(self) -> bool:
+        current_rank = get_rank()
+
+        if self.ranks is None:
+            return current_rank == 0
+        elif isinstance(self.ranks, list):
+            return current_rank in self.ranks
+        elif isinstance(self.ranks, str):  # Handle string shortcuts for parallel groups
+            world_mesh = get_world_mesh()
+            if world_mesh is None:
+                if self.ranks != "all":
+                    log.warning("No world mesh available, falling back to rank 0 only")
+                return current_rank == 0
+
+            try:
+                if self.ranks == "dp":
+                    dp_mesh = get_dp_mesh(world_mesh)
+                    return dp_mesh.get_local_rank() == 0
+                elif self.ranks == "tp":
+                    tp_mesh = get_tp_mesh(world_mesh)
+                    return tp_mesh.get_local_rank() == 0
+                elif self.ranks == "cp":
+                    cp_mesh = get_cp_mesh(world_mesh)
+                    return cp_mesh.get_local_rank() == 0
+                elif self.ranks == "pp":
+                    pp_mesh = get_pp_mesh(world_mesh)
+                    return pp_mesh.get_local_rank() == 0
+                elif self.ranks == "ep":
+                    ep_mesh = get_ep_mesh(world_mesh)
+                    return ep_mesh.get_local_rank() == 0
+                elif self.ranks == "all":
+                    return True
+                else:
+                    raise ValueError(f"Unknown rank shortcut '{self.ranks}'")
+            except RuntimeError as e:
+                log.warning(
+                    f"Failed to determine parallel mesh for '{self.ranks}': {e}, falling back to rank 0 only"
+                )
+                return current_rank == 0
+        else:
+            raise TypeError(f"Invalid ranks specification: {self.ranks}")
+
     def pre_train(self):
-        if not self.enabled or get_rank() != 0:
+        if not self.enabled or not self._should_profile_rank():
             return
 
         from torch.profiler import ProfilerActivity, profile, schedule
@@ -67,8 +141,8 @@ class ProfilerCallback(Callback):
             profile(
                 activities=activities,
                 record_shapes=False,
-                profile_memory=False,
-                with_stack=True,
+                profile_memory=self.profile_memory,
+                with_stack=self.with_stack,
                 schedule=profiling_schedule,
                 on_trace_ready=self._on_trace_ready,
             )
@@ -76,7 +150,7 @@ class ProfilerCallback(Callback):
         self._first_batch = True
 
     def pre_load_batch(self):
-        if not self.enabled or get_rank() != 0:
+        if not self.enabled or not self._should_profile_rank():
             return
 
         if self._first_batch:
@@ -95,7 +169,7 @@ class ProfilerCallback(Callback):
         log.info("Saving chrome trace from profiler...")
         output_dir = self.trainer.work_dir / "profiler"
         output_dir.mkdir(exist_ok=True, parents=True)
-        trace_path = output_dir / f"step-{prof.step_num}.chrome_trace.json.gz"
+        trace_path = output_dir / f"rank-{get_rank()}-step-{prof.step_num}.chrome_trace.json.gz"
         prof.export_chrome_trace(str(trace_path))
         final_path = self.trainer.persist_working_file(trace_path)
         log.info(f"Chrome trace saved to '{final_path}'")

--- a/src/olmo_core/train/callbacks/profiler.py
+++ b/src/olmo_core/train/callbacks/profiler.py
@@ -64,6 +64,7 @@ class ProfilerCallback(Callback):
     ranks: str | None = None
     """
     Ranks to profile. Can be:
+
     - ``None``: Only rank 0 is profiled
     - String shortcuts:
       - ``"dp"``: Profile one rank (local rank 0) in each data parallel group
@@ -74,7 +75,7 @@ class ProfilerCallback(Callback):
       - ``"all"``: Profile all ranks
 
     Useful in conjunction with https://github.com/facebookresearch/HolisticTraceAnalysis
-      to analyze traces from a distributed training job.
+    to analyze traces from a distributed training job.
     """
 
     _exit_stack = None

--- a/src/olmo_core/train/callbacks/profiler.py
+++ b/src/olmo_core/train/callbacks/profiler.py
@@ -125,7 +125,12 @@ class ProfilerCallback(Callback):
         if not self.enabled or not self._should_profile_rank():
             return
 
-        from torch.profiler import ProfilerActivity, _ExperimentalConfig, profile, schedule
+        from torch.profiler import (
+            ProfilerActivity,
+            _ExperimentalConfig,
+            profile,
+            schedule,
+        )
 
         profiling_schedule = schedule(
             wait=self.wait,


### PR DESCRIPTION
Useful in conjunction with https://hta.readthedocs.io/en/latest/ for profiling distributed training runs.

For example can be useful for analyzing skew across ranks:
![image](https://github.com/user-attachments/assets/595cf8f5-abae-43df-b7de-461bda377b51)

![image](https://github.com/user-attachments/assets/659589bb-daff-4706-8368-5d7caf9723ea)


