### PR TITLE
Fix race condition in SamplingInstanceSource index cache

### DIFF
--- a/src/olmo_core/data/composable/sampling_instance_source.py
+++ b/src/olmo_core/data/composable/sampling_instance_source.py
@@ -157,7 +157,7 @@ class SamplingInstanceSource(InstanceSource):
                 self.work_dir / f"{self.fingerprint}-{source.fingerprint}-indices.npy"
             )
             source_sample_paths.append(source_sample_path)
-            if self.fs_local_rank == 0:
+            if self.fs_local_rank == 0 and not source_sample_path.is_file():
                 n_repetitions = sample_size // len(source)
                 remaining_sample_size = sample_size % len(source)
                 source_indices = build_global_indices(


### PR DESCRIPTION
## Summary

- When multiple jobs share the same `work_dir` cache (e.g. model ladder runs launched together via `launch-all`), `SamplingInstanceSource` can hit a race condition writing index cache files. The file name is fingerprint-based and deterministic, so all jobs derive the same path. If one job atomically replaces the file via `tmp_path.replace(path)` while another is reading it, the reader gets a `FileNotFoundError`:

  ```
  FileNotFoundError: [Errno 2] No such file or directory:
    '/weka/.../cache/SamplingInstanceSource/...-indices.npy'
  ```

- This PR adds a simple `and not source_sample_path.is_file()` guard so that rank-0 skips the write when the cache file already exists. Since the filename encodes the fingerprint (seed, source fingerprints, sample sizes), an existing file is guaranteed to have identical content.

## Test plan

- [x] Verified fix resolves the crash in concurrent ladder runs (190M–760M sizes were failing; 100M and 1B happened to not race)

Made with [Cursor](https://cursor.com)