### PR TITLE
Add missing return in init

### DIFF
--- a/src/olmo_core/nn/transformer/init.py
+++ b/src/olmo_core/nn/transformer/init.py
@@ -15,6 +15,7 @@ from ..moe import DroplessMoEMLP, MoEBase, MoELinearRouter, MoEMLP
 def _apply_init(init_fun, x: torch.Tensor, *args, **kwargs):
     if not isinstance(x, DTensor):
         init_fun(x, *args, **kwargs)
+        return
 
     # Initialize full version of x locally, then apply init to that.
     full_x = torch.zeros(x.shape, dtype=x.dtype, device=x.device)


### PR DESCRIPTION
Fixing a bug that breaks some local tests I made for muP. Caused by https://github.com/allenai/OLMo-core/pull/319