### PR TITLE
Log chinchilla multiple from `SpeedMonitorCallback`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for Muon and Dion optimizers.
 - Added support for Ulysses-style context parallelism.
 - Added 60M and 1M model sizes.
+- `SpeedMonitorCallback` will log Chinchilla multiple number of tokens during training with a `TransformerTrainModule`.
 
 ### Fixed
 


### PR DESCRIPTION
Nice to have in W&B for an alternative x-axis metric.