### PR TITLE
Use metadata-backed document boundaries for SFT datasets

### DIFF
--- a/src/olmo_core/data/__init__.py
+++ b/src/olmo_core/data/__init__.py
@@ -48,7 +48,7 @@ from .numpy_dataset import (
     VSLNaturalCurriculum,
 )
 from .tokenizer import TokenizerConfig, TokenizerName
-from .types import LongDocStrategy, NumpyDatasetDType
+from .types import DocumentBoundaryMode, LongDocStrategy, NumpyDatasetDType
 
 __all__ = [
     "composable",
@@ -73,6 +73,7 @@ __all__ = [
     "VSLCurriculumType",
     "VSLCurriculumConfig",
     "NumpyDatasetDType",
+    "DocumentBoundaryMode",
     "TokenizerConfig",
     "TokenizerName",
     "DataMixBase",

--- a/src/olmo_core/data/composable/numpy_document_source.py
+++ b/src/olmo_core/data/composable/numpy_document_source.py
@@ -16,12 +16,13 @@ from olmo_core.utils import log_once
 
 from ..mixes import DataMix, DataMixBase
 from ..tokenizer import TokenizerConfig
-from ..types import LongDocStrategy, NumpyDatasetDType, NumpyUIntTypes
+from ..types import DocumentBoundaryMode, LongDocStrategy, NumpyDatasetDType, NumpyUIntTypes
 from ..utils import (
     chunked,
     iter_document_indices,
     iter_document_indices_with_max_sequence_length,
     load_array_slice,
+    resolve_document_boundary_mode,
 )
 from .token_source import DocumentSource, DocumentSourceConfig, TokenRange
 from .utils import path_map, resolve_seed
@@ -52,6 +53,10 @@ class NumpyDocumentSourceConfigBase(DocumentSourceConfig):
     long_doc_strategy: LongDocStrategy = LongDocStrategy.truncate
     """
     How to handle long documents when ``max_document_length`` is set.
+    """
+    document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.auto
+    """
+    How to resolve document boundaries for document-aware iteration.
     """
 
     def __post_init__(self):
@@ -218,6 +223,7 @@ class NumpyDocumentSourceConfig(NumpyDocumentSourceConfigBase):
             label=label,
             max_document_length=self.max_document_length,
             long_doc_strategy=self.long_doc_strategy,
+            document_boundaries=self.document_boundaries,
         )
 
         if self.source_group_size > 0:
@@ -337,6 +343,7 @@ class NumpyDocumentSource(DocumentSource):
         label: Optional[str] = None,
         max_document_length: Optional[int] = None,
         long_doc_strategy: LongDocStrategy = LongDocStrategy.truncate,
+        document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.auto,
         _source_sizes: Optional[Sequence[int]] = None,
         _label_mask_sizes: Optional[Sequence[int]] = None,
     ):
@@ -360,6 +367,11 @@ class NumpyDocumentSource(DocumentSource):
         self._tokenizer = tokenizer
         self._max_document_length = max_document_length
         self._long_doc_strategy = long_doc_strategy
+        (
+            self._document_boundaries,
+            self._document_boundary_metadata_paths,
+            self._document_boundary_metadata_sizes,
+        ) = self._resolve_document_boundaries(document_boundaries)
 
         source_sizes: Sequence[int]
         if _source_sizes is not None:
@@ -443,6 +455,10 @@ class NumpyDocumentSource(DocumentSource):
     def long_doc_strategy(self) -> LongDocStrategy:
         return self._long_doc_strategy
 
+    @property
+    def document_boundaries(self) -> DocumentBoundaryMode:
+        return self._document_boundaries
+
     @ft.cached_property
     def fingerprint(self) -> str:
         sha256_hash = hashlib.sha256()
@@ -452,6 +468,7 @@ class NumpyDocumentSource(DocumentSource):
                 f"{self.dtype=},"
                 f"{self.eos_token_id=},"
                 f"{self.bos_token_id=},"
+                f"{self.document_boundaries=},"
             ).encode()
         )
 
@@ -462,6 +479,11 @@ class NumpyDocumentSource(DocumentSource):
         # by hashing their paths and sizes instead. This should be sufficient to detect changes 99.99% of the time.
         for path, size in zip(self.source_paths, self.source_sizes):
             sha256_hash.update(f"{path=},{size=},".encode())
+        if self.document_boundaries == DocumentBoundaryMode.metadata:
+            for path in self.source_paths:
+                metadata_path = self._document_boundary_metadata_paths[path]
+                metadata_size = self._document_boundary_metadata_sizes[path]
+                sha256_hash.update(f"{metadata_path=},{metadata_size=},".encode())
         if self.label_mask_paths is not None:
             for label_path, size in zip(self.label_mask_paths, self.source_sizes):
                 sha256_hash.update(f"{label_path=},{size=},".encode())
@@ -500,6 +522,9 @@ class NumpyDocumentSource(DocumentSource):
                 tokenizer=self.tokenizer,
                 label_mask_paths=label_mask_paths,
                 label=self.label,
+                max_document_length=self.max_document_length,
+                long_doc_strategy=self.long_doc_strategy,
+                document_boundaries=self.document_boundaries,
                 _source_sizes=source_sizes,
                 _label_mask_sizes=label_mask_sizes,
             )
@@ -562,6 +587,7 @@ class NumpyDocumentSource(DocumentSource):
             if self.max_document_length is None:
                 indices = iter_document_indices(
                     source_path,
+                    document_boundaries=self.document_boundaries,
                     eos_token_id=self.eos_token_id,
                     bos_token_id=self.bos_token_id,
                     dtype=self.dtype,
@@ -570,6 +596,7 @@ class NumpyDocumentSource(DocumentSource):
                 indices = iter_document_indices_with_max_sequence_length(
                     source_path,
                     self.max_document_length,
+                    document_boundaries=self.document_boundaries,
                     eos_token_id=self.eos_token_id,
                     bos_token_id=self.bos_token_id,
                     dtype=self.dtype,
@@ -591,3 +618,18 @@ class NumpyDocumentSource(DocumentSource):
 
     def children(self):
         return []
+
+    def _resolve_document_boundaries(
+        self, document_boundaries: DocumentBoundaryMode
+    ) -> Tuple[DocumentBoundaryMode, Dict[PathOrStr, PathOrStr], Dict[PathOrStr, int]]:
+        document_boundaries, metadata_paths = resolve_document_boundary_mode(
+            self.source_paths, document_boundaries=document_boundaries
+        )
+        metadata_path_by_source = dict(zip(self.source_paths, metadata_paths))
+        metadata_sizes: Dict[PathOrStr, int] = {}
+        if document_boundaries == DocumentBoundaryMode.metadata:
+            metadata_sizes = {
+                path: io.get_file_size(metadata_path_by_source[path]) for path in self.source_paths
+            }
+        log.info("Resolved document boundaries for %s to '%s'", self.__class__.__name__, document_boundaries)
+        return document_boundaries, metadata_path_by_source, metadata_sizes

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -47,7 +47,7 @@ from ..io import (
 from .mixes import DataMix, DataMixBase
 from .source_mixture import SourceMixtureDatasetConfig
 from .tokenizer import TokenizerConfig
-from .types import LongDocStrategy, NumpyDatasetDType, NumpyUIntTypes
+from .types import DocumentBoundaryMode, LongDocStrategy, NumpyDatasetDType, NumpyUIntTypes
 from .utils import (
     bucket_documents,
     chunk_array,
@@ -60,6 +60,7 @@ from .utils import (
     load_array_slice_into_tensor,
     memmap_to_write,
     pack_documents_into_instances,
+    resolve_document_boundary_mode,
     run_worker_func,
     segment_documents_into_instances,
     write_array_to_disk,
@@ -220,7 +221,16 @@ class NumpyDatasetBase(ABC):
             sha256_hash.update(f"{field_name}={field_value},".encode())
         for path, size in zip(self.paths, self.file_sizes):
             sha256_hash.update(f"path={os.path.basename(path)},size={size},".encode())
+        for path, size in self.fingerprint_extra_sources:
+            sha256_hash.update(f"path={path},size={size},".encode())
         return sha256_hash.hexdigest()
+
+    @property
+    def fingerprint_extra_sources(self) -> Tuple[Tuple[PathOrStr, int], ...]:
+        """
+        Extra path/size pairs to include in the dataset fingerprint.
+        """
+        return ()
 
     @property
     def fs_local_rank(self) -> int:
@@ -442,10 +452,15 @@ class NumpyFSLDatasetBase(NumpyDatasetBase, Dataset[Dict[str, Any]]):
                 source_path = self._label_mask_path_to_source_path[source_path]
             sha256_hash.update(str(source_path).encode())
             sha256_hash.update(str(self._get_file_size(source_path)).encode())
+        for extra_id in self._get_indices_path_extra_ids(*source_paths):
+            sha256_hash.update(str(extra_id).encode())
         for extra_id in extra_ids or []:
             sha256_hash.update(extra_id.encode())
         path_hash = sha256_hash.hexdigest()
         return self.work_dir / "dataset-common" / f"{name}-{self.sequence_length}-{path_hash}.npy"
+
+    def _get_indices_path_extra_ids(self, *source_paths: PathOrStr) -> Tuple[str, ...]:
+        return ()
 
 
 class NumpyFSLDataset(NumpyFSLDatasetBase):
@@ -860,6 +875,7 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
         include_instance_metadata: Optional[bool] = None,
         instance_filter_config: Optional[InstanceFilterConfig] = None,
         label_mask_paths: Optional[List[PathOrStr]] = None,
+        document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.auto,
     ):
         super().__init__(
             *paths,
@@ -874,6 +890,11 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
             instance_filter_config=instance_filter_config,
             label_mask_paths=label_mask_paths,
         )
+        (
+            self._document_boundaries,
+            self._document_boundary_metadata_paths,
+            self._document_boundary_metadata_sizes,
+        ) = self._resolve_document_boundaries(document_boundaries)
         self._array_instance_offsets: Optional[Tuple[Tuple[int, int], ...]] = None
 
     @property
@@ -886,6 +907,20 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
             "max_target_sequence_length",
             "bos_token_id",
             "sequence_length",
+            "document_boundaries",
+        )
+
+    @property
+    def fingerprint_extra_sources(self) -> Tuple[Tuple[PathOrStr, int], ...]:
+        if self.document_boundaries != DocumentBoundaryMode.metadata:
+            return ()
+        return tuple(
+            (
+                self._document_boundary_metadata_paths[path],
+                self._document_boundary_metadata_sizes[path],
+            )
+            for path in self.paths
+            if path in self._document_boundary_metadata_sizes
         )
 
     @property
@@ -909,6 +944,10 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
         self,
     ) -> NumpyUIntTypes:
         return np.uint32
+
+    @property
+    def document_boundaries(self) -> DocumentBoundaryMode:
+        return self._document_boundaries
 
     def prepare(self):
         if self.fs_local_rank == 0:
@@ -941,6 +980,36 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
     def _get_instance_indices_path(self, source_path: PathOrStr) -> Path:
         return self._get_indices_path("instance-indices", source_path)
 
+    def _resolve_document_boundaries(
+        self, document_boundaries: DocumentBoundaryMode
+    ) -> Tuple[DocumentBoundaryMode, Dict[PathOrStr, PathOrStr], Dict[PathOrStr, int]]:
+        document_boundaries, metadata_paths = resolve_document_boundary_mode(
+            self.paths, document_boundaries=document_boundaries
+        )
+        metadata_path_by_source = dict(zip(self.paths, metadata_paths))
+        metadata_sizes: Dict[PathOrStr, int] = {}
+        if document_boundaries == DocumentBoundaryMode.metadata:
+            metadata_sizes = {
+                path: get_file_size(metadata_path_by_source[path]) for path in self.paths
+            }
+        log.info("Resolved document boundaries for %s to '%s'", self.__class__.__name__, document_boundaries)
+        return document_boundaries, metadata_path_by_source, metadata_sizes
+
+    def _get_indices_path_extra_ids(self, *source_paths: PathOrStr) -> Tuple[str, ...]:
+        extra_ids = [f"document_boundaries={self.document_boundaries}"]
+        if self.document_boundaries == DocumentBoundaryMode.metadata:
+            for source_path in source_paths:
+                source_path = self._label_mask_path_to_source_path.get(source_path, source_path)
+                metadata_path = self._document_boundary_metadata_paths[source_path]
+                metadata_size = self._document_boundary_metadata_sizes[source_path]
+                extra_ids.extend(
+                    [
+                        f"metadata_path={metadata_path}",
+                        f"metadata_size={metadata_size}",
+                    ]
+                )
+        return tuple(extra_ids)
+
     def _write_instance_indices(self):
         paths_needed: List[PathOrStr] = []
         for path in self.paths:
@@ -962,9 +1031,11 @@ class NumpyPaddedFSLDataset(NumpyFSLDataset):
                         path,
                         indices_path,
                         max_sequence_length=self.sequence_length,
+                        document_boundaries=self.document_boundaries,
                         eos_token_id=self.eos_token_id,
                         dtype=self.dtype,
                         indices_dtype=self.indices_dtype,
+                        bos_token_id=self.bos_token_id,
                     )
                     futures.append(future)
 
@@ -1014,6 +1085,7 @@ class NumpyPackedFSLDataset(NumpyFSLDatasetBase):
         label_mask_paths: Optional[List[PathOrStr]] = None,
         long_doc_strategy: LongDocStrategy = LongDocStrategy.truncate,
         source_group_size: int = 1,
+        document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.auto,
     ):
         super().__init__(
             *paths,
@@ -1034,6 +1106,11 @@ class NumpyPackedFSLDataset(NumpyFSLDatasetBase):
 
         self._long_doc_strategy = long_doc_strategy
         self._source_group_size = source_group_size
+        (
+            self._document_boundaries,
+            self._document_boundary_metadata_paths,
+            self._document_boundary_metadata_sizes,
+        ) = self._resolve_document_boundaries(document_boundaries)
 
         self._source_path_groups = list(chunked(self.paths, self.source_group_size))
         self._label_mask_path_groups: Optional[List[List[PathOrStr]]] = None
@@ -1059,6 +1136,7 @@ class NumpyPackedFSLDataset(NumpyFSLDatasetBase):
             "long_doc_strategy",
             "bos_token_id",
             "sequence_length",
+            "document_boundaries",
         )
         # For backwards compat, only add this when it's not the default.
         if self._source_group_size > 1:
@@ -1072,6 +1150,23 @@ class NumpyPackedFSLDataset(NumpyFSLDatasetBase):
     @property
     def source_group_size(self) -> int:
         return self._source_group_size
+
+    @property
+    def document_boundaries(self) -> DocumentBoundaryMode:
+        return self._document_boundaries
+
+    @property
+    def fingerprint_extra_sources(self) -> Tuple[Tuple[PathOrStr, int], ...]:
+        if self.document_boundaries != DocumentBoundaryMode.metadata:
+            return ()
+        return tuple(
+            (
+                self._document_boundary_metadata_paths[path],
+                self._document_boundary_metadata_sizes[path],
+            )
+            for path in self.paths
+            if path in self._document_boundary_metadata_sizes
+        )
 
     @property
     def indices_dtype(
@@ -1176,6 +1271,7 @@ class NumpyPackedFSLDataset(NumpyFSLDatasetBase):
 
         # Load token IDs and maybe label masks for each document.
         document_token_ids: List[torch.Tensor] = []
+        document_lengths: List[int] = []
         document_label_masks: Optional[List[torch.Tensor]] = (
             None if label_mask_paths is None else []
         )
@@ -1203,6 +1299,7 @@ class NumpyPackedFSLDataset(NumpyFSLDatasetBase):
                 raise RuntimeError("we shouldn't be here!")
 
             assert source_path is not None
+            document_lengths.append(document_end - document_start)
             document_token_ids.append(
                 load_array_slice_into_tensor(source_path, document_start, document_end, self.dtype)
             )
@@ -1234,10 +1331,38 @@ class NumpyPackedFSLDataset(NumpyFSLDatasetBase):
             metadata = self._metadata_groups[source_group_index]
             out["metadata"] = deepcopy(metadata)
         if self._generate_doc_lengths:
-            out["doc_lens"] = get_document_lengths(
-                input_ids, self.eos_token_id, bos_token_id=self.bos_token_id
-            )
+            out["doc_lens"] = torch.tensor(document_lengths, dtype=torch.int32)
         return out
+
+    def _resolve_document_boundaries(
+        self, document_boundaries: DocumentBoundaryMode
+    ) -> Tuple[DocumentBoundaryMode, Dict[PathOrStr, PathOrStr], Dict[PathOrStr, int]]:
+        document_boundaries, metadata_paths = resolve_document_boundary_mode(
+            self.paths, document_boundaries=document_boundaries
+        )
+        metadata_path_by_source = dict(zip(self.paths, metadata_paths))
+        metadata_sizes: Dict[PathOrStr, int] = {}
+        if document_boundaries == DocumentBoundaryMode.metadata:
+            metadata_sizes = {
+                path: get_file_size(metadata_path_by_source[path]) for path in self.paths
+            }
+        log.info("Resolved document boundaries for %s to '%s'", self.__class__.__name__, document_boundaries)
+        return document_boundaries, metadata_path_by_source, metadata_sizes
+
+    def _get_indices_path_extra_ids(self, *source_paths: PathOrStr) -> Tuple[str, ...]:
+        extra_ids = [f"document_boundaries={self.document_boundaries}"]
+        if self.document_boundaries == DocumentBoundaryMode.metadata:
+            for source_path in source_paths:
+                source_path = self._label_mask_path_to_source_path.get(source_path, source_path)
+                metadata_path = self._document_boundary_metadata_paths[source_path]
+                metadata_size = self._document_boundary_metadata_sizes[source_path]
+                extra_ids.extend(
+                    [
+                        f"metadata_path={metadata_path}",
+                        f"metadata_size={metadata_size}",
+                    ]
+                )
+        return tuple(extra_ids)
 
     def _get_document_indices_path(self, *source_paths: PathOrStr) -> Path:
         return self._get_indices_path(
@@ -1270,6 +1395,7 @@ class NumpyPackedFSLDataset(NumpyFSLDatasetBase):
         instances, document_indices, total_tokens = pack_documents_into_instances(
             *source_paths,
             max_sequence_length=self.sequence_length,
+            document_boundaries=self.document_boundaries,
             eos_token_id=self.eos_token_id,
             bos_token_id=self.bos_token_id,
             dtype=self.dtype,
@@ -2630,6 +2756,10 @@ class NumpyPaddedFSLDatasetConfig(NumpyDatasetConfig):
     """
     The paths/URLs to numpy bool files indicating which tokens should be masked.
     """
+    document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.auto
+    """
+    How to resolve document boundaries for padded document-aware datasets.
+    """
 
     def validate(self):
         if self.sequence_length <= 0:
@@ -2652,6 +2782,7 @@ class NumpyPaddedFSLDatasetConfig(NumpyDatasetConfig):
             include_instance_metadata=self.include_instance_metadata,
             instance_filter_config=self.instance_filter_config,
             label_mask_paths=label_masks,
+            document_boundaries=self.document_boundaries,
         )
         return self._finalize(dataset)
 
@@ -2678,6 +2809,10 @@ class NumpyPackedFSLDatasetConfig(NumpyDatasetConfig):
     source_group_size: int = 1
     """
     The number of source npy files to process together when packing.
+    """
+    document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.auto
+    """
+    How to resolve document boundaries for packed document-aware datasets.
     """
 
     def validate(self):
@@ -2708,6 +2843,7 @@ class NumpyPackedFSLDatasetConfig(NumpyDatasetConfig):
             long_doc_strategy=self.long_doc_strategy,
             label_mask_paths=label_masks,
             source_group_size=self.source_group_size,
+            document_boundaries=self.document_boundaries,
         )
         return self._finalize(dataset)
 

--- a/src/olmo_core/data/types.py
+++ b/src/olmo_core/data/types.py
@@ -7,6 +7,28 @@ from olmo_core.config import StrEnum
 NumpyUIntTypes = Union[Type[np.uint8], Type[np.uint16], Type[np.uint32], Type[np.uint64]]
 
 
+class DocumentBoundaryMode(StrEnum):
+    """
+    Specifies how document boundaries should be resolved for document-aware datasets.
+    """
+
+    auto = "auto"
+    """
+    Prefer explicit metadata when it exists for every source, otherwise fall back to tokenizer
+    boundary detection.
+    """
+
+    metadata = "metadata"
+    """
+    Require explicit metadata files for every source.
+    """
+
+    tokenizer = "tokenizer"
+    """
+    Infer document boundaries from tokenizer EOS/BOS tokens.
+    """
+
+
 class LongDocStrategy(StrEnum):
     """
     Specifies how to handle documents that are longer than the max sequence length when packing.

--- a/src/olmo_core/data/utils.py
+++ b/src/olmo_core/data/utils.py
@@ -1,5 +1,6 @@
 import functools as ft
 import gzip
+import logging
 import math
 import os
 import random
@@ -30,14 +31,20 @@ import torch.nn.functional as F
 from olmo_core.aliases import PathOrStr
 from olmo_core.io import (
     add_cached_path_clients,
+    file_exists,
     get_bytes_range,
     get_file_size,
+    get_parent,
     is_url,
+    join_path,
     resource_path,
 )
 from olmo_core.utils import capped_powers_of_2
 
-from .types import LongDocStrategy
+from .types import DocumentBoundaryMode, LongDocStrategy
+
+
+log = logging.getLogger(__name__)
 
 
 def split_batch(batch: Dict[str, Any], num_microbatch_instances: int) -> List[Dict[str, Any]]:
@@ -167,11 +174,60 @@ def write_document_indices(data_path: Path, *, dtype, eos_token_id: int) -> Path
     return metadata_path
 
 
+def get_document_boundary_metadata_path(data_path: PathOrStr) -> PathOrStr:
+    """
+    Get the sibling ``.csv.gz`` metadata path corresponding to a token ID source file.
+    """
+    metadata_filename = os.path.basename(str(data_path)).replace(".npy", ".csv.gz")
+    return join_path(get_parent(data_path), metadata_filename)
+
+
+def resolve_document_boundary_mode(
+    paths: Sequence[PathOrStr],
+    document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.auto,
+) -> Tuple[DocumentBoundaryMode, Tuple[PathOrStr, ...]]:
+    """
+    Resolve the effective document-boundary mode for a collection of sources.
+
+    Returns the effective mode together with the corresponding metadata paths.
+    """
+    metadata_paths = tuple(get_document_boundary_metadata_path(path) for path in paths)
+
+    if document_boundaries == DocumentBoundaryMode.tokenizer:
+        return DocumentBoundaryMode.tokenizer, metadata_paths
+
+    metadata_exists = tuple(file_exists(path) for path in metadata_paths)
+
+    if document_boundaries == DocumentBoundaryMode.auto:
+        if all(metadata_exists):
+            return DocumentBoundaryMode.metadata, metadata_paths
+        elif not any(metadata_exists):
+            return DocumentBoundaryMode.tokenizer, metadata_paths
+        else:
+            present = [str(path) for path, exists in zip(metadata_paths, metadata_exists) if exists]
+            missing = [str(path) for path, exists in zip(metadata_paths, metadata_exists) if not exists]
+            raise RuntimeError(
+                "Found document boundary metadata for only some source files while "
+                f"document_boundaries='{DocumentBoundaryMode.auto}'. Present: {present}. Missing: {missing}."
+            )
+
+    if document_boundaries == DocumentBoundaryMode.metadata:
+        missing = [str(path) for path, exists in zip(metadata_paths, metadata_exists) if not exists]
+        if missing:
+            raise RuntimeError(
+                f"document_boundaries='{DocumentBoundaryMode.metadata}' requires metadata for every source, "
+                f"but these files are missing: {missing}"
+            )
+        return DocumentBoundaryMode.metadata, metadata_paths
+    return DocumentBoundaryMode.tokenizer, metadata_paths
+
+
 def iter_document_indices(
     data_path: PathOrStr,
     *,
     local_cache: Optional[PathOrStr] = None,
     use_array_if_local: Optional[bool] = None,
+    document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.tokenizer,
     eos_token_id: Optional[int] = None,
     bos_token_id: Optional[int] = None,
     dtype=None,
@@ -185,11 +241,54 @@ def iter_document_indices(
     :param use_array_if_local: Use the numpy data array to find the document indices if the array
         is on the local filesystem and ``eos_token_id`` and ``dtype`` are provided.
         This can be a lot faster. Otherwise relies on the metadata file.
+        Ignored when ``document_boundaries='metadata'`` or when ``document_boundaries='auto'``
+        resolves to metadata.
+    :param document_boundaries: How to resolve document boundaries.
     :param eos_token_id: The EOS token ID.
         Required to use the local data array instead of the metadata file.
     :param dtype: The data type of the numpy data array.
         Required to use the local data array instead of the metadata file.
     """
+    document_boundaries, metadata_paths = resolve_document_boundary_mode(
+        (data_path,), document_boundaries=document_boundaries
+    )
+
+    if document_boundaries == DocumentBoundaryMode.metadata:
+        metadata_path = metadata_paths[0]
+        metadata_filename = os.path.basename(str(metadata_path))
+        log.info(
+            "Using document boundary metadata for '%s' from '%s'",
+            data_path,
+            metadata_filename,
+        )
+        metadata_path = resource_path(
+            get_parent(data_path),
+            metadata_filename,
+            local_cache=local_cache,
+        )
+
+        total_tokens: Optional[int] = None
+        if dtype is not None:
+            total_tokens = get_file_size(data_path) // dtype(0).itemsize
+
+        with gzip.open(metadata_path, "rt") as f:
+            for line in f:
+                start_index_str, end_index_str, *_ = line.split(",")
+                start_index, end_index = int(start_index_str), int(end_index_str)
+                if total_tokens is not None:
+                    if start_index >= total_tokens:
+                        raise RuntimeError(
+                            f"Document start index {start_index:,d} from metadata file "
+                            f"for source '{data_path}' with {total_tokens:,d} tokens is out-of-bounds"
+                        )
+                    if end_index > total_tokens:
+                        raise RuntimeError(
+                            f"Document end index {end_index:,d} from metadata file "
+                            f"for source '{data_path}' with {total_tokens:,d} tokens is out-of-bounds"
+                        )
+                yield start_index, end_index
+        return
+
     if use_array_if_local is None:
         if eos_token_id is not None and dtype is not None and not is_url(data_path):
             use_array_if_local = True
@@ -214,10 +313,15 @@ def iter_document_indices(
             yield start_idx, end_idx
             start_idx = end_idx
     else:
-        metadata_filename = os.path.basename(data_path).replace(".npy", ".csv.gz")
+        metadata_filename = os.path.basename(str(get_document_boundary_metadata_path(data_path)))
+        log.info(
+            "Using tokenizer EOS/BOS boundaries for '%s'%s",
+            data_path,
+            " via local array scan" if not is_url(data_path) and use_array_if_local else "",
+        )
         try:
             metadata_path = resource_path(
-                os.path.dirname(data_path),
+                get_parent(data_path),
                 metadata_filename,
                 local_cache=local_cache,
             )
@@ -256,6 +360,7 @@ def iter_document_indices_with_max_sequence_length(
     *,
     local_cache: Optional[PathOrStr] = None,
     use_array_if_local: Optional[bool] = None,
+    document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.tokenizer,
     eos_token_id: Optional[int] = None,
     bos_token_id: Optional[int] = None,
     dtype=None,
@@ -269,6 +374,7 @@ def iter_document_indices_with_max_sequence_length(
         data_path,
         local_cache=local_cache,
         use_array_if_local=use_array_if_local,
+        document_boundaries=document_boundaries,
         eos_token_id=eos_token_id,
         bos_token_id=bos_token_id,
         dtype=dtype,
@@ -286,12 +392,18 @@ def iter_document_indices_with_max_sequence_length(
 
 
 def get_document_indices(
-    data_path: PathOrStr, local_cache: Optional[PathOrStr] = None
+    data_path: PathOrStr,
+    local_cache: Optional[PathOrStr] = None,
+    document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.tokenizer,
 ) -> List[Tuple[int, int]]:
     """
     Like :func:`iter_document_indices` but returns a list.
     """
-    return list(iter_document_indices(data_path, local_cache=local_cache))
+    return list(
+        iter_document_indices(
+            data_path, local_cache=local_cache, document_boundaries=document_boundaries
+        )
+    )
 
 
 def load_array_slice(
@@ -543,6 +655,7 @@ def segment_documents_into_instances(
         Type[np.uint8], Type[np.uint16], Type[np.uint32], Type[np.uint64]
     ] = np.uint32,
     bos_token_id: Optional[int] = None,
+    document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.tokenizer,
     sample: Optional[Tuple[int, int]] = None,
 ) -> Tuple[int, int]:
     """
@@ -557,7 +670,11 @@ def segment_documents_into_instances(
     idx_gen = (
         idx
         for start_idx, end_idx in iter_document_indices(
-            path, eos_token_id=eos_token_id, bos_token_id=bos_token_id, dtype=dtype
+            path,
+            document_boundaries=document_boundaries,
+            eos_token_id=eos_token_id,
+            bos_token_id=bos_token_id,
+            dtype=dtype,
         )
         for idx in (start_idx, start_idx + min(end_idx - start_idx, max_sequence_length))
     )
@@ -888,6 +1005,7 @@ def pack_documents_into_instances(
     eos_token_id: int,
     dtype: Union[Type[np.uint8], Type[np.uint16], Type[np.uint32], Type[np.uint64]],
     bos_token_id: Optional[int] = None,
+    document_boundaries: DocumentBoundaryMode = DocumentBoundaryMode.tokenizer,
     indices_dtype: Union[
         Type[np.uint8], Type[np.uint16], Type[np.uint32], Type[np.uint64]
     ] = np.uint64,
@@ -924,6 +1042,7 @@ def pack_documents_into_instances(
             for start_idx, end_idx in iter_document_indices_with_max_sequence_length(
                 path,
                 max_sequence_length,
+                document_boundaries=document_boundaries,
                 eos_token_id=eos_token_id,
                 bos_token_id=bos_token_id,
                 dtype=dtype,

--- a/src/scripts/train/sft/README.md
+++ b/src/scripts/train/sft/README.md
@@ -63,7 +63,7 @@ uv sync --extra beaker --extra transformers
 
     > NOTE: This script uses GPUs to ensure sufficient CPU resources for large-scale tokenization. The chat template `olmo123` is a placeholder—the chat template is loaded from the tokenizer in the command.
 
-    *Be careful with your choice of chat template!* It is highly recommended to use the `olmo` chat template for tokenization. Olmo-core uses `[eos]` tokens to find document boundaries, and the `olmo` chat template uses a single `eos` token to mark the end of a conversation, enabling document packing to work correctly.
+    *Be careful with your choice of chat template!* When the tokenized dataset includes sibling `.csv.gz` metadata files from the upstream conversion pipeline, Olmo-core will use that metadata to recover conversation boundaries during packing. This means chat templates such as Qwen's, where the tokenizer EOS can appear at message boundaries, no longer require overriding the tokenizer EOS just to preserve conversation boundaries. The `olmo` chat template remains a safe default, but it is no longer required for this reason.
 
     Download the tokenizer to your local filesystem (e.g., Weka at AI2) before launching the tokenization script. This avoids repeated downloads and network latency during processing. The example above demonstrates this pattern with `huggingface-cli download`.
 

--- a/src/test/data/composable/numpy_document_source_test.py
+++ b/src/test/data/composable/numpy_document_source_test.py
@@ -1,3 +1,4 @@
+import gzip
 from pathlib import Path
 
 import numpy as np
@@ -11,6 +12,12 @@ def _write_mmap(path, data, dtype):
     mmap = np.memmap(path, mode="w+", dtype=dtype, shape=(len(data),))
     mmap[:] = data
     mmap.flush()
+
+
+def _write_metadata(path: Path, *spans: tuple[int, int]):
+    with gzip.open(path.with_suffix(".csv.gz"), "wt") as f:
+        for start, end in spans:
+            f.write(f"{start},{end}\n")
 
 
 def test_numpy_document_source(tmp_path: Path):
@@ -57,6 +64,25 @@ def test_numpy_document_source(tmp_path: Path):
     assert list(source[-3:]["input_ids"]) == [21, 22, 0]
 
     assert list(source.get_document_offsets()) == [(0, 2), (2, 12), (12, 23), (23, 26)]
+
+
+def test_numpy_document_source_prefers_metadata(tmp_path: Path):
+    dtype = np.uint16
+    tokenizer = TokenizerConfig(vocab_size=32_000, eos_token_id=0, pad_token_id=-1)
+
+    path = tmp_path / "mmap.npy"
+    data = [1, 0, 2, 0, 3, 0]
+    _write_mmap(path, data, dtype)
+    _write_metadata(path, (0, len(data)))
+
+    source = NumpyDocumentSource(
+        source_paths=[path],
+        dtype=dtype,
+        tokenizer=tokenizer,
+        work_dir=tmp_path,
+    )
+
+    assert list(source.get_document_offsets()) == [(0, len(data))]
 
 
 def test_numpy_document_source_concatenated(tmp_path: Path):

--- a/src/test/data/numpy_dataset_test.py
+++ b/src/test/data/numpy_dataset_test.py
@@ -1,3 +1,4 @@
+import gzip
 import math
 from pathlib import Path
 from typing import List
@@ -6,6 +7,7 @@ import numpy as np
 import pytest
 
 from olmo_core.data import (
+    DocumentBoundaryMode,
     LongDocStrategy,
     NumpyFSLDataset,
     NumpyFSLDatasetConfig,
@@ -24,6 +26,12 @@ from olmo_core.data.types import NumpyDatasetDType
 from olmo_core.data.utils import get_document_indices, write_document_indices
 
 from .utils import mk_mmaps
+
+
+def _write_metadata(path: Path, *spans: tuple[int, int]):
+    with gzip.open(path.with_suffix(".csv.gz"), "wt") as f:
+        for start, end in spans:
+            f.write(f"{start},{end}\n")
 
 
 def test_numpy_fsl_dataset(tmp_path: Path):
@@ -210,6 +218,49 @@ def test_numpy_padded_fsl_dataset(tmp_path: Path):
     assert len(ds) == 4
 
 
+def test_numpy_padded_fsl_dataset_prefers_metadata(tmp_path: Path):
+    data = [1, 0, 2, 0, 3, 0]
+    path = tmp_path / "mmap.npy"
+    mmap = np.memmap(path, mode="w+", dtype=np.uint16, shape=(len(data),))
+    mmap[:] = data
+    mmap.flush()
+    _write_metadata(path, (0, len(data)))
+
+    ds = NumpyPaddedFSLDataset(
+        path,
+        sequence_length=8,
+        pad_token_id=0,
+        eos_token_id=0,
+        vocab_size=32_000,
+    )
+    ds.prepare()
+
+    assert len(ds) == 1
+    assert ds[0]["input_ids"].tolist() == [1, 0, 2, 0, 3, 0, 0, 0]
+    assert ds[0]["label_mask"].tolist() == [True] * 6 + [False] * 2
+
+
+def test_numpy_padded_fsl_dataset_rejects_mixed_metadata_presence(tmp_path: Path):
+    data = [1, 0, 2, 0]
+    path1 = tmp_path / "mmap1.npy"
+    path2 = tmp_path / "mmap2.npy"
+    for path in (path1, path2):
+        mmap = np.memmap(path, mode="w+", dtype=np.uint16, shape=(len(data),))
+        mmap[:] = data
+        mmap.flush()
+    _write_metadata(path1, (0, len(data)))
+
+    with pytest.raises(RuntimeError, match="some source files"):
+        NumpyPaddedFSLDataset(
+            path1,
+            path2,
+            sequence_length=8,
+            pad_token_id=0,
+            eos_token_id=0,
+            vocab_size=32_000,
+        )
+
+
 def test_numpy_padded_fsl_dataset_with_label_mask(tmp_path: Path):
     data1 = [1, 2, 3, 4, 5, 6, 7, 0, 8, 9, 10, 0]
     mmap1 = np.memmap(tmp_path / "mmap1.npy", mode="w+", dtype=np.uint16, shape=(len(data1),))
@@ -305,6 +356,64 @@ def test_numpy_packed_fsl_dataset(tmp_path: Path, long_doc_strategy):
         assert ds[5]["label_mask"].tolist() == [True] * 6 + [False] * 2
     else:
         raise ValueError(long_doc_strategy)
+
+
+def test_numpy_packed_fsl_dataset_doc_lens_use_metadata_spans(tmp_path: Path):
+    data = [1, 0, 2, 0, 3, 0]
+    path = tmp_path / "mmap.npy"
+    mmap = np.memmap(path, mode="w+", dtype=np.uint16, shape=(len(data),))
+    mmap[:] = data
+    mmap.flush()
+    _write_metadata(path, (0, len(data)))
+
+    ds = NumpyPackedFSLDataset(
+        path,
+        sequence_length=8,
+        pad_token_id=-1,
+        eos_token_id=0,
+        vocab_size=32_000,
+        generate_doc_lengths=True,
+    )
+    ds.prepare()
+
+    assert len(ds) == 1
+    assert ds[0]["input_ids"].tolist() == [1, 0, 2, 0, 3, 0, -1, -1]
+    assert ds[0]["doc_lens"].tolist() == [6]
+
+
+def test_numpy_padded_fsl_dataset_fingerprint_and_cache_track_metadata(tmp_path: Path):
+    data = [1, 0, 2, 0]
+    path = tmp_path / "mmap.npy"
+    mmap = np.memmap(path, mode="w+", dtype=np.uint16, shape=(len(data),))
+    mmap[:] = data
+    mmap.flush()
+
+    _write_metadata(path, (0, len(data)))
+    ds1 = NumpyPaddedFSLDataset(
+        path,
+        sequence_length=8,
+        pad_token_id=0,
+        eos_token_id=0,
+        vocab_size=32_000,
+        document_boundaries=DocumentBoundaryMode.metadata,
+    )
+    fingerprint1 = ds1.fingerprint
+    indices_path1 = ds1._get_instance_indices_path(path)
+
+    _write_metadata(path, (0, 2), (2, len(data)))
+    ds2 = NumpyPaddedFSLDataset(
+        path,
+        sequence_length=8,
+        pad_token_id=0,
+        eos_token_id=0,
+        vocab_size=32_000,
+        document_boundaries=DocumentBoundaryMode.metadata,
+    )
+    fingerprint2 = ds2.fingerprint
+    indices_path2 = ds2._get_instance_indices_path(path)
+
+    assert fingerprint1 != fingerprint2
+    assert indices_path1 != indices_path2
 
 
 @pytest.mark.parametrize("long_doc_strategy", [LongDocStrategy.truncate, LongDocStrategy.fragment])

--- a/src/test/data/utils_test.py
+++ b/src/test/data/utils_test.py
@@ -1,9 +1,11 @@
+import gzip
 from collections import namedtuple
 
 import numpy as np
 import pytest
 import torch
 
+from olmo_core.data import DocumentBoundaryMode
 from olmo_core.data.utils import (
     InstancePacker,
     SegmentTree,
@@ -63,6 +65,36 @@ def test_iter_document_indices(tmp_path):
     assert list(
         iter_document_indices(data_path, eos_token_id=0, dtype=np.uint16, use_array_if_local=True)
     ) == [(0, 9), (9, len(data))]
+
+
+def test_iter_document_indices_prefers_metadata_over_local_eos_scan(tmp_path):
+    data = [1, 0, 2, 0, 3, 0]
+    data_path = tmp_path / "data.npy"
+    mmap = np.memmap(data_path, mode="w+", dtype=np.uint16, shape=(len(data),))
+    mmap[:] = data
+    mmap.flush()
+
+    with gzip.open(data_path.with_suffix(".csv.gz"), "wt") as f:
+        f.write(f"0,{len(data)}\n")
+
+    assert list(
+        iter_document_indices(
+            data_path,
+            document_boundaries=DocumentBoundaryMode.auto,
+            eos_token_id=0,
+            dtype=np.uint16,
+            use_array_if_local=True,
+        )
+    ) == [(0, len(data))]
+    assert list(
+        iter_document_indices(
+            data_path,
+            document_boundaries=DocumentBoundaryMode.tokenizer,
+            eos_token_id=0,
+            dtype=np.uint16,
+            use_array_if_local=True,
+        )
+    ) == [(0, 2), (2, 4), (4, 6)]
 
 
 @pytest.mark.parametrize("bos_token_id, eos_token_id", [(98, 99), (99, 99)])


### PR DESCRIPTION
## Summary
This PR fixes issue #594 by making document-aware SFT paths prefer sibling `.csv.gz` boundary metadata over rediscovering boundaries from tokenizer EOS tokens.

The key behavior changes are:
- add explicit `DocumentBoundaryMode` support with `auto`, `metadata`, and `tokenizer` modes
- make `NumpyPackedFSLDataset`, `NumpyPaddedFSLDataset`, and `NumpyDocumentSource` use metadata-backed boundaries in `auto` mode when metadata exists for all source files
- reject mixed metadata presence in `auto` mode instead of silently mixing modes
- compute packed `doc_lens` from the packed document spans instead of rescanning token values
- include effective boundary mode and metadata file identity in fingerprints/cache keys when metadata-backed boundaries are used
- update the SFT README to reflect the new metadata-backed behavior

## Motivation
Issue #594 showed that Qwen-style SFT data can break when the tokenizer EOS token also appears at message boundaries. In that case, recovering document boundaries from tokenizer EOS fragments one conversation into many smaller documents.

The upstream SFT conversion pipeline already writes authoritative conversation boundaries into sibling `.csv.gz` metadata files, so this PR uses that metadata directly in the document-aware dataset paths implicated by the issue.

## Design Notes
The change is intentionally narrow:
- low-level utility helpers still default to tokenizer-based behavior so unrelated dataset paths do not change semantics accidentally
- metadata-first behavior is enabled explicitly in the document-aware packed, padded, and composable source paths that need it
- packed runtime `doc_lens` now come from known packed spans, which removes an unnecessary EOS-token dependency from the masking path

## Testing
Focused regression coverage added for:
- metadata precedence over local EOS scanning
- mixed metadata presence failures
- packed `doc_lens` generation from metadata-backed spans
- padded metadata-backed segmentation
- composable `NumpyDocumentSource` metadata-backed offsets
- fingerprint/cache changes when metadata changes

Commands run:
- `uv run pytest src/test/data/utils_test.py src/test/data/numpy_dataset_test.py src/test/data/composable/numpy_document_source_test.py -q`
- `uv run pytest src/test/data -k 'not mixes_test' -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/olmo_core/data/types.py src/olmo_core/data/utils.py src/olmo_core/data/numpy_dataset.py src/olmo_core/data/composable/numpy_document_source.py src/olmo_core/data/__init__.py src/test/data/utils_test.py src/test/data/numpy_dataset_test.py src/test/data/composable/numpy_document_source_test.py`

## Related
- Closes #594