### PR TITLE
Fix OverflowError in pack_documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug where `glob_directory()` would fail to match certain glob patterns.
 - Added one more type of error to retry on when the Google Storage API throws it.
 - Perform a garbage collection after checkpointing to avoid running out of CPU memory.
+- Avoidable overflow error when using NumpyPackedFSLDataset.
 
 ### Changed
 

--- a/src/olmo_core/data/utils.py
+++ b/src/olmo_core/data/utils.py
@@ -841,7 +841,7 @@ class InstancePacker:
 
         # Sort document indices by document length, decreasing.
         document_lengths = document_indices[:, 1] - document_indices[:, 0]
-        sorted_index = np.argsort(document_lengths)[::-1]
+        sorted_index = np.argsort(-1 * document_lengths.astype(np.int64))
         document_indices = np.take(document_indices, sorted_index, axis=0)
 
         # Pack documents into instances.


### PR DESCRIPTION
Fix this error: https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K6E7W9A2SQ4E5VKVKCR6DGG4/logs?jobId=01K6E7W9N5A7HHH7KZ23XPQH9G

```
2025-09-30T21:50:56.017Z _RemoteTraceback: 
2025-09-30T21:50:56.017Z """
2025-09-30T21:50:56.017Z Traceback (most recent call last):
2025-09-30T21:50:56.017Z   File "/opt/conda/lib/python3.11/concurrent/futures/process.py", line 261, in _process_worker
2025-09-30T21:50:56.017Z     r = call_item.fn(*call_item.args, **call_item.kwargs)
2025-09-30T21:50:56.017Z         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-09-30T21:50:56.017Z   File "/olmo-core-runtime/src/olmo_core/data/utils.py", line 559, in run_worker_func
2025-09-30T21:50:56.017Z     return func(*args, **kwargs)
2025-09-30T21:50:56.017Z            ^^^^^^^^^^^^^^^^^^^^^
2025-09-30T21:50:56.017Z   File "/olmo-core-runtime/src/olmo_core/data/numpy_dataset.py", line 1263, in _pack_documents_from_source_into_instances
2025-09-30T21:50:56.017Z     instances, document_indices, total_tokens = pack_documents_into_instances(
2025-09-30T21:50:56.017Z                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-09-30T21:50:56.017Z   File "/olmo-core-runtime/src/olmo_core/data/utils.py", line 913, in pack_documents_into_instances
2025-09-30T21:50:56.017Z     return instance_packer.pack_documents(document_indices)
2025-09-30T21:50:56.017Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-09-30T21:50:56.017Z   File "/olmo-core-runtime/src/olmo_core/data/utils.py", line 844, in pack_documents
2025-09-30T21:50:56.017Z     sorted_index = np.argsort(-1 * document_lengths)
2025-09-30T21:50:56.017Z                               ~~~^~~~~~~~~~~~~~~~~~
2025-09-30T21:50:56.017Z OverflowError: Python integer -1 out of bounds for uint64
```