### PR TITLE
Port task groups from cookbook to OlmoCore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SlackNotifierCallback` will now notify on checkpoint saved and post epoch events.
 - `BeakerLaunchConfig.launch()` will now send Slack notifications by default when `follow=True` if the env var `SLACK_WEBHOOK_URL` is set.
 - `src/examples/llama/` has been renamed to `src/examples/llm/`.
-- Refactored eval task groups, ported  task group (`OLMO2_DEV_1B_TASKS`) used for internal development.
+- Refactored eval task groups into `task_groups.py`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SlackNotifierCallback` will now notify on checkpoint saved and post epoch events.
 - `BeakerLaunchConfig.launch()` will now send Slack notifications by default when `follow=True` if the env var `SLACK_WEBHOOK_URL` is set.
 - `src/examples/llama/` has been renamed to `src/examples/llm/`.
+- Refactored eval task groups, ported  task group (`OLMO2_DEV_1B_TASKS`) used for internal development.
 
 ### Added
 

--- a/src/olmo_core/eval/task_groups.py
+++ b/src/olmo_core/eval/task_groups.py
@@ -1,0 +1,184 @@
+from typing import Dict, List
+
+# For training runs where we don't expect the model to acquire MC (e.g., 1B-5xC, short 7B training runs)
+FULL_TASKS_SMALL_COMPUTE = [
+    # OLMES Core 9(-ish) RC
+    "arc_challenge_test_rc_5shot",
+    "arc_easy_test_rc_5shot",
+    "hellaswag_rc_5shot",  # 1K subset of HellaSwag
+    "winogrande_val_rc_5shot",  # Helpful after 750M-5xC scale
+    "csqa_val_rc_5shot",
+    "piqa_val_rc_5shot",
+    "socialiqa_val_rc_5shot",
+    # Too noisy to be worth tracking
+    # "boolq_val_rc_5shot",
+    # "openbookqa_test_rc_5shot",
+    # MMLU RC
+    "mmlu_stem_val_rc_5shot",
+    "mmlu_humanities_val_rc_5shot",
+    "mmlu_social_sciences_val_rc_5shot",
+    "mmlu_other_val_rc_5shot",
+    "mmlu_stem_test_rc_5shot",
+    "mmlu_humanities_test_rc_5shot",
+    "mmlu_social_sciences_test_rc_5shot",
+    "mmlu_other_test_rc_5shot",
+    # Gen tasks BPB
+    "gsm8k_gold_bpb_5shot",
+    "minerva_math_algebra_gold_bpb_0shot",
+    "minerva_math_counting_and_probability_gold_bpb_0shot",
+    "minerva_math_geometry_gold_bpb_0shot",
+    "minerva_math_intermediate_algebra_gold_bpb_0shot",
+    "minerva_math_number_theory_gold_bpb_0shot",
+    "minerva_math_prealgebra_gold_bpb_0shot",
+    "minerva_math_precalculus_gold_bpb_0shot",
+    "codex_humaneval_gold_bpb_3shot",
+    "codex_mbpp_gold_bpb_3shot",
+    # MT MBPP tasks
+    "mt_mbpp_rust_gold_bpb_3shot",
+    "mt_mbpp_java_gold_bpb_3shot",
+    "mt_mbpp_cpp_gold_bpb_3shot",
+    # Sanity check for MCQA ability
+    "copycolors_10way_fast",
+    # Basic Skills
+    "basic_skills_arithmetic_rc_5shot",
+    "basic_skills_coding_rc_5shot",
+    "basic_skills_common_knowledge_rc_5shot",
+    "basic_skills_logical_reasoning_rc_5shot",
+    "basic_skills_pattern_rc_5shot",
+    "basic_skills_string_operations_rc_5shot",
+]
+
+# For training runs where we expect the model to acquire MC
+FULL_TASKS_LARGE_COMPUTE = [
+    # OLMES Core 9(-ish) MC
+    "arc_challenge_test_mc_5shot_fast",
+    "arc_easy_test_mc_5shot_fast",
+    "hellaswag_rc_5shot",  # 1K subset of HellaSwag
+    "csqa_val_mc_5shot_fast",
+    "piqa_val_mc_5shot_fast",
+    "socialiqa_val_mc_5shot_fast",
+    "winogrande_val_rc_5shot",
+    # Too noisy to be worth tracking
+    # "boolq_val_mc_5shot_fast",
+    # "openbookqa_test_mc_5shot_fast",
+    # MMLU MC BPB
+    "mmlu_stem_val_mc_5shot_fast",
+    "mmlu_humanities_val_mc_5shot_fast",
+    "mmlu_social_sciences_val_mc_5shot_fast",
+    "mmlu_other_val_mc_5shot_fast",
+    "mmlu_stem_test_mc_5shot_fast",
+    "mmlu_humanities_test_mc_5shot_fast",
+    "mmlu_social_sciences_test_mc_5shot_fast",
+    "mmlu_other_test_mc_5shot_fast",
+    # Gen tasks BPB
+    "gsm8k_gold_bpb_5shot",
+    "minerva_math_algebra_gold_bpb_0shot",
+    "minerva_math_counting_and_probability_gold_bpb_0shot",
+    "minerva_math_geometry_gold_bpb_0shot",
+    "minerva_math_intermediate_algebra_gold_bpb_0shot",
+    "minerva_math_number_theory_gold_bpb_0shot",
+    "minerva_math_prealgebra_gold_bpb_0shot",
+    "minerva_math_precalculus_gold_bpb_0shot",
+    "codex_humaneval_gold_bpb_3shot",
+    "codex_mbpp_gold_bpb_3shot",
+    # MT MBPP tasks
+    "mt_mbpp_rust_gold_bpb_3shot",
+    "mt_mbpp_java_gold_bpb_3shot",
+    "mt_mbpp_cpp_gold_bpb_3shot",
+    # Sanity check for MCQA ability
+    "copycolors_10way_fast",
+    # Basic Skills
+    "basic_skills_arithmetic_rc_5shot",
+    "basic_skills_coding_rc_5shot",
+    "basic_skills_common_knowledge_rc_5shot",
+    "basic_skills_logical_reasoning_rc_5shot",
+    "basic_skills_pattern_rc_5shot",
+    "basic_skills_string_operations_rc_5shot",
+]
+
+# Unfortunately we need the same metrics for everything, so we run them all.
+FULL_TASKS = list(set(FULL_TASKS_SMALL_COMPUTE + FULL_TASKS_LARGE_COMPUTE))
+
+# Subset of "full" task set that is roughly 2-3x faster
+FAST_TASKS = [
+    # Subset of OLMES
+    "arc_challenge_test_bpb_5shot",
+    "arc_challenge_test_mc_5shot_fast",
+    "arc_easy_test_bpb_5shot",
+    "arc_easy_test_mc_5shot_fast",
+    "hellaswag_bpb_5shot",
+    "mmlu_humanities_test_bpb_5shot",
+    "mmlu_humanities_test_mc_5shot_fast",
+    "mmlu_other_test_bpb_5shot",
+    "mmlu_other_test_mc_5shot_fast",
+    "mmlu_social_sciences_test_bpb_5shot",
+    "mmlu_social_sciences_test_mc_5shot_fast",
+    "mmlu_stem_test_bpb_5shot",
+    "mmlu_stem_test_mc_5shot_fast",
+    # Basic Skills
+    "basic_skills_arithmetic_rc_5shot",
+    "basic_skills_coding_rc_5shot",
+    "basic_skills_common_knowledge_rc_5shot",
+    "basic_skills_logical_reasoning_rc_5shot",
+    "basic_skills_pattern_rc_5shot",
+    "basic_skills_string_operations_rc_5shot",
+    # Gen tasks BPB
+    "codex_humaneval_gold_bpb_3shot",
+    "codex_mbpp_gold_bpb_3shot",
+    "minerva_math_500_gold_bpb_0shot",
+    "mt_mbpp_cpp_gold_bpb_3shot",
+    "mt_mbpp_java_gold_bpb_3shot",
+    "mt_mbpp_rust_gold_bpb_3shot",
+    # Sanity check for MCQA ability
+    "copycolors_10way_fast",
+]
+
+# NOTE: preserved for backwards compatibility, OLMO2_DEV_1B_TASKS is the same as
+# FULL_TASKS_SMALL_COMPUTE but with "copycolors_10way" instead of "copycolors_10way_fast"
+OLMO2_DEV_1B_TASKS = [
+    # OLMES Core 9(-ish) RC
+    "arc_challenge_test_rc_5shot",
+    "arc_easy_test_rc_5shot",
+    "hellaswag_rc_5shot",  # 1K subset of HellaSwag
+    "winogrande_val_rc_5shot",  # Helpful after 750M-5xC scale
+    "csqa_val_rc_5shot",
+    "piqa_val_rc_5shot",
+    "socialiqa_val_rc_5shot",
+    # MMLU RC
+    "mmlu_stem_val_rc_5shot",
+    "mmlu_humanities_val_rc_5shot",
+    "mmlu_social_sciences_val_rc_5shot",
+    "mmlu_other_val_rc_5shot",
+    "mmlu_stem_test_rc_5shot",
+    "mmlu_humanities_test_rc_5shot",
+    "mmlu_social_sciences_test_rc_5shot",
+    "mmlu_other_test_rc_5shot",
+    # Gen tasks BPB
+    "gsm8k_gold_bpb_5shot",
+    "minerva_math_algebra_gold_bpb_0shot",
+    "minerva_math_counting_and_probability_gold_bpb_0shot",
+    "minerva_math_geometry_gold_bpb_0shot",
+    "minerva_math_intermediate_algebra_gold_bpb_0shot",
+    "minerva_math_number_theory_gold_bpb_0shot",
+    "minerva_math_prealgebra_gold_bpb_0shot",
+    "minerva_math_precalculus_gold_bpb_0shot",
+    "codex_humaneval_gold_bpb_0shot",
+    "codex_mbpp_gold_bpb_0shot",
+    # Sanity check for MCQA ability
+    "copycolors_10way",
+    # Basic Skills rc 5shot
+    "basic_skills_arithmetic_rc_5shot",
+    "basic_skills_coding_rc_5shot",
+    "basic_skills_common_knowledge_rc_5shot",
+    "basic_skills_logical_reasoning_rc_5shot",
+    "basic_skills_pattern_rc_5shot",
+    "basic_skills_string_operations_rc_5shot",
+]
+
+TASK_GROUPS: Dict[str, List[str]] = {
+    "full__small_compute": FULL_TASKS_SMALL_COMPUTE,
+    "full__large_compute": FULL_TASKS_LARGE_COMPUTE,
+    "full": FULL_TASKS,
+    "fast": FAST_TASKS,
+    "olmo2_dev_1b": OLMO2_DEV_1B_TASKS,
+}

--- a/src/olmo_core/eval/task_groups.py
+++ b/src/olmo_core/eval/task_groups.py
@@ -133,52 +133,10 @@ FAST_TASKS = [
     "copycolors_10way_fast",
 ]
 
-# NOTE: preserved for backwards compatibility, OLMO2_DEV_1B_TASKS is the same as
-# FULL_TASKS_SMALL_COMPUTE but with "copycolors_10way" instead of "copycolors_10way_fast"
-OLMO2_DEV_1B_TASKS = [
-    # OLMES Core 9(-ish) RC
-    "arc_challenge_test_rc_5shot",
-    "arc_easy_test_rc_5shot",
-    "hellaswag_rc_5shot",  # 1K subset of HellaSwag
-    "winogrande_val_rc_5shot",  # Helpful after 750M-5xC scale
-    "csqa_val_rc_5shot",
-    "piqa_val_rc_5shot",
-    "socialiqa_val_rc_5shot",
-    # MMLU RC
-    "mmlu_stem_val_rc_5shot",
-    "mmlu_humanities_val_rc_5shot",
-    "mmlu_social_sciences_val_rc_5shot",
-    "mmlu_other_val_rc_5shot",
-    "mmlu_stem_test_rc_5shot",
-    "mmlu_humanities_test_rc_5shot",
-    "mmlu_social_sciences_test_rc_5shot",
-    "mmlu_other_test_rc_5shot",
-    # Gen tasks BPB
-    "gsm8k_gold_bpb_5shot",
-    "minerva_math_algebra_gold_bpb_0shot",
-    "minerva_math_counting_and_probability_gold_bpb_0shot",
-    "minerva_math_geometry_gold_bpb_0shot",
-    "minerva_math_intermediate_algebra_gold_bpb_0shot",
-    "minerva_math_number_theory_gold_bpb_0shot",
-    "minerva_math_prealgebra_gold_bpb_0shot",
-    "minerva_math_precalculus_gold_bpb_0shot",
-    "codex_humaneval_gold_bpb_0shot",
-    "codex_mbpp_gold_bpb_0shot",
-    # Sanity check for MCQA ability
-    "copycolors_10way",
-    # Basic Skills rc 5shot
-    "basic_skills_arithmetic_rc_5shot",
-    "basic_skills_coding_rc_5shot",
-    "basic_skills_common_knowledge_rc_5shot",
-    "basic_skills_logical_reasoning_rc_5shot",
-    "basic_skills_pattern_rc_5shot",
-    "basic_skills_string_operations_rc_5shot",
-]
 
 TASK_GROUPS: Dict[str, List[str]] = {
     "full__small_compute": FULL_TASKS_SMALL_COMPUTE,
     "full__large_compute": FULL_TASKS_LARGE_COMPUTE,
     "full": FULL_TASKS,
     "fast": FAST_TASKS,
-    "olmo2_dev_1b": OLMO2_DEV_1B_TASKS,
 }

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -62,7 +62,7 @@ class EvaluatorCallback(Callback):
 
     cancel_after_first_eval: bool = False
     """
-    If ``True``, cancel the run after running evals for the first time. 
+    If ``True``, cancel the run after running evals for the first time.
     This combined with ``eval_on_startup=True`` is useful if you just want to run in-loop evals
     without training any longer.
     """

--- a/src/olmo_core/train/config.py
+++ b/src/olmo_core/train/config.py
@@ -8,6 +8,8 @@ from typing import Dict, Optional
 import torch
 import torch.distributed as dist
 
+from olmo_core.eval.task_groups import FAST_TASKS, FULL_TASKS, TASK_GROUPS
+
 from ..config import Config
 from ..data import DataLoaderBase, TokenizerConfig
 from ..exceptions import OLMoConfigurationError
@@ -85,149 +87,17 @@ class TrainerConfig(Config):
             LMEvaluatorCallbackConfig,
         )
 
-        if task_set == "full":
-            # For training runs where we don't expect the model to acquire MC (e.g., 1B-5xC, short 7B training runs)
-            tasks_small_compute = [
-                # OLMES Core 9(-ish) RC
-                "arc_challenge_test_rc_5shot",
-                "arc_easy_test_rc_5shot",
-                "hellaswag_rc_5shot",  # 1K subset of HellaSwag
-                "winogrande_val_rc_5shot",  # Helpful after 750M-5xC scale
-                "csqa_val_rc_5shot",
-                "piqa_val_rc_5shot",
-                "socialiqa_val_rc_5shot",
-                # Too noisy to be worth tracking
-                # "boolq_val_rc_5shot",
-                # "openbookqa_test_rc_5shot",
-                # MMLU RC
-                "mmlu_stem_val_rc_5shot",
-                "mmlu_humanities_val_rc_5shot",
-                "mmlu_social_sciences_val_rc_5shot",
-                "mmlu_other_val_rc_5shot",
-                "mmlu_stem_test_rc_5shot",
-                "mmlu_humanities_test_rc_5shot",
-                "mmlu_social_sciences_test_rc_5shot",
-                "mmlu_other_test_rc_5shot",
-                # Gen tasks BPB
-                "gsm8k_gold_bpb_5shot",
-                "minerva_math_algebra_gold_bpb_0shot",
-                "minerva_math_counting_and_probability_gold_bpb_0shot",
-                "minerva_math_geometry_gold_bpb_0shot",
-                "minerva_math_intermediate_algebra_gold_bpb_0shot",
-                "minerva_math_number_theory_gold_bpb_0shot",
-                "minerva_math_prealgebra_gold_bpb_0shot",
-                "minerva_math_precalculus_gold_bpb_0shot",
-                "codex_humaneval_gold_bpb_3shot",
-                "codex_mbpp_gold_bpb_3shot",
-                # MT MBPP tasks
-                "mt_mbpp_rust_gold_bpb_3shot",
-                "mt_mbpp_java_gold_bpb_3shot",
-                "mt_mbpp_cpp_gold_bpb_3shot",
-                # Sanity check for MCQA ability
-                "copycolors_10way_fast",
-                # Basic Skills
-                "basic_skills_arithmetic_rc_5shot",
-                "basic_skills_coding_rc_5shot",
-                "basic_skills_common_knowledge_rc_5shot",
-                "basic_skills_logical_reasoning_rc_5shot",
-                "basic_skills_pattern_rc_5shot",
-                "basic_skills_string_operations_rc_5shot",
-            ]
-
-            # For training runs where we expect the model to acquire MC
-            tasks_large_compute = [
-                # OLMES Core 9(-ish) MC
-                "arc_challenge_test_mc_5shot_fast",
-                "arc_easy_test_mc_5shot_fast",
-                "hellaswag_rc_5shot",  # 1K subset of HellaSwag
-                "csqa_val_mc_5shot_fast",
-                "piqa_val_mc_5shot_fast",
-                "socialiqa_val_mc_5shot_fast",
-                "winogrande_val_rc_5shot",
-                # Too noisy to be worth tracking
-                # "boolq_val_mc_5shot_fast",
-                # "openbookqa_test_mc_5shot_fast",
-                # MMLU MC BPB
-                "mmlu_stem_val_mc_5shot_fast",
-                "mmlu_humanities_val_mc_5shot_fast",
-                "mmlu_social_sciences_val_mc_5shot_fast",
-                "mmlu_other_val_mc_5shot_fast",
-                "mmlu_stem_test_mc_5shot_fast",
-                "mmlu_humanities_test_mc_5shot_fast",
-                "mmlu_social_sciences_test_mc_5shot_fast",
-                "mmlu_other_test_mc_5shot_fast",
-                # Gen tasks BPB
-                "gsm8k_gold_bpb_5shot",
-                "minerva_math_algebra_gold_bpb_0shot",
-                "minerva_math_counting_and_probability_gold_bpb_0shot",
-                "minerva_math_geometry_gold_bpb_0shot",
-                "minerva_math_intermediate_algebra_gold_bpb_0shot",
-                "minerva_math_number_theory_gold_bpb_0shot",
-                "minerva_math_prealgebra_gold_bpb_0shot",
-                "minerva_math_precalculus_gold_bpb_0shot",
-                "codex_humaneval_gold_bpb_3shot",
-                "codex_mbpp_gold_bpb_3shot",
-                # MT MBPP tasks
-                "mt_mbpp_rust_gold_bpb_3shot",
-                "mt_mbpp_java_gold_bpb_3shot",
-                "mt_mbpp_cpp_gold_bpb_3shot",
-                # Sanity check for MCQA ability
-                "copycolors_10way_fast",
-                # Basic Skills
-                "basic_skills_arithmetic_rc_5shot",
-                "basic_skills_coding_rc_5shot",
-                "basic_skills_common_knowledge_rc_5shot",
-                "basic_skills_logical_reasoning_rc_5shot",
-                "basic_skills_pattern_rc_5shot",
-                "basic_skills_string_operations_rc_5shot",
-            ]
-            # Unfortunately we need the same metrics for everything, so we run them all.
-            tasks = list(set(tasks_small_compute + tasks_large_compute))
-        elif task_set == "fast":
-            # Subset of "full" task set that is roughly 2-3x faster
-            tasks = [
-                # Subset of OLMES
-                "arc_challenge_test_bpb_5shot",
-                "arc_challenge_test_mc_5shot_fast",
-                "arc_easy_test_bpb_5shot",
-                "arc_easy_test_mc_5shot_fast",
-                "hellaswag_bpb_5shot",
-                "mmlu_humanities_test_bpb_5shot",
-                "mmlu_humanities_test_mc_5shot_fast",
-                "mmlu_other_test_bpb_5shot",
-                "mmlu_other_test_mc_5shot_fast",
-                "mmlu_social_sciences_test_bpb_5shot",
-                "mmlu_social_sciences_test_mc_5shot_fast",
-                "mmlu_stem_test_bpb_5shot",
-                "mmlu_stem_test_mc_5shot_fast",
-                # Basic Skills
-                "basic_skills_arithmetic_rc_5shot",
-                "basic_skills_coding_rc_5shot",
-                "basic_skills_common_knowledge_rc_5shot",
-                "basic_skills_logical_reasoning_rc_5shot",
-                "basic_skills_pattern_rc_5shot",
-                "basic_skills_string_operations_rc_5shot",
-                # Gen tasks BPB
-                "codex_humaneval_gold_bpb_3shot",
-                "codex_mbpp_gold_bpb_3shot",
-                "minerva_math_500_gold_bpb_0shot",
-                "mt_mbpp_cpp_gold_bpb_3shot",
-                "mt_mbpp_java_gold_bpb_3shot",
-                "mt_mbpp_rust_gold_bpb_3shot",
-                # Sanity check for MCQA ability
-                "copycolors_10way_fast",
-            ]
-        else:
-            raise ValueError(f"Task set not recognized: {task_set}")
+        try:
+            tasks = TASK_GROUPS[task_set]
+        except KeyError as e:
+            raise ValueError(f"Task set not recognized: {task_set}") from e
 
         tasks.sort()
 
         return self.with_callback(
             "downstream_evaluator",
             DownstreamEvaluatorCallbackConfig(
-                tasks=tasks,
-                tokenizer=tokenizer,
-                eval_interval=eval_interval,
+                tasks=tasks, tokenizer=tokenizer, eval_interval=eval_interval
             ),
         ).with_callback(
             "lm_evaluator",

--- a/src/olmo_core/train/config.py
+++ b/src/olmo_core/train/config.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional
 import torch
 import torch.distributed as dist
 
-from olmo_core.eval.task_groups import FAST_TASKS, FULL_TASKS, TASK_GROUPS
+from olmo_core.eval.task_groups import TASK_GROUPS
 
 from ..config import Config
 from ..data import DataLoaderBase, TokenizerConfig


### PR DESCRIPTION
Getting ready to get rid of this in cookbook: https://github.com/allenai/olmo-cookbook/blob/olmo3-anneals/src/cookbook/model/evaluators.py#L6