### PR TITLE
Replace OmegaConf with dataclass-extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "cached-path>=1.7.2",
     "requests",
     "packaging",
-    "dataclass-extensions>=0.2.5",
+    "dataclass-extensions>=0.2.6",
     "pyyaml",
     "rich",
     "safetensors",

--- a/src/olmo_core/config.py
+++ b/src/olmo_core/config.py
@@ -265,9 +265,9 @@ class Config:
                         return decode(cls_o, new_dict)
                     except Exception as e:
                         if prefix:
-                            msg = f"Failed to construct '{prefix}' in config"
+                            msg = f"Failed to construct '{prefix}' in config: {e}"
                         else:
-                            msg = "Error building config"
+                            msg = f"Error building config: {e}"
                         raise OLMoConfigurationError(msg) from e
                 return new_dict
             elif isinstance(d, (list, tuple, set)):


### PR DESCRIPTION
[dataclass-extensions](https://github.com/epwalsh/dataclass-extensions) is a little library I wrote to improve the experience of using dataclasses as configs (encode/decode to/from JSON/YAML), and bring back the old `Registrable` functionality from the [AllenNLP library](https://github.com/allenai/allennlp) for config-based polymorphism in a way that doesn't give me nightmares trying to maintain it.

This PR ignores utilizing the `Registrable` functionality and just focuses for now on replacing OmegaConf with `dataclasses-extentions` in a way that's completely backwards compatible.