### PR TITLE
Add chat template verification step to SFT README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added documentation for verifying chat template settings before running evals after SFT.
 - Added `olmo_core.data.composable` module.
 - Added `PeriNormTransformerBlock`.
 - Added exponential learning rate scheduler to `olmo_core.optim.scheduler`.

--- a/src/scripts/train/sft/README.md
+++ b/src/scripts/train/sft/README.md
@@ -160,7 +160,15 @@ uv sync --extra beaker --extra transformers
     - Only install the project + extras you need (the image already has CUDA dependencies)
     - Beaker images follow the pattern `<user>/olmo-core-tch<torch>cu<cuda>-<date>`
 
-2. Launch evaluations using the submit_eval_jobs.sh script in `open-instruct` using a command such as:
+2. **Verify chat template and tokenizer settings before running evals.**
+
+    After converting to HuggingFace format, check that your model has the correct chat template for evaluation (either in `tokenizer_config.json` or as a separate `chat_template.jinja` file). The HF conversion copies whatever tokenizer was saved with the checkpoint, but that tokenizer's chat template may not be correct for evals—you may need to update it manually.
+
+    For OLMo 3 models, see the [OLMo 3 tokenizer and chat template settings](https://allenai.github.io/open-instruct/olmo3) in open-instruct for the recommended configuration. This includes the correct `chat_template`, `eos_token`, and other tokenizer settings required for evals to work properly.
+
+    **Example from OLMo 3:** Think models were trained with the Instruct chat template (to work around a `<think>` token masking issue during tokenization), but for evals required swapping in a chat template that includes `<think>` in `add_generation_prompt`—otherwise the model wouldn't start its response with `<think>`.
+
+3. Launch evaluations using the submit_eval_jobs.sh script in `open-instruct` using a command such as:
 
     ```bash
     python scripts/submit_eval_jobs.py \


### PR DESCRIPTION
## Summary
- Adds a step in the SFT evaluation workflow to verify chat template and tokenizer settings after HF conversion
- Links to open-instruct docs for OLMo 3 tokenizer/chat template configuration
- Warns users that skipping this step can cause incorrect eval results

## Dependencies
This PR should be merged **after** https://github.com/allenai/open-instruct/pull/1455 lands, as the linked documentation for OLMo 3 chat template settings is added in that PR.

## Test plan
- [ ] Verify the link works once open-instruct PR is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)