### PR TITLE
DDP parameter dtype casting for 16-bit precision and flash attention support

### DIFF
--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -714,6 +714,7 @@ class Transformer(nn.Module):
     def apply_ddp(
         self,
         dp_mesh: Optional[DeviceMesh] = None,
+        param_dtype: Optional[torch.dtype] = None,
         compile_enabled: bool = False,
         autograd_compile_enabled: bool = False,
     ):
@@ -721,6 +722,11 @@ class Transformer(nn.Module):
         Apply DDP to the model.
         """
         from torch.distributed._composable.replicate import replicate
+
+        # Cast model explicitly to the specified dtype before applying DDP
+        target_dtype = param_dtype or self.dtype
+        if target_dtype != self.dtype:
+            self.to(dtype=target_dtype)
 
         # Adapted from
         # https://github.com/pytorch/torchtitan/blob/90c889e972b56b9faadebbb78fc985dedc537ed9/torchtitan/parallelisms/parallelize_llama.py#L328

--- a/src/olmo_core/train/train_module/transformer/common.py
+++ b/src/olmo_core/train/train_module/transformer/common.py
@@ -114,10 +114,10 @@ def parallelize_model(
     if dp_config is not None:
         assert world_mesh is not None
         dp_mesh = get_dp_model_mesh(world_mesh)
-        if dp_config.name in (DataParallelType.fsdp, DataParallelType.hsdp):
-            param_dtype = (
+        param_dtype = (
                 dp_config.param_dtype.as_pt() if dp_config.param_dtype is not None else None
             )
+        if dp_config.name in (DataParallelType.fsdp, DataParallelType.hsdp):
             for m in model_parts:
                 if m.is_moe:
                     cast(MoETransformer, m).prepare_experts_for_fsdp(
@@ -139,7 +139,9 @@ def parallelize_model(
             for m in model_parts:
                 if m.is_moe:
                     cast(MoETransformer, m).prepare_experts_for_ddp(world_mesh)
-                m.apply_ddp(dp_mesh=dp_mesh, compile_enabled=compile_model)
+                m.apply_ddp(dp_mesh=dp_mesh,
+                    compile_enabled=compile_model,
+                    param_dtype=param_dtype)
             log.info(f"Applied DDP to the model with {get_device_mesh_info(dp_mesh)}")
         else:
             raise NotImplementedError(dp_config.name)


### PR DESCRIPTION
## Issue: 
`RuntimeError: FlashAttention only support fp16 and bf16 data type` when doing a forward pass with any model with DDP. No explicit casting was done for DDP-based trainers.
Additionally, FlashAttention requires the parameters to be in 16-bit precision, and this could not be set by the user

## Fix: 
Explicit casting to `param_dtype` in `apply_ddp()` given the `param_dtype` of the user defined `TransformerDataParallelConfig`
DDP will now pick up the given dtype and allows for user-defined 16-bit precision dtype to support FlashAttention

## Minimal example (to be run with `torchrun --nproc_per_node 2`)
```
import torch
import os
from olmo_core.config import DType
from olmo_core.distributed.utils import get_world_size
from olmo_core.nn.transformer import TransformerConfig
from olmo_core.distributed.parallel import (
    DataParallelType,
    build_world_mesh,
)
from olmo_core.train.train_module import (
    TransformerDataParallelConfig,
)
import torch.distributed as dist
from olmo_core.utils import get_default_device
from olmo_core.train.train_module.transformer.common import parallelize_model

torch.distributed.init_process_group(backend='nccl', init_method='env://')

local_rank = int(os.environ.get("LOCAL_RANK", 0))
device = torch.device(f"cuda:{local_rank}")
torch.cuda.set_device(device)

dp_config = TransformerDataParallelConfig(
    name=DataParallelType.ddp,
    param_dtype=DType.bfloat16,
    reduce_dtype=DType.float32,
    num_replicas=dist.get_world_size(),
)

world_mesh = build_world_mesh(dp=dp_config, device_type=device.type)
config = TransformerConfig.olmo2_190M(vocab_size=64000, use_flash=True)

model = config.build(init_device="meta")

model = parallelize_model(
    model,
    world_mesh=world_mesh,
    device=device,
    max_sequence_length=1024,
    rank_microbatch_size=1024,
    dp_config=dp_config,
)

model(input_ids=torch.randint(0, 64000, (2, 128))).sum().backward()
```