### PR TITLE
Make SLACK_WEBHOOK_URL not actually required

### DIFF
--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -587,7 +587,9 @@ class BeakerLaunchConfig(Config):
             else:
                 # Pull from secret if available.
                 for env_secret in self.env_secrets:
-                    if env_secret.name == SLACK_WEBHOOK_URL_ENV_VAR and self._secret_exists(env_secret):
+                    if env_secret.name == SLACK_WEBHOOK_URL_ENV_VAR and self._secret_exists(
+                        env_secret
+                    ):
                         secret = beaker.secret.get(env_secret.secret)
                         slack_webhook_url = beaker.secret.read(secret)
                         break


### PR DESCRIPTION
SLACK_WEBHOOK_URL is marked as not required, but we try to check its existence in a way that will throw an error if it doesnt exist.