### PR TITLE
Ensure Beaker workloads submitted from CI are canceled gracefully

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Install Gantry
         run:
           # uv tool install git+https://github.com/allenai/beaker-gantry
-          uv tool install 'beaker-gantry>=3.1,<4.0'
+          uv tool install 'beaker-gantry>=3.4.5,<4.0'
 
       - name: Determine Beaker workspace
         if: env.BEAKER_TOKEN != ''
@@ -227,7 +227,7 @@ jobs:
       - name: GPU Tests
         if: env.BEAKER_TOKEN != ''
         run: |
-          gantry run \
+          exec gantry run \
             --show-logs \
             --yes \
             --workspace ${{ env.BEAKER_WORKSPACE }} \


### PR DESCRIPTION
When GitHub Actions cancels a job, it sends SIGINT followed by SIGTERM. However those signals don't propagate to the process unless it's run with `exec`, which means gantry wasn't getting those signals and therefore wasn't canceling the Beaker jobs. See here for a discussion on the topic: https://github.com/orgs/community/discussions/26311