### PR TITLE
Allow cordoning nodes

### DIFF
--- a/src/scripts/lambda/launch.sh
+++ b/src/scripts/lambda/launch.sh
@@ -43,7 +43,7 @@ SBATCH_ARGS=(
 )
 
 if [ -f "/data/ai2/cordoned-nodes.txt" ]; then
-    cordoned_nodes=$(tr '\n' ',' < /data/ai2/cordoned_nodes.txt | sed 's/,$//')
+    cordoned_nodes=$(tr '\n' ',' < /data/ai2/cordoned-nodes.txt | sed 's/,$//')
     echo "Cordoned nodes detected: $cordoned_nodes"
     SBATCH_ARGS+=(--exclude="$cordoned_nodes")
 fi


### PR DESCRIPTION
Idea: add the hostnames of cordoned nodes to `/data/ai2/cordoned-nodes.txt`.
Our launch script reads those and excludes them from sbatch.