### PR TITLE
Fix flaky and broken transformer model tests

### DIFF
--- a/src/test/nn/transformer/model_test.py
+++ b/src/test/nn/transformer/model_test.py
@@ -1,5 +1,6 @@
 import logging
 from dataclasses import replace
+from test.nn.attention_test import BF16_ATOL, BF16_RTOL
 from typing import Optional, cast
 
 import pytest
@@ -54,7 +55,6 @@ from olmo_core.testing import (
     run_distributed_test,
 )
 from olmo_core.utils import get_default_device, seed_all
-from test.nn.attention_test import BF16_ATOL, BF16_RTOL
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Flaky test due to low precision and randomness: test_context_parallel_transformer_ulysses

Broken tests due to OOM: test_gemma3_builder_configs, test_qwen3_builder_configs