### PR TITLE
Do GC after checkpointing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GarbageCollectorCallback` will restore `gc` settings even when `Trainer.fit()` exits on an error.
 - Make `move_to_device` blocking for MPS device to fix possible incorrect transfer of data from CPU to MPS.
 - Fixed bug where `glob_directory()` would fail to match certain glob patterns.
+- Perform a garbage collection after checkpointing to avoid running out of CPU memory.
 
 ### Changed
 

--- a/src/olmo_core/train/callbacks/garbage_collector.py
+++ b/src/olmo_core/train/callbacks/garbage_collector.py
@@ -3,8 +3,8 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from .callback import Callback
 from ...aliases import PathOrStr
+from .callback import Callback
 
 log = logging.getLogger(__name__)
 

--- a/src/olmo_core/train/callbacks/garbage_collector.py
+++ b/src/olmo_core/train/callbacks/garbage_collector.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from .callback import Callback
+from ...aliases import PathOrStr
 
 log = logging.getLogger(__name__)
 
@@ -44,3 +45,9 @@ class GarbageCollectorCallback(Callback):
             return
         if self._start_state:
             gc.enable()
+
+    def post_checkpoint_saved(self, path: PathOrStr):
+        del path
+        if not self.enabled:
+            return
+        gc.collect(1)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a post-checkpoint hook to run gen1 garbage collection and documents it in the changelog.
> 
> - **Callbacks**:
>   - `GarbageCollectorCallback`: add `post_checkpoint_saved(path: PathOrStr)` to run `gc.collect(1)` after saving a checkpoint; import `PathOrStr`.
> - **Changelog**:
>   - Note GC after checkpointing to mitigate CPU memory pressure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc7dbb81cf44794880c85ed8e18cd940cb623aef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->