### PR TITLE
Fix MFU calculation to account for SWA and GQA (Fixes #475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed `olmo_core.distributed.utils.scatter_object()` to `broadcast_object()` for correctness.
 
+### Fixed
+
+- Fixed MFU calculation to account for sliding window attention (SWA) and grouped-query attention (GQA). The `num_flops_per_token()` method in `TransformerConfig` and `Transformer` now correctly computes FLOPS per layer, using window sizes for SWA and `n_kv_heads` for GQA instead of assuming full attention and equal query/key-value heads.
+
 ## [v2.4.0](https://github.com/allenai/OLMo-core/releases/tag/v2.4.0) - 2025-11-20
 
 ### Added

--- a/src/olmo_core/nn/transformer/config.py
+++ b/src/olmo_core/nn/transformer/config.py
@@ -452,20 +452,48 @@ class TransformerConfig(Config):
     def num_flops_per_token(self, seq_len: int) -> int:
         """
         Get the approximate number of flops per token.
+
+        Accounts for sliding window attention (SWA) and grouped-query attention (GQA).
+        For SWA, uses the window size for each layer instead of the full sequence length.
+        For GQA, uses n_kv_heads instead of n_heads for the attention computation.
         """
-        n, h, q, t = (
-            self.n_layers,
-            self.block.attention.n_heads,
-            self.d_model // self.block.attention.n_heads,
-            seq_len,
-        )
-        # Reasoning behind the factor of 12 for the self-attention part of the formula:
-        # 1. each self-attention has 2 matmul in the forward and 4 in the backward (6)
-        # 2. the flash attention does 1 more matmul recomputation in the backward
-        #    but recomputation should not be counted in calculating MFU           (+0)
-        # 3. each matmul performs 1 multiplication and 1 addition                 (*2)
-        # 4. we follow the convention and do not account for sparsity in causal attention
-        flop_per_token = 6 * self.num_non_embedding_params + 12 * n * h * q * t
+        # Base FLOPS from non-attention operations (FFN, layer norms, etc.)
+        # This is 6 * params because: forward (1x) + backward (2x) = 3x, and each op has mult+add = 2x
+        base_flops = 6 * self.num_non_embedding_params
+
+        # Attention FLOPS per layer
+        # The original formula: 12 * n * h * q * t
+        # Where: n = layers, h = heads, q = head_dim, t = seq_len
+        # We need to sum over layers because SWA can have different window sizes per layer
+        attention_flops = 0
+        q = self.d_model // self.block.attention.n_heads
+
+        for layer_idx in range(self.n_layers):
+            # Get block config for this layer (may be overridden)
+            block_config = self.block
+            if self.block_overrides is not None and layer_idx in self.block_overrides:
+                block_config = self.block_overrides[layer_idx]
+
+            n_heads = block_config.attention.n_heads
+            n_kv_heads = block_config.attention.n_kv_heads or n_heads
+
+            # Determine effective sequence length for this layer
+            # If SWA is used, use window size; otherwise use full sequence length
+            effective_seq_len = seq_len
+            if block_config.attention.sliding_window is not None:
+                sliding_window_cfg = block_config.attention.sliding_window
+                if sliding_window_cfg.should_use_swa(layer_idx, self.n_layers):
+                    window_size = sliding_window_cfg.get_window_size(layer_idx, self.n_layers)
+                    effective_seq_len = window_size
+
+            # The original formula uses n_heads, but with GQA the attention computation
+            # is limited by n_kv_heads (since K/V have fewer heads).
+            # We use n_kv_heads to account for the reduced FLOPS in GQA.
+            # The factor 12 accounts for: 2 matmuls (QK^T, attn@V) * 2 (forward+backward) * 2 (mult+add) * 1.5 (approximate)
+            layer_attention_flops = 12 * n_kv_heads * q * effective_seq_len
+            attention_flops += layer_attention_flops
+
+        flop_per_token = base_flops + attention_flops
 
         return flop_per_token
 


### PR DESCRIPTION
# Fix MFU calculation to account for SWA and GQA

Fixes #475

## Problem

The Model FLOPS Utilization (MFU) calculation in `SpeedMonitorCallback` was inaccurate when using:
- **Sliding Window Attention (SWA)**: The calculation assumed full attention across the entire sequence length, ignoring the
size
- **Grouped Query Attention (GQA)**: The calculation assumed `n_heads == n_kv_heads`, ignoring the reduced number of key-val

This caused the MFU metric to be inflated, making it appear that the model was performing more FLOPS than it actually was, l
incorrect performance measurements.

## Solution

Updated `num_flops_per_token()` methods in both `TransformerConfig` and `Transformer` to:
1. **Iterate per layer** to handle layer-specific configurations (especially important for SWA patterns that vary by layer)
2. **Use window sizes for SWA**: When SWA is enabled, use the layer-specific window size instead of the full sequence length
3. **Use `n_kv_heads` for GQA**: When GQA is used, use `n_kv_heads` instead of `n_heads` in the attention FLOPS calculation,
projections have fewer heads

## Changes Made

### Core Implementation
- **`src/olmo_core/nn/transformer/config.py`**: Updated `TransformerConfig.num_flops_per_token()` to iterate over layers and
window sizes and GQA `n_kv_heads`
- **`src/olmo_core/nn/transformer/model.py`**: 
  - Store block configs during initialization for FLOPS calculation
  - Updated `Transformer.num_flops_per_token()` with the same logic as the config class

### Testing
- **`src/test/nn/transformer/model_test.py`**: Added comprehensive test coverage:
  - `test_num_flops_per_token_with_gqa`: Verifies GQA reduces FLOPS correctly
  - `test_num_flops_per_token_with_swa`: Verifies SWA reduces FLOPS correctly
  - `test_num_flops_per_token_with_swa_and_gqa`: Verifies combined effect of both
  - `test_num_flops_per_token_with_swa_pattern`: Verifies SWA patterns with different window sizes per layer

### Documentation
- **`CHANGELOG.md`**: Added entry documenting the fix

## Testing

All new tests pass:
- `test_num_flops_per_token_with_gqa`
- `test_num_flops_per_token_with_swa`
- `test_num_flops_per_token_with_swa_and_gqa`
- `test_num_flops_per_token_with_swa_pattern`

Existing tests continue to pass, ensuring backward compatibility for models without SWA or GQA.

## Impact

This fix ensures that:
- MFU metrics accurately reflect the actual computational cost when using SWA or GQA
- Performance monitoring provides correct insights for models with these optimizations
- The calculation correctly handles per-layer variations in SWA window sizes
- Backward compatibility is maintained for standard dense attention models

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects FLOPS-per-token to account for sliding window attention and grouped-query attention with per-layer logic, adds tests, and updates changelog.
> 
> - **Core**:
>   - `src/olmo_core/nn/transformer/config.py`: Update `TransformerConfig.num_flops_per_token()` to sum attention FLOPS per layer using SWA window sizes and `n_kv_heads` for GQA.
>   - `src/olmo_core/nn/transformer/model.py`: Store per-layer block configs and revise `Transformer.num_flops_per_token()` with the same per-layer SWA/GQA logic.
> - **Tests**:
>   - `src/test/nn/transformer/model_test.py`: Add tests for GQA reduction, SWA reduction, combined SWA+GQA, and SWA pattern handling.
> - **Docs**:
>   - `CHANGELOG.md`: Document fix to MFU/FLOPS calculation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63ca943e847ab17d602e62a9b1b7d2374ebd978e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->