### PR TITLE
Add the ability to send Slack notifications from `launch.beaker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Increased NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS from 10 minutes to 30 minutes.
+- Increased `NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS` from 10 minutes to 30 minutes.
+- `SlackNotifierCallback` will now notify on checkpoint saved and post epoch events.
+- `BeakerLaunchConfig.launch()` will now send Slack notifications by default when `follow=True` if the env var `SLACK_WEBHOOK_URL` is set.
 
 ### Added
 
 - Adds a custom block that does LayerNorm Scaling
 - Adds the `HalfCos` learning rate scheduler
-
 
 ## [v2.2.0](https://github.com/allenai/OLMo-core/releases/tag/v2.2.0) - 2025-08-26
 


### PR DESCRIPTION
This adds the option to send direct Slack messages from our `olmo_core.launch.beaker` module 
when following a job simply by setting the environment variable `SLACK_WEBHOOK_URL` locally. With this we'll get more reliable notifications on failure.

Example notification when a run has launched:

<img width="648" height="68" alt="image" src="https://github.com/user-attachments/assets/d6bf316e-c7e1-4440-b137-356b6cd71908" />

This also adds more notification events to our `SlackNotifierCallback`, so we'll get updates each time a checkpoint is saved or an epoch is completed.