### PR TITLE
loosen numpy requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.9"
 license = { file = "LICENSE" }
 dependencies = [
-    "numpy<2.0",
+    "numpy",
     "torch>=2.6.0",
     "cached-path>=1.7.2",
     "requests",


### PR DESCRIPTION
Loosen numpy requirement as ai2-olmo-eval no longer depends on numpy<2.0.