### PR TITLE
More Rope Scaling Implementations (PI, Yarn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `foreach` support in `SkipStepAdamW`.
 - Added `budget` mode for activation checkpointing configuration.
 - Added `io.remove_file()` function.
+- Added ABF, PI, and YaRN rope scaling strategies.
 
 ### Changed
 

--- a/src/olmo_core/config.py
+++ b/src/olmo_core/config.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from dataclasses import dataclass, fields, is_dataclass, replace
 from enum import Enum
@@ -201,6 +202,12 @@ class Config:
         Creates a new object of the same type, replacing fields with values from ``changes``.
         """
         return replace(self, **changes)
+
+    def copy(self, deep: bool = True) -> Self:
+        """
+        Creates a new object of the same type, with the same values.
+        """
+        return copy.deepcopy(self) if deep else copy.copy(self)
 
     @classmethod
     def from_dict(cls: Type[C], data: Dict[str, Any], overrides: Optional[List[str]] = None) -> C:

--- a/src/olmo_core/nn/rope.py
+++ b/src/olmo_core/nn/rope.py
@@ -370,10 +370,7 @@ class RotaryEmbedding(RotaryEmbeddingBase):
 
         with torch.autocast(device.type, enabled=False):
             if self.scaling is None:
-                inv_freq = 1.0 / (
-                    self.theta
-                    ** (torch.arange(0, self.dim, 2, device=device, dtype=torch.float) / self.dim)
-                )
+                inv_freq = compute_inv_freqs(self.theta, self.dim, device)
                 attention_rescale_factor = 1.0
             else:
                 inv_freq, attention_rescale_factor = self.scaling.compute_scaled_inv_freq(

--- a/src/olmo_core/nn/transformer/config.py
+++ b/src/olmo_core/nn/transformer/config.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Dict, List, Optional
@@ -868,6 +869,9 @@ class TransformerConfig(Config):
         fused_ops: bool = False,
         use_flash: bool = False,
         block_name: TransformerBlockType = TransformerBlockType.default,
+        block_mods: Optional[
+            Dict[int, Callable[[TransformerBlockConfig], TransformerBlockConfig]]
+        ] = None,
         dtype: DType = DType.float32,
         rope_scaling: Optional[RoPEScalingConfig] = None,
         feed_forward: Optional[FeedForwardConfig] = None,
@@ -881,6 +885,7 @@ class TransformerConfig(Config):
         :param hidden_size_multiplier: Custom multiplier for the FFN hidden size.
         :param fused_ops: Use fused operations where possible.
         :param use_flash: Use flash-attn.
+        :param block_mods: A dictionary of block indices to functions that take the base block config and return a modified block config.
         :param dtype: The default data type to use for all parameters.
         """
         # Resolve hidden size of FFN in blocks.
@@ -927,6 +932,16 @@ class TransformerConfig(Config):
             layer_norm=layer_norm,
         )
 
+        if block_mods and kwargs.get("block_overrides"):
+            raise OLMoConfigurationError(
+                "`block_mods` and `block_overrides` cannot be used together."
+            )
+        block_overrides = None
+        if block_mods:
+            block_overrides = {i: block_mods[i](block.copy()) for i in block_mods}
+        elif kwargs.get("block_overrides"):
+            block_overrides = kwargs.get("block_overrides")
+
         return cls(
             d_model=d_model,
             vocab_size=vocab_size,
@@ -934,6 +949,7 @@ class TransformerConfig(Config):
             block=block,
             lm_head=LMHeadConfig(layer_norm=layer_norm, bias=False, dtype=dtype),
             dtype=dtype,
+            block_overrides=block_overrides,
             **kwargs,
         )
 

--- a/src/test/nn/rope_test.py
+++ b/src/test/nn/rope_test.py
@@ -2,9 +2,13 @@ import pytest
 import torch
 
 from olmo_core.nn.rope import (
+    ABFRoPEScalingConfig,
     ComplexRotaryEmbedding,
     FusedRotaryEmbedding,
+    PIRoPEScalingConfig,
     RotaryEmbedding,
+    StepwiseRoPEScalingConfig,
+    YaRNRoPEScalingConfig,
 )
 from olmo_core.testing import DEVICES, requires_flash_attn, requires_gpu
 
@@ -129,3 +133,217 @@ def test_complex_rope_with_past_key_values(device, head_first):
 
         torch.testing.assert_close(q_full[:, :, -1:, :], q_part)
         torch.testing.assert_close(k_full, k_part)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_abf_rope_scaling(device):
+    B, T, d_model, n_heads = 2, 12, 16, 4
+    head_size = d_model // n_heads
+
+    # Test case where new_theta == theta, output should be identical
+    rope_vanilla = RotaryEmbedding(head_size=head_size, theta=500_000)
+    rope_abf = RotaryEmbedding(head_size=head_size, scaling=ABFRoPEScalingConfig(new_theta=500_000))
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+
+        q1, k1 = rope_vanilla(q, k)
+        q2, k2 = rope_abf(q.clone(), k.clone())
+
+        torch.testing.assert_close(q1, q2, rtol=1e-5, atol=1e-5)
+        torch.testing.assert_close(k1, k2, rtol=1e-5, atol=1e-5)
+
+    # Test case where new_theta != theta, output should be different
+    rope_abf_new_theta = RotaryEmbedding(
+        head_size=head_size, scaling=ABFRoPEScalingConfig(new_theta=16_000_000)
+    )
+
+    with torch.no_grad():
+        q3, k3 = rope_abf_new_theta(q.clone(), k.clone())
+
+        assert not torch.allclose(q1, q3, rtol=1e-5, atol=1e-5)
+        assert not torch.allclose(k1, k3, rtol=1e-5, atol=1e-5)
+
+        assert q1.shape == q3.shape
+        assert k1.shape == k3.shape
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_pi_rope_scaling(device):
+    B, T, d_model, n_heads = 2, 12, 16, 4
+    head_size = d_model // n_heads
+
+    # Test vanilla RoPE vs PI scaling with factor=1 (should be identical)
+    rope_vanilla = RotaryEmbedding(head_size=head_size)
+    rope_pi_factor1 = RotaryEmbedding(head_size=head_size, scaling=PIRoPEScalingConfig(factor=1.0))
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+
+        q1, k1 = rope_vanilla(q, k)
+        q2, k2 = rope_pi_factor1(q.clone(), k.clone())
+
+        torch.testing.assert_close(q1, q2, rtol=1e-5, atol=1e-5)
+        torch.testing.assert_close(k1, k2, rtol=1e-5, atol=1e-5)
+
+    # Test PI scaling with factor=2 (should compress positions)
+    rope_pi_factor2 = RotaryEmbedding(head_size=head_size, scaling=PIRoPEScalingConfig(factor=2.0))
+
+    with torch.no_grad():
+        q3, k3 = rope_pi_factor2(q.clone(), k.clone())
+
+        # With factor=2, the embeddings should be different from vanilla
+        assert not torch.allclose(q1, q3, rtol=1e-5, atol=1e-5)
+        assert not torch.allclose(k1, k3, rtol=1e-5, atol=1e-5)
+
+        # But the shapes should be the same
+        assert q1.shape == q3.shape
+        assert k1.shape == k3.shape
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_per_frequency_rope_scaling(device):
+    B, T, d_model, n_heads = 2, 12, 512, 4  # head_size = 128
+    head_size = d_model // n_heads
+
+    rope_vanilla = RotaryEmbedding(head_size=head_size)
+    rope_per_freq = RotaryEmbedding(head_size=head_size, scaling=StepwiseRoPEScalingConfig())
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+
+        q_van, k_van = rope_vanilla(q, k)
+        q_pf, k_pf = rope_per_freq(q.clone(), k.clone())
+
+        # Per-freq scaling keeps the very first (highest-frequency) rotary pair unchanged.
+        torch.testing.assert_close(
+            q_van[..., :1],  # first rotary pair → highest frequency
+            q_pf[..., :1],
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        torch.testing.assert_close(
+            k_van[..., :1],
+            k_pf[..., :1],
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+        # Lower-frequency components *should* differ from vanilla RoPE.
+        assert not torch.allclose(q_van[..., -1:], q_pf[..., -1:], rtol=1e-5, atol=1e-5)
+        assert not torch.allclose(k_van[..., -1:], k_pf[..., -1:], rtol=1e-5, atol=1e-5)
+
+        # Shapes stay identical.
+        assert q_van.shape == q_pf.shape
+        assert k_van.shape == k_pf.shape
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_yarn_rope_scaling(device):
+    B, T, d_model, n_heads = 2, 12, 512, 4  # head_size = 128
+    head_size = d_model // n_heads
+
+    rope_vanilla = RotaryEmbedding(head_size=head_size)
+    rope_yarn = RotaryEmbedding(head_size=head_size, scaling=YaRNRoPEScalingConfig())
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+
+        q_van, k_van = rope_vanilla(q, k)
+        q_yarn, k_yarn = rope_yarn(q.clone(), k.clone())
+
+        assert not torch.allclose(q_van, q_yarn, rtol=1e-5, atol=1e-5)
+        assert not torch.allclose(k_van, k_yarn, rtol=1e-5, atol=1e-5)
+
+        # Shapes stay identical.
+        assert q_van.shape == q_yarn.shape
+        assert k_van.shape == k_yarn.shape
+
+
+@pytest.mark.parametrize("seq_len", [4, 8, 16, 32], ids=lambda t: f"T={t}")
+def test_rope_scaling_with_different_seq_lengths(seq_len):
+    B, d_model, n_heads = 2, 16, 4
+    head_size = d_model // n_heads
+    device = torch.device("cpu")
+
+    rope = RotaryEmbedding(head_size=head_size, scaling=PIRoPEScalingConfig(factor=2.0))
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, seq_len, head_size, device=device)
+        k = torch.rand(B, n_heads, seq_len, head_size, device=device)
+
+        q_out, k_out = rope(q, k)
+
+        # Shapes must remain unchanged.
+        assert q_out.shape == q.shape
+        assert k_out.shape == k.shape
+
+        # Ensure no NaN or Inf values are present.
+        assert torch.isfinite(q_out).all()
+        assert torch.isfinite(k_out).all()
+
+
+@pytest.mark.parametrize(
+    "scaling_config",
+    [
+        pytest.param(ABFRoPEScalingConfig(new_theta=8_000_000), id="abf"),
+        pytest.param(PIRoPEScalingConfig(factor=2.0), id="pi"),
+        pytest.param(
+            PIRoPEScalingConfig(factor=4.0, attention_rescale_factor=1.2), id="pi_rescale"
+        ),
+        pytest.param(StepwiseRoPEScalingConfig(factor=16.0), id="perfreq"),
+        pytest.param(YaRNRoPEScalingConfig(factor=8.0), id="yarn"),
+    ],
+)
+def test_rope_scaling_consistency(scaling_config):
+    B, T, d_model, n_heads = 2, 8, 16, 4
+    head_size = d_model // n_heads
+    device = torch.device("cpu")
+
+    rope = RotaryEmbedding(head_size=head_size, scaling=scaling_config)
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+
+        # Multiple calls should produce identical results
+        # (1st call populates cache and 2nd call uses cache)
+        q1, k1 = rope(q.clone(), k.clone())
+        q2, k2 = rope(q.clone(), k.clone())
+
+        torch.testing.assert_close(q1, q2)
+        torch.testing.assert_close(k1, k2)
+
+
+def test_rope_scaling_attention_rescale_factor():
+    """Test attention rescale factor functionality."""
+    B, T, d_model, n_heads = 2, 8, 16, 4
+    head_size = d_model // n_heads
+    device = torch.device("cpu")
+
+    # Test with custom attention rescale factor
+    rope_rescaled = RotaryEmbedding(
+        head_size=head_size, scaling=PIRoPEScalingConfig(factor=2.0, attention_rescale_factor=1.5)
+    )
+
+    rope_normal = RotaryEmbedding(
+        head_size=head_size, scaling=PIRoPEScalingConfig(factor=2.0, attention_rescale_factor=1.0)
+    )
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+
+        q1, k1 = rope_normal(q.clone(), k.clone())
+        q2, k2 = rope_rescaled(q.clone(), k.clone())
+
+        # With attention rescaling, the embeddings should be scaled
+        expected_q2 = q1 * 1.5
+        expected_k2 = k1 * 1.5
+
+        torch.testing.assert_close(q2, expected_q2, rtol=1e-5, atol=1e-5)
+        torch.testing.assert_close(k2, expected_k2, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
Implements
1. Absolute base frequency change
2. Position Interpolation
3. Stepwise (llama 3.1) scaling
4. Yarn


Note that per-layer rope theta modifications are already supported via the `block_overrides` arg to `TransformerConfig`