### PR TITLE
Add support for accessing Google cloud on non-Google clusters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           python-version: ${{ matrix.python }}
           cache-prefix: ${{ env.CACHE_PREFIX }}
 
-      - name: Set Google credentials
+      - name: Setup Google credentials
         run: |
           mkdir -p $HOME/.google
           printenv GOOGLE_CREDENTIALS > $HOME/.google/credentials.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   BEAKER_TOKEN: ${{ secrets.BEAKER_TOKEN }}
+  GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
 
 jobs:
   checks:
@@ -75,8 +76,8 @@ jobs:
 
       - name: Set Google credentials
         run: |
-          echo "${{ secrets.GOOGLE_CREDENTIALS }}" > $HOME/.google/credentials.json
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/.google/credentials.json" >> $GITHUB_ENV
+          printenv GOOGLE_CREDENTIALS > /.google/credentials.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/.google/credentials.json" >> $GITHUB_ENV
 
       - name: Restore mypy cache
         if: matrix.task.name == 'Type check'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Set Google credentials
         run: |
           mkdir -p /.google
-          printenv GOOGLE_CREDENTIALS > /.google/credentials.json
-          echo "GOOGLE_APPLICATION_CREDENTIALS=/.google/credentials.json" >> $GITHUB_ENV
+          printenv GOOGLE_CREDENTIALS > $HOME/.google/credentials.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/.google/credentials.json" >> $GITHUB_ENV
 
       - name: Restore mypy cache
         if: matrix.task.name == 'Type check'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,11 @@ jobs:
           python-version: ${{ matrix.python }}
           cache-prefix: ${{ env.CACHE_PREFIX }}
 
+      - name: Set Google credentials
+        run: |
+          echo "${{ secrets.GOOGLE_CREDENTIALS }}" > $HOME/.google/credentials.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/.google/credentials.json" >> $GITHUB_ENV
+
       - name: Restore mypy cache
         if: matrix.task.name == 'Type check'
         uses: actions/cache@v4
@@ -204,6 +209,12 @@ jobs:
                     secret: AWS_ACCESS_KEY_ID
                   - name: AWS_SECRET_ACCESS_KEY
                     secret: AWS_SECRET_ACCESS_KEY
+                  - name: GOOGLE_APPLICATION_CREDENTIALS
+                    value: "/.google/credentials.json"
+                datasets:
+                  - mountPath:  "/.google/credentials.json"
+                    source:
+                      secret: GOOGLE_CREDENTIALS
                 command:
                   - "bash"
                   - "-c"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Set Google credentials
         run: |
-          mkdir -p /.google
+          mkdir -p $HOME/.google
           printenv GOOGLE_CREDENTIALS > $HOME/.google/credentials.json
           echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/.google/credentials.json" >> $GITHUB_ENV
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Set Google credentials
         run: |
+          mkdir -p /.google
           printenv GOOGLE_CREDENTIALS > /.google/credentials.json
           echo "GOOGLE_APPLICATION_CREDENTIALS=/.google/credentials.json" >> $GITHUB_ENV
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add BOS token in in-loop evals, when specified by the tokenizer (`ai2-olmo-eval==0.8.4`)
 - Add support for BOS token matching EOS token for intra-document masking in FSL numpy datasets.
 - Added option to allow profiler to record on multiple ranks.
+- Added support for accessing Google on non-Google clusters via auth with service account keys.
 
 ### Changed
 
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug causing slow evals in BPB/RC in-loop evals due to fast MC
 - Changed default precision of converted HF models in `src/examples/huggingface/convert_checkpoint_to_hf.py` to bfloat16.
 - Changed default cluster to `saturn` in `src/examples/llama/train_launch.py`.
+- Made some beaker secrets optional for internal experiments.
 
 ### Fixed
 

--- a/src/olmo_core/internal/common.py
+++ b/src/olmo_core/internal/common.py
@@ -3,8 +3,9 @@ from functools import lru_cache
 from typing import List, Optional
 
 import torch
-from beaker import Beaker, BeakerError
+from beaker import Beaker, BeakerError, SecretNotFound
 
+from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.io import is_url
 from olmo_core.launch.beaker import (
     BeakerEnvSecret,
@@ -32,6 +33,34 @@ def get_beaker_username() -> Optional[str]:
     if beaker is not None:
         return beaker.account.whoami().name
     else:
+        return None
+
+
+def beaker_secret_exists(secret: str, workspace: Optional[str] = None) -> bool:
+    beaker = get_beaker_client()
+    if beaker is None:
+        raise RuntimeError(
+            "Environment not configured correctly for Beaker, you may be missing the BEAKER_TOKEN env var."
+        )
+
+    try:
+        beaker.secret.get(secret, workspace=workspace)
+        return True
+    except SecretNotFound:
+        return False
+
+
+def _to_beaker_env_secret(
+    name: str, secret: str, *, workspace: Optional[str] = None, required: bool = True
+) -> Optional[BeakerEnvSecret]:
+    if beaker_secret_exists(secret, workspace=workspace):
+        return BeakerEnvSecret(name=name, secret=secret)
+    elif required:
+        raise OLMoConfigurationError(
+            f"Secret {secret} not configured in beaker workspace {workspace}"
+        )
+    else:
+        log.info(f"Secret {secret} not configured in beaker workspace {workspace}")
         return None
 
 
@@ -78,6 +107,46 @@ def build_launch_config(
             "Environment not configured correctly for Beaker, you may be missing the BEAKER_TOKEN env var."
         )
 
+    env_secrets = [
+        _to_beaker_env_secret(
+            name="BEAKER_TOKEN", secret=f"{beaker_user}_BEAKER_TOKEN", workspace=workspace
+        ),
+        _to_beaker_env_secret(
+            name="WANDB_API_KEY",
+            secret=f"{beaker_user}_WANDB_API_KEY",
+            required=False,
+            workspace=workspace,
+        ),
+        _to_beaker_env_secret(
+            name="COMET_API_KEY",
+            secret=f"{beaker_user}_COMET_API_KEY",
+            required=False,
+            workspace=workspace,
+        ),
+        _to_beaker_env_secret(
+            name="AWS_CONFIG", secret=f"{beaker_user}_AWS_CONFIG", workspace=workspace
+        ),
+        _to_beaker_env_secret(
+            name="AWS_CREDENTIALS", secret=f"{beaker_user}_AWS_CREDENTIALS", workspace=workspace
+        ),
+        _to_beaker_env_secret(
+            name="R2_ENDPOINT_URL", secret="R2_ENDPOINT_URL", required=False, workspace=workspace
+        ),
+        _to_beaker_env_secret(
+            name="WEKA_ENDPOINT_URL",
+            secret="WEKA_ENDPOINT_URL",
+            required=False,
+            workspace=workspace,
+        ),
+        _to_beaker_env_secret(
+            name="SLACK_WEBHOOK_URL",
+            secret="SLACK_WEBHOOK_URL",
+            required=False,
+            workspace=workspace,
+        ),
+    ]
+    env_secrets = [env_secret for env_secret in env_secrets if env_secret is not None]
+
     return BeakerLaunchConfig(
         name=f"{name}-{generate_uuid()[:8]}",
         budget=budget,
@@ -92,16 +161,7 @@ def build_launch_config(
         shared_filesystem=not is_url(root_dir),
         allow_dirty=False,
         env_vars=[BeakerEnvVar(name="NCCL_DEBUG", value="INFO" if nccl_debug else "WARN")],
-        env_secrets=[
-            BeakerEnvSecret(name="BEAKER_TOKEN", secret=f"{beaker_user}_BEAKER_TOKEN"),
-            BeakerEnvSecret(name="WANDB_API_KEY", secret=f"{beaker_user}_WANDB_API_KEY"),
-            BeakerEnvSecret(name="COMET_API_KEY", secret=f"{beaker_user}_COMET_API_KEY"),
-            BeakerEnvSecret(name="AWS_CONFIG", secret=f"{beaker_user}_AWS_CONFIG"),
-            BeakerEnvSecret(name="AWS_CREDENTIALS", secret=f"{beaker_user}_AWS_CREDENTIALS"),
-            BeakerEnvSecret(name="R2_ENDPOINT_URL", secret="R2_ENDPOINT_URL"),
-            BeakerEnvSecret(name="WEKA_ENDPOINT_URL", secret="WEKA_ENDPOINT_URL"),
-            BeakerEnvSecret(name="SLACK_WEBHOOK_URL", secret="SLACK_WEBHOOK_URL"),
-        ],
+        env_secrets=env_secrets,
         setup_steps=[
             # Clone repo.
             'git clone "$REPO_URL" .',

--- a/src/olmo_core/internal/common.py
+++ b/src/olmo_core/internal/common.py
@@ -156,7 +156,6 @@ def build_launch_config(
         ),
         google_creds,
     ]
-    env_secrets = [env_secret for env_secret in env_secrets if env_secret is not None]
 
     launch_config = BeakerLaunchConfig(
         name=f"{name}-{generate_uuid()[:8]}",
@@ -172,7 +171,7 @@ def build_launch_config(
         shared_filesystem=not is_url(root_dir),
         allow_dirty=False,
         env_vars=[BeakerEnvVar(name="NCCL_DEBUG", value="INFO" if nccl_debug else "WARN")],
-        env_secrets=env_secrets,
+        env_secrets=[env_secret for env_secret in env_secrets if env_secret is not None],
         setup_steps=[
             # Clone repo.
             'git clone "$REPO_URL" .',

--- a/src/olmo_core/internal/experiment.py
+++ b/src/olmo_core/internal/experiment.py
@@ -142,6 +142,7 @@ def build_common_components(
     include_instance_filter: bool = False,
     beaker_image: str = OLMoCoreBeakerImage.stable,
     num_nodes: int = 1,
+    beaker_workspace: str = "ai2/OLMo-core",
 ) -> CommonComponents:
     root_dir = get_root_dir(cluster)
 
@@ -160,6 +161,7 @@ def build_common_components(
             nccl_debug=False,
             beaker_image=beaker_image,
             num_nodes=num_nodes,
+            workspace=beaker_workspace,
         )
 
     tokenizer_config = TokenizerConfig.dolma2()
@@ -329,6 +331,7 @@ def main(
     include_instance_filter: bool = False,
     beaker_image: str = OLMoCoreBeakerImage.stable,
     num_nodes: int = 1,
+    beaker_workspace: str = "ai2/OLMo-core",
 ):
     usage = f"""
 [yellow]Usage:[/] [i blue]python[/] [i cyan]{sys.argv[0]}[/] [i b magenta]{'|'.join(SubCmd)}[/] [i b]RUN_NAME CLUSTER[/] [i][OVERRIDES...][/]
@@ -374,6 +377,7 @@ $ [i]python {sys.argv[0]} {SubCmd.launch} run01 ai2/pluto-cirrascale --launch.nu
         include_instance_filter=include_instance_filter,
         beaker_image=beaker_image,
         num_nodes=num_nodes,
+        beaker_workspace=beaker_workspace,
     )
 
     cmd.run(config)

--- a/src/test/distributed/checkpoint/filesystem_test.py
+++ b/src/test/distributed/checkpoint/filesystem_test.py
@@ -60,7 +60,7 @@ def test_save_and_load_locally_with_dtensors(backend, tmp_path):
 
 @pytest.mark.parametrize("backend", BACKENDS)
 @pytest.mark.parametrize("throttle", [True, False])
-def test_save_and_load_remotely_with_dtensors(backend, s3_checkpoint_dir, throttle):
+def test_save_and_load_remotely_to_s3_with_dtensors(backend, s3_checkpoint_dir, throttle):
     from botocore.exceptions import NoCredentialsError
 
     try:
@@ -72,5 +72,23 @@ def test_save_and_load_remotely_with_dtensors(backend, s3_checkpoint_dir, thrott
         run_save_and_load_with_dtensors,
         backend=backend,
         func_args=(s3_checkpoint_dir, throttle),
+        start_method="spawn",  # NOTE: forking causes a crash with boto3
+    )
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("throttle", [True, False])
+def test_save_and_load_remotely_to_gcs_with_dtensors(backend, gcs_checkpoint_dir, throttle):
+    from google.auth.exceptions import DefaultCredentialsError
+
+    try:
+        dir_is_empty(gcs_checkpoint_dir)
+    except DefaultCredentialsError:
+        pytest.skip("Requires authentication with Google Cloud")
+
+    run_distributed_test(
+        run_save_and_load_with_dtensors,
+        backend=backend,
+        func_args=(gcs_checkpoint_dir, throttle),
         start_method="spawn",  # NOTE: forking causes a crash with boto3
     )

--- a/src/test/train/checkpoint_test.py
+++ b/src/test/train/checkpoint_test.py
@@ -48,7 +48,7 @@ def test_checkpointer_with_local_dir(tmp_path, tiny_model_factory):
     )
 
 
-def test_checkpointer_with_remote_dir(s3_checkpoint_dir, tmp_path, tiny_model_factory):
+def test_checkpointer_with_remote_s3_dir(s3_checkpoint_dir, tmp_path, tiny_model_factory):
     from botocore.exceptions import NoCredentialsError
 
     try:
@@ -59,6 +59,21 @@ def test_checkpointer_with_remote_dir(s3_checkpoint_dir, tmp_path, tiny_model_fa
     run_distributed_test(
         run_checkpointer,
         func_args=(s3_checkpoint_dir, tmp_path / "work_dir", tiny_model_factory),
+        start_method="spawn",
+    )
+
+
+def test_checkpointer_with_remote_gcs_dir(gcs_checkpoint_dir, tmp_path, tiny_model_factory):
+    from google.auth.exceptions import DefaultCredentialsError
+
+    try:
+        dir_is_empty(gcs_checkpoint_dir)
+    except DefaultCredentialsError:
+        pytest.skip("Requires authentication with Google Cloud")
+
+    run_distributed_test(
+        run_checkpointer,
+        func_args=(gcs_checkpoint_dir, tmp_path / "work_dir", tiny_model_factory),
         start_method="spawn",
     )
 
@@ -99,7 +114,7 @@ def test_async_checkpointer_with_local_dir(tmp_path, tiny_model_factory):
     )
 
 
-def test_async_checkpointer_with_remote_dir(s3_checkpoint_dir, tmp_path, tiny_model_factory):
+def test_async_checkpointer_with_remote_s3_dir(s3_checkpoint_dir, tmp_path, tiny_model_factory):
     from botocore.exceptions import NoCredentialsError
 
     try:
@@ -110,5 +125,20 @@ def test_async_checkpointer_with_remote_dir(s3_checkpoint_dir, tmp_path, tiny_mo
     run_distributed_test(
         run_async_checkpointer,
         func_args=(s3_checkpoint_dir, tmp_path / "work_dir", tiny_model_factory),
+        start_method="spawn",
+    )
+
+
+def test_async_checkpointer_with_remote_gcs_dir(gcs_checkpoint_dir, tmp_path, tiny_model_factory):
+    from google.auth.exceptions import DefaultCredentialsError
+
+    try:
+        dir_is_empty(gcs_checkpoint_dir)
+    except DefaultCredentialsError:
+        pytest.skip("Requires authentication with Google Cloud")
+
+    run_distributed_test(
+        run_async_checkpointer,
+        func_args=(gcs_checkpoint_dir, tmp_path / "work_dir", tiny_model_factory),
         start_method="spawn",
     )


### PR DESCRIPTION
This PR adds support for accessing Google cloud on non Google clusters. While doing this, I made a few beaker secrets optional (like `SLACK_WEBHOOK_URL`).

For auth, I created a service account key for an existing service account account. I mount this in a json file in the cluster and then set `GOOGLE_APPLICATION_CREDENTIALS` to point that the file path, following https://cloud.google.com/docs/authentication/set-up-adc-local-dev-environment#local-key. For others to onboard, they can grab my service account key (or create a new one), and put it in the right beaker workspace at `GOOGLE_CREDENTIALS`. They also need to pass the workspace into `main`.

Healthy runs when credentials are provided while using GCS mix base dir:
https://beaker.allen.ai/orgs/ai2/workspaces/shanea/work/01JY22CGZZ2FHXT98H9W6P5HJC/logs?jobId=01JY22CH3ZJEG6JTN088DES5VB
https://beaker.allen.ai/orgs/ai2/workspaces/shanea/work/01JXZT6XDNEWMGEH8BE99YMBKK/logs?jobId=01JXZTR0K8ASAB7TD4J8W52TCF
Failing run when credentials are not provided while using GCS mix base dir:  https://beaker.allen.ai/orgs/ai2/workspaces/shanea/work/01JXZW3Q8VRMKSN8S30ZDGZS1D?taskId=01JXZW3Q934EYRQ9PRYQYMQ4HR&jobId=01JXZW3QCZ1FHKX7ST0ZVNJ8EC
Healthy run when credentials are not provided while not using GCS mix base dir: https://beaker.allen.ai/orgs/ai2/workspaces/shanea/work/01JXZYWQ13GJ6MGRWZAN9KV0WG?taskId=01JXZYWQ19JM0W0M59W8X8Z151&jobId=01JXZYWQ5WG3Y20579J2BJ9WAS

Since the tests use a bucket in a different GCS project, the credentials I have added in `ai2/OLMo-core` and Github won't work with `ai2-llm`.