### PR TITLE
redo base dir calculation for new cluster names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed parsing username+password git remote URLs in `launch.beaker` module.
+- Cluster names in Beaker have changed.
 
 ### Changed
 
 - Increased NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS from 10 minutes to 30 minutes.
+
 
 ## [v2.2.0](https://github.com/allenai/OLMo-core/releases/tag/v2.2.0) - 2025-08-26
 

--- a/src/olmo_core/internal/common.py
+++ b/src/olmo_core/internal/common.py
@@ -69,9 +69,9 @@ def _to_beaker_env_secret(
 
 def get_root_dir(cluster: str) -> str:
     root_dir: str = "weka://oe-training-default/ai2-llm"
-    if "cirrascale" in cluster or cluster == "ai2/test-h100":
+    if cluster in ["ai2/test-h100", "ai2/jupiter", "ai2/saturn", "ai2/ceres", "ai2/neptune", "ai2/titan", "ai2/rhea", "ai2/phobos"]:
         root_dir = "/weka/oe-training-default/ai2-llm"
-    elif "google" in cluster:
+    elif cluster == "ai2/augusta":
         root_dir = "gs://ai2-llm"
     elif "local" in cluster:
         root_dir = "gs://ai2-llm"

--- a/src/olmo_core/internal/common.py
+++ b/src/olmo_core/internal/common.py
@@ -69,7 +69,16 @@ def _to_beaker_env_secret(
 
 def get_root_dir(cluster: str) -> str:
     root_dir: str = "weka://oe-training-default/ai2-llm"
-    if cluster in ["ai2/test-h100", "ai2/jupiter", "ai2/saturn", "ai2/ceres", "ai2/neptune", "ai2/titan", "ai2/rhea", "ai2/phobos"]:
+    if cluster in [
+        "ai2/test-h100",
+        "ai2/jupiter",
+        "ai2/saturn",
+        "ai2/ceres",
+        "ai2/neptune",
+        "ai2/titan",
+        "ai2/rhea",
+        "ai2/phobos",
+    ]:
         root_dir = "/weka/oe-training-default/ai2-llm"
     elif cluster == "ai2/augusta":
         root_dir = "gs://ai2-llm"


### PR DESCRIPTION
Because the canonical cluster names no longer have `-cirrascale` or `-google`, the logic here for detecting the base dir is wrong. this causes runs on augusta that use this logic to infer the wrong location for pretraining data.

Listing out the cluster names isn't the most elegant solution-- not sure if there's a better way to do this?