### PR TITLE
Fix error in SourceMixtureDataset

### DIFF
--- a/src/olmo_core/data/source_mixture.py
+++ b/src/olmo_core/data/source_mixture.py
@@ -278,9 +278,9 @@ class SourceMixtureDatasetConfig(Config):
                 flat_entries.append((source_name, path_tokens, instances, remainder))
 
         training_steps = math.ceil(self.requested_tokens / self.global_batch_size)
-        assert (
-            self.global_batch_size % sequence_length == 0
-        ), "global_batch_size must be multiple of sequence_length"
+        assert self.global_batch_size % sequence_length == 0, (
+            "global_batch_size must be multiple of sequence_length"
+        )
         num_instances_per_batch = self.global_batch_size // sequence_length
         requested_instances = training_steps * num_instances_per_batch
 

--- a/src/test/data/numpy_dataset_test.py
+++ b/src/test/data/numpy_dataset_test.py
@@ -466,9 +466,9 @@ def test_numpy_fsl_mixture_dataset(tmp_path: Path):
     # Note that changing the seed here could result in the inclusion of the first sequence from the mock data.
     # assert not np.array_equal(first_src_sequence, first_ds_item)
     expected = "aff421"
-    assert ds.fingerprint.endswith(
-        expected
-    ), f"Fingerprint mismatch, expected {expected}, got {ds.fingerprint[-6:]}...Do you need to update expected fingerprint?"
+    assert ds.fingerprint.endswith(expected), (
+        f"Fingerprint mismatch, expected {expected}, got {ds.fingerprint[-6:]}...Do you need to update expected fingerprint?"
+    )
     assert first_ds_item == [56423, 24546, 15796, 52203]  # stable because we pass a seed
     assert ds.num_tokens == 10_112  # oversamples to handle rounding error
     assert len(ds) == 2528
@@ -491,16 +491,14 @@ def test_numpy_fsl_mixture_dataset_truncated_instance(tmp_path: Path):
     mixture_config = SourceMixtureDatasetConfig(
         render_tables=False,
         requested_tokens=8,
-        source_list=SourceMixtureList(
-            [
-                SourceMixtureConfig(
-                    source_name="short",
-                    paths=[str(mmap_path)],
-                    target_ratio=1.0,
-                    max_repetition_ratio=2.0,
-                )
-            ]
-        ),
+        source_configs=[
+            SourceMixtureConfig(
+                source_name="short",
+                paths=[str(mmap_path)],
+                target_ratio=1.0,
+                max_repetition_ratio=2.0,
+            )
+        ],
         seed=0,
         global_batch_size=sequence_length * 2,
     )
@@ -593,9 +591,9 @@ def test_numpy_fsl_mixture_dataset_with_repetition(tmp_path: Path):
     # Note that changing the seed here could result in the inclusion of the first sequence from the mock data.
     # assert not np.array_equal(first_src_sequence, first_ds_item)
 
-    assert ds.fingerprint.endswith(
-        expected_fingerprint
-    ), f"Fingerprint mismatch, expected {expected_fingerprint}, got {ds.fingerprint[-6:]}...Do you need to update expected fingerprint?"
+    assert ds.fingerprint.endswith(expected_fingerprint), (
+        f"Fingerprint mismatch, expected {expected_fingerprint}, got {ds.fingerprint[-6:]}...Do you need to update expected fingerprint?"
+    )
     assert first_ds_item == [
         12761,
         6996,


### PR DESCRIPTION
SourceMixtureDataset isn't producing complete instances in some cases:

```
1Z Original Traceback (most recent call last):
2025-10-01T21:40:47.121Z   File "/opt/conda/lib/python3.11/site-packages/torch/utils/data/_utils/worker.py", line 349, in _worker_loop
2025-10-01T21:40:47.121Z     data = fetcher.fetch(index)  # type: ignore[possibly-undefined]
2025-10-01T21:40:47.121Z            ^^^^^^^^^^^^^^^^^^^^
2025-10-01T21:40:47.121Z   File "/opt/conda/lib/python3.11/site-packages/torch/utils/data/_utils/fetch.py", line 42, in fetch
2025-10-01T21:40:47.121Z     data = next(self.dataset_iter)
2025-10-01T21:40:47.121Z            ^^^^^^^^^^^^^^^^^^^^^^^
2025-10-01T21:40:47.121Z   File "/olmo-core-runtime/src/olmo_core/data/data_loader.py", line 1045, in <genexpr>
2025-10-01T21:40:47.121Z     return (
2025-10-01T21:40:47.121Z            ^
2025-10-01T21:40:47.121Z   File "/olmo-core-runtime/src/olmo_core/data/utils.py", line 401, in iter_batched
2025-10-01T21:40:47.121Z     raise RuntimeError(
2025-10-01T21:40:47.121Z RuntimeError: Items in batch don't have the same shape! Expected (8192,), got (5081,)
```