### PR TITLE
Refine hostname constraints for beaker experiments on Google clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `namespace` option to `nn.buffer_cache.BufferCache`.
 - Added the option to configure `head_stride` for context parallelism with ring-flash-attn.
 - Added the option to group multiple npy source files together for packing with the packed FSL dataset by setting `source_group_size` to an integer greater than 1.
+- Added optional hostname constraints for beaker experiments on Google clusters.
 
 ### Changed
 

--- a/src/olmo_core/exceptions.py
+++ b/src/olmo_core/exceptions.py
@@ -40,5 +40,9 @@ class BeakerExperimentFailedError(OLMoError):
     pass
 
 
+class BeakerInsufficientResourcesError(OLMoError):
+    pass
+
+
 class OLMoUploadError(OLMoError):
     pass

--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -33,7 +33,7 @@ from ..exceptions import BeakerExperimentFailedError, OLMoConfigurationError
 from ..train.callbacks.beaker import BEAKER_RESULT_DIR
 from ..utils import LOG_FILTER_TYPE_ENV_VAR, LogFilterType
 from ..version import VERSION
-from .select_beaker_hosts import get_host_name_constraints
+from .select_beaker_hosts import get_beaker_hostname_constraints
 from .utils import GIT_BRANCH_ENV_VAR, GIT_REF_ENV_VAR, GIT_REPO_URL_ENV_VAR, GitConfig
 
 log = logging.getLogger(__name__)
@@ -242,6 +242,22 @@ class BeakerLaunchConfig(Config):
     The directory of the Beaker results dataset.
     """
 
+    use_hostname_constraints: bool = False
+    """
+    Uses hostname constraints to restrict the hostnames on which the experiment runs. This is currently
+    only supported for Augusta clusters, and can benefit performance by forcing the use of colocated nodes.
+
+    This is NOT recommended to be used lower priority preemptible jobs, since hostname constraints are not
+    updated on preemption.
+    """
+
+    num_execution_units: Optional[int] = None
+    """
+    Number of \"execution units\", defaults to ``max(1, num_nodes // 32)``. An \"execution unit\" is abstraction
+    for any node-using entity of which 1 or more copies are run, where each unit wants its nodes to be
+    from colocated hardware (e.g., a model replica for large jobs, or a full distributed model for small jobs).
+    """
+
     # NOTE: don't assign a type here because omegaconf can't validate arbitrary classes
     #  _beaker: Optional[Beaker] = None
     _beaker = None
@@ -404,9 +420,18 @@ class BeakerLaunchConfig(Config):
 
         entrypoint_dataset = self._create_script_dataset("entrypoint.sh", entrypoint_script)
 
-        if len(self.clusters) == 1 and "augusta" in self.clusters[0]:
-            host_name_constraints = get_host_name_constraints(
-                self.num_nodes, min(32, self.num_nodes), 1
+        if (
+            self.use_hostname_constraints
+            and len(self.clusters) == 1
+            and "augusta" in self.clusters[0]
+        ):
+            host_name_constraints = get_beaker_hostname_constraints(
+                self.num_nodes,
+                self.num_execution_units or max(1, self.num_nodes // 32),
+                1,
+                "us-central1-b",
+                beaker_cluster=self.clusters[0],
+                beaker_priority=self.priority,
             )
             assert (
                 len(host_name_constraints) == 1 and len(host_name_constraints[0]) >= self.num_nodes

--- a/src/olmo_core/launch/select_beaker_hosts.py
+++ b/src/olmo_core/launch/select_beaker_hosts.py
@@ -1,47 +1,179 @@
 import argparse
+import logging
 from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
 
+import google.auth
+from beaker import Job, Priority
 from google.cloud.compute_v1.services.instances.client import InstancesClient
-from google.cloud.compute_v1.types import ResourceStatusPhysicalHostTopology
+
+log = logging.getLogger(__name__)
 
 
-def get_machines_metadata() -> dict[str, ResourceStatusPhysicalHostTopology]:
-    client = InstancesClient()
-    instance_pages = client.list(project="h100-cluster-owner", zone="us-central1-b").pages
+@dataclass
+class HostMetadata:
+    block: str
+    """
+    The ID of the block in which the running instance is located. Instances within the same block
+    experience low network latency.
+    """
+
+    subblock: str
+    """
+    The ID of the sub-block in which the running instance is located. Instances in the same sub-block
+    experience lower network latency than instances in the same block.
+    """
+
+    machine: str
+    """
+    The ID of the machine ('host' according to Google) on which the running instance is located.
+    Instances on the same machine experience the lowest possible network latency.
+    """
+
+
+def get_hosts_metadata_from_gcp(
+    zone: str, *, credentials_path: Optional[Path] = None
+) -> dict[str, HostMetadata]:
+    if credentials_path:
+        credentials, project_id = google.auth.load_credentials_from_file(str(credentials_path))
+    else:
+        credentials, project_id = google.auth.default()
+
+    if project_id != "h100-cluster-owner":
+        raise RuntimeError(
+            f"Expected credentials for 'h100-cluster-owner', got credentials for {project_id}"
+        )
+
+    client = InstancesClient(credentials=credentials)
+    instance_pages = client.list(project=project_id, zone=zone).pages
     return {
-        instance.name: instance.resource_status.physical_host_topology
+        f"{instance.name}.reviz.ai2.in": HostMetadata(
+            block=instance.resource_status.physical_host_topology.block,
+            subblock=instance.resource_status.physical_host_topology.subblock,
+            machine=instance.resource_status.physical_host_topology.host,
+        )
         for page in instance_pages
         for instance in page.items
     }
 
 
+def _is_job_preemptible(job: Job, desired_priority: Priority) -> bool:
+    if not job.is_preemptible:
+        return False
+
+    assert job.priority is not None
+    # Priorities are sorted highest to lowest by default
+    sorted_priorities = list(Priority)
+    return sorted_priorities.index(desired_priority) < sorted_priorities.index(job.priority)
+
+
 def get_host_name_constraints(
+    hosts_metadata: dict[str, HostMetadata],
+    num_hosts_per_replica: int,
+    num_hosts_per_task: int,
+    num_tasks: int,
+) -> list[list[str]]:
+    hosts_by_block: defaultdict[str, list[str]] = defaultdict(list)
+    for host, metadata in hosts_metadata.items():
+        hosts_by_block[metadata.block].append(host)
+
+    hosts_per_task: list[list[str]] = []
+    for block, hosts in sorted(hosts_by_block.items(), key=lambda item: len(item[1]), reverse=True):
+        # We want no model replicas to have nodes from different blocks.
+        # To make this possible, within a task, either 1) every host must be from the same block or
+        # 2) we must have exactly as many hosts as the task size, and the number of hosts from each block
+        # must be a multiple of the model replica size.
+
+        if len(hosts) > num_hosts_per_task:
+            # Use all the hosts that we desire! They are all from the same block
+
+            for _ in range(0, len(hosts), num_hosts_per_task):
+                hosts_per_task.append(list(hosts))
+        else:
+            # We must constrain the hosts so that we have exactly as many hosts as the task size. This
+            # forces the tasks to be on those specific hosts
+
+            # Only keep a multiple of replica_size number of hosts from each block, to avoid having replicas
+            # go across block boundaries
+            host_count_from_block = (len(hosts) // num_hosts_per_replica) * num_hosts_per_replica
+
+            used_hosts_count = 0
+
+            if len(hosts_per_task) > 0 and len(hosts_per_task[-1]) < num_hosts_per_task:
+                # Last task needs more hosts, fill them up from here
+                needed_hosts = num_hosts_per_task - len(hosts_per_task[-1])
+                assert needed_hosts % num_hosts_per_replica == 0
+
+                # Take the nearest multiple of num_hosts_per_replica as the number of hosts to give to that task
+                used_hosts_count = min(
+                    needed_hosts,
+                    host_count_from_block // num_hosts_per_replica * num_hosts_per_replica,
+                )
+                assert used_hosts_count % num_hosts_per_replica == 0
+
+                hosts_per_task[-1].extend(hosts[:used_hosts_count])
+
+            # Deal with when last host didn't get filled up
+
+            # Put remaining hosts into next task
+            assert host_count_from_block - used_hosts_count <= num_hosts_per_task
+            assert (host_count_from_block - used_hosts_count) % num_hosts_per_replica == 0
+            hosts_per_task.append(list(hosts[used_hosts_count:host_count_from_block]))
+
+    hosts_per_task = hosts_per_task[:num_tasks]
+
+    if len(hosts_per_task) < num_tasks:
+        raise RuntimeError(f"Could only satisfy {len(hosts_per_task)} tasks")
+    if len(hosts_per_task[-1]) < num_hosts_per_task:
+        raise RuntimeError(
+            f"Could not satisfy task number {len(hosts_per_task) - 1}, only got {len(hosts_per_task[-1])} hosts"
+        )
+
+    return hosts_per_task
+
+
+def get_beaker_host_name_constraints(
     num_nodes: int,
     num_model_replica_nodes: int,
     beaker_task_count: int,
-    skip_urgent_nodes: bool = True,
-):
+    gcp_zone: str,
+    *,
+    beaker_cluster: str,
+    beaker_priority: Priority,
+    gcp_credentials_path: Optional[Path] = None,
+    remove_occupied_hosts: bool = False,
+) -> list[list[str]]:
+    if beaker_cluster != "augusta-google-1":
+        raise ValueError(
+            "Only Augusta is supported. Making this work for other clusters probably would be a bad idea..."
+        )
+
+    if beaker_priority != Priority.urgent:
+        log.warning(
+            "This script depends on cluster having nodes with jobs running at lower priority."
+            "It is relatively unlikely to work on non-urgent priorities."
+        )
+
+    assert num_nodes > 0
     assert num_nodes % num_model_replica_nodes == 0
     assert num_nodes % beaker_task_count == 0
+    beaker_num_hosts_per_task = num_nodes // beaker_task_count
 
-    assert num_nodes % beaker_task_count == 0
-    beaker_task_size = num_nodes // beaker_task_count
+    if beaker_task_count != 1:
+        raise NotImplementedError("Multiple task are not (fully) supported")
 
-    # assert beaker_task_count == 1, "Other task counts not supported"
+    machines_metadata = get_hosts_metadata_from_gcp(gcp_zone, credentials_path=gcp_credentials_path)
 
-    machines_metadata = get_machines_metadata()
-    machines_metadata = {
-        f"{host}.reviz.ai2.in": metadata for host, metadata in machines_metadata.items()
-    }
-
-    # Remove hosts with jobs running on urgent priority
-    if skip_urgent_nodes:
+    # Remove hosts with jobs running on equal or higher priority
+    if remove_occupied_hosts:
         from olmo_core.internal.common import get_beaker_client
 
         beaker = get_beaker_client()
         assert beaker is not None
 
-        cluster = beaker.cluster.get("augusta-google-1")
+        cluster = beaker.cluster.get(beaker_cluster)
         jobs = beaker.job.list(cluster=cluster)
 
         for job in jobs:
@@ -55,91 +187,73 @@ def get_host_name_constraints(
             if (
                 job.is_running
                 and job.execution
-                and job.execution.spec.resources
                 and job.execution.spec.resources.gpu_count > 0
-            ) and (not job.is_preemptible or job.priority == "urgent"):
+                and _is_job_preemptible(job, beaker_priority)
+            ):
                 del machines_metadata[host]
 
-    hosts_by_block: defaultdict[str, list[str]] = defaultdict(list)
-    for host, metadata in machines_metadata.items():
-        hosts_by_block[metadata.block].append(host)
-
-    hosts_per_task: list[list[str]] = []
-    for block, hosts in sorted(hosts_by_block.items(), key=lambda item: len(item[1]), reverse=True):
-        # If beaker_task_size is too big, then we might specify every host we need for things to work.
-        # If beaker_task_size is small, then we might specify every host we need for things to work.
-        # Within a task, either every host must be from the same block or we must have exactly as many hosts as the task size!
-
-        if len(hosts) > beaker_task_size:
-            # Use all the hosts that we desire! They are all from the same block
-
-            for _ in range(0, len(hosts), beaker_task_size):
-                hosts_per_task.append(list(hosts))
-        else:
-            # We must constrain the hosts so that we have exactly as many hosts as the task size. This
-            # forces the tasks to be on those specific hosts
-
-            # Only keep a multiple of replica_size number of hosts from each block, to avoid having replicas
-            # go across block boundaries
-            host_count_from_block = (
-                len(hosts) // num_model_replica_nodes
-            ) * num_model_replica_nodes
-
-            used_hosts_count = 0
-
-            if len(hosts_per_task) > 0 and len(hosts_per_task[-1]) < beaker_task_size:
-                # Last task needs more hosts, fill them up from here
-                needed_hosts = beaker_task_size - len(hosts_per_task[-1])
-                assert needed_hosts % num_model_replica_nodes == 0
-
-                # Take the nearest multiple of num_model_replica_nodes as the number of hosts to give to that task
-                used_hosts_count = min(
-                    needed_hosts,
-                    host_count_from_block // num_model_replica_nodes * num_model_replica_nodes,
-                )
-
-                hosts_per_task[-1].extend(hosts[:used_hosts_count])
-
-            # Put remaining hosts into next task
-            assert host_count_from_block - used_hosts_count <= beaker_task_size
-            assert (host_count_from_block - used_hosts_count) % num_model_replica_nodes == 0
-            hosts_per_task.append(list(hosts[used_hosts_count:host_count_from_block]))
-
-    hosts_per_task = hosts_per_task[:beaker_task_count]
-
-    if len(hosts_per_task) < beaker_task_count:
-        raise RuntimeError(f"Could only satisfy {len(hosts_per_task)} tasks")
-    if len(hosts_per_task[-1]) < beaker_task_size:
-        raise RuntimeError(
-            f"Could not satisfy task number {len(hosts_per_task) - 1}, only got {len(hosts_per_task[-1])} hosts"
-        )
-
-    return hosts_per_task
+    return get_host_name_constraints(
+        machines_metadata, num_model_replica_nodes, beaker_num_hosts_per_task, beaker_task_count
+    )
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("num_nodes", type=int, help="Total number of nodes")
-    parser.add_argument("num_model_replica_nodes", type=int, help="Number of nodes in each replica")
+    parser.add_argument("num-nodes", type=int, required=True, help="Total number of nodes")
     parser.add_argument(
-        "beaker_task_count",
-        type=int,
-        help="Number of beaker (pre-replication) tasks this job is being spread across",
+        "num-model-replica-nodes", type=int, required=True, help="Number of nodes in each replica"
     )
     parser.add_argument(
-        "--ignore-urgent",
-        action="store_false",
-        dest="skip_urgent_nodes",
+        "--task-count",
+        type=int,
+        required=True,
         help="Number of beaker (pre-replication) tasks this job is being spread across",
+    )
+
+    # Beaker-related settings
+    parser.add_argument(
+        "--priority",
+        type=Priority,
+        default=Priority.normal,
+        help="Desired beaker job priority.",
+    )
+    parser.add_argument(
+        "--cluster",
+        type=str,
+        default="augusta-google-1",
+        help="The beaker cluster. This defaults to and is assumed to be Augusta for now.",
+    )
+    parser.add_argument(
+        "--allow-occupied-hosts",
+        action="store_false",
+        dest="remove_occupied_hosts",
+        help="If set, allow selecting hosts with equal/higher priority GPU jobs.",
+    )
+
+    # GCP-related settings
+    parser.add_argument(
+        "--zone",
+        type=str,
+        default="us-central1-b",
+        help="The GCP zone where the Augusta nodes are located.",
+    )
+    parser.add_argument(
+        "--credentials-path",
+        type=Path,
+        required=True,
+        help="The path to GCP credetials.",
     )
     args = parser.parse_args()
 
     print(
-        get_host_name_constraints(
+        get_beaker_host_name_constraints(
             args.num_nodes,
             args.num_model_replica_nodes,
-            args.beaker_task_count,
-            skip_urgent_nodes=args.skip_urgent_nodes,
+            args.task_count,
+            args.zone,
+            beaker_cluster=args.cluster,
+            beaker_priority=args.priority,
+            remove_occupied_hosts=args.remove_occupied_hosts,
         )
     )
 

--- a/src/olmo_core/launch/select_beaker_hosts.py
+++ b/src/olmo_core/launch/select_beaker_hosts.py
@@ -71,7 +71,7 @@ def _is_job_preemptible(job: Job, desired_priority: Priority) -> bool:
     return sorted_priorities.index(desired_priority) < sorted_priorities.index(job.priority)
 
 
-def get_host_name_constraints(
+def get_hostname_constraints(
     hosts_metadata: dict[str, HostMetadata],
     num_hosts_per_replica: int,
     num_hosts_per_task: int,
@@ -138,7 +138,7 @@ def get_host_name_constraints(
     return hosts_per_task
 
 
-def get_beaker_host_name_constraints(
+def get_beaker_hostname_constraints(
     num_nodes: int,
     num_model_replica_nodes: int,
     beaker_task_count: int,
@@ -190,7 +190,7 @@ def get_beaker_host_name_constraints(
         ):
             del machines_metadata[host]
 
-    return get_host_name_constraints(
+    return get_hostname_constraints(
         machines_metadata, num_model_replica_nodes, beaker_num_hosts_per_task, beaker_task_count
     )
 
@@ -238,7 +238,7 @@ def main():
     args = parser.parse_args()
 
     print(
-        get_beaker_host_name_constraints(
+        get_beaker_hostname_constraints(
             args.num_nodes,
             args.num_model_replica_nodes,
             args.task_count,

--- a/src/test/launch/select_beaker_hosts_test.py
+++ b/src/test/launch/select_beaker_hosts_test.py
@@ -3,7 +3,7 @@ from collections import Counter
 import pytest
 
 from olmo_core.exceptions import BeakerInsufficientResourcesError
-from olmo_core.launch.select_beaker_hosts import HostMetadata, get_host_name_constraints
+from olmo_core.launch.select_beaker_hosts import HostMetadata, get_hostname_constraints
 
 
 def create_hosts_metadata(num_hosts_by_block: list[int]):
@@ -14,22 +14,22 @@ def create_hosts_metadata(num_hosts_by_block: list[int]):
     }
 
 
-def test_get_host_name_constraints_one_super_block():
+def test_get_hostname_constraints_one_super_block():
     num_hosts_by_block = [20]
     num_hosts_per_replica = 4
     num_tasks = 1
     num_hosts_per_task = 16
 
     hosts_metadata = create_hosts_metadata(num_hosts_by_block)
-    host_name_constraints = get_host_name_constraints(
+    hostname_constraints = get_hostname_constraints(
         hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks
     )
 
-    assert len(host_name_constraints) == num_tasks
-    assert len(host_name_constraints[0]) >= num_hosts_per_task
+    assert len(hostname_constraints) == num_tasks
+    assert len(hostname_constraints[0]) >= num_hosts_per_task
 
 
-def test_get_host_name_constraints_one_insufficient_block():
+def test_get_hostname_constraints_one_insufficient_block():
     num_hosts_by_block = [10]
     num_hosts_per_replica = 4
     num_tasks = 1
@@ -38,31 +38,31 @@ def test_get_host_name_constraints_one_insufficient_block():
     hosts_metadata = create_hosts_metadata(num_hosts_by_block)
 
     with pytest.raises(BeakerInsufficientResourcesError) as exc_info:
-        get_host_name_constraints(
+        get_hostname_constraints(
             hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks
         )
         assert exc_info.match("Could not satisfy task number 0, only got 10 hosts")
 
 
-def test_get_host_name_constraints_multiple_blocks():
+def test_get_hostname_constraints_multiple_blocks():
     num_hosts_by_block = [5, 13]
     num_hosts_per_replica = 4
     num_tasks = 1
     num_hosts_per_task = 16
 
     hosts_metadata = create_hosts_metadata(num_hosts_by_block)
-    host_name_constraints = get_host_name_constraints(
+    hostname_constraints = get_hostname_constraints(
         hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks
     )
 
-    assert len(host_name_constraints) == num_tasks
-    assert len(host_name_constraints[0]) >= num_hosts_per_task
-    blocks_host_count = Counter(host.split("_")[0] for host in host_name_constraints[0])
+    assert len(hostname_constraints) == num_tasks
+    assert len(hostname_constraints[0]) >= num_hosts_per_task
+    blocks_host_count = Counter(host.split("_")[0] for host in hostname_constraints[0])
     assert blocks_host_count["block0"] == 4
     assert blocks_host_count["block1"] == 12
 
 
-def test_get_host_name_constraints_multiple_insufficient_blocks():
+def test_get_hostname_constraints_multiple_insufficient_blocks():
     num_hosts_by_block = [5, 11]
     num_hosts_per_replica = 4
     num_tasks = 1
@@ -71,7 +71,7 @@ def test_get_host_name_constraints_multiple_insufficient_blocks():
     hosts_metadata = create_hosts_metadata(num_hosts_by_block)
 
     with pytest.raises(BeakerInsufficientResourcesError) as exc_info:
-        get_host_name_constraints(
+        get_hostname_constraints(
             hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks
         )
         assert exc_info.match("Could not satisfy task number 0, only got 12 hosts")

--- a/src/test/launch/select_beaker_hosts_test.py
+++ b/src/test/launch/select_beaker_hosts_test.py
@@ -1,0 +1,17 @@
+from olmo_core.launch.select_beaker_hosts import get_host_name_constraints, HostMetadata
+
+
+
+def test_host_name_constraints():
+    num_hosts_by_block = [2, 4, 6, 8]
+    num_hosts_per_replica = 4
+    num_tasks = 1
+    num_hosts_per_task = 16
+
+    hosts_metadata = {
+        f"block{i}_host{j}": HostMetadata(block=str(i), subblock="", machine="")
+        for i, block_hosts in enumerate(num_hosts_by_block)
+        for j in range(block_hosts) 
+    }
+
+    get_host_name_constraints(hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks)

--- a/src/test/launch/select_beaker_hosts_test.py
+++ b/src/test/launch/select_beaker_hosts_test.py
@@ -1,17 +1,77 @@
-from olmo_core.launch.select_beaker_hosts import get_host_name_constraints, HostMetadata
+from collections import Counter
+
+import pytest
+
+from olmo_core.exceptions import BeakerInsufficientResourcesError
+from olmo_core.launch.select_beaker_hosts import HostMetadata, get_host_name_constraints
 
 
+def create_hosts_metadata(num_hosts_by_block: list[int]):
+    return {
+        f"block{i}_host{j}": HostMetadata(block=str(i), subblock="", machine="")
+        for i, block_hosts in enumerate(num_hosts_by_block)
+        for j in range(block_hosts)
+    }
 
-def test_host_name_constraints():
-    num_hosts_by_block = [2, 4, 6, 8]
+
+def test_get_host_name_constraints_one_super_block():
+    num_hosts_by_block = [20]
     num_hosts_per_replica = 4
     num_tasks = 1
     num_hosts_per_task = 16
 
-    hosts_metadata = {
-        f"block{i}_host{j}": HostMetadata(block=str(i), subblock="", machine="")
-        for i, block_hosts in enumerate(num_hosts_by_block)
-        for j in range(block_hosts) 
-    }
+    hosts_metadata = create_hosts_metadata(num_hosts_by_block)
+    host_name_constraints = get_host_name_constraints(
+        hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks
+    )
 
-    get_host_name_constraints(hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks)
+    assert len(host_name_constraints) == num_tasks
+    assert len(host_name_constraints[0]) >= num_hosts_per_task
+
+
+def test_get_host_name_constraints_one_insufficient_block():
+    num_hosts_by_block = [10]
+    num_hosts_per_replica = 4
+    num_tasks = 1
+    num_hosts_per_task = 16
+
+    hosts_metadata = create_hosts_metadata(num_hosts_by_block)
+
+    with pytest.raises(BeakerInsufficientResourcesError) as exc_info:
+        get_host_name_constraints(
+            hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks
+        )
+        assert exc_info.match("Could not satisfy task number 0, only got 10 hosts")
+
+
+def test_get_host_name_constraints_multiple_blocks():
+    num_hosts_by_block = [5, 13]
+    num_hosts_per_replica = 4
+    num_tasks = 1
+    num_hosts_per_task = 16
+
+    hosts_metadata = create_hosts_metadata(num_hosts_by_block)
+    host_name_constraints = get_host_name_constraints(
+        hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks
+    )
+
+    assert len(host_name_constraints) == num_tasks
+    assert len(host_name_constraints[0]) >= num_hosts_per_task
+    blocks_host_count = Counter(host.split("_")[0] for host in host_name_constraints[0])
+    assert blocks_host_count["block0"] == 4
+    assert blocks_host_count["block1"] == 12
+
+
+def test_get_host_name_constraints_multiple_insufficient_blocks():
+    num_hosts_by_block = [5, 11]
+    num_hosts_per_replica = 4
+    num_tasks = 1
+    num_hosts_per_task = 16
+
+    hosts_metadata = create_hosts_metadata(num_hosts_by_block)
+
+    with pytest.raises(BeakerInsufficientResourcesError) as exc_info:
+        get_host_name_constraints(
+            hosts_metadata, num_hosts_per_replica, num_hosts_per_task, num_tasks
+        )
+        assert exc_info.match("Could not satisfy task number 0, only got 12 hosts")


### PR DESCRIPTION
This PR cleans up the beaker host selection logic for runs on Google clusters. Options for disabling hostname constraints and for specifying the number of 'execution units' (e.g. model replicas) are added. Host selection logic is switched from hardcoded on to opt-in, since host selection logic is basically incompatible with preemption (if one of your nodes is taken by a higher prio job, you might not be able to relaunch even though nodes free up later on).