### PR TITLE
Add support for FlexOlmo conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `CONTRIBUTING.md` guidelines.
 - Added a lightweight, gantry-like Beaker launch CLI: `python -m olmo_core.launch.beaker`.
 - Added [Beaker images with torch 2.8](https://beaker.allen.ai/orgs/ai2/workspaces/OLMo-core/images?searchQuery=tch280). There is `olmo-core-tch280cu128-2025-09-18` and `olmo-core-tch280cu129-2025-09-18` for CUDA 12.8 and 12.9, respectively.
+- Added support for converting FlexOlmo models from OLMo Core to HF format.
 
 ## [v2.2.0](https://github.com/allenai/OLMo-core/releases/tag/v2.2.0) - 2025-08-26
 

--- a/docs/source/nn/hf.rst
+++ b/docs/source/nn/hf.rst
@@ -5,13 +5,21 @@
    :members:
    :member-order: bysource
 
-.. autodata:: olmo_core.nn.hf.convert.HF_TO_OLMO_CORE_MAPPINGS
+.. autodata:: olmo_core.nn.hf.convert.HF_TO_OLMO_CORE_WEIGHT_MAPPINGS
    :no-value:
-.. autodata:: olmo_core.nn.hf.convert.MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS
+.. autodata:: olmo_core.nn.hf.convert.HF_TO_OLMO_CORE_MODULE_MAPPINGS
+   :no-value:
+.. autodata:: olmo_core.nn.hf.convert.MODEL_SPECIFIC_HF_TO_OLMO_CORE_WEIGHT_MAPPINGS
+   :no-value:
+.. autodata:: olmo_core.nn.hf.convert.MODEL_SPECIFIC_HF_TO_OLMO_CORE_MODULE_MAPPINGS
    :no-value:
 .. autodata:: olmo_core.nn.hf.convert.HF_TO_OLMO_CORE_TEMPLATE_MAPPINGS
    :no-value:
-.. autodata:: olmo_core.nn.hf.convert.OLMO_CORE_TO_HF_MAPPINGS
+.. autodata:: olmo_core.nn.hf.convert.OLMO_CORE_TO_HF_WEIGHT_MAPPINGS
+   :no-value:
+.. autodata:: olmo_core.nn.hf.convert.OLMO_CORE_TO_HF_MODULE_MAPPINGS
    :no-value:
 .. autodata:: olmo_core.nn.hf.convert.OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS
+   :no-value:
+.. autodata:: olmo_core.nn.hf.convert.MODEL_TYPE_SPECIFIC_OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS
    :no-value:

--- a/src/examples/huggingface/convert_checkpoint_from_hf.py
+++ b/src/examples/huggingface/convert_checkpoint_from_hf.py
@@ -8,6 +8,7 @@ other models can be added by updating the constants in :mod:`olmo_core.nn.hf.con
 
 import json
 import logging
+import re
 import tempfile
 from argparse import ArgumentParser
 from functools import partial
@@ -15,16 +16,23 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Optional, Tuple
 
+try:
+    import flash_attn  # type: ignore
+except ImportError:
+    flash_attn = None
+
 import torch
 import torch.distributed.checkpoint.state_dict as dist_cp_sd
+import torch.nn.functional as F
 from cached_path import cached_path
-from transformers import AutoModelForCausalLM
+from transformers import AutoConfig, AutoModelForCausalLM
 
 from olmo_core.aliases import PathOrStr
 from olmo_core.data.tokenizer import TokenizerConfig
 from olmo_core.distributed.checkpoint import save_model_and_optim_state
 from olmo_core.io import copy_file, file_exists, join_path
-from olmo_core.nn.conversion.state_mapping import TemplatePlaceholder
+from olmo_core.nn.attention import AttentionType
+from olmo_core.nn.conversion.state_mapping import StateType, TemplatePlaceholder
 from olmo_core.nn.hf.checkpoint import load_hf_model
 from olmo_core.nn.hf.convert import get_converter_from_hf
 from olmo_core.nn.transformer.config import TransformerConfig
@@ -83,10 +91,10 @@ def convert_checkpoint_from_hf(
     *,
     hf_revision: str = "main",
     model_id: str | None = None,
-    max_sequence_length: int = -1,
     validate: bool = True,
     debug: bool = False,
     device: torch.device | None = None,
+    validation_sliding_window: int | None = None,
 ) -> None:
     """
     Convert a HF checkpoint to an OLMo core checkpoint.
@@ -97,9 +105,6 @@ def convert_checkpoint_from_hf(
         transformer_config_dict: Dictionary form of OLMo core model config
         tokenizer_config_dict: Dictionary form of OLMo core tokenizer config
     """
-    if max_sequence_length <= 0:
-        raise ValueError(f"Missing or invalid sequence length: {max_sequence_length}")
-
     # Remove deprecated transformer config options
     if "compile" in transformer_config_dict:
         del transformer_config_dict["compile"]
@@ -110,9 +115,38 @@ def convert_checkpoint_from_hf(
     if "float8_config" in transformer_config_dict:
         del transformer_config_dict["float8_config"]
 
-    model = TransformerConfig.from_dict(transformer_config_dict).build()
-    device = device or get_default_device()
-    model.to_empty(device=device)
+    model_config = TransformerConfig.from_dict(transformer_config_dict)
+
+    if torch.cuda.is_available():
+        torch.cuda.init()
+
+    validation_device = device or get_default_device()
+    flash_attn_supported = flash_attn is not None and device != torch.device("cuda")
+
+    if not flash_attn_supported and model_config.block.attention.sliding_window is not None:
+        raise NotImplementedError(
+            "Converting a model with sliding window attention is not yet supported."
+        )
+
+    if not flash_attn_supported and validate:
+        if model_config.block.attention.name == AttentionType.fused:
+            log.warning(
+                "Running conversion without cuda or flash attention on a fused attention model, validation would fail so we are disabling it."
+            )
+            validate = False
+
+    if validate and model_config.block.attention.use_flash:
+        if (
+            model_config.block.attention.name != AttentionType.fused
+            and model_config.block.attention.sliding_window is None
+        ):
+            log.info(
+                "Flash attention is not required and can cause minor changes in outputs, switching to SDPA to stop validation from failing."
+            )
+            model_config.block.attention.use_flash = False
+
+    model = model_config.build(init_device="meta")
+    model.to_empty(device=device or torch.device("cpu"))
 
     state_dict_options = dist_cp_sd.StateDictOptions(
         flatten_optimizer_state_dict=True, cpu_offload=True
@@ -162,7 +196,8 @@ def convert_checkpoint_from_hf(
             hf_revision=hf_revision,
             model_id=model_id,
             debug=debug,
-            device=device,
+            device=validation_device,
+            sliding_window=validation_sliding_window,
         )
         log.info("Validation completed successful")
 
@@ -175,28 +210,51 @@ def _register_debug_hooks(hf_model: torch.nn.Module, model: Transformer):
 
     def module_hook(
         debug_state: Dict[str, Tuple[int, torch.Tensor]],
+        model_type: str,
         name: str,
         _: torch.nn.Module,
         args,
         output,
     ):
+        if (
+            model_type == "hf"
+            and re.match(r"model.layers.\d+.block_sparse_moe$", name)
+            and isinstance(output, tuple)
+        ):
+            # Special casing for HF moe
+            assert isinstance(output[0], torch.Tensor), (name, output)
+            output = output[0]
+        if model_type == "hf" and re.match(r"model.layers.\d+.block_sparse_moe.gate", name):
+            # Special casing for HF moe router
+            assert isinstance(output, torch.Tensor), (name, output)
+            router_logits = output.detach().clone()
+            routing_weights = F.sigmoid(router_logits.float())
+            # Like topk, but we keep all the data. This will hopefully go ok.
+            routing_weights, routing_indices = torch.sort(routing_weights, descending=True, dim=-1)
+            output = routing_weights
+        if model_type == "olmo_core" and re.match(r"blocks.\d+.feed_forward_moe.router", name):
+            # Special casing for OLMo Core moe router
+            assert isinstance(output, tuple), (name, output)
+            assert isinstance(output[0], torch.Tensor), (name, output[0])
+            output = output[0]
+
         if len(args) >= 1 and isinstance(args[0], torch.Tensor):
             state_name = f"{name}|input"
             input = args[0].detach()
             for i, size in enumerate(input.shape):
                 input = input.narrow(i, 0, min(size, MAX_DIM_SIZE))
-            debug_state[state_name] = (len(debug_state), input.float())
+            debug_state[state_name] = (len(debug_state), input)
         if isinstance(output, torch.Tensor):
             state_name = f"{name}|output"
             output = output.detach()
             for i, size in enumerate(output.shape):
                 output = output.narrow(i, 0, min(size, MAX_DIM_SIZE))
-            debug_state[state_name] = (len(debug_state), output.float())
+            debug_state[state_name] = (len(debug_state), output)
 
     for name, module in model.named_modules():
-        module.register_forward_hook(partial(module_hook, olmo_core_debug_state, name))
+        module.register_forward_hook(partial(module_hook, olmo_core_debug_state, "olmo_core", name))
     for name, module in hf_model.named_modules():
-        module.register_forward_hook(partial(module_hook, hf_debug_state, name))
+        module.register_forward_hook(partial(module_hook, hf_debug_state, "hf", name))
 
     return olmo_core_debug_state, hf_debug_state
 
@@ -209,28 +267,69 @@ def validate_conversion(
     model_id: str | None = None,
     debug: bool = False,
     device: torch.device | None = None,
+    sliding_window: int | None = None,
 ):
-    if torch.cuda.is_available():
-        torch.cuda.init()
-
     device = device or get_default_device()
+    log.info(f"Running validation on {device}")
 
-    B, T = 1, 120
+    B, T = 1, 60
     input_ids = torch.randint(0, vocab_size, (B, T)).to(device)
 
-    log.info("Loading converted checkpoint for validation...")
-    hf_model = AutoModelForCausalLM.from_pretrained(hf_path, revision=hf_revision).to(device).eval()
+    attn_implementation = "sdpa"
+
+    is_sliding = any(
+        hasattr(block.attention, "window_size") and block.attention.window_size != (-1, -1)
+        for block in model.blocks.values()
+    )
+
+    log.info("Loading HF checkpoint for validation...")
+    kwargs = {}
+    if is_sliding and sliding_window is not None:
+        kwargs["sliding_window"] = sliding_window
+    config = AutoConfig.from_pretrained(
+        hf_path,
+        revision=hf_revision,
+        **kwargs,
+    )
+    hf_model = (
+        AutoModelForCausalLM.from_pretrained(
+            hf_path,
+            revision=hf_revision,
+            torch_dtype="auto",
+            config=config,
+            attn_implementation=attn_implementation,
+        )
+        .to(device)
+        .eval()
+    )
+    hf_config = hf_model.config
 
     olmo_core_state, hf_state = {}, {}
-    state_mapping = None
     if debug:
         olmo_core_state, hf_state = _register_debug_hooks(hf_model, model)
-        state_converter = get_converter_from_hf(model_id=model_id)
 
-        if not hasattr(hf_model.config, "num_hidden_layers"):
-            raise ValueError(f"Number of hidden layers missing in HF config: {hf_model.config}")
-        n_layers: int = hf_model.config.num_hidden_layers
-        n_experts: int | None = getattr(hf_model.config, "num_experts", None)
+    log.info("Running OLMo core and HF models for validation...")
+    with torch.no_grad():
+        hf_logits = hf_model(input_ids=input_ids).logits
+
+    del hf_model
+
+    if is_sliding and sliding_window is not None:
+        for block in model.blocks.values():
+            if block.attention.window_size != (-1, -1):
+                block.attention.window_size = (sliding_window - 1, 0)
+    dtype = getattr(hf_config, "torch_dtype", torch.float32)
+    model = model.to(dtype=dtype)
+    model.eval()
+    with torch.no_grad():
+        logits = model(input_ids=input_ids)
+
+    if debug:
+        state_converter = get_converter_from_hf(model_id=model_id)
+        if not hasattr(hf_config, "num_hidden_layers"):
+            raise ValueError(f"Number of hidden layers missing in HF config: {hf_config}")
+        n_layers: int = hf_config.num_hidden_layers
+        n_experts: int | None = getattr(hf_config, "num_experts", None)
 
         placeholder_bounds = {
             TemplatePlaceholder.LAYER: n_layers,
@@ -238,79 +337,91 @@ def validate_conversion(
         if n_experts:
             placeholder_bounds[TemplatePlaceholder.EXPERT] = n_experts
 
-        state_mapping = state_converter.get_mappings(hf_model.state_dict(), placeholder_bounds)
+        hf_debug_empty_state = {key.split("|")[0]: None for key in hf_state.keys()}
+        state_mapping = state_converter.get_mappings(
+            hf_debug_empty_state, placeholder_bounds, state_type=StateType.module
+        )
+        del hf_debug_empty_state
 
-    log.info("Running OLMo core and HF models for validation...")
-    with torch.no_grad():
-        hf_logits, *_ = hf_model(input_ids=input_ids, return_dict=False)
-
-    del hf_model
-
-    model = model.to(device).eval()
-    with torch.no_grad():
-        logits = model(input_ids=input_ids)
-
-    if debug:
-        assert state_mapping is not None
-
-        simple_key_mapping = {
-            mapping.source_keys[0]
-            .replace(".weight", ""): mapping.dest_keys[0]
-            .replace(".weight", "")
+        simple_module_name_mapping = {
+            mapping.source_keys[0]: mapping.dest_keys
             for mapping in state_mapping
-            if len(mapping.source_keys) == 1 and len(mapping.dest_keys) == 1
+            if len(mapping.source_keys) == 1
         }
 
-        log.info(f"simple mapping: {simple_key_mapping}")
+        log.info(f"simple mapping: {simple_module_name_mapping}")
         log.info(f"hf_state keys: {hf_state.keys()}")
         log.info(f"olmo_core_state keys: {olmo_core_state.keys()}")
 
         for hf_state_name, (_, hf_tensor) in sorted(hf_state.items(), key=lambda item: item[1][0]):
             hf_key, state_type = hf_state_name.split("|")
-            if hf_key not in simple_key_mapping:
+            if hf_key in simple_module_name_mapping:
+                hf_module_name = hf_key
+            else:
+                log.warning(
+                    f"No 1-to-many param mapping found for module {hf_key}, cannot compare to HF"
+                )
                 continue
 
-            olmo_core_state_name = f"{simple_key_mapping[hf_key]}|{state_type}"
-            if olmo_core_state_name not in olmo_core_state:
-                continue
+            olmo_core_param_names = simple_module_name_mapping[hf_module_name]
+            for i_key, olmo_core_param_name in enumerate(olmo_core_param_names):
+                olmo_core_state_name = f"{olmo_core_param_name}|{state_type}"
+                if f"{olmo_core_param_name}|{state_type}" in olmo_core_state:
+                    olmo_core_state_name = f"{olmo_core_param_name}|{state_type}"
+                else:
+                    log.warning(
+                        f"No OLMo Core state found for param {hf_state_name}, cannot compare to HF"
+                    )
+                    continue
 
-            _, olmo_core_tensor = olmo_core_state[olmo_core_state_name]
+                _, olmo_core_tensor = olmo_core_state[olmo_core_state_name]
+                if olmo_core_tensor.shape[0] < len(olmo_core_param_names):
+                    log.warning(
+                        f"Unable to chunk olmo_core state {olmo_core_state_name} into {len(olmo_core_param_names)} pieces"
+                    )
+                    continue
+                olmo_core_tensor = olmo_core_tensor.tensor_split(len(olmo_core_param_names), dim=0)[
+                    i_key
+                ]
 
-            if olmo_core_tensor.shape != hf_tensor.shape:
-                log.info(
-                    f"{hf_state_name}, {olmo_core_state_name} shape mismatch: {hf_tensor.shape} {olmo_core_tensor.shape}"
-                )
-            if olmo_core_tensor.dtype != hf_tensor.dtype:
-                log.info(
-                    f"{hf_state_name}, {olmo_core_state_name} dtype mismatch: {hf_tensor.dtype} {olmo_core_tensor.dtype}"
-                )
-            if len(olmo_core_tensor.shape) == len(hf_tensor.shape):
-                common_shape = tuple(
-                    min(olmo_core_dim, hf_dim)
-                    for olmo_core_dim, hf_dim in zip(olmo_core_tensor.shape, hf_tensor.shape)
-                )
-                for i, dim in enumerate(common_shape):
-                    olmo_core_tensor = olmo_core_tensor.narrow(i, 0, dim)
-                    hf_tensor = hf_tensor.narrow(i, 0, dim)
-                log.info(
-                    f"{hf_state_name}, {olmo_core_state_name} element diff abs mean: {(olmo_core_tensor - hf_tensor).float().abs().mean()}"
-                )
+                if hf_tensor.shape != olmo_core_tensor.shape:
+                    log.info(
+                        f"{hf_state_name}, {olmo_core_state_name} shape mismatch: {hf_tensor.shape} {olmo_core_tensor.shape}"
+                    )
+                if hf_tensor.dtype != olmo_core_tensor.dtype:
+                    log.info(
+                        f"{hf_state_name}, {olmo_core_state_name} dtype mismatch: {hf_tensor.dtype} {olmo_core_tensor.dtype}"
+                    )
+                if len(hf_tensor.squeeze().shape) == len(olmo_core_tensor.squeeze().shape):
+                    hf_tensor = hf_tensor.squeeze()
+                    olmo_core_tensor = olmo_core_tensor.squeeze()
 
-    torch.testing.assert_close(hf_logits[..., :vocab_size], logits[..., :vocab_size])
+                    common_shape = tuple(
+                        min(hf_dim, olmo_core_dim)
+                        for hf_dim, olmo_core_dim in zip(hf_tensor.shape, olmo_core_tensor.shape)
+                    )
+                    for i, dim in enumerate(common_shape):
+                        hf_tensor = hf_tensor.narrow(i, 0, dim)
+                        olmo_core_tensor = olmo_core_tensor.narrow(i, 0, dim)
+                    log.info(
+                        f"{hf_state_name}, {olmo_core_state_name} element diff abs mean: {(hf_tensor - olmo_core_tensor).float().abs().mean()}"
+                    )
+
+    torch.testing.assert_close(
+        hf_logits[..., :vocab_size].float(), logits[..., :vocab_size].float(), rtol=1e-4, atol=1e-4
+    )
 
 
-def load_config(checkpoint_input_dir: PathOrStr) -> Optional[dict]:
-    if not file_exists(f"{checkpoint_input_dir}/config.json"):
-        log.warning(f"Config file not found at {checkpoint_input_dir}")
+def load_config(config_path: PathOrStr) -> Optional[dict]:
+    if not file_exists(config_path):
+        log.warning(f"Config file not found at {config_path}")
         return None
 
-    with cached_path(f"{checkpoint_input_dir}/config.json").open("r", encoding="utf-8") as f:
+    with cached_path(config_path).open("r", encoding="utf-8") as f:
         config_dict = json.load(f)
 
     if "model" not in config_dict:
-        log.warning(
-            f"Config file at {checkpoint_input_dir} is not an OLMo core experiment config, ignoring"
-        )
+        log.warning(f"Config file at {config_path} is not an OLMo core experiment config, ignoring")
         return None
 
     return config_dict
@@ -364,8 +475,7 @@ def parse_args():
         "-s",
         "--max-sequence-length",
         type=int,
-        required=True,
-        help="Max sequence length supported by the model.",
+        help="Deprecated, do not use. Max sequence length supported by the model.",
     )
     parser.add_argument(
         "--model-id",
@@ -388,13 +498,18 @@ def parse_args():
         type=torch.device,
         help="The device on which conversion and validation occurs. Defaults to CUDA or MPS if available and initialized.",
     )
+    parser.add_argument(
+        "--validation-sliding-window",
+        help="If set, overrides the model's sliding window size during validation. Useful for checking that sliding window is correctly implemented.",
+        type=int,
+    )
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
 
-    experiment_config = load_config(args.config_path or args.checkpoint_input_path)
+    experiment_config = load_config(args.config_path or f"{args.checkpoint_input_path}/config.json")
     transformer_config_dict = None
     if experiment_config is not None:
         transformer_config_dict = experiment_config["model"]
@@ -418,10 +533,10 @@ def main():
         transformer_config_dict=transformer_config_dict,
         tokenizer_config_dict=tokenizer_config_dict,
         model_id=args.model_id,
-        max_sequence_length=args.max_sequence_length,
         validate=args.validate,
         debug=args.debug,
         device=args.device,
+        validation_sliding_window=args.validation_sliding_window,
     )
 
 

--- a/src/olmo_core/nn/conversion/state_mapping.py
+++ b/src/olmo_core/nn/conversion/state_mapping.py
@@ -16,6 +16,24 @@ class TemplatePlaceholder(StrEnum):
     """"""
 
 
+class StateType(StrEnum):
+    """
+    The category the state being converted corresponds to.
+    """
+
+    weight = "weight"
+    """
+    The state being converted corresponds to a weight. This is useful for converting between checkpoints,
+    where the state is the weight itself.
+    """
+
+    module = "module"
+    """
+    The state being converted corresponds to a modules. This can be useful for comparing activations between
+    different implementations of the same model, where the states are the activations of submodules.
+    """
+
+
 @dataclass
 class StateMappingTemplate:
     """
@@ -38,6 +56,8 @@ class StateMappingTemplate:
     """
     The key or keys of the state(s) being mapping to.
     """
+
+    state_type: StateType = StateType.weight
 
     source_key_per_placeholder: TemplatePlaceholder | None = None
     """
@@ -203,6 +223,7 @@ class StateMappingTemplate:
         return StateMapping(
             source_keys,
             dest_keys,
+            state_type=self.state_type,
             source_concat_dim=self.source_concat_dim,
             unflatten_dim=unflatten_dim,
             dims_permutation=self.dims_permutation,
@@ -231,6 +252,8 @@ class StateMapping:
     """
     The key or keys of the state(s) being mapping to.
     """
+
+    state_type: StateType = StateType.weight
 
     source_concat_dim: int = 0
     """

--- a/src/olmo_core/nn/hf/__init__.py
+++ b/src/olmo_core/nn/hf/__init__.py
@@ -1,7 +1,7 @@
 """
 Utilities for converting models between OLMo Core and Hugging Face formats. To configure the
 mappings between OLMo Core and Hugging Face, you may change the variables in
-:mod:`olmo_core.nn.hf.convert` (e.g. :data:`olmo_core.nn.hf.convert.HF_TO_OLMO_CORE_MAPPINGS`).
+:mod:`olmo_core.nn.hf.convert` (e.g. :data:`olmo_core.nn.hf.convert.HF_TO_OLMO_CORE_WEIGHT_MAPPINGS`).
 """
 
 from .checkpoint import load_hf_model, save_hf_model

--- a/src/olmo_core/nn/hf/config.py
+++ b/src/olmo_core/nn/hf/config.py
@@ -2,20 +2,83 @@ from transformers import Olmo2Config, PretrainedConfig
 
 from olmo_core.doc_utils import beta_feature
 from olmo_core.nn.attention import Attention
-from olmo_core.nn.transformer.block import ReorderedNormTransformerBlock
+from olmo_core.nn.moe.mlp import MoEMLP
+from olmo_core.nn.transformer.block import (
+    MoEReorderedNormTransformerBlock,
+    ReorderedNormTransformerBlock,
+)
 from olmo_core.nn.transformer.model import (
     MoETransformer,
     NormalizedTransformer,
     Transformer,
 )
 
+try:
+    from transformers import FlexOlmoConfig  # type: ignore
+except ImportError:
+    FlexOlmoConfig = None
+
+
+def _get_flex_olmo_config(model: MoETransformer) -> PretrainedConfig:
+    blocks = list(model.blocks.values())
+    for block in blocks:
+        if not isinstance(block, MoEReorderedNormTransformerBlock):
+            raise NotImplementedError(
+                f"Block is not a {MoEReorderedNormTransformerBlock.__name__}, unable to build HF config for {model.__class__.__name__}"
+            )
+
+        if not isinstance(block.experts.mlp, MoEMLP):
+            raise NotImplementedError(
+                f"MoE mlp is not a {MoEMLP.__name__}, unable to build HF config for {model.__class__.__name__}"
+            )
+
+        if not isinstance(block.attention, Attention):
+            raise NotImplementedError(
+                f"Attention is not a {Attention.__name__}, unable to build HF config for {model.__class__.__name__}"
+            )
+        if block.attention.rope is None:
+            raise NotImplementedError(
+                f"Attention does not use rope, unable to build HF config for {model.__class__.__name__}"
+            )
+
+    block = blocks[0]
+    assert isinstance(block, MoEReorderedNormTransformerBlock)
+    assert isinstance(block.attention, Attention)
+    assert block.attention.rope is not None
+
+    if FlexOlmoConfig is None:
+        raise RuntimeError("The installed transformers version does not support FlexOlmo")
+
+    return FlexOlmoConfig(
+        vocab_size=model.vocab_size,
+        hidden_size=model.d_model,
+        intermediate_size=block.feed_forward_moe.experts.mlp.hidden_size,
+        num_hidden_layers=model.n_layers,
+        num_attention_heads=block.attention.n_heads,
+        num_key_value_heads=block.attention.n_kv_heads,
+        hidden_act="silu",
+        max_position_embeddings=-1,
+        attention_bias=block.attention.w_out.bias is not None,
+        rope_theta=block.attention.rope.theta,
+        pad_token_id=None,  # type: ignore
+        bos_token_id=None,
+        eos_token_id=None,  # type: ignore
+        rms_norm_eps=block.feed_forward_norm.eps,
+        num_experts_per_tok=block.feed_forward_moe.router.top_k,
+        num_experts=block.feed_forward_moe.router.num_experts,
+        tie_word_embeddings=False,
+    )
+
 
 @beta_feature
 def get_hf_config(model: Transformer) -> PretrainedConfig:
-    if isinstance(model, (MoETransformer, NormalizedTransformer)):
+    if isinstance(model, NormalizedTransformer):
         raise NotImplementedError(
             f"Building HF config not implemented for {model.__class__.__name__}"
         )
+
+    if isinstance(model, MoETransformer):
+        return _get_flex_olmo_config(model)
 
     block = next(iter(model.blocks.values()))
     if not isinstance(block, ReorderedNormTransformerBlock):

--- a/src/olmo_core/nn/hf/convert.py
+++ b/src/olmo_core/nn/hf/convert.py
@@ -42,13 +42,9 @@ HF_TO_OLMO_CORE_WEIGHT_MAPPINGS: Dict[str, str] = {
     f"model.layers.{LAYER}.self_attn.q_norm.weight": f"blocks.{LAYER}.attention.q_norm.weight",
     f"model.layers.{LAYER}.self_attn.k_norm.weight": f"blocks.{LAYER}.attention.k_norm.weight",
     # MoEMLP.
-    f"model.layers.{LAYER}.mlp.gate.weight": f"blocks.{LAYER}.feed_forward_moe.router.weight",
-    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight": f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
-    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight": f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
-    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight": f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
-    f"model.layers.{LAYER}.mlp.shared_mlp.gate_proj.weight": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w1.weight",
-    f"model.layers.{LAYER}.mlp.shared_mlp.down_proj.weight": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w2.weight",
-    f"model.layers.{LAYER}.mlp.shared_mlp.up_proj.weight": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w3.weight",
+    f"model.layers.{LAYER}.block_sparse_moe.shared_mlp.gate_proj.weight": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w1.weight",
+    f"model.layers.{LAYER}.block_sparse_moe.shared_mlp.down_proj.weight": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w2.weight",
+    f"model.layers.{LAYER}.block_sparse_moe.shared_mlp.up_proj.weight": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w3.weight",
 }
 
 
@@ -126,32 +122,61 @@ MODEL_SPECIFIC_HF_TO_OLMO_CORE_MODULE_MAPPINGS: Dict[str, Dict[str, str]] = {
 #: For simple one-to-one mappings from HF to OLMo Core, see
 #: :data:`HF_TO_OLMO_CORE_MAPPINGS`.
 HF_TO_OLMO_CORE_TEMPLATE_MAPPINGS: Dict[str, StateMappingTemplate] = {
-    f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.gate_proj.weight": StateMappingTemplate(
-        f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.gate_proj.weight",
+    f"model.layers.{LAYER}.block_sparse_moe.experts.{EXPERT}.gate_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.block_sparse_moe.experts.{EXPERT}.gate_proj.weight",
         f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
         source_key_per_placeholder=TemplatePlaceholder.EXPERT,
         source_concat_dim=1,
         dims_permutation=(1, 0),
         dest_chunk_dim=0,
     ),
-    f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.down_proj.weight": StateMappingTemplate(
-        f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.down_proj.weight",
+    f"model.layers.{LAYER}.block_sparse_moe.experts.{EXPERT}.down_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.block_sparse_moe.experts.{EXPERT}.down_proj.weight",
         f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
         source_key_per_placeholder=TemplatePlaceholder.EXPERT,
         source_concat_dim=1,
         dims_permutation=(1, 0),
         dest_chunk_dim=0,
     ),
-    f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.up_proj.weight": StateMappingTemplate(
-        f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.up_proj.weight",
+    f"model.layers.{LAYER}.block_sparse_moe.experts.{EXPERT}.up_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.block_sparse_moe.experts.{EXPERT}.up_proj.weight",
         f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
         source_key_per_placeholder=TemplatePlaceholder.EXPERT,
         source_concat_dim=1,
         dims_permutation=(1, 0),
         dest_chunk_dim=0,
     ),
-    f"model.layers.{LAYER}.mlp.block_sparse_moe.gate.weight": StateMappingTemplate(
-        f"model.layers.{LAYER}.mlp.block_sparse_moe.gate.weight",
+    f"model.layers.{LAYER}.block_sparse_moe.gate.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.block_sparse_moe.gate.weight",
+        f"blocks.{LAYER}.feed_forward_moe.router.weight",
+        flatten_dims=(0, 1),
+    ),
+    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight",
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
+        source_key_per_placeholder=TemplatePlaceholder.EXPERT,
+        source_concat_dim=1,
+        dims_permutation=(1, 0),
+        dest_chunk_dim=0,
+    ),
+    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight",
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
+        source_key_per_placeholder=TemplatePlaceholder.EXPERT,
+        source_concat_dim=1,
+        dims_permutation=(1, 0),
+        dest_chunk_dim=0,
+    ),
+    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight",
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
+        source_key_per_placeholder=TemplatePlaceholder.EXPERT,
+        source_concat_dim=1,
+        dims_permutation=(1, 0),
+        dest_chunk_dim=0,
+    ),
+    f"model.layers.{LAYER}.mlp.gate.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.gate.weight",
         f"blocks.{LAYER}.feed_forward_moe.router.weight",
         flatten_dims=(0, 1),
     ),

--- a/src/olmo_core/nn/hf/convert.py
+++ b/src/olmo_core/nn/hf/convert.py
@@ -6,6 +6,7 @@ from olmo_core.doc_utils import beta_feature
 from olmo_core.nn.conversion.state_converter import StateConverter
 from olmo_core.nn.conversion.state_mapping import (
     StateMappingTemplate,
+    StateType,
     TemplatePlaceholder,
 )
 
@@ -13,15 +14,15 @@ LAYER = TemplatePlaceholder.LAYER
 EXPERT = TemplatePlaceholder.EXPERT
 
 
-#: Map of Hugging Face keys to OLMo Core keys, that is used to determine how HF state
+#: Map of Hugging Face weight keys to OLMo Core weight keys, that is used to determine how HF state
 #: maps to OLMo Core state. Different HF models may use different names for a given OLMo
 #: Core state. You may configure this to change how HF state maps to OLMo Core state.
 #:
 #: This map only captures one-to-one mappings from HF to OLMo Core. For many-to-many mappings
 #: or mappings that require additional manipulation of state, see
 #: :data:`HF_TO_OLMO_CORE_TEMPLATE_MAPPINGS`. If a given HF key can refer to different OLMo Core
-#: states depending on the HF model, see :data:`MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS`.
-HF_TO_OLMO_CORE_MAPPINGS: Dict[str, str] = {
+#: states depending on the HF model, see :data:`MODEL_SPECIFIC_HF_TO_OLMO_CORE_WEIGHT_MAPPINGS`.
+HF_TO_OLMO_CORE_WEIGHT_MAPPINGS: Dict[str, str] = {
     "model.embed_tokens.weight": "embeddings.weight",
     "model.norm.weight": "lm_head.norm.weight",
     "lm_head.weight": "lm_head.w_out.weight",
@@ -45,19 +46,73 @@ HF_TO_OLMO_CORE_MAPPINGS: Dict[str, str] = {
     f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight": f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
     f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight": f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
     f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight": f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
+    f"model.layers.{LAYER}.mlp.shared_mlp.gate_proj.weight": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w1.weight",
+    f"model.layers.{LAYER}.mlp.shared_mlp.down_proj.weight": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w2.weight",
+    f"model.layers.{LAYER}.mlp.shared_mlp.up_proj.weight": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w3.weight",
 }
 
 
-#: Map of Hugging Face keys to OLMo Core keys. This map captures overrides of the standard
+#: Map of Hugging Face module keys to OLMo Core module keys, that is used to determine how HF state
+#: maps to OLMo Core state. Different HF models may use different names for a given OLMo
+#: Core state. You may configure this to change how HF state maps to OLMo Core state.
+#:
+#: This map only captures one-to-one mappings from HF to OLMo Core. For many-to-many mappings
+#: or mappings that require additional manipulation of state, see
+#: :data:`HF_TO_OLMO_CORE_TEMPLATE_MAPPINGS`. If a given HF key can refer to different OLMo Core
+#: states depending on the HF model, see :data:`MODEL_SPECIFIC_HF_TO_OLMO_CORE_MODULE_MAPPINGS`.
+HF_TO_OLMO_CORE_MODULE_MAPPINGS: Dict[str, str] = {
+    "model.embed_tokens": "embeddings",
+    "model.norm": "lm_head.norm",
+    "lm_head": "lm_head.w_out",
+    # Attention.
+    f"model.layers.{LAYER}.self_attn.q_proj": f"blocks.{LAYER}.attention.w_q",
+    f"model.layers.{LAYER}.self_attn.k_proj": f"blocks.{LAYER}.attention.w_k",
+    f"model.layers.{LAYER}.self_attn.v_proj": f"blocks.{LAYER}.attention.w_v",
+    f"model.layers.{LAYER}.self_attn.o_proj": f"blocks.{LAYER}.attention.w_out",
+    # MLP.
+    f"model.layers.{LAYER}.mlp.gate_proj": f"blocks.{LAYER}.feed_forward.w1",
+    f"model.layers.{LAYER}.mlp.down_proj": f"blocks.{LAYER}.feed_forward.w2",
+    f"model.layers.{LAYER}.mlp.up_proj": f"blocks.{LAYER}.feed_forward.w3",
+    # Layer norms.
+    f"model.layers.{LAYER}.input_layernorm": f"blocks.{LAYER}.attention_norm",
+    f"model.layers.{LAYER}.post_attention_layernorm": f"blocks.{LAYER}.attention_norm",
+    f"model.layers.{LAYER}.post_feedforward_layernorm": f"blocks.{LAYER}.feed_forward_norm",
+    f"model.layers.{LAYER}.self_attn.q_norm": f"blocks.{LAYER}.attention.q_norm",
+    f"model.layers.{LAYER}.self_attn.k_norm": f"blocks.{LAYER}.attention.k_norm",
+    # MoEMLP.
+    f"model.layers.{LAYER}.block_sparse_moe": f"blocks.{LAYER}.feed_forward_moe",
+    f"model.layers.{LAYER}.post_moe_norm": f"blocks.{LAYER}.feed_forward_moe_norm",
+    f"model.layers.{LAYER}.block_sparse_moe.gate": f"blocks.{LAYER}.feed_forward_moe.router",
+    f"model.layers.{LAYER}.block_sparse_moe.shared_mlp": f"blocks.{LAYER}.feed_forward_moe.shared_mlp",
+    f"model.layers.{LAYER}.block_sparse_moe.shared_mlp.gate_proj": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w1",
+    f"model.layers.{LAYER}.block_sparse_moe.shared_mlp.down_proj": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w2",
+    f"model.layers.{LAYER}.block_sparse_moe.shared_mlp.up_proj": f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w3",
+}
+
+
+#: Map of Hugging Face weight keys to OLMo Core weight keys. This map captures overrides of the standard
 #: one-to-one mappings in :data:`HF_TO_OLMO_CORE_MAPPINGS`, in case a given HF key can refer to
 #: different OLMo Core states depending on the HF model. You may configure this to change
 #: how HF state maps to OLMo Core state.
-MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS: Dict[str, Dict[str, str]] = {
+MODEL_SPECIFIC_HF_TO_OLMO_CORE_WEIGHT_MAPPINGS: Dict[str, Dict[str, str]] = {
     "meta-llama/Llama-3.2-1B": {
         f"model.layers.{LAYER}.post_attention_layernorm.weight": f"blocks.{LAYER}.feed_forward_norm.weight"
     },
     "meta-llama/Meta-Llama-3-8B-Instruct": {
         f"model.layers.{LAYER}.post_attention_layernorm.weight": f"blocks.{LAYER}.feed_forward_norm.weight"
+    },
+}
+
+#: Map of Hugging Face module keys to OLMo Core module keys. This map captures overrides of the standard
+#: one-to-one mappings in :data:`HF_TO_OLMO_CORE_MAPPINGS`, in case a given HF key can refer to
+#: different OLMo Core states depending on the HF model. You may configure this to change
+#: how HF state maps to OLMo Core state.
+MODEL_SPECIFIC_HF_TO_OLMO_CORE_MODULE_MAPPINGS: Dict[str, Dict[str, str]] = {
+    "meta-llama/Llama-3.2-1B": {
+        f"model.layers.{LAYER}.post_attention_layernorm": f"blocks.{LAYER}.feed_forward_norm"
+    },
+    "meta-llama/Meta-Llama-3-8B-Instruct": {
+        f"model.layers.{LAYER}.post_attention_layernorm": f"blocks.{LAYER}.feed_forward_norm"
     },
 }
 
@@ -71,44 +126,44 @@ MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS: Dict[str, Dict[str, str]] = {
 #: For simple one-to-one mappings from HF to OLMo Core, see
 #: :data:`HF_TO_OLMO_CORE_MAPPINGS`.
 HF_TO_OLMO_CORE_TEMPLATE_MAPPINGS: Dict[str, StateMappingTemplate] = {
-    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight": StateMappingTemplate(
-        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight",
+    f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.gate_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.gate_proj.weight",
         f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
         source_key_per_placeholder=TemplatePlaceholder.EXPERT,
         source_concat_dim=1,
         dims_permutation=(1, 0),
         dest_chunk_dim=0,
     ),
-    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight": StateMappingTemplate(
-        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight",
+    f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.down_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.down_proj.weight",
         f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
         source_key_per_placeholder=TemplatePlaceholder.EXPERT,
         source_concat_dim=1,
         dims_permutation=(1, 0),
         dest_chunk_dim=0,
     ),
-    f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight": StateMappingTemplate(
-        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight",
+    f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.up_proj.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.block_sparse_moe.experts.{EXPERT}.up_proj.weight",
         f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
         source_key_per_placeholder=TemplatePlaceholder.EXPERT,
         source_concat_dim=1,
         dims_permutation=(1, 0),
         dest_chunk_dim=0,
     ),
-    f"model.layers.{LAYER}.mlp.gate.weight": StateMappingTemplate(
-        f"model.layers.{LAYER}.mlp.gate.weight",
+    f"model.layers.{LAYER}.mlp.block_sparse_moe.gate.weight": StateMappingTemplate(
+        f"model.layers.{LAYER}.mlp.block_sparse_moe.gate.weight",
         f"blocks.{LAYER}.feed_forward_moe.router.weight",
         flatten_dims=(0, 1),
     ),
 }
 
 
-#: Map of OLMo Core keys to Hugging Face keys, that is used to determine how OLMo Core state
+#: Map of OLMo Core weight keys to Hugging Face weight keys, that is used to determine how OLMo Core state
 #: maps to HF state. You may configure this to change how OLMo Core state maps to HF state.
 #:
 #: This map only captures one-to-one mappings from OLMo Core to HF. For many-to-many mappings
 #: or mappings that require additional manipulation of state, see :data:`OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS`.
-OLMO_CORE_TO_HF_MAPPINGS: Dict[str, str] = {
+OLMO_CORE_TO_HF_WEIGHT_MAPPINGS: Dict[str, str] = {
     "embeddings.weight": "model.embed_tokens.weight",
     "lm_head.norm.weight": "model.norm.weight",
     "lm_head.w_out.weight": "lm_head.weight",
@@ -127,10 +182,46 @@ OLMO_CORE_TO_HF_MAPPINGS: Dict[str, str] = {
     f"blocks.{LAYER}.attention.q_norm.weight": f"model.layers.{LAYER}.self_attn.q_norm.weight",
     f"blocks.{LAYER}.attention.k_norm.weight": f"model.layers.{LAYER}.self_attn.k_norm.weight",
     # MoEMLP.
-    f"blocks.{LAYER}.feed_forward_moe.router.weight": f"model.layers.{LAYER}.mlp.gate.weight",
-    f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1": f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight",
-    f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2": f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight",
-    f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3": f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight",
+    # f"blocks.{LAYER}.feed_forward_moe.router.weight": f"model.layers.{LAYER}.mlp.gate.weight",
+    f"blocks.{LAYER}.feed_forward_moe_norm.weight": f"model.layers.{LAYER}.post_moe_norm.weight",
+    f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w1.weight": f"model.layers.{LAYER}.mlp.shared_mlp.gate_proj.weight",
+    f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w2.weight": f"model.layers.{LAYER}.mlp.shared_mlp.down_proj.weight",
+    f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w3.weight": f"model.layers.{LAYER}.mlp.shared_mlp.up_proj.weight",
+}
+
+
+#: Map of OLMo Core module keys to Hugging Face module keys, that is used to determine how OLMo Core state
+#: maps to HF state. You may configure this to change how OLMo Core state maps to HF state.
+#:
+#: This map only captures one-to-one mappings from OLMo Core to HF. For many-to-many mappings
+#: or mappings that require additional manipulation of state, see :data:`OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS`.
+OLMO_CORE_TO_HF_MODULE_MAPPINGS: Dict[str, str] = {
+    "embeddings": "model.embed_tokens",
+    "lm_head.norm": "model.norm",
+    "lm_head.w_out": "lm_head",
+    # Attention.
+    f"blocks.{LAYER}.attention.w_q": f"model.layers.{LAYER}.self_attn.q_proj",
+    f"blocks.{LAYER}.attention.w_k": f"model.layers.{LAYER}.self_attn.k_proj",
+    f"blocks.{LAYER}.attention.w_v": f"model.layers.{LAYER}.self_attn.v_proj",
+    f"blocks.{LAYER}.attention.w_out": f"model.layers.{LAYER}.self_attn.o_proj",
+    # MLP.
+    f"blocks.{LAYER}.feed_forward": f"model.layers.{LAYER}.mlp",
+    f"blocks.{LAYER}.feed_forward.w1": f"model.layers.{LAYER}.mlp.gate_proj",
+    f"blocks.{LAYER}.feed_forward.w2": f"model.layers.{LAYER}.mlp.down_proj",
+    f"blocks.{LAYER}.feed_forward.w3": f"model.layers.{LAYER}.mlp.up_proj",
+    # Layer norms.
+    f"blocks.{LAYER}.attention_norm": f"model.layers.{LAYER}.post_attention_layernorm",
+    f"blocks.{LAYER}.feed_forward_norm": f"model.layers.{LAYER}.post_feedforward_layernorm",
+    f"blocks.{LAYER}.attention.q_norm": f"model.layers.{LAYER}.self_attn.q_norm",
+    f"blocks.{LAYER}.attention.k_norm": f"model.layers.{LAYER}.self_attn.k_norm",
+    # MoEMLP.
+    f"blocks.{LAYER}.feed_forward_moe": f"model.layers.{LAYER}.block_sparse_moe",
+    f"blocks.{LAYER}.feed_forward_moe_norm": f"model.layers.{LAYER}.post_moe_norm",
+    f"blocks.{LAYER}.feed_forward_moe.router": f"model.layers.{LAYER}.block_sparse_moe.gate",
+    f"blocks.{LAYER}.feed_forward_moe.shared_mlp": f"model.layers.{LAYER}.block_sparse_moe.shared_mlp",
+    f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w1": f"model.layers.{LAYER}.block_sparse_moe.shared_mlp.gate_proj",
+    f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w2": f"model.layers.{LAYER}.block_sparse_moe.shared_mlp.down_proj",
+    f"blocks.{LAYER}.feed_forward_moe.shared_mlp.w3": f"model.layers.{LAYER}.block_sparse_moe.shared_mlp.up_proj",
 }
 
 
@@ -144,7 +235,7 @@ OLMO_CORE_TO_HF_MAPPINGS: Dict[str, str] = {
 OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS: Dict[str, StateMappingTemplate] = {
     f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1": StateMappingTemplate(
         f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
-        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight",
+        f"model.layers.{LAYER}.block_sparse_moe.experts.{EXPERT}.gate_proj.weight",
         dest_key_per_placeholder=TemplatePlaceholder.EXPERT,
         source_concat_dim=0,
         dims_permutation=(1, 0),
@@ -152,7 +243,7 @@ OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS: Dict[str, StateMappingTemplate] = {
     ),
     f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2": StateMappingTemplate(
         f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
-        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight",
+        f"model.layers.{LAYER}.block_sparse_moe.experts.{EXPERT}.down_proj.weight",
         dest_key_per_placeholder=TemplatePlaceholder.EXPERT,
         source_concat_dim=0,
         dims_permutation=(1, 0),
@@ -160,7 +251,7 @@ OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS: Dict[str, StateMappingTemplate] = {
     ),
     f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3": StateMappingTemplate(
         f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
-        f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight",
+        f"model.layers.{LAYER}.block_sparse_moe.experts.{EXPERT}.up_proj.weight",
         dest_key_per_placeholder=TemplatePlaceholder.EXPERT,
         source_concat_dim=0,
         dims_permutation=(1, 0),
@@ -168,9 +259,57 @@ OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS: Dict[str, StateMappingTemplate] = {
     ),
     f"blocks.{LAYER}.feed_forward_moe.router.weight": StateMappingTemplate(
         f"blocks.{LAYER}.feed_forward_moe.router.weight",
-        f"model.layers.{LAYER}.mlp.gate.weight",
+        f"model.layers.{LAYER}.block_sparse_moe.gate.weight",
         unflatten_dim=(0, (TemplatePlaceholder.EXPERT, -1)),
     ),
+}
+
+
+#: Map of OLMo Core keys to Hugging Face keys, that is used to determine how OLMo Core state
+#: maps to HF state. This map captures overrides of the standard mappings in
+#: :data:`OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS`, in case a given OLMo Core key can refer to
+#: different HF states depending on the HF model. You may configure this to change how OLMo Core
+#: state maps to HF state.
+MODEL_TYPE_SPECIFIC_OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS: Dict[
+    str, Dict[str, StateMappingTemplate]
+] = {
+    "flex_olmo": {
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1": StateMappingTemplate(
+            f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w1",
+            f"model.layers.{LAYER}.mlp.experts.{EXPERT}.gate_proj.weight",
+            dest_key_per_placeholder=TemplatePlaceholder.EXPERT,
+            source_concat_dim=0,
+            dims_permutation=(1, 0),
+            dest_chunk_dim=1,
+        ),
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2": StateMappingTemplate(
+            f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w2",
+            f"model.layers.{LAYER}.mlp.experts.{EXPERT}.down_proj.weight",
+            dest_key_per_placeholder=TemplatePlaceholder.EXPERT,
+            source_concat_dim=0,
+            dims_permutation=(1, 0),
+            dest_chunk_dim=1,
+        ),
+        f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3": StateMappingTemplate(
+            f"blocks.{LAYER}.feed_forward_moe.experts.mlp.w3",
+            f"model.layers.{LAYER}.mlp.experts.{EXPERT}.up_proj.weight",
+            dest_key_per_placeholder=TemplatePlaceholder.EXPERT,
+            source_concat_dim=0,
+            dims_permutation=(1, 0),
+            dest_chunk_dim=1,
+        ),
+        f"blocks.{LAYER}.feed_forward_moe.router.weight": StateMappingTemplate(
+            f"blocks.{LAYER}.feed_forward_moe.router.weight",
+            f"model.layers.{LAYER}.mlp.gate.weight",
+            unflatten_dim=(0, (TemplatePlaceholder.EXPERT, -1)),
+        ),
+        f"blocks.{LAYER}.feed_forward_moe.router": StateMappingTemplate(
+            f"blocks.{LAYER}.feed_forward_moe.router",
+            f"model.layers.{LAYER}.mlp.gate",
+            state_type=StateType.module,
+            unflatten_dim=(0, (TemplatePlaceholder.EXPERT, -1)),
+        ),
+    }
 }
 
 
@@ -178,13 +317,30 @@ def _get_hf_model_to_olmo_core_one_to_one_templates(
     model_id: str | None = None,
 ) -> List[StateMappingTemplate]:
     mapping_templates = {
-        hf_key: StateMappingTemplate(hf_key, olmo_core_key)
-        for hf_key, olmo_core_key in HF_TO_OLMO_CORE_MAPPINGS.items()
+        hf_key: StateMappingTemplate(hf_key, olmo_core_key, state_type=StateType.weight)
+        for hf_key, olmo_core_key in HF_TO_OLMO_CORE_WEIGHT_MAPPINGS.items()
     }
-    if model_id in MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS:
+
+    for hf_key, olmo_core_key in HF_TO_OLMO_CORE_MODULE_MAPPINGS.items():
+        mapping_templates[hf_key] = StateMappingTemplate(
+            hf_key, olmo_core_key, state_type=StateType.module
+        )
+
+    if model_id in MODEL_SPECIFIC_HF_TO_OLMO_CORE_WEIGHT_MAPPINGS:
         model_specific_mapping_templates = {
-            hf_key: StateMappingTemplate(hf_key, olmo_core_key)
-            for hf_key, olmo_core_key in MODEL_SPECIFIC_HF_TO_OLMO_CORE_MAPPINGS[model_id].items()
+            hf_key: StateMappingTemplate(hf_key, olmo_core_key, state_type=StateType.weight)
+            for hf_key, olmo_core_key in MODEL_SPECIFIC_HF_TO_OLMO_CORE_WEIGHT_MAPPINGS[
+                model_id
+            ].items()
+        }
+        mapping_templates.update(model_specific_mapping_templates)
+
+    if model_id in MODEL_SPECIFIC_HF_TO_OLMO_CORE_MODULE_MAPPINGS:
+        model_specific_mapping_templates = {
+            hf_key: StateMappingTemplate(hf_key, olmo_core_key, state_type=StateType.module)
+            for hf_key, olmo_core_key in MODEL_SPECIFIC_HF_TO_OLMO_CORE_MODULE_MAPPINGS[
+                model_id
+            ].items()
         }
         mapping_templates.update(model_specific_mapping_templates)
 
@@ -234,18 +390,30 @@ def convert_state_from_hf(
     return converter.convert(hf_state, placeholder_bounds)
 
 
-def _get_converter_to_hf() -> StateConverter:
-    mapping_templates = [
-        StateMappingTemplate(olmo_core_key, hf_key)
-        for olmo_core_key, hf_key in OLMO_CORE_TO_HF_MAPPINGS.items()
-    ]
-    mapping_templates += list(OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS.values())
-    return StateConverter(mapping_templates)
+def _get_converter_to_hf(model_type: str | None = None) -> StateConverter:
+    mapping_templates = {
+        olmo_core_key: StateMappingTemplate(olmo_core_key, hf_key, state_type=StateType.module)
+        for olmo_core_key, hf_key in OLMO_CORE_TO_HF_MODULE_MAPPINGS.items()
+    }
+    mapping_templates.update(
+        {
+            olmo_core_key: StateMappingTemplate(olmo_core_key, hf_key, state_type=StateType.weight)
+            for olmo_core_key, hf_key in OLMO_CORE_TO_HF_WEIGHT_MAPPINGS.items()
+        }
+    )
+    mapping_templates.update(OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS)
+
+    if model_type:
+        mapping_templates.update(
+            MODEL_TYPE_SPECIFIC_OLMO_CORE_TO_HF_TEMPLATE_MAPPINGS.get(model_type, {})
+        )
+
+    return StateConverter(list(mapping_templates.values()))
 
 
 @beta_feature
-def get_converter_to_hf() -> StateConverter:
-    return _get_converter_to_hf()
+def get_converter_to_hf(model_type: str | None = None) -> StateConverter:
+    return _get_converter_to_hf(model_type)
 
 
 @beta_feature
@@ -260,7 +428,7 @@ def convert_state_to_hf(
         :class:`DTensor` or :class:`ShardedTensor`
     """
 
-    converter = _get_converter_to_hf()
+    converter = _get_converter_to_hf(getattr(config, "model_type", None))
 
     if not hasattr(config, "num_hidden_layers"):
         raise ValueError(f"Number of hidden layers missing in HF config: {config}")

--- a/src/test/examples/huggingface/convert_checkpoint_from_hf_test.py
+++ b/src/test/examples/huggingface/convert_checkpoint_from_hf_test.py
@@ -85,7 +85,6 @@ def test_convert_checkpoint_from_hf_correct_config(
         output_path=output_dir,
         transformer_config_dict=transformer_config.as_config_dict(),
         tokenizer_config_dict=tokenizer_config.as_config_dict(),
-        max_sequence_length=256,
         validate=False,
     )
 
@@ -112,7 +111,6 @@ def test_convert_checkpoint_from_hf_correct_model(
         output_path=output_dir,
         transformer_config_dict=transformer_config.as_config_dict(),
         tokenizer_config_dict=tokenizer_config.as_config_dict(),
-        max_sequence_length=256,
         validate=False,
     )
 

--- a/src/test/nn/hf/convert_test.py
+++ b/src/test/nn/hf/convert_test.py
@@ -1,7 +1,13 @@
+import pytest
 import torch
 from transformers import Olmo2Config
 
 from olmo_core.nn.hf.convert import convert_state_from_hf, convert_state_to_hf
+
+try:
+    from transformers import FlexOlmoConfig  # type: ignore
+except ImportError:
+    FlexOlmoConfig = None
 
 
 def _get_olmo2_config() -> Olmo2Config:
@@ -97,7 +103,7 @@ def test_convert_state_from_hf_and_flatten():
     for i in range(hf_config.num_hidden_layers):
         hf_state.update(
             {
-                f"model.layers.{i}.mlp.gate.weight": torch.randn(5, 6),
+                f"model.layers.{i}.block_sparse_moe.gate.weight": torch.randn(5, 6),
             }
         )
 
@@ -106,7 +112,7 @@ def test_convert_state_from_hf_and_flatten():
     for i in range(hf_config.num_hidden_layers):
         torch.testing.assert_close(
             converted_state[f"blocks.{i}.feed_forward_moe.router.weight"],
-            hf_state[f"model.layers.{i}.mlp.gate.weight"].flatten(),
+            hf_state[f"model.layers.{i}.block_sparse_moe.gate.weight"].flatten(),
         )
 
 
@@ -166,6 +172,40 @@ def test_convert_layers_to_hf():
 def test_convert_state_to_hf_and_unflatten():
     hf_config = _get_olmo2_config()
     hf_config.num_experts = hf_config.hidden_size // 2
+
+    olmo_core_state = {}
+    for i in range(hf_config.num_hidden_layers):
+        olmo_core_state.update(
+            {
+                f"blocks.{i}.feed_forward_moe.router.weight": torch.randn(
+                    hf_config.num_experts * hf_config.hidden_size
+                ),
+            }
+        )
+
+    converted_state = convert_state_to_hf(hf_config, olmo_core_state)
+
+    for i in range(hf_config.num_hidden_layers):
+        torch.testing.assert_close(
+            converted_state[f"model.layers.{i}.block_sparse_moe.gate.weight"].flatten(),
+            olmo_core_state[f"blocks.{i}.feed_forward_moe.router.weight"],
+        )
+
+
+def test_convert_state_to_flex_olmo_hf():
+    if FlexOlmoConfig is None:
+        pytest.skip("The installed transformers version does not support FlexOlmo")
+
+    hf_config = FlexOlmoConfig(
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_experts=2,
+        max_position_embeddings=64,
+        eos_token_id=42,
+    )
 
     olmo_core_state = {}
     for i in range(hf_config.num_hidden_layers):


### PR DESCRIPTION
The PR (messily) adds support for conversion to FlexOlmo models.

The changes in [convert_checkpoint_from_hf.py](https://github.com/allenai/OLMo-core/compare/shanea/flex-olmo-2?expand=1#diff-c72fd6ea0acda0f4f9e01b878239ec5b5784fdd0baa0cc5266f0520d4d2fb0d7) and [state_converter.py](https://github.com/allenai/OLMo-core/compare/shanea/flex-olmo-2?expand=1#diff-adb9b3a72fab234bee98ed75be280c80f6acfa72d563cf86b42d07a96f0f19b1) are closer to quality-of-life than necessities and are the most complicated part of this change... The only part needed from them is the checks in `convert_checkpoint_from_hf.py` for making sure flash attention is present when converting/validating.