### PR TITLE
"Better" sorting of Augusta ranks at runtime

### DIFF
--- a/src/olmo_core/launch/reorder_ranks_in_gcp.py
+++ b/src/olmo_core/launch/reorder_ranks_in_gcp.py
@@ -13,6 +13,11 @@ def main():
     parser.add_argument("master_addr", help="Hostname of worker 0")
     parser.add_argument("--master_port", type=int, default=29501, help="Port for TCPStore")
     parser.add_argument("--debug", action="store_true", help="Enable debug mode (outside of GCP)")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print the whole list of node ids in order on rank 0 to stderr",
+    )
     args = parser.parse_args()
 
     # Create or connect to the store

--- a/src/olmo_core/launch/reorder_ranks_in_gcp.py
+++ b/src/olmo_core/launch/reorder_ranks_in_gcp.py
@@ -86,7 +86,7 @@ def main():
             all_blocks[rank],
             all_subblocks[rank],
             all_machines[rank],
-            rank
+            rank,
         )
     )
     assert ranks[0] == 0

--- a/src/olmo_core/launch/reorder_ranks_in_gcp.py
+++ b/src/olmo_core/launch/reorder_ranks_in_gcp.py
@@ -54,12 +54,45 @@ def main():
     all_host_ids = [store.get(f"node_{i}_hostid").decode("UTF-8") for i in range(args.world_size)]
     assert len(set(all_host_ids)) == len(all_host_ids)
     assert host_id in all_host_ids
-    rank0_host_id = all_host_ids[0]
-    all_host_ids.sort()
-    # Rank 0 needs to remain rank 0, so we reshuffle around it
-    rank0_index = all_host_ids.index(rank0_host_id)
-    all_host_ids = all_host_ids[rank0_index:] + all_host_ids[:rank0_index]
-    print(all_host_ids.index(host_id))
+
+    # hostid is of the form "/block/subblock/machine", extract each component from all ranks.
+    all_blocks = [hostid.strip("/").split("/")[0] for hostid in all_host_ids]
+    all_subblocks = [hostid.strip("/").split("/")[1] for hostid in all_host_ids]
+    all_machines = [hostid.strip("/").split("/")[2] for hostid in all_host_ids]
+
+    rank0_block = all_blocks[0]
+    rank0_subblock = all_subblocks[0]
+    rank0_machine = all_machines[0]
+
+    ranks = list(range(args.world_size))
+    # We want that 1) rank 0 remains rank 0, 2) blocks are grouped up, subblocks are grouped
+    # up within blocks, and machines are grouped up within subblocks.
+    # To achieve this, sort ranks so that the rank 0 block, subblock and machine are first
+    # by sorting on making its block, subblock and machine falsey in the sorting key.
+    # After this separation, sort so that blocks are together, subblocks are together
+    # within blocks, and machines are together within subblocks.
+    # Lastly, if 2 ranks are on the same block + subblock + machine, make the lowest
+    # rank first.
+    ranks.sort(
+        key=lambda rank: (
+            all_blocks[rank] != rank0_block,
+            all_subblocks[rank] != rank0_subblock,
+            all_machines[rank] != rank0_machine,
+            all_blocks[rank],
+            all_subblocks[rank],
+            all_machines[rank],
+            rank
+        )
+    )
+    assert ranks[0] == 0
+
+    if args.verbose and args.rank == 0:
+        for rank in ranks:
+            print(
+                f"Initial rank: {rank}, Final rank: {ranks.index(rank)}, Hostids: {all_host_ids[rank]}",
+                file=sys.stderr,
+            )
+    print(ranks.index(args.rank))
 
     # Make sure we're all done before exiting
     store.set(f"node_{args.rank}_done", host_id)


### PR DESCRIPTION
Issue: Augusta is made up of 2 blocks of nodes. When a model replica in a distributed job is split across the blocks, perf goes bad. We reorder ranks to avoid this happening, but the current logic has a 1 in N chance (for replica size N) of letting this happen even in the ideal case where there is an ordering that can avoid this.

This PR uses a slightly convoluted sorting that ensures model replicas in a distributed job are not split across the blocks if it's possible. This reduces our block splitting problem to ensuring that the number of nodes from each block is a multiple of the replica size N (separate PR eventually).