### PR TITLE
Fix fingerprints for various FSLDatasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - W&B callback uses working directory instead of save folder for local cache.
 - Reset speed monitor callback after changing batch size.
 - Fixed parallelism compatiblity between cp + tp and cp + pp and added test to catch regressions.
+- Fixed fingerprinting for FSL datasets
 
 ## [v2.1.0](https://github.com/allenai/OLMo-core/releases/tag/v2.1.0) - 2025-04-14
 

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -867,6 +867,18 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
         self._array_instance_offsets: Optional[Tuple[Tuple[int, int], ...]] = None
 
     @property
+    def fingerprint_fields(self) -> Tuple[str, ...]:
+        return (
+            "vocab_size",
+            "pad_token_id",
+            "eos_token_id",
+            "dtype",
+            "max_target_sequence_length",
+            "bos_token_id",
+            "sequence_length",
+        )
+
+    @property
     def offsets(self) -> Tuple[Tuple[int, int], ...]:
         if self._array_instance_offsets is None:
             item_size = self.indices_dtype(0).itemsize
@@ -2279,7 +2291,7 @@ class NumpyDatasetConfig(Config):
     """
     The number of documents to interleave per instance in
     :class:`NumpyInterleavedFSLDataset`.
-    
+
     Dataset document are truncated down to length ``sequence_length // docs_per_instance``, so
     that the overall sequence length after interleaving is up to ``sequence_length``.
     """

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -1318,6 +1318,9 @@ class NumpyInterleavedFSLDataset(NumpyPaddedFSLDataset):
             "_docs_per_instance",
             "_seed",
             "_interleaving_exempt_paths",
+            "max_target_sequence_length",
+            "bos_token_id",
+            "sequence_length",
         )
 
     def __len__(self) -> int:

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -1036,6 +1036,7 @@ class NumpyPackedFSLDataset(NumpyFSLDatasetBase):
             "dtype",
             "long_doc_strategy",
             "bos_token_id",
+            "sequence_length",
         )
 
     @property


### PR DESCRIPTION
Various options that are used to generate cached files aren't correctly included in the fingerprint. These are soon-to-be-relevant for SFT training.