### PR TITLE
Fix MFU Calculation for SWA and GQA (Issue #475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed MFU calculation to account for sliding window attention (SWA) and grouped-query attention (GQA). The `num_flops_per_token()` method in `TransformerConfig` and `Transformer` now correctly computes FLOPS per layer, using window sizes for SWA and `n_kv_heads` for GQA instead of assuming full attention and equal query/key-value heads.
+- Fixed MFU calculation to account for sliding window attention (SWA) and grouped-query attention (GQA). The `num_flops_per_token()` method in `TransformerConfig` and `Transformer` now correctly computes FLOPS per layer, using window sizes for SWA (capped at the actual sequence length) and `n_kv_heads` for GQA instead of assuming full attention and equal query/key-value heads. Head dimensions are recalculated per layer so block overrides with custom `n_heads` values are handled correctly.
 
 ## [v2.4.0](https://github.com/allenai/OLMo-core/releases/tag/v2.4.0) - 2025-11-20
 

--- a/src/examples/moe/train.py
+++ b/src/examples/moe/train.py
@@ -103,20 +103,22 @@ def build_config(run_name: str, overrides: List[str]) -> ExperimentConfig:
     train_module_config = TransformerTrainModuleConfig(
         rank_microbatch_size=16 * SEQUENCE_LENGTH,
         max_sequence_length=SEQUENCE_LENGTH,
-        optim=AdamWConfig(
-            lr=1e-3,
-            group_overrides=[
-                OptimGroupOverride(params=["embeddings.weight"], opts=dict(weight_decay=0.0))
-            ],
-            fused=True,
-        )
-        if not skip_step_optim
-        else SkipStepAdamWConfig(
-            lr=1e-3,
-            group_overrides=[
-                OptimGroupOverride(params=["embeddings.weight"], opts=dict(weight_decay=0.0))
-            ],
-            compile=True,
+        optim=(
+            AdamWConfig(
+                lr=1e-3,
+                group_overrides=[
+                    OptimGroupOverride(params=["embeddings.weight"], opts=dict(weight_decay=0.0))
+                ],
+                fused=True,
+            )
+            if not skip_step_optim
+            else SkipStepAdamWConfig(
+                lr=1e-3,
+                group_overrides=[
+                    OptimGroupOverride(params=["embeddings.weight"], opts=dict(weight_decay=0.0))
+                ],
+                compile=True,
+            )
         ),
         compile_model=True,
         pp_config=TransformerPipelineParallelConfig(

--- a/src/olmo_core/data/data_loader.py
+++ b/src/olmo_core/data/data_loader.py
@@ -2,6 +2,7 @@
 Distributed, deterministic, stateful data loaders used by the :class:`~olmo_core.train.Trainer`.
 
 """
+
 import functools
 import logging
 import math

--- a/src/olmo_core/internal/cookbook.py
+++ b/src/olmo_core/internal/cookbook.py
@@ -80,12 +80,14 @@ def configure_train_module(
             if cp_degree
             else None
         ),
-        ac_config=TransformerActivationCheckpointingConfig(
-            mode=TransformerActivationCheckpointingMode.budget,
-            activation_memory_budget=activation_memory_budget,
-        )
-        if activation_memory_budget < 1.0
-        else None,
+        ac_config=(
+            TransformerActivationCheckpointingConfig(
+                mode=TransformerActivationCheckpointingMode.budget,
+                activation_memory_budget=activation_memory_budget,
+            )
+            if activation_memory_budget < 1.0
+            else None
+        ),
         float8_config=Float8Config(
             enabled=float8_enabled,
             ao=AOFloat8LinearConfig(

--- a/src/olmo_core/internal/experiment.py
+++ b/src/olmo_core/internal/experiment.py
@@ -237,10 +237,12 @@ def build_default_data_components(
         # max target sequence length doesn't affect how the data is loaded, just how it's cached behind the scenes
         max_target_sequence_length=max(common.max_sequence_length, 8192),
         generate_doc_lengths=intra_document_masking,
-        instance_filter_config=None
-        if not include_instance_filter
-        else InstanceFilterConfig(
-            repetition_max_period=13, repetition_min_period=1, repetition_max_count=32
+        instance_filter_config=(
+            None
+            if not include_instance_filter
+            else InstanceFilterConfig(
+                repetition_max_period=13, repetition_min_period=1, repetition_max_count=32
+            )
         ),
     )
 

--- a/src/olmo_core/nn/hf/config.py
+++ b/src/olmo_core/nn/hf/config.py
@@ -160,9 +160,11 @@ def get_hf_config(model: Transformer) -> PretrainedConfig:
         olmo3_specific_args = {
             "sliding_window": common_window_size_value + 1,
             "layer_types": [
-                "sliding_attention"
-                if block.attention.backend.window_size != (-1, -1)
-                else "full_attention"
+                (
+                    "sliding_attention"
+                    if block.attention.backend.window_size != (-1, -1)
+                    else "full_attention"
+                )
                 for block in blocks
             ],
         }

--- a/src/olmo_core/nn/lm_head.py
+++ b/src/olmo_core/nn/lm_head.py
@@ -305,14 +305,16 @@ class LMHead(nn.Module):
                 loss_div_factor=loss_div_factor,
                 reduce_across_tp_group=False,
             ),
-            z_loss=None
-            if z_loss is None
-            else self._finalize_loss(
-                z_loss.detach(),
-                B,
-                loss_reduction=loss_reduction,
-                loss_div_factor=loss_div_factor,
-                reduce_across_tp_group=False,
+            z_loss=(
+                None
+                if z_loss is None
+                else self._finalize_loss(
+                    z_loss.detach(),
+                    B,
+                    loss_reduction=loss_reduction,
+                    loss_div_factor=loss_div_factor,
+                    reduce_across_tp_group=False,
+                )
             ),
         )
 
@@ -379,12 +381,14 @@ class LMHead(nn.Module):
             device_mesh=tp_mesh,
             parallelize_plan=PrepareModuleInput(
                 input_layouts=None if input_layouts is None else input_layouts[0],
-                desired_input_layouts=Shard(1)
-                if (
-                    self.loss_implementation == LMLossImplementation.fused_linear
-                    or self.norm is not None
-                )
-                else Replicate(),
+                desired_input_layouts=(
+                    Shard(1)
+                    if (
+                        self.loss_implementation == LMLossImplementation.fused_linear
+                        or self.norm is not None
+                    )
+                    else Replicate()
+                ),
                 input_kwarg_layouts=None if input_layouts is None else {"labels": input_layouts[1]},
                 desired_input_kwarg_layouts={"labels": Shard(1)},
             ),
@@ -530,14 +534,16 @@ class NormalizedLMHead(LMHead):
                 loss_div_factor=loss_div_factor,
                 reduce_across_tp_group=False,
             ),
-            z_loss=None
-            if z_loss is None
-            else self._finalize_loss(
-                z_loss.detach(),
-                B,
-                loss_reduction=loss_reduction,
-                loss_div_factor=loss_div_factor,
-                reduce_across_tp_group=False,
+            z_loss=(
+                None
+                if z_loss is None
+                else self._finalize_loss(
+                    z_loss.detach(),
+                    B,
+                    loss_reduction=loss_reduction,
+                    loss_div_factor=loss_div_factor,
+                    reduce_across_tp_group=False,
+                )
             ),
         )
 

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -864,8 +864,8 @@ class Transformer(nn.Module):
         # Attention FLOPS per layer
         # The original formula: 12 * n * h * q * t
         # We need to sum over layers because SWA can have different window sizes per layer
+        # and block overrides can have different n_heads per layer
         attention_flops = 0
-        q = self.d_model // self.n_attn_heads
 
         for layer_idx in range(self.n_layers):
             # Get block config for this layer (may be overridden)
@@ -873,15 +873,18 @@ class Transformer(nn.Module):
 
             n_heads = block_config.attention.n_heads
             n_kv_heads = block_config.attention.n_kv_heads or n_heads
+            # Calculate head dimension for this layer (may differ if block overrides change n_heads)
+            q = self.d_model // n_heads
 
             # Determine effective sequence length for this layer
             # If SWA is used, use window size; otherwise use full sequence length
+            # Cap window size at sequence length to avoid overestimating FLOPS for short sequences
             effective_seq_len = seq_len
             if block_config.attention.sliding_window is not None:
                 sliding_window_cfg = block_config.attention.sliding_window
                 if sliding_window_cfg.should_use_swa(layer_idx, self.n_layers):
                     window_size = sliding_window_cfg.get_window_size(layer_idx, self.n_layers)
-                    effective_seq_len = window_size
+                    effective_seq_len = min(window_size, seq_len)
 
             # The original formula uses n_heads, but with GQA the attention computation
             # is limited by n_kv_heads (since K/V have fewer heads).

--- a/src/scripts/train/OLMo2/OLMo2-7B-long-context.py
+++ b/src/scripts/train/OLMo2/OLMo2-7B-long-context.py
@@ -56,9 +56,11 @@ def build_train_module_config(common: CommonComponents) -> TransformerTrainModul
             reduce_dtype=DType.float32,
             wrapping_strategy=TransformerDataParallelWrappingStrategy.fine_grained,
         ),
-        cp_config=TransformerContextParallelConfig.llama3(degree=8)
-        if INTRA_DOCUMENT_MASKING
-        else TransformerContextParallelConfig.zig_zag(degree=8),
+        cp_config=(
+            TransformerContextParallelConfig.llama3(degree=8)
+            if INTRA_DOCUMENT_MASKING
+            else TransformerContextParallelConfig.zig_zag(degree=8)
+        ),
         float8_config=Float8Config(enabled=False),
         max_grad_norm=1.0,
         scheduler=CosWithWarmup(warmup_steps=2000),

--- a/src/scripts/train/OLMo3/OLMo3-32B-long-context.py
+++ b/src/scripts/train/OLMo3/OLMo3-32B-long-context.py
@@ -161,10 +161,12 @@ def build_data_components(
         generate_doc_lengths=intra_document_masking,  # enables intra-document masking
         source_group_size=8,
         source_permutation_seed=123,
-        instance_filter_config=None
-        if not include_instance_filter
-        else InstanceFilterConfig(
-            repetition_max_period=13, repetition_min_period=1, repetition_max_count=32
+        instance_filter_config=(
+            None
+            if not include_instance_filter
+            else InstanceFilterConfig(
+                repetition_max_period=13, repetition_min_period=1, repetition_max_count=32
+            )
         ),
     )
 

--- a/src/scripts/train/OLMo3/OLMo3-32B.py
+++ b/src/scripts/train/OLMo3/OLMo3-32B.py
@@ -102,10 +102,12 @@ def build_data_components(
         sequence_length=common.max_sequence_length,
         max_target_sequence_length=max(common.max_sequence_length, 8192),
         generate_doc_lengths=intra_document_masking,
-        instance_filter_config=None
-        if not include_instance_filter
-        else InstanceFilterConfig(
-            repetition_max_period=13, repetition_min_period=1, repetition_max_count=32
+        instance_filter_config=(
+            None
+            if not include_instance_filter
+            else InstanceFilterConfig(
+                repetition_max_period=13, repetition_min_period=1, repetition_max_count=32
+            )
         ),
     )
 

--- a/src/scripts/train/OLMo3/OLMo3-7B.py
+++ b/src/scripts/train/OLMo3/OLMo3-7B.py
@@ -86,10 +86,12 @@ def build_data_components(
         # max target sequence length doesn't affect how the data is loaded, just how it's cached behind the scenes
         max_target_sequence_length=max(common.max_sequence_length, 8192),
         generate_doc_lengths=intra_document_masking,
-        instance_filter_config=None
-        if not include_instance_filter
-        else InstanceFilterConfig(
-            repetition_max_period=13, repetition_min_period=1, repetition_max_count=32
+        instance_filter_config=(
+            None
+            if not include_instance_filter
+            else InstanceFilterConfig(
+                repetition_max_period=13, repetition_min_period=1, repetition_max_count=32
+            )
         ),
     )
 

--- a/src/test/distributed/checkpoint_test.py
+++ b/src/test/distributed/checkpoint_test.py
@@ -46,8 +46,9 @@ def run_save_and_load_torch_fsdp_model(dir, model_factory, model_data_factory, u
     load_model_and_optim_state(dir, fsdp_model2, optim2)
 
     # Check model parameters.
-    with FSDP.summon_full_params(fsdp_model, recurse=True), FSDP.summon_full_params(
-        fsdp_model2, recurse=True
+    with (
+        FSDP.summon_full_params(fsdp_model, recurse=True),
+        FSDP.summon_full_params(fsdp_model2, recurse=True),
     ):
         torch.testing.assert_close(fsdp_model.state_dict(), fsdp_model2.state_dict())
 


### PR DESCRIPTION
# Fix MFU Calculation for SWA and GQA (Issue #475)

Fixes #475

## Problem

`SpeedMonitorCallback` derives MFU from `num_flops_per_token()`, but the helper assumed dense attention with `n_heads == n_kv_heads` and that every layer attended over the full sequence. When Sliding Window Attention (SWA), Grouped Query Attention (GQA), or block overrides were enabled, the FLOPS estimate (and therefore MFU) was inflated because:

- SWA windows were ignored, so FLOPS used the full sequence length instead of the per-layer window.
- GQA still used `n_heads` instead of `n_kv_heads`.
- Block overrides that changed `n_heads` never recalculated the head dimension `q`.

## Solution

1. **Accurate FLOPS calculation**
   - `src/olmo_core/nn/transformer/config.py`: `TransformerConfig.num_flops_per_token()` now iterates per layer, recomputes `q = d_model // 
n_heads`, uses each layer’s `n_kv_heads`, and caps SWA window sizes at the actual sequence length.
   - `src/olmo_core/nn/transformer/model.py`: `Transformer.num_flops_per_token()` mirrors the same logic and stores the block configs so 
overrides with custom `n_heads` are honoured.
2. **Tests**
   - Added/expanded coverage in `src/test/nn/transformer/model_test.py` for:
     - GQA-only, SWA-only, and combined SWA+GQA scenarios.
     - SWA patterns with alternating window sizes.
     - Block overrides that change `n_heads`.
     - SWA window sizes larger than the actual sequence length.
3. **Docs**
   - `CHANGELOG.md` documents that MFU accounts for SWA (with window capping) and per-layer head counts.

## Files Changed

- `src/olmo_core/nn/transformer/config.py`
- `src/olmo_core/nn/transformer/model.py`
- `src/test/nn/transformer/model_test.py`
- `CHANGELOG.md`
- Other files were auto-formatted via `make style`.

## Testing

```bash
pytest src/test/nn/transformer/model_test.py -k "num_flops" -v
make style
make docs
make build
make checks
```

All FLOPS-related tests pass and the repo passes the style/docs/build/checks targets, confirming MFU now reflects the true FLOPS for SWA and GQA configurations and the tree is clean.
