### PR TITLE
Add option to greedily pack documents with the padded FSL dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a script to compare two WandB runs
 - Added `namespace` option to `nn.buffer_cache.BufferCache`.
 - Added the option to configure `head_stride` for context parallelism with ring-flash-attn.
+- Added option to the padded FSL dataset to do greedy packing by source path.
 
 ### Changed
 

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -833,8 +833,14 @@ class NumpyFSLDatasetMixture(NumpyFSLDataset):
 
 class NumpyPaddedFSLDataset(NumpyFSLDataset):
     """
-    An FSL dataset that creates a single instance from each document.
-    The resulting instances will all have exactly ``sequence_length`` tokens, using padding if needed.
+    An FSL dataset that creates that uses padding to avoid fragmenting documents.
+    If ``do_greedy_packing`` is ``False`` (the default), each source document becomes its own
+    instance with padding added as needed to reach the desired ``sequence_length``.
+    If ``do_greedy_packing`` is ``True``, documents are packed greedily into instances, resulting
+    in less padding overall.
+
+    Regardless of the value of ``do_greedy_packing``, the resulting instances will all have exactly
+    ``sequence_length`` tokens.
     """
 
     def __init__(
@@ -850,6 +856,7 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
         include_instance_metadata: Optional[bool] = None,
         instance_filter_config: Optional[InstanceFilterConfig] = None,
         label_mask_paths: Optional[List[PathOrStr]] = None,
+        do_greedy_packing: bool = False,
     ):
         super().__init__(
             *paths,
@@ -865,10 +872,11 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
             label_mask_paths=label_mask_paths,
         )
         self._array_instance_offsets: Optional[Tuple[Tuple[int, int], ...]] = None
+        self._do_greedy_packing = do_greedy_packing
 
     @property
     def fingerprint_fields(self) -> Tuple[str, ...]:
-        return (
+        fields = (
             "vocab_size",
             "pad_token_id",
             "eos_token_id",
@@ -877,6 +885,10 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
             "bos_token_id",
             "sequence_length",
         )
+        # For backwards compat, don't add this unless it's true.
+        if self._do_greedy_packing:
+            fields = fields + ("_do_greedy_packing",)
+        return fields
 
     @property
     def offsets(self) -> Tuple[Tuple[int, int], ...]:
@@ -929,7 +941,10 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
         return data
 
     def _get_instance_indices_path(self, source_path: PathOrStr) -> Path:
-        return self._get_indices_path(source_path, "instance-indices")
+        if self._do_greedy_packing:
+            return self._get_indices_path(source_path, "instance-indices", "greedily-packed")
+        else:
+            return self._get_indices_path(source_path, "instance-indices")
 
     def _write_instance_indices(self):
         paths_needed: List[PathOrStr] = []
@@ -955,6 +970,7 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
                         eos_token_id=self.eos_token_id,
                         dtype=self.dtype,
                         indices_dtype=self.indices_dtype,
+                        do_greedy_packing=self._do_greedy_packing,
                     )
                     futures.append(future)
 
@@ -962,10 +978,10 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
 
                 # Log results.
                 for path, future in zip(paths_needed, futures):
-                    _, total_instances = future.result()
+                    total_docs, total_instances = future.result()
                     log.info(
                         f"Created {total_instances:,d} instances of sequence length up to "
-                        f"{self.sequence_length} from '{path}'"
+                        f"{self.sequence_length} from {total_docs:,d} documents at '{path}'."
                     )
 
 
@@ -2335,6 +2351,10 @@ class NumpyDatasetConfig(Config):
     """
     Determines how long documents are handled with the packed FSL dataset.
     """
+    do_greedy_packing: Optional[bool] = False
+    """
+    Only valid for the padded FSL dataset.
+    """
 
     def validate(self):
         if self.name in (NumpyDatasetType.fsl, NumpyDatasetType.padded_fsl):
@@ -2506,6 +2526,10 @@ class NumpyDatasetConfig(Config):
                 raise OLMoConfigurationError(
                     "'interleaving_exempt_paths' is only valid for the interleaved FSL dataset"
                 )
+            if self.do_greedy_packing is not None:
+                raise OLMoConfigurationError(
+                    "'do_greedy_packing' is only valid for the padded FSL dataset"
+                )
             if self.source_mixture_config:
                 if label_mask_paths is not None:
                     raise OLMoConfigurationError(
@@ -2603,6 +2627,7 @@ class NumpyDatasetConfig(Config):
                 include_instance_metadata=self.include_instance_metadata,
                 instance_filter_config=self.instance_filter_config,
                 label_mask_paths=label_mask_paths,
+                do_greedy_packing=self.do_greedy_packing or False,
             )
         elif self.name == NumpyDatasetType.packed_fsl:
             if self.sequence_length is None:
@@ -2642,6 +2667,10 @@ class NumpyDatasetConfig(Config):
             if self.interleaving_exempt_paths is not None:
                 raise OLMoConfigurationError(
                     "'interleaving_exempt_paths' is only valid for the interleaved FSL dataset"
+                )
+            if self.do_greedy_packing is not None:
+                raise OLMoConfigurationError(
+                    "'do_greedy_packing' is only valid for the padded FSL dataset"
                 )
             dataset = NumpyPackedFSLDataset(
                 *paths,
@@ -2703,6 +2732,10 @@ class NumpyDatasetConfig(Config):
                 raise OLMoConfigurationError(
                     "'long_doc_strategy' is only a valid field for the packed FSL dataset"
                 )
+            if self.do_greedy_packing is not None:
+                raise OLMoConfigurationError(
+                    "'do_greedy_packing' is only valid for the padded FSL dataset"
+                )
 
             interleaving_exempt_paths = cast(
                 Optional[List[PathOrStr]], self.interleaving_exempt_paths
@@ -2761,6 +2794,10 @@ class NumpyDatasetConfig(Config):
             if self.tokenizer.bos_token_id is not None:
                 raise OLMoConfigurationError(
                     "'bos_token_id' is not yet supported for the VSL dataset"
+                )
+            if self.do_greedy_packing is not None:
+                raise OLMoConfigurationError(
+                    "'do_greedy_packing' is only valid for the padded FSL dataset"
                 )
             dataset = NumpyVSLDataset(
                 *paths,

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -37,6 +37,7 @@ from ..aliases import PathOrStr
 from ..config import Config, StrEnum
 from ..distributed.utils import barrier, get_fs_local_rank
 from ..io import _get_s3_client, get_file_size
+from ..io import glob as olmo_glob
 from .mixes import DataMix, DataMixBase
 from .source_mixture import SourceMixtureDatasetConfig
 from .tokenizer import TokenizerConfig
@@ -2442,11 +2443,9 @@ class NumpyDatasetConfig(Config):
         metadata = self.metadata
         label_mask_paths: Optional[List[PathOrStr]] = None
         if self.paths and self.expand_glob:
-            from glob import glob
-
             for glob_path in self.paths:
                 log.info(f"Expanding '{glob_path}'...")
-                matches = sorted(glob(glob_path))
+                matches = sorted(olmo_glob(glob_path))
                 if not matches:
                     raise FileNotFoundError(glob_path)
                 for path in matches:
@@ -2457,7 +2456,7 @@ class NumpyDatasetConfig(Config):
                 label_mask_paths = []
                 for glob_path in self.label_mask_paths:
                     log.info(f"Expanding '{glob_path}'...")
-                    matches = sorted(glob(glob_path))
+                    matches = sorted(olmo_glob(glob_path))
                     if not matches:
                         raise FileNotFoundError(glob_path)
                     for path in matches:

--- a/src/olmo_core/data/utils.py
+++ b/src/olmo_core/data/utils.py
@@ -527,7 +527,7 @@ def segment_documents_into_instances(
                     # If document is at least 'max_sequence_length' long, just yield that as an instance.
                     if doc_length >= max_sequence_length:
                         yield start_idx
-                        yield end_idx
+                        yield start_idx + max_sequence_length
                         continue
 
                     # Otherwise start a new instance with this document.
@@ -537,8 +537,8 @@ def segment_documents_into_instances(
                     # Document is too long to add to current instance without truncating, so start a new instance.
                     yield instance_start
                     yield instance_start + instance_length
-                    instance_start = None
-                    instance_length = 0
+                    instance_start = start_idx
+                    instance_length = doc_length
                 else:
                     # We can add the document to the current instance.
                     instance_length += doc_length

--- a/src/olmo_core/data/utils.py
+++ b/src/olmo_core/data/utils.py
@@ -495,6 +495,7 @@ def segment_documents_into_instances(
         Type[np.uint8], Type[np.uint16], Type[np.uint32], Type[np.uint64]
     ] = np.uint32,
     sample: Optional[Tuple[int, int]] = None,
+    do_greedy_packing: bool = False,
 ) -> Tuple[int, int]:
     """
     Segment documents into instances of at most ``sequence_length`` tokens.
@@ -505,15 +506,48 @@ def segment_documents_into_instances(
     Returns the number of original documents and the number of resulting instances documents.
     """
     total_og_docs = 0
-    idx_gen = (
-        idx
-        for start_idx, end_idx in iter_document_indices(
-            path, eos_token_id=eos_token_id, dtype=dtype
-        )
-        for idx in (start_idx, start_idx + min(end_idx - start_idx, max_sequence_length))
-    )
-    indices = np.fromiter(idx_gen, dtype=indices_dtype)
-    total_og_docs = len(indices) // 2
+
+    def _gen_indices():
+        nonlocal total_og_docs
+        doc_indices = iter(iter_document_indices(path, eos_token_id=eos_token_id, dtype=dtype))
+        if not do_greedy_packing:
+            for start_idx, end_idx in doc_indices:
+                total_og_docs += 1
+                yield start_idx
+                yield start_idx + min(end_idx - start_idx, max_sequence_length)
+        else:
+            instance_start: Optional[int] = None
+            instance_length = 0
+            for start_idx, end_idx in doc_indices:
+                total_og_docs += 1
+                doc_length = end_idx - start_idx
+
+                if instance_start is None:
+                    # Start of a new instance...
+                    # If document is at least 'max_sequence_length' long, just yield that as an instance.
+                    if doc_length >= max_sequence_length:
+                        yield start_idx
+                        yield end_idx
+                        continue
+
+                    # Otherwise start a new instance with this document.
+                    instance_start = start_idx
+                    instance_length = doc_length
+                elif instance_length + doc_length > max_sequence_length:
+                    # Document is too long to add to current instance without truncating, so start a new instance.
+                    yield instance_start
+                    yield instance_start + instance_length
+                    instance_start = None
+                    instance_length = 0
+                else:
+                    # We can add the document to the current instance.
+                    instance_length += doc_length
+
+            if instance_start is not None:
+                yield instance_start
+                yield instance_start + instance_length
+
+    indices = np.fromiter(_gen_indices(), dtype=indices_dtype)
 
     if sample is not None:
         max_instances, seed = sample

--- a/src/olmo_core/io.py
+++ b/src/olmo_core/io.py
@@ -1,3 +1,4 @@
+import fnmatch
 import io
 import logging
 import os
@@ -375,6 +376,16 @@ def clear_directory(dir: PathOrStr, force: bool = False):
             )
     elif Path(dir).is_dir():
         shutil.rmtree(dir, ignore_errors=True)
+
+
+def glob(pattern: str, recurse: bool = True) -> Generator[str, None, None]:
+    """
+    Like ``glob.glob()`` from the standard library, but works with remote directories as well.
+    """
+    dir = pattern.split("*", 1)[0]
+    for path in list_directory(dir, recurse=recurse):
+        if fnmatch.fnmatch(path, pattern):
+            yield path
 
 
 def list_directory(

--- a/src/test/data/utils_test.py
+++ b/src/test/data/utils_test.py
@@ -47,6 +47,45 @@ def test_segment_documents_into_instances(tmp_path):
     assert all([r[1] == 2 for r in results])
 
 
+def test_segment_documents_into_instances_with_greedy_packing(tmp_path):
+    dtype = np.uint16
+    data = [1, 2, 3, 4, 0, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 0]
+    data_path = tmp_path / "data.npy"
+    mmap = np.memmap(data_path, mode="w+", dtype=dtype, shape=(len(data),))
+    mmap[:] = data
+    mmap.flush()
+
+    indices_path = tmp_path / "indices.npy"
+    list(
+        segment_documents_into_instances(
+            path=data_path,
+            target=indices_path,
+            max_sequence_length=5,
+            eos_token_id=0,
+            dtype=dtype,
+            indices_dtype=dtype,
+            do_greedy_packing=True,
+        )
+    )
+    indices = np.memmap(indices_path, mode="r", dtype=dtype).reshape((-1, 2)).tolist()
+    assert indices == [[0, 5], [5, 10], [10, 15]]
+
+    indices_path = tmp_path / "indices.npy"
+    list(
+        segment_documents_into_instances(
+            path=data_path,
+            target=indices_path,
+            max_sequence_length=12,
+            eos_token_id=0,
+            dtype=dtype,
+            indices_dtype=dtype,
+            do_greedy_packing=True,
+        )
+    )
+    indices = np.memmap(indices_path, mode="r", dtype=dtype).reshape((-1, 2)).tolist()
+    assert indices == [[0, 10], [10, 16]]
+
+
 def test_iter_document_indices(tmp_path):
     data = [1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 0]
     data_path = tmp_path / "data.npy"


### PR DESCRIPTION
Currently the padded FSL dataset creates a single instance for each document, adding padding when necessary to ensure all instances at runtime have the target sequence length. This is nice for evals, for we're thinking we could potentially use this for training if we made it a little more efficient by greedily packing documents into instances. There will still be some padding, how much depends on the composition of source files.

You can enable this in a training script by adding the options:

```
dataset.name=padded_fsl --dataset.do_greedy_packing=true
```

Note: this probably shouldn't be used when training with tensor or context parallelism. Since instances will be right-padded, the highest rank within a TP/CP group will see fewer trainable tokens on average, which essentially means those tokens will get higher weight.