### PR TITLE
make lm evaluator data deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed LM in-loop evaluator data-order drift across repeated runs by resetting loader bookkeeping before each pass and making deterministic reshuffling the default.
+
+### Changed
+
+- Added a documented `deterministic` option to `LMEvaluator` and `LMEvaluatorCallbackConfig` so callers can opt out of fixed eval ordering when desired.
+
 ## [v2.5.0](https://github.com/allenai/OLMo-core/releases/tag/v2.5.0) - 2026-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v2.5.0](https://github.com/allenai/OLMo-core/releases/tag/v2.5.0) - 2026-04-01
+
 ### Added
 
 - Added API reference and user guide for the `olmo_core.generate` module and interactive chat interface.

--- a/src/olmo_core/eval/evaluator.py
+++ b/src/olmo_core/eval/evaluator.py
@@ -20,6 +20,15 @@ class Evaluator(metaclass=ABCMeta):
     :param batches_factory: A callable that returns an iterable over batches. This is an
         alternative to providing the ``batches`` argument directly.
     :param device: The device to compute/reduce metrics on.
+    :param deterministic: When ``True`` and :data:`batches` is a
+        :class:`~olmo_core.data.data_loader.DataLoaderBase`, each evaluation pass resets the data
+        loader and reshuffles with ``epoch=1`` so repeated evals read the same batches in the same
+        order. This is useful when eval loops are truncated via
+        :class:`~olmo_core.train.common.Duration`. When ``False``, the data loader still resets to
+        batch 0 before each pass, but reshuffles without pinning the epoch so the batch order may
+        change between eval runs. This does not implement a moving window across evals; if an eval
+        is truncated, different reshuffles may result in different instances being evaluated each
+        time.
     """
 
     def __init__(
@@ -29,6 +38,7 @@ class Evaluator(metaclass=ABCMeta):
         batches: Optional[Iterable[Dict[str, Any]]] = None,
         batches_factory: Optional[Callable[[], Iterable[Dict[str, Any]]]] = None,
         device: Optional[torch.device] = None,
+        deterministic: bool = True,
     ):
         if batches is None:
             assert (
@@ -42,6 +52,7 @@ class Evaluator(metaclass=ABCMeta):
         self.batches = batches
         self.batches_factory = batches_factory
         self.device = device
+        self.deterministic = deterministic
 
     def __iter__(self) -> Iterator[Dict[str, Any]]:
         """
@@ -51,7 +62,13 @@ class Evaluator(metaclass=ABCMeta):
             assert self.batches_factory is not None
             self.batches = self.batches_factory()
         if isinstance(self.batches, DataLoaderBase):
-            self.batches.reshuffle(in_memory=True)
+            # Reset bookkeeping before reshuffling so eval_duration-limited evals always restart
+            # from batch 0 instead of resuming from the previous partial pass.
+            self.batches.reset()
+            if self.deterministic:
+                self.batches.reshuffle(epoch=1, in_memory=True)
+            else:
+                self.batches.reshuffle(in_memory=True)
         for batch in self.batches:
             yield batch
         if isinstance(self.batches, DataLoaderBase):

--- a/src/olmo_core/eval/lm_evaluator.py
+++ b/src/olmo_core/eval/lm_evaluator.py
@@ -23,6 +23,7 @@ class LMEvaluator(Evaluator):
         with, and should be included in the ``labels`` argument to this class.
 
     :param labels: All of the task labels.
+    :param deterministic: See :class:`Evaluator` for details.
     """
 
     def __init__(
@@ -32,8 +33,9 @@ class LMEvaluator(Evaluator):
         batches: Iterable[Dict[str, Any]],
         labels: Sequence[str],
         device: Optional[torch.device] = None,
+        deterministic: bool = True,
     ):
-        super().__init__(name=name, batches=batches, device=device)
+        super().__init__(name=name, batches=batches, device=device, deterministic=deterministic)
         self.metrics = {label: MeanMetric(device=device) for label in labels}
 
     @classmethod
@@ -50,6 +52,7 @@ class LMEvaluator(Evaluator):
         num_threads: Optional[int] = None,
         num_workers: int = 0,
         prefetch_factor: Optional[int] = None,
+        deterministic: bool = True,
     ) -> "LMEvaluator":
         """
         Initialize an :class:`LMEvaluator` from a :class:`~olmo_core.data.numpy_dataset.NumpyPaddedFSLDataset`.
@@ -85,6 +88,7 @@ class LMEvaluator(Evaluator):
             batches=data_loader,
             labels=list(labels),
             device=device,
+            deterministic=deterministic,
         )
 
     def update_metrics(

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -227,6 +227,7 @@ class LMEvaluatorCallbackConfig(CallbackConfig):
     cancel_after_first_eval: bool = False
     eval_duration: Duration = field(default_factory=lambda: Duration.epochs(1))
     log_interval: int = 5
+    deterministic: bool = True
     enabled: bool = True
 
     def build(self, trainer: "Trainer") -> Optional[Callback]:
@@ -282,6 +283,7 @@ class LMEvaluatorCallbackConfig(CallbackConfig):
             collator=trainer.data_loader.collator,
             device=trainer.device,
             dp_process_group=trainer.dp_process_group,
+            deterministic=self.deterministic,
         )
         return EvaluatorCallback(
             evaluators=[evaluator],

--- a/src/olmo_core/version.py
+++ b/src/olmo_core/version.py
@@ -1,5 +1,5 @@
 _MAJOR = "2"
-_MINOR = "4"
+_MINOR = "5"
 _PATCH = "0"
 _SUFFIX = ""
 


### PR DESCRIPTION
**Fix LM evaluator data-order drift across repeated eval passes**

When eval_duration truncates an eval pass early, the data loader's internal bookkeeping (batches_processed, tokens_processed) was carried over into the next eval, causing subsequent passes to resume from a stale offset rather than restarting from batch 0. This meant repeated evals over the same checkpoint could silently evaluate different subsets of data.

This PR adds a reset() call before each reshuffle() in Evaluator.__iter__, and introduces a deterministic flag (default True) that pins epoch=1 during reshuffling so that every eval pass produces the same batch order. Callers can opt out with deterministic=False if varying order is desired.