### PR TITLE
fix rounding error with mixing datasets

### DIFF
--- a/src/olmo_core/data/source_mixture.py
+++ b/src/olmo_core/data/source_mixture.py
@@ -180,6 +180,10 @@ class SourceMixtureDatasetConfig(Config):
     """
     The data type of the dataset.
     """
+    global_batch_size: int
+    """
+    The global batch size for training, in tokens.
+    """
     processes: int = 1
     """
     The number of processes to use for counting tokens in parallel.
@@ -259,7 +263,7 @@ class SourceMixtureDatasetConfig(Config):
 
         # Increase the number of tokens per path until we have enough instances, handling rounding issues 
         all_tokens_per_path = [path.tokens for source_path_tokens in tokens_per_path_per_source.values() for path in source_path_tokens]
-        requested_instances = self.max_tokens // self.sequence_length
+        requested_instances = math.ceil(self.max_tokens / self.global_batch_size) * int(self.global_batch_size / self.sequence_length)
         padding = 0
         while True:
             if sum([(tokens_per_path + padding) // self.sequence_length for tokens_per_path in all_tokens_per_path]) >= requested_instances:

--- a/src/test/data/fixtures.py
+++ b/src/test/data/fixtures.py
@@ -53,6 +53,7 @@ def get_fsl_mixture(
         dtype=NumpyDatasetDType.uint16,
         processes=1,
         seed=seed,
+        global_batch_size=sequence_length * 32,
     )
 
     ds = NumpyDatasetConfig(

--- a/src/test/data/numpy_dataset_test.py
+++ b/src/test/data/numpy_dataset_test.py
@@ -309,6 +309,7 @@ def test_numpy_fsl_mixture_dataset(tmp_path: Path):
         dtype=NumpyDatasetDType.uint16,
         processes=1,
         seed=seed,
+        global_batch_size=sequence_length * 32
     )
 
     ds = NumpyDatasetConfig(
@@ -384,6 +385,7 @@ def test_numpy_fsl_mixture_dataset_with_repetition(tmp_path: Path):
         dtype=NumpyDatasetDType.uint16,
         processes=1,
         seed=seed,
+        global_batch_size=sequence_length * 32,  # 10k sequences of length 4
     )
 
     ds = NumpyDatasetConfig(

--- a/src/test/data/source_mixture_test.py
+++ b/src/test/data/source_mixture_test.py
@@ -39,12 +39,13 @@ def test_source_mixture_config(tmp_path: Path, caplog, capsys):
     ]
 
     max_tokens = 5_000_000
+    sequence_length = 1024
 
     config = SourceMixtureDatasetConfig(
         max_tokens=max_tokens,
         source_configs=source_configs,
         dtype=NumpyDatasetDType.uint32,
-        sequence_length=1024,
+        sequence_length=sequence_length,
         quiet=True,
         render_tables=True,
     )
@@ -55,6 +56,7 @@ def test_source_mixture_config(tmp_path: Path, caplog, capsys):
         config.validate()
         mixture = config.build()
         assert isinstance(mixture, SourceMixtureDataset)
+        assert sum([tokens // sequence_length for _, tokens in mixture.to_index().items()]) == max_tokens // sequence_length
         #  print(caplog.text)  # uncomment if you want to see the table
 
 


### PR DESCRIPTION
When handling a mixing dataset (i.e., `SourceMixtureDataset`), there is a rounding error in converting target ratios into number of tokens per path, into number of instances per path. The precise issue:

> tokens_requested_per_path = target_ratio * num_tokens_in_path
> instances_requested_per_path = tokens_requested_per_path // sequence_length 
> sum(instances_requested_per_path) / batch_size != training_steps

where `batch_size` is at the instance level (i.e. `global_batch_size / sequence_length`) and `training_steps = math.ceil(max_tokens / global_batch_size)`.  

The consequence of this: Cookbook trains for `max_tokens` duration on the dataset, but the dataset has fewer than `max_tokens` due to this rounding error. Training thus goes 5-30 steps into epoch 2. We didn't notice this error on pre-training experiments, but it becomes obvious on mid-training anneals, as the training loss suddenly drops. 

<img src="https://github.com/user-attachments/assets/75134cb8-a1dd-40c2-a0a5-8543c283f7cd" width="400" />


The fix: request more tokens for each path:
> tokens_requested_per_path = target_ratio x num_tokens_in_path + padding, 

where padding is the smallest constant number such that 
> sum(instances_requested_per_path) / batch_size == training_steps

This way, we handle the rounding error evenly throughout the dataset; the padding approach roughly preserves the target ratios. 

Example runs:
Before fix
https://wandb.ai/ai2-llm/olmo-cookbook/runs/jeylqj50

After fix 
https://wandb.ai/ai2-llm/olmo-cookbook/runs/nbdfadys

<img src="https://github.com/user-attachments/assets/c7136e01-8625-429b-8783-4a538df30a93" width="400"/>

Note: this change does not impact non-mixing datasets.