### PR TITLE
Only check for beaker secrets in non-distributed settings

### DIFF
--- a/src/olmo_core/internal/common.py
+++ b/src/olmo_core/internal/common.py
@@ -56,7 +56,7 @@ def _to_beaker_env_secret(
 ) -> Optional[BeakerEnvSecret]:
     # Assume beaker secret exists if we are in a distributed setting (e.g., during a training job)
     # so that we don't DOS beaker.
-    if not is_distributed() or beaker_secret_exists(secret, workspace=workspace):
+    if is_distributed() or beaker_secret_exists(secret, workspace=workspace):
         return BeakerEnvSecret(name=name, secret=secret)
     elif required:
         raise OLMoConfigurationError(


### PR DESCRIPTION
Checking for beaker secrets in distributed settings can result in a lot of requests to beaker. This DOS'd beaker causing it to raise 5XX errors. This PR only checks for beaker secrets in non-distributed settings.