### PR TITLE
Fix empty config.json output in convert_checkpoint_from_hf

### DIFF
--- a/src/examples/huggingface/convert_checkpoint_from_hf.py
+++ b/src/examples/huggingface/convert_checkpoint_from_hf.py
@@ -149,6 +149,7 @@ def convert_checkpoint_from_hf(
 
     with tempfile.NamedTemporaryFile(mode="w") as temp_file:
         json.dump(experiment_config_dict, temp_file)
+        temp_file.flush()  # make sure data is written to disk, json.dump doesn't flush.
         copy_file(temp_file.name, config_path, save_overwrite=True)
         log.info(f"Successfully wrote partial experiment config to '{config_path}'")
 


### PR DESCRIPTION
The config JSON written by `convert_checkpoint_from_hf.py` could be empty if data wasn't flushed before copy. Adds a flash after `json.dump` to make sure this is the case.