### PR TITLE
Min python version to 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10"]
+        python: ["3.11"]
         task:
           - name: Lint
             run: make lint-check
@@ -69,7 +69,7 @@ jobs:
               cd docs && make html SPHINXOPTS="-W --keep-going"
 
         include:
-          - python: "3.9"
+          - python: "3.10"
             task:
               name: Lint (min Python)
               run: make lint-check
@@ -229,7 +229,7 @@ jobs:
       - name: Setup Python environment
         uses: ./.github/actions/setup-venv
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache-prefix: ${{ env.CACHE_PREFIX }}
 
       - name: Prepare environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Core training module for the Open Language Model (OLMo)"
 authors = [
     { name = "Allen Institute for Artificial Intelligence", email = "olmo@allenai.org" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = [
     "numpy",


### PR DESCRIPTION
Python 3.9 is no longer supported (https://devguide.python.org/versions/), we should bump our min python version.

Among other things this would let us use nicer / more concise typing syntax: https://docs.python.org/3/whatsnew/3.10.html#new-features-related-to-type-hints

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raise minimum Python to 3.10 and move CI/release to Python 3.11.
> 
> - **CI / GitHub Actions**:
>   - Update matrix default `python` to `3.11` in `.github/workflows/main.yml`.
>   - Set release job `python-version` to `3.11`.
>   - Bump "Lint (min Python)" include from `3.9` to `3.10`.
> - **Packaging**:
>   - Raise minimum supported Python to `>=3.10` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fb34242548eff16e240f00e1498b3aab73de38f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->