### PR TITLE
Add `TrainModule.pre_train()`, fix pain point with BZ scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a "interleaved" numpy FSL variant that interleaves several documents into sequences following the work from [LongSkywork: A Training Recipe for Efficiently Extending Context Length in Large Language Models](https://arxiv.org/pdf/2406.00605).
 - Added sliding window attention as a feature
 - Added `BatchSizeSchedulerCallback` for setting a batch size schedule over the course of a training run.
+- Added optional `TrainModule` method, `.pre_train()`, which runs right after `Callback.pre_train()`.
 - The `BeakerCallback` will save the config and Python requirements to the results dataset.
 - Added `from_file` method to `Config` class.
 - Added in-loop evals for OLMES basic skills eval

--- a/src/olmo_core/train/callbacks/batch_size_scheduler.py
+++ b/src/olmo_core/train/callbacks/batch_size_scheduler.py
@@ -86,10 +86,9 @@ class BatchSizeSchedulerCallback(Callback):
 
     def post_checkpoint_loaded(self, *args):
         del args
-        # NOTE: we set the batch size correctly after loading a checkpoint because
+        # NOTE: we set the "initial_lr_field" correctly after loading a checkpoint because
         # the "initial_lr_field" in the optimizer state always gets reset to the value from
-        # the config, not the checkpoint, and same for the "batches_processed" field in the
-        # data loader.
+        # the config, not the checkpoint.
         self._maybe_update_batch_size_and_lr()
 
     def pre_load_batch(self):

--- a/src/olmo_core/train/train_module/train_module.py
+++ b/src/olmo_core/train/train_module/train_module.py
@@ -121,6 +121,12 @@ class TrainModule(Stateful, metaclass=ABCMeta):
         Runs as soon as the :class:`~olmo_core.train.Trainer` has been attached.
         """
 
+    def pre_train(self):
+        """
+        Runs before the training loop starts and right after ``pre_train()`` has been called on all
+        callbacks.
+        """
+
     @abstractmethod
     def state_dict(self, *, optim: bool = True) -> Dict[str, Any]:
         """

--- a/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
@@ -241,7 +241,7 @@ class TransformerPipelineTrainModule(TrainModule):
         del labels
         return output
 
-    def on_attach(self):
+    def pre_train(self):
         # Validate batch size.
         dp_ws = get_world_size(self.trainer.dp_process_group)
         if self.trainer.global_batch_size % (self.rank_microbatch_size * dp_ws) != 0:

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -227,8 +227,10 @@ class TransformerTrainModule(TrainModule):
     def _reduce_divide_factor(self) -> float:
         return get_reduce_divide_factor(self.world_size)
 
-    def on_attach(self):
+    def pre_train(self):
         # Validate batch size.
+        # NOTE: we run this in `pre_train()` instead of, say, `on_attach()` because callbacks
+        # like `BatchSizeScheduler` may change the global batch size after the module is attached.
         dp_ws = get_world_size(self.trainer.dp_process_group)
         if self.trainer.global_batch_size % (self.rank_microbatch_size * dp_ws) != 0:
             raise OLMoConfigurationError(

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -638,6 +638,7 @@ class Trainer:
 
         for callback in self._iter_callbacks():
             callback.pre_train()
+        self.train_module.pre_train()
 
         barrier()
 


### PR DESCRIPTION
We have a pain point with the `BatchSizeScheduler` where a batch size check will fail (raising a `RuntimeError`) when restarting a run after a batch size increase with a bigger world size than would have been allowed with the previous batch size. As a result we've had to change parts of training script before relaunching, which is annoying, easy to forget, and error-prone.

The issue happens because the batch size check occurs before the `BatchSizeScheduler` updates the new batch size on `.post_checkpoint_loaded()`. So to fix this, this PR postpones the batch size check until right before training starts by moving it to a new `TrainModule` method `.pre_train()`, which runs right after `Callback.pre_train()`.