### PR TITLE
Start a v3 ladder with zero-centered RMSNorm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added zero-centered reparameterization option to `RMSNorm` and `LayerNormConfig` that uses `(1 + weight)` scaling with weight initialized to zero for more natural weight decay behavior.
 - Added support for in-loop perplexity evals with context parallelism (CP) and tensor parallelism (TP).
 - Added documentation for verifying chat template settings before running evals after SFT.
 - Added `olmo_core.data.composable` module.

--- a/src/olmo_core/nn/layer_norm.py
+++ b/src/olmo_core/nn/layer_norm.py
@@ -65,7 +65,7 @@ class LayerNormConfig(ModuleConfig):
     bias: Optional[bool] = None
     full_precision: Optional[bool] = None
     dtype: Optional[DType] = None
-    zero_centered_weights: Optional[bool] = None # use reparameterized (1 + weight) version
+    zero_centered_weights: Optional[bool] = None  # use reparameterized (1 + weight) version
 
     def num_params(self, size: int) -> int:
         """

--- a/src/olmo_core/nn/layer_norm.py
+++ b/src/olmo_core/nn/layer_norm.py
@@ -65,6 +65,7 @@ class LayerNormConfig(ModuleConfig):
     bias: Optional[bool] = None
     full_precision: Optional[bool] = None
     dtype: Optional[DType] = None
+    zero_centered_weights: Optional[bool] = None # use reparameterized (1 + weight) version
 
     def num_params(self, size: int) -> int:
         """
@@ -203,7 +204,48 @@ class LayerNorm(nn.Module):
 class RMSNorm(LayerNorm):
     """
     RMSNorm, a simplified layer norm implementation.
+
+    :param zero_centered_weights: If ``True``, reparameterize the scale as ``(1 + weight)`` with
+        ``weight`` initialized to zero, instead of the standard ``weight`` initialized to one.
     """
+
+    def __init__(
+        self,
+        *,
+        size: int,
+        eps: float = 1e-5,
+        elementwise_affine: bool = True,
+        bias: bool = True,
+        full_precision: bool = True,
+        dtype: torch.dtype = torch.float32,
+        init_device: str = "cpu",
+        zero_centered_weights: bool = False,
+    ):
+        self.zero_centered_weights = zero_centered_weights
+        super().__init__(
+            size=size,
+            eps=eps,
+            elementwise_affine=elementwise_affine,
+            bias=bias,
+            full_precision=full_precision,
+            dtype=dtype,
+            init_device=init_device,
+        )
+
+    def extra_repr(self):
+        s = super().extra_repr()
+        if self.zero_centered_weights:
+            s += ", zero_centered_weights=True"
+        return s
+
+    def reset_parameters(self):
+        if self.weight is not None:
+            if self.zero_centered_weights:
+                torch.nn.init.zeros_(self.weight)
+            else:
+                torch.nn.init.ones_(self.weight)
+        if self.bias is not None:
+            torch.nn.init.zeros_(self.bias)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
@@ -221,10 +263,15 @@ class RMSNorm(LayerNorm):
             x = x * torch.rsqrt(variance + self.eps)
 
             if self.weight is not None:
+                w = (
+                    (1 + self.weight.type_as(x))
+                    if self.zero_centered_weights
+                    else self.weight.type_as(x)
+                )
                 if self.bias is not None:
-                    x = self.weight.type_as(x) * x + self.bias.type_as(x)
+                    x = w * x + self.bias.type_as(x)
                 else:
-                    x = self.weight.type_as(x) * x
+                    x = w * x
 
             return x.to(og_dtype)
 

--- a/src/scripts/train/ladder/gemma_like_ladder.py
+++ b/src/scripts/train/ladder/gemma_like_ladder.py
@@ -489,6 +489,265 @@ class GemmaLikeTransformerConfig(TransformerConfig):
             **kwargs,
         )
 
+    @classmethod
+    def v3(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
+        # Clone of v2 with zero-centered RMSNorm weights (zero_centered_weights=True).
+
+        d_model: int = kwargs.pop("d_model")
+        n_layers: int = kwargs.pop("n_layers")
+        n_heads: int = kwargs.pop("n_heads")
+        hidden_size: int = kwargs.pop("hidden_size")
+        n_kv_heads = 8
+        head_dim = 128
+        global_layer_interval = 5
+        global_rope_theta = 1_000_000
+        layer_norm_eps = 1e-6
+        dtype = DType.float32
+        attn_backend = kwargs.pop("attn_backend", AttentionBackendName.flash_3)
+        lm_head_loss_impl = kwargs.pop("lm_head_loss_impl", LMLossImplementation.default)
+        use_gdn = kwargs.pop("use_gdn", False)
+
+        local_rope_theta = 10_000
+        local_window_size = 1024
+
+        layer_norm = LayerNormConfig(
+            name=LayerNormType.rms,
+            eps=layer_norm_eps,
+            bias=False,
+            dtype=dtype,
+            zero_centered_weights=True
+        )
+
+        feed_forward = FeedForwardConfig(
+            hidden_size=hidden_size,
+            bias=False,
+            dtype=dtype,
+            activation=ActivationFunction.silu,
+        )
+
+        if use_gdn:
+            # Default block uses GatedDeltaNet (replaces sliding window attention layers).
+            block = TransformerBlockConfig(
+                name=TransformerBlockType.peri_norm,
+                sequence_mixer=GatedDeltaNetConfig(
+                    n_heads=n_heads,
+                    n_v_heads=n_heads,  # for GDN, we intentionally match the number of heads.
+                    head_dim=head_dim,
+                    expand_v=1.0,
+                    dtype=dtype,
+                ),
+                feed_forward=feed_forward,
+                layer_norm=layer_norm,
+            )
+        else:
+            # Default block uses sliding window attention (like v1/gemma3_like).
+            block = TransformerBlockConfig(
+                name=TransformerBlockType.peri_norm,
+                sequence_mixer=AttentionConfig(
+                    name=AttentionType.default,
+                    n_heads=n_heads,
+                    n_kv_heads=n_kv_heads,
+                    head_dim=head_dim,
+                    bias=False,
+                    rope=RoPEConfig(name=RoPEType.default, theta=local_rope_theta),
+                    gate=GateConfig(
+                        granularity=GateGranularity.elementwise,
+                        full_precision=True,
+                    ),
+                    qk_norm=layer_norm,
+                    use_head_qk_norm=True,
+                    backend=attn_backend,
+                    sliding_window=SlidingWindowAttentionConfig(
+                        pattern=[local_window_size] * (global_layer_interval - 1) + [-1],
+                        force_full_attention_on_first_layer=False,
+                        force_full_attention_on_last_layer=False,
+                    ),
+                    dtype=dtype,
+                ),
+                feed_forward=feed_forward,
+                layer_norm=layer_norm,
+            )
+
+        # Override every `global_layer_interval`-th layer with full global attention.
+        block_overrides: Dict[int, TransformerBlockConfig] = {}
+        for layer_idx in range(n_layers):
+            if layer_idx % global_layer_interval == (global_layer_interval - 1):
+                global_block = TransformerBlockConfig(
+                    name=TransformerBlockType.peri_norm,
+                    sequence_mixer=AttentionConfig(
+                        name=AttentionType.default,
+                        n_heads=n_heads,
+                        n_kv_heads=n_kv_heads,
+                        head_dim=head_dim,
+                        bias=False,
+                        rope=RoPEConfig(name=RoPEType.default, theta=global_rope_theta),
+                        gate=GateConfig(
+                            granularity=GateGranularity.elementwise,
+                            full_precision=True,
+                        ),
+                        qk_norm=layer_norm,
+                        use_head_qk_norm=True,
+                        backend=attn_backend,
+                        dtype=dtype,
+                    ),
+                    feed_forward=feed_forward,
+                    layer_norm=layer_norm,
+                )
+                block_overrides[layer_idx] = global_block
+
+        return cls(
+            d_model=d_model,
+            vocab_size=vocab_size,
+            n_layers=n_layers,
+            block=block,
+            lm_head=LMHeadConfig(
+                loss_implementation=lm_head_loss_impl,
+                layer_norm=layer_norm,
+                bias=False,
+                dtype=dtype,
+            ),
+            dtype=dtype,
+            block_overrides=block_overrides if block_overrides else None,
+            embed_scale=math.sqrt(d_model),
+            **kwargs,
+        )
+
+    @classmethod
+    def v3_260M(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
+        """
+        A 260M model config.
+
+        259,551,360 total params
+        195,326,080 non-embedding params
+        """
+        return cls.v3(
+            d_model=640,
+            hidden_size=640 * 8,
+            n_layers=10,
+            n_heads=8,
+            vocab_size=vocab_size,
+            **kwargs,
+        )
+
+    @classmethod
+    def v3_709M(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
+        """
+        A 709M model config.
+
+        708,903,680 total params
+        606,143,232 non-embedding params
+        """
+        return cls.v3(
+            d_model=1024,
+            hidden_size=1024 * 8,
+            n_layers=15,
+            n_heads=16,
+            vocab_size=vocab_size,
+            **kwargs,
+        )
+
+    @classmethod
+    def v3_1p3B(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
+        """
+        A 1.3B model config.
+
+        1,253,157,120 total params
+        1,124,706,560 non-embedding params
+        """
+        return cls.v3(
+            d_model=1280,
+            hidden_size=1280 * 8,
+            n_layers=20,
+            n_heads=16,
+            vocab_size=vocab_size,
+            **kwargs,
+        )
+
+    @classmethod
+    def v3_2B(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
+        """
+        A 2.2B model config.
+
+        2,156,558,080 total params
+        2,002,417,408 non-embedding params
+        """
+        return cls.v3(
+            d_model=1536,
+            hidden_size=1536 * 8,
+            n_layers=25,
+            n_heads=24,
+            vocab_size=vocab_size,
+            **kwargs,
+        )
+
+    @classmethod
+    def v3_4B(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
+        """
+        A 4.3B model config.
+
+        4,312,000,000 total params
+        4,106,479,104 non-embedding params
+        """
+        return cls.v3(
+            d_model=2048,
+            hidden_size=2048 * 8,
+            n_layers=30,
+            n_heads=32,
+            vocab_size=vocab_size,
+            **kwargs,
+        )
+
+    @classmethod
+    def v3_8B(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
+        """
+        An 8B model config.
+
+        8,588,259,840 total params
+        8,331,358,720 non-embedding params
+        """
+        return cls.v3(
+            d_model=2560,
+            hidden_size=2560 * 8,
+            n_layers=40,
+            n_heads=40,
+            vocab_size=vocab_size,
+            **kwargs,
+        )
+
+    @classmethod
+    def v3_15B(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
+        """
+        A 15B model config.
+
+        15,087,541,760 total params
+        14,779,260,416 non-embedding params
+        """
+        return cls.v3(
+            d_model=3072,
+            hidden_size=3072 * 8,
+            n_layers=50,
+            n_heads=48,
+            vocab_size=vocab_size,
+            **kwargs,
+        )
+
+    @classmethod
+    def v3_34B(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
+        """
+        A 34B model config.
+
+        34,084,000,000 total params
+        33,672,958,208 non-embedding params
+        """
+        return cls.v3(
+            d_model=4096,
+            hidden_size=4096 * 8,
+            n_layers=65,
+            n_heads=64,
+            vocab_size=vocab_size,
+            **kwargs,
+        )
+
 
 @dataclass
 class _ModelSizeSettings:

--- a/src/scripts/train/ladder/gemma_like_ladder.py
+++ b/src/scripts/train/ladder/gemma_like_ladder.py
@@ -491,7 +491,7 @@ class GemmaLikeTransformerConfig(TransformerConfig):
 
     @classmethod
     def v3(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
-        # Clone of v2 with zero-centered RMSNorm weights (zero_centered_weights=True).
+        # Clone of v2 with embedding norm (RMSNorm on embeddings).
         # More changes to come until we declare v3 done.
 
         d_model: int = kwargs.pop("d_model")
@@ -516,7 +516,6 @@ class GemmaLikeTransformerConfig(TransformerConfig):
             eps=layer_norm_eps,
             bias=False,
             dtype=dtype,
-            zero_centered_weights=True,
         )
 
         feed_forward = FeedForwardConfig(
@@ -610,6 +609,11 @@ class GemmaLikeTransformerConfig(TransformerConfig):
             dtype=dtype,
             block_overrides=block_overrides if block_overrides else None,
             embed_scale=math.sqrt(d_model),
+            embedding_norm=LayerNormConfig(
+                name=LayerNormType.rms,
+                eps=layer_norm_eps,
+                bias=False,
+            ),
             **kwargs,
         )
 
@@ -795,7 +799,7 @@ class GemmaLikeOlmoV2(StrEnum):
             )
 
         settings = settings_map[self]
-        config_method = getattr(GemmaLikeTransformerConfig, f"v2_{settings.size}")
+        config_method = getattr(GemmaLikeTransformerConfig, f"v3_{settings.size}")
         model_config = config_method(vocab_size, use_gdn=use_gdn)
         return model_config, settings
 

--- a/src/scripts/train/ladder/gemma_like_ladder.py
+++ b/src/scripts/train/ladder/gemma_like_ladder.py
@@ -516,7 +516,7 @@ class GemmaLikeTransformerConfig(TransformerConfig):
             eps=layer_norm_eps,
             bias=False,
             dtype=dtype,
-            zero_centered_weights=True
+            zero_centered_weights=True,
         )
 
         feed_forward = FeedForwardConfig(

--- a/src/scripts/train/ladder/gemma_like_ladder.py
+++ b/src/scripts/train/ladder/gemma_like_ladder.py
@@ -492,6 +492,7 @@ class GemmaLikeTransformerConfig(TransformerConfig):
     @classmethod
     def v3(cls, vocab_size: int, **kwargs) -> "TransformerConfig":
         # Clone of v2 with zero-centered RMSNorm weights (zero_centered_weights=True).
+        # More changes to come until we declare v3 done.
 
         d_model: int = kwargs.pop("d_model")
         n_layers: int = kwargs.pop("n_layers")

--- a/src/test/nn/layer_norm_test.py
+++ b/src/test/nn/layer_norm_test.py
@@ -51,6 +51,31 @@ def test_cute_rms_norm():
     torch.testing.assert_close(x.grad, x_ref.grad)
 
 
+@pytest.mark.parametrize("bias", [pytest.param(True, id="bias"), pytest.param(False, id="no-bias")])
+def test_rms_norm_zero_centered_weights(bias):
+    dim = 64
+    norm = RMSNorm(size=dim, bias=bias, zero_centered_weights=True)
+    ref_norm = RMSNorm(size=dim, bias=bias, zero_centered_weights=False)
+
+    # Check initialization: zero_centered starts at 0, standard starts at 1
+    assert torch.all(norm.weight == 0.0)
+    assert torch.all(ref_norm.weight == 1.0)
+
+    # The outputs must match at initialization.
+    x = torch.randn(4, dim)
+    torch.testing.assert_close(norm(x), ref_norm(x))
+
+    # Set zero_centered weight=0.5 => effective scale = 1.5
+    # Set standard weight to 1.5 to match
+    with torch.no_grad():
+        norm.weight.fill_(0.5)
+        ref_norm.weight.fill_(1.5)
+        if bias:
+            norm.bias.fill_(0.1)
+            ref_norm.bias.fill_(0.1)
+    torch.testing.assert_close(norm(x), ref_norm(x))
+
+
 def test_layer_norm_builder_config():
     norm = LayerNormConfig(name=LayerNormType.l2_norm).build(size=1024)
     assert isinstance(norm, L2Norm)


### PR DESCRIPTION
A new v3 ladder.

Changes:
- adds embedding norm to v3

Other changes which are not in the v3 ladder:
- adds zero-centered RMSNorm that has a more natural resting state for weight decay

Pending:
- some restructuring is required for versioning correctly; parts of the code are hardcoded to v2 

More v3 changes will be added in separate PRs.