### PR TITLE
fix initialization (again)

### DIFF
--- a/src/olmo_core/nn/transformer/init.py
+++ b/src/olmo_core/nn/transformer/init.py
@@ -2,12 +2,27 @@ from typing import Optional, Union, cast
 
 import torch
 import torch.nn as nn
+from torch.distributed.tensor import DTensor
 
 from olmo_core.config import StrEnum
+from olmo_core.distributed.utils import distribute_like, get_local_tensor
 
 from ..attention import Attention, AttentionBase, FusedAttention
 from ..feed_forward import FeedForward
 from ..moe import DroplessMoEMLP, MoEBase, MoELinearRouter, MoEMLP
+
+
+def _apply_init(init_fun, x: torch.Tensor, *args, **kwargs):
+    if not isinstance(x, DTensor):
+        init_fun(x, *args, **kwargs)
+
+    # Initialize full version of x locally, then apply init to that.
+    full_x = torch.zeros(x.shape, dtype=x.dtype, device=x.device)
+    init_fun(full_x, *args, **kwargs)
+    full_x = distribute_like(x, full_x)
+
+    # Now copy over the corresponding shard of `full_x` into `x`.
+    get_local_tensor(x).copy_(get_local_tensor(full_x))
 
 
 class InitMethod(StrEnum):
@@ -37,8 +52,14 @@ class InitMethod(StrEnum):
     def _init_linear(
         self, m: nn.Linear, *, std: float = 0.02, generator: Optional[torch.Generator] = None
     ):
-        nn.init.trunc_normal_(
-            m.weight, mean=0.0, std=std, a=-3 * std, b=3 * std, generator=generator
+        _apply_init(
+            nn.init.trunc_normal_,
+            m.weight,
+            mean=0.0,
+            std=std,
+            a=-3 * std,
+            b=3 * std,
+            generator=generator,
         )
         if m.bias is not None:
             nn.init.zeros_(m.bias)
@@ -52,12 +73,18 @@ class InitMethod(StrEnum):
         generator: Optional[torch.Generator] = None,
     ):
         if self in (InitMethod.llama, InitMethod.llama_depth):
-            nn.init.normal_(m.weight, generator=generator)
+            _apply_init(nn.init.normal_, m.weight, generator=generator)
         elif self == InitMethod.normalized:
-            nn.init.normal_(m.weight, std=d_model**-0.5)
+            _apply_init(nn.init.normal_, m.weight, generator=generator, std=d_model**-0.5)
         else:
-            nn.init.trunc_normal_(
-                m.weight, mean=0.0, std=std, a=-3 * std, b=3 * std, generator=generator
+            _apply_init(
+                nn.init.trunc_normal_,
+                m.weight,
+                mean=0.0,
+                std=std,
+                a=-3 * std,
+                b=3 * std,
+                generator=generator,
             )
 
     def init_final_w_out(
@@ -149,7 +176,8 @@ class InitMethod(StrEnum):
         elif self == InitMethod.llama_depth:
             std = std / (2 * (block_idx + 1)) ** 0.5
 
-        nn.init.trunc_normal_(
+        _apply_init(
+            nn.init.trunc_normal_,
             cast(MoELinearRouter, m.router).weight,
             mean=0.0,
             std=std,
@@ -157,7 +185,8 @@ class InitMethod(StrEnum):
             b=3 * std,
             generator=generator,
         )
-        nn.init.trunc_normal_(
+        _apply_init(
+            nn.init.trunc_normal_,
             cast(Union[MoEMLP, DroplessMoEMLP], m.experts.mlp).w1,
             mean=0.0,
             std=std,
@@ -165,7 +194,8 @@ class InitMethod(StrEnum):
             b=3 * std,
             generator=generator,
         )
-        nn.init.trunc_normal_(
+        _apply_init(
+            nn.init.trunc_normal_,
             cast(Union[MoEMLP, DroplessMoEMLP], m.experts.mlp).w2,
             mean=0.0,
             std=std,
@@ -173,7 +203,8 @@ class InitMethod(StrEnum):
             b=3 * std,
             generator=generator,
         )
-        nn.init.trunc_normal_(
+        _apply_init(
+            nn.init.trunc_normal_,
             cast(Union[MoEMLP, DroplessMoEMLP], m.experts.mlp).w3,
             mean=0.0,
             std=std,

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -21,7 +21,8 @@ from torch.distributed.tensor import Replicate, Shard
 from torch.distributed.tensor.parallel import RowwiseParallel, parallelize_module
 
 from olmo_core.data.utils import get_cumulative_document_lengths
-from olmo_core.distributed.utils import get_rank, hide_from_torch, unhide_from_torch
+from olmo_core.distributed.parallel import get_pp_mesh
+from olmo_core.distributed.utils import hide_from_torch, unhide_from_torch
 from olmo_core.doc_utils import beta_feature
 from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.float8 import Float8Config
@@ -212,6 +213,7 @@ class Transformer(nn.Module):
         max_seq_len: Optional[int] = None,
         max_local_microbatch_size: Optional[int] = None,
         device: Optional[torch.device] = None,
+        world_mesh: Optional[DeviceMesh] = None,
     ) -> torch.Generator:
         """
         Initialize the model weights.
@@ -229,7 +231,10 @@ class Transformer(nn.Module):
             if hasattr(module, "reset_parameters"):
                 module.reset_parameters()  # type: ignore
 
-        seed = self.init_seed + get_rank()
+        seed = self.init_seed
+        if world_mesh is not None and self.pp_enabled:
+            seed += get_pp_mesh(world_mesh).get_local_rank()
+
         generator = torch.Generator(device).manual_seed(seed)
 
         if self.embeddings is not None:
@@ -831,13 +836,8 @@ class NormalizedTransformer(Transformer):
         return block
 
     @torch.no_grad()
-    def init_weights(
-        self,
-        *,
-        max_seq_len: Optional[int] = None,
-        device: Optional[torch.device] = None,
-    ) -> torch.Generator:
-        generator = super().init_weights(max_seq_len=max_seq_len, device=device)
+    def init_weights(self, *args, **kwargs) -> torch.Generator:
+        generator = super().init_weights(*args, **kwargs)
         self.normalize_matrices()
         return generator
 

--- a/src/olmo_core/train/train_module/transformer/common.py
+++ b/src/olmo_core/train/train_module/transformer/common.py
@@ -151,6 +151,7 @@ def parallelize_model(
             max_seq_len=max_sequence_length,
             max_local_microbatch_size=rank_microbatch_size,
             device=device,
+            world_mesh=world_mesh,
         )
 
     return model


### PR DESCRIPTION
# Background
While fixing one thing, #307 introduced a different issue with HSDP. Unlike DDP, PyTorch's `fully_shard()` (FSDP) wrapper doesn't synchronize to make sure parameters are consistent across the process group. So when you init your rank-local tensors with different seeds, you end up with inconsistent parameters across replica groups. That means replica 1 has completely different parameters than replica 2, and so on. When we restarted the bad run, this actually helped it out because now the replicas all ended up with the same parameters (the params from the first replica, because that's what was saved to the checkpoint).

# Changes
This PR reverts #307 more or less, and introduces a different way of initializing DTensors in general such that:
1. We don't run into this bug with HSDP.
2. We get the same full tensors after initialization regardless of world size.

# Integration test
I tested this end-to-end with the exact same OLMo3-1B settings where we observed the issue in the first place. You can find the runs here named `OLMo3-1B-swafix-initfix`: https://wandb.ai/ai2-llm/olmo3/workspace?nw=2kjfyryx4wm

![image](https://github.com/user-attachments/assets/7beff958-2fd8-4e34-be08-38fb542eea45)

Interestingly we also see lower peak GPU memory usage with this method.

![image](https://github.com/user-attachments/assets/5ef5e7c3-5e4a-45cb-b56e-cca019bd93d8)
