### PR TITLE
Fix glob_directory bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Callback.post_train()` will still be called even if the run is canceled before the dry-run batch.
 - `GarbageCollectorCallback` will restore `gc` settings even when `Trainer.fit()` exits on an error.
 - Make `move_to_device` blocking for MPS device to fix possible incorrect transfer of data from CPU to MPS.
+- Fixed bug where `glob_directory()` would fail to match certain glob patterns.
 
 ### Changed
 

--- a/src/olmo_core/io.py
+++ b/src/olmo_core/io.py
@@ -445,19 +445,26 @@ def glob_directory(pattern: str) -> Generator[str, None, None]:
         Only a subset of glob patterns are supported. Specifically, ``*`` and ``**`` wildcards,
         which the follow the semantics defined here https://docs.python.org/3/library/pathlib.html#pattern-language.
     """
-    # Pull out base directory from pattern.
-    dir = pattern.split("*", 1)[0]
+    # Pull out base directory from pattern by finding the first part before any wildcard.
+    # Split by '/' and take path components until we hit one with a wildcard.
+    parts = pattern.split("/")
+    base_parts = []
+    for part in parts:
+        if "*" in part:
+            break
+        base_parts.append(part)
+    dir = "/".join(base_parts) if base_parts else "."
 
     # Translate the glob pattern into a regex.
     # For example, "src/examples/**/*.py" --> "^src/examples/.*[^/]*\\.py$".
-    regex = re.compile(
+    pattern_regex = re.compile(
         "^"
         + re.escape(pattern).replace(r"\*\*/", ".*").replace(r"\*\*", ".*").replace(r"\*", "[^/]*")
         + "$"
     )
 
     for path in list_directory(dir, recurse="**" in pattern):
-        if regex.match(path):
+        if pattern_regex.match(path):
             yield path
 
 
@@ -574,7 +581,7 @@ def _http_file_size(url: str) -> int:
 @retriable()
 def _http_get_bytes_range(url: str, bytes_start: int, num_bytes: int) -> bytes:
     response = requests.get(
-        url, headers={"Range": f"bytes={bytes_start}-{bytes_start+num_bytes-1}"}
+        url, headers={"Range": f"bytes={bytes_start}-{bytes_start + num_bytes - 1}"}
     )
     if response.status_code == 404:
         raise FileNotFoundError(url)
@@ -1047,6 +1054,6 @@ class _WekaClient(SchemeClient):
 
     def get_bytes_range(self, index: int, length: int) -> bytes:
         response = self.s3.get_object(
-            Bucket=self.bucket_name, Key=self.path, Range=f"bytes={index}-{index+length-1}"
+            Bucket=self.bucket_name, Key=self.path, Range=f"bytes={index}-{index + length - 1}"
         )
         return response["Body"].read()

--- a/src/test/io_test.py
+++ b/src/test/io_test.py
@@ -24,6 +24,7 @@ def test_local_functionality(tmp_path):
     (tmp_path / "file1.json").touch()
     (tmp_path / "dir1").mkdir()
     (tmp_path / "dir1" / "file2").touch()
+    (tmp_path / "dir1" / "file3.json").touch()
 
     # Should only list immediate children (files and dirs), but not files in subdirs.
     # The paths returned should be full paths.
@@ -32,16 +33,41 @@ def test_local_functionality(tmp_path):
         f"{tmp_path}/file1.json",
         f"{tmp_path}/dir1",
         f"{tmp_path}/dir1/file2",
+        f"{tmp_path}/dir1/file3.json",
     }
 
     (tmp_path / "dir1" / "subdir1").mkdir()
     (tmp_path / "dir1" / "subdir1" / "file1").touch()
+    (tmp_path / "dir1" / "subdir1" / "file4.json").touch()
 
     copy_dir(tmp_path / "dir1", tmp_path / "dir2")
     assert set(list_directory(tmp_path / "dir2", recurse=True)) == {
         f"{tmp_path}/dir2/file2",
+        f"{tmp_path}/dir2/file3.json",
         f"{tmp_path}/dir2/subdir1",
         f"{tmp_path}/dir2/subdir1/file1",
+        f"{tmp_path}/dir2/subdir1/file4.json",
+    }
+
+    # Test glob_directory with local files
+    # Should list top-level json files
+    assert set(glob_directory(f"{tmp_path}/*.json")) == {
+        f"{tmp_path}/file1.json",
+    }
+
+    # Should list all json files
+    assert set(glob_directory(f"{tmp_path}/**/*.json")) == {
+        f"{tmp_path}/file1.json",
+        f"{tmp_path}/dir1/file3.json",
+        f"{tmp_path}/dir1/subdir1/file4.json",
+        f"{tmp_path}/dir2/file3.json",
+        f"{tmp_path}/dir2/subdir1/file4.json",
+    }
+
+    # Should list nested json files in dir1
+    assert set(glob_directory(f"{tmp_path}/dir1/**/file*.json")) == {
+        f"{tmp_path}/dir1/file3.json",
+        f"{tmp_path}/dir1/subdir1/file4.json",
     }
 
 
@@ -81,6 +107,11 @@ def _run_remote_functionality(tmp_path, remote_dir):
     # Should list all json files.
     assert set(glob_directory(f"{remote_dir}/**/*.json")) == {
         f"{remote_dir}/file1.json",
+        f"{remote_dir}/dir1/file2.json",
+    }
+
+    # Should list nested json file
+    assert set(glob_directory(f"{remote_dir}/dir1/file*.json")) == {
         f"{remote_dir}/dir1/file2.json",
     }
 


### PR DESCRIPTION
`glob_directory` fails when a glob such as `/my/path/to/tokenized_*.json` is passed. It expects `/my/path/to/*.json`. This makes `glob_directory` handle the former case.