### PR TITLE
Add ReduceType.weighted_mean for weighted metric reduction

### DIFF
--- a/src/olmo_core/train/common.py
+++ b/src/olmo_core/train/common.py
@@ -153,6 +153,15 @@ class ReduceType(StrEnum):
     across the process group to produce the global L2 norm.
     """
 
+    weighted_mean = "weighted_mean"
+    """
+    Weighted average across the process group. Requires a ``weight`` to be provided when
+    recording the metric. The result is ``sum(value * weight) / sum(weight)`` across all ranks.
+    """
+
+
+WEIGHTED_MEAN_WEIGHT_PREFIX = "__wm_weight__/"
+
 
 class MetricMergeStrategy(StrEnum):
     """

--- a/src/olmo_core/train/train_module/train_module.py
+++ b/src/olmo_core/train/train_module/train_module.py
@@ -217,6 +217,7 @@ class TrainModule(Stateful, metaclass=ABCMeta):
         reduce_type: Optional[ReduceType] = None,
         namespace: Optional[str] = None,
         merge_strategy: MetricMergeStrategy = MetricMergeStrategy.warn,
+        weight: Optional[Union[float, torch.Tensor]] = None,
     ):
         """
         Record a metric. This is simply a convenience method that calls out to
@@ -226,7 +227,12 @@ class TrainModule(Stateful, metaclass=ABCMeta):
             Use :meth:`record_ce_loss()` to record the cross-entropy loss, specifically.
         """
         return self.trainer.record_metric(
-            name, value, reduce_type=reduce_type, namespace=namespace, merge_strategy=merge_strategy
+            name,
+            value,
+            reduce_type=reduce_type,
+            namespace=namespace,
+            merge_strategy=merge_strategy,
+            weight=weight,
         )
 
     def record_ce_loss(

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -58,6 +58,7 @@ from .checkpoint import Checkpointer
 from .common import (
     TRAIN_CE_LOSS_METRIC,
     TRAIN_PPL_METRIC,
+    WEIGHTED_MEAN_WEIGHT_PREFIX,
     Duration,
     DurationUnit,
     LoadStrategy,
@@ -986,6 +987,7 @@ class Trainer:
         reduce_type: Optional[ReduceType] = None,
         namespace: Optional[str] = None,
         merge_strategy: MetricMergeStrategy = MetricMergeStrategy.warn,
+        weight: Optional[Union[float, torch.Tensor]] = None,
     ):
         """
         Record a new metric for the current step.
@@ -999,6 +1001,8 @@ class Trainer:
             ``None`` means no reduction.
         :param namespace: A namespace to record the metric under, i.g. "train" or "optim".
         :param merge_strategy: How to merge metrics when duplicates are logged.
+        :param weight: The weight for the metric. Required when ``reduce_type`` is
+            :data:`ReduceType.weighted_mean`.
         """
         if namespace is not None:
             name = f"{namespace.rstrip('/')}/{name.lstrip('/')}"
@@ -1008,6 +1012,35 @@ class Trainer:
         else:
             value = get_local_tensor(value.detach()).float()
 
+        if reduce_type == ReduceType.weighted_mean:
+            if weight is None:
+                raise ValueError(
+                    "'weight' is required when reduce_type is ReduceType.weighted_mean"
+                )
+            if not isinstance(weight, torch.Tensor):
+                weight = torch.tensor(weight)
+            else:
+                weight = get_local_tensor(weight.detach()).float()
+            value = value * weight
+        elif weight is not None:
+            raise ValueError(
+                "'weight' should only be provided when reduce_type is ReduceType.weighted_mean"
+            )
+
+        self._store_metric(name, value, reduce_type, merge_strategy)
+
+        if reduce_type == ReduceType.weighted_mean:
+            assert weight is not None
+            weight_name = WEIGHTED_MEAN_WEIGHT_PREFIX + name
+            self._store_metric(weight_name, weight, ReduceType.sum, merge_strategy)
+
+    def _store_metric(
+        self,
+        name: str,
+        value: torch.Tensor,
+        reduce_type: Optional[ReduceType],
+        merge_strategy: MetricMergeStrategy,
+    ):
         if self.global_step not in self._metrics:
             self._metrics[self.global_step] = OrderedDict()
 
@@ -1033,7 +1066,6 @@ class Trainer:
         else:
             raise NotImplementedError(merge_strategy)
 
-        # reduce type must be consistent to avoid issues
         if name in self._metrics_reduce_type and self._metrics_reduce_type[name] != reduce_type:
             raise RuntimeError(
                 f"expected '{self._metrics_reduce_type[name]}' reduce type for metric '{name}' "
@@ -1348,6 +1380,9 @@ class Trainer:
 
     def _check_and_pass_on_metrics(self, metrics: Dict[int, Dict[str, float]]):
         for step in sorted(metrics.keys()):
+            for key in list(metrics[step].keys()):
+                if key.startswith(WEIGHTED_MEAN_WEIGHT_PREFIX):
+                    del metrics[step][key]
             # Check for nan/inf loss and add perplexity.
             if (ce_loss := metrics[step].get(TRAIN_CE_LOSS_METRIC)) is not None:
                 if not math.isfinite(ce_loss):

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -1030,7 +1030,6 @@ class Trainer:
         self._store_metric(name, value, reduce_type, merge_strategy)
 
         if reduce_type == ReduceType.weighted_mean:
-            assert weight is not None
             weight_name = WEIGHTED_MEAN_WEIGHT_PREFIX + name
             self._store_metric(weight_name, weight, ReduceType.sum, merge_strategy)
 

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -1066,6 +1066,7 @@ class Trainer:
         else:
             raise NotImplementedError(merge_strategy)
 
+        # reduce type must be consistent to avoid issues
         if name in self._metrics_reduce_type and self._metrics_reduce_type[name] != reduce_type:
             raise RuntimeError(
                 f"expected '{self._metrics_reduce_type[name]}' reduce type for metric '{name}' "

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -1007,20 +1007,14 @@ class Trainer:
         if namespace is not None:
             name = f"{namespace.rstrip('/')}/{name.lstrip('/')}"
 
-        if not isinstance(value, torch.Tensor):
-            value = torch.tensor(value)
-        else:
-            value = get_local_tensor(value.detach()).float()
+        value = self._to_metric_tensor(value)
 
         if reduce_type == ReduceType.weighted_mean:
             if weight is None:
                 raise ValueError(
                     "'weight' is required when reduce_type is ReduceType.weighted_mean"
                 )
-            if not isinstance(weight, torch.Tensor):
-                weight = torch.tensor(weight)
-            else:
-                weight = get_local_tensor(weight.detach()).float()
+            weight = self._to_metric_tensor(weight, like=value)
             value = value * weight
         elif weight is not None:
             raise ValueError(
@@ -1032,6 +1026,22 @@ class Trainer:
         if reduce_type == ReduceType.weighted_mean:
             weight_name = WEIGHTED_MEAN_WEIGHT_PREFIX + name
             self._store_metric(weight_name, weight, ReduceType.sum, merge_strategy)
+
+    @staticmethod
+    def _to_metric_tensor(
+        value: Union[float, torch.Tensor],
+        *,
+        like: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if isinstance(value, torch.Tensor):
+            tensor = get_local_tensor(value.detach())
+        else:
+            tensor = torch.tensor(value)
+
+        tensor = tensor.float()
+        if like is not None:
+            tensor = tensor.to(device=like.device, dtype=like.dtype)
+        return tensor
 
     def _store_metric(
         self,
@@ -1380,9 +1390,6 @@ class Trainer:
 
     def _check_and_pass_on_metrics(self, metrics: Dict[int, Dict[str, float]]):
         for step in sorted(metrics.keys()):
-            for key in list(metrics[step].keys()):
-                if key.startswith(WEIGHTED_MEAN_WEIGHT_PREFIX):
-                    del metrics[step][key]
             # Check for nan/inf loss and add perplexity.
             if (ce_loss := metrics[step].get(TRAIN_CE_LOSS_METRIC)) is not None:
                 if not math.isfinite(ce_loss):

--- a/src/test/train/utils_test.py
+++ b/src/test/train/utils_test.py
@@ -12,10 +12,6 @@ from olmo_core.utils import get_default_device
 
 def run_reduce_metrics():
     device = get_default_device()
-    # For weighted_mean, the stored value is already value * weight.
-    # Rank 0: value=1.0, weight=3.0 → stored as 3.0 (1.0*3.0)
-    # Rank 1: value=2.0, weight=1.0 → stored as 2.0 (2.0*1.0)
-    # Expected: (3.0 + 2.0) / (3.0 + 1.0) = 1.25
     wm_weight_prefix = "__wm_weight__/"
     raw_metrics = {
         0: {


### PR DESCRIPTION
## Summary
- Adds `ReduceType.weighted_mean` which computes `sum(value * weight) / sum(weight)` across ranks
- Useful when ranks process different amounts of data (e.g. different token counts per rank)
- Adds `weight` parameter to `Trainer.record_metric()` and `TrainModule.record_metric()`

## Test plan
- [x] Added non-distributed unit test for `reduce_metrics` with `weighted_mean`
- [x] Added `weighted_mean` case to existing distributed `reduce_metrics` test
- [x] Linting and style checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)