### PR TITLE
Add position_ids-based varlen RoPE support for packed inputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,10 @@ jobs:
 
           - name: Test olmo3 ladder
             run: |
+              if [ -z "$BEAKER_TOKEN" ]; then
+                echo "Skipping OLMo 3 ladder dry-runs because BEAKER_TOKEN is unavailable."
+                exit 0
+              fi
               for size in 190M 370M 600M 760M 1B 3B 7B 13B; do
                 python ./src/scripts/train/ladder/olmo3_ladder.py dry-run --size="$size" --output-dir=./
               done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `HFConverterCallback`, which can be used to convert models to huggingface format at the end of the training run.
 - Trainer now records checkpoint save and load durations as `train/checkpoint_save_duration_s` and `train/checkpoint_load_duration_s` metrics.
+- Added `position_ids`-based variable-length RoPE support for packed transformer inputs.
 
 ### Fixed
 

--- a/src/olmo_core/data/utils.py
+++ b/src/olmo_core/data/utils.py
@@ -399,7 +399,8 @@ def get_position_ids_from_doc_lens(doc_lens: torch.Tensor, seq_len: int) -> torc
     This is intended for packed or intra-document masked training batches where every document
     should reset its RoPE positions back to zero. Padding to ``seq_len`` is filled with zeros.
 
-    :param doc_lens: A 1D or 2D tensor of document lengths.
+    :param doc_lens: A 1D tensor of document lengths for a single packed instance or a 2D batch
+        of zero-padded document lengths.
     :param seq_len: The padded sequence length for each batch item.
     """
     squeeze_output = False
@@ -409,25 +410,37 @@ def get_position_ids_from_doc_lens(doc_lens: torch.Tensor, seq_len: int) -> torc
     elif doc_lens.ndim != 2:
         raise ValueError(f"'doc_lens' must be 1D or 2D (got {doc_lens.ndim}D)")
 
-    position_ids = torch.zeros(
-        (doc_lens.size(0), seq_len), dtype=torch.long, device=doc_lens.device
+    if doc_lens.numel() == 0 or doc_lens.size(1) == 0:
+        position_ids = torch.zeros(
+            (doc_lens.size(0), seq_len), dtype=torch.long, device=doc_lens.device
+        )
+        return position_ids[0] if squeeze_output else position_ids
+
+    if doc_lens.numel() and int(doc_lens.min().item()) < 0:
+        raise ValueError(
+            f"document lengths must be non-negative (got {int(doc_lens.min().item())})"
+        )
+
+    cumulative_doc_ends = torch.cumsum(doc_lens, dim=1, dtype=torch.long)
+    total_lengths = cumulative_doc_ends[:, -1]
+    max_total_length = int(total_lengths.max().item())
+    if max_total_length > seq_len:
+        raise ValueError(
+            f"document lengths sum to {max_total_length}, which exceeds seq_len={seq_len}"
+        )
+
+    # Keep this fully tensorized since it runs in the packed-training hot path.
+    token_positions = (
+        torch.arange(seq_len, device=doc_lens.device, dtype=torch.long)
+        .expand(doc_lens.size(0), -1)
+        .contiguous()
     )
-    for row_idx, row in enumerate(doc_lens):
-        offset = 0
-        for doc_len in row.tolist():
-            if doc_len == 0:
-                continue
-            if doc_len < 0:
-                raise ValueError(f"document lengths must be non-negative (got {doc_len})")
-            next_offset = offset + doc_len
-            if next_offset > seq_len:
-                raise ValueError(
-                    f"document lengths sum to {next_offset}, which exceeds seq_len={seq_len}"
-                )
-            position_ids[row_idx, offset:next_offset] = torch.arange(
-                doc_len, device=doc_lens.device, dtype=torch.long
-            )
-            offset = next_offset
+    doc_indices = torch.searchsorted(cumulative_doc_ends.contiguous(), token_positions, right=True)
+    doc_indices.clamp_(max=doc_lens.size(1) - 1)
+
+    doc_start_offsets = cumulative_doc_ends - doc_lens.to(dtype=torch.long)
+    position_ids = token_positions - doc_start_offsets.gather(1, doc_indices)
+    position_ids.masked_fill_(token_positions >= total_lengths.unsqueeze(1), 0)
 
     return position_ids[0] if squeeze_output else position_ids
 

--- a/src/olmo_core/data/utils.py
+++ b/src/olmo_core/data/utils.py
@@ -392,6 +392,46 @@ def get_cumulative_document_lengths(doc_lens: torch.Tensor) -> torch.Tensor:
     )
 
 
+def get_position_ids_from_doc_lens(doc_lens: torch.Tensor, seq_len: int) -> torch.Tensor:
+    """
+    Build per-token RoPE positions from document lengths.
+
+    This is intended for packed or intra-document masked training batches where every document
+    should reset its RoPE positions back to zero. Padding to ``seq_len`` is filled with zeros.
+
+    :param doc_lens: A 1D or 2D tensor of document lengths.
+    :param seq_len: The padded sequence length for each batch item.
+    """
+    squeeze_output = False
+    if doc_lens.ndim == 1:
+        doc_lens = doc_lens.unsqueeze(0)
+        squeeze_output = True
+    elif doc_lens.ndim != 2:
+        raise ValueError(f"'doc_lens' must be 1D or 2D (got {doc_lens.ndim}D)")
+
+    position_ids = torch.zeros(
+        (doc_lens.size(0), seq_len), dtype=torch.long, device=doc_lens.device
+    )
+    for row_idx, row in enumerate(doc_lens):
+        offset = 0
+        for doc_len in row.tolist():
+            if doc_len == 0:
+                continue
+            if doc_len < 0:
+                raise ValueError(f"document lengths must be non-negative (got {doc_len})")
+            next_offset = offset + doc_len
+            if next_offset > seq_len:
+                raise ValueError(
+                    f"document lengths sum to {next_offset}, which exceeds seq_len={seq_len}"
+                )
+            position_ids[row_idx, offset:next_offset] = torch.arange(
+                doc_len, device=doc_lens.device, dtype=torch.long
+            )
+            offset = next_offset
+
+    return position_ids[0] if squeeze_output else position_ids
+
+
 def iter_batched(
     iterable: Iterable[Dict[str, Any]], batch_num_tokens: int
 ) -> Iterable[Tuple[Dict[str, Any], ...]]:

--- a/src/olmo_core/nn/attention/__init__.py
+++ b/src/olmo_core/nn/attention/__init__.py
@@ -484,6 +484,22 @@ class Attention(SequenceMixer):
     def cp_enabled(self) -> bool:
         return self.backend.cp_enabled
 
+    def _validate_rope_forward_inputs(
+        self,
+        *,
+        position_ids: Optional[torch.Tensor] = None,
+        pos_sin: Optional[torch.Tensor] = None,
+        pos_cos: Optional[torch.Tensor] = None,
+        freqs_cis: Optional[torch.Tensor] = None,
+    ) -> None:
+        if self.kv_cache_manager is not None and position_ids is not None:
+            raise RuntimeError("position_ids are not supported with KV caching")
+        if self.cp_enabled and all(x is None for x in (position_ids, pos_sin, pos_cos, freqs_cis)):
+            raise RuntimeError(
+                "RoPE buffers or position_ids must be passed through to attention after "
+                "being properly sharded by the context parallel load balancer"
+            )
+
     def sdpa(
         self,
         q: torch.Tensor,
@@ -574,6 +590,8 @@ class Attention(SequenceMixer):
             Required together with ``max_doc_len`` when using intra-document masking.
         :param max_doc_len: The maximum document length in the input ``x``.
             Required together with ``cu_doc_lens`` when using intra-document masking.
+        :param position_ids: Optional explicit per-token RoPE positions of shape
+            ``(batch_size, seq_len)``.
 
         :returns: The output of attention with shape ``(batch_size, seq_len, d_model)``.
         """
@@ -611,21 +629,12 @@ class Attention(SequenceMixer):
                 k = self.k_norm(k)
 
         if self.rope is not None:
-            if self.kv_cache_manager is not None and position_ids is not None:
-                raise RuntimeError("position_ids are not supported with KV caching")
-            # In context-parallel mode we must be given pre-sharded buffers
-            if (
-                self.cp_enabled
-                and position_ids is None
-                and pos_sin is None
-                and pos_cos is None
-                and freqs_cis is None
-            ):
-                raise RuntimeError(
-                    "RoPE buffers or position_ids must be passed through to attention after "
-                    "being properly sharded by the context parallel load balancer"
-                )
-
+            self._validate_rope_forward_inputs(
+                position_ids=position_ids,
+                pos_sin=pos_sin,
+                pos_cos=pos_cos,
+                freqs_cis=freqs_cis,
+            )
             start_pos = self.kv_cache_manager.current_position() if self.kv_cache_manager else None
             q, k = self._apply_rope(
                 q,
@@ -931,20 +940,12 @@ class NormalizedAttention(Attention):
         v = v.view(B, T, self.n_kv_heads, self.head_dim)
 
         if self.rope is not None:
-            if self.kv_cache_manager is not None and position_ids is not None:
-                raise RuntimeError("position_ids are not supported with KV caching")
-            if (
-                self.cp_enabled
-                and position_ids is None
-                and pos_sin is None
-                and pos_cos is None
-                and freqs_cis is None
-            ):
-                raise RuntimeError(
-                    "RoPE buffers or position_ids must be passed through to attention after "
-                    "being properly sharded by the context parallel load balancer"
-                )
-
+            self._validate_rope_forward_inputs(
+                position_ids=position_ids,
+                pos_sin=pos_sin,
+                pos_cos=pos_cos,
+                freqs_cis=freqs_cis,
+            )
             start_pos = self.kv_cache_manager.current_position() if self.kv_cache_manager else None
             q, k = self._apply_rope(
                 q,

--- a/src/olmo_core/nn/attention/__init__.py
+++ b/src/olmo_core/nn/attention/__init__.py
@@ -525,6 +525,7 @@ class Attention(SequenceMixer):
         pos_cos: Optional[torch.Tensor],
         freqs_cis: Optional[torch.Tensor],
         cu_doc_lens: Optional[torch.Tensor],
+        position_ids: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         assert self.rope is not None
         rope_kwargs = {}
@@ -540,6 +541,7 @@ class Attention(SequenceMixer):
             k,
             head_first=False,
             start_pos=start_pos,
+            position_ids=position_ids,
             pos_sin=pos_sin,
             pos_cos=pos_cos,
             freqs_cis=freqs_cis,
@@ -556,6 +558,7 @@ class Attention(SequenceMixer):
         max_doc_len_q: Optional[int] = None,
         max_doc_len_k: Optional[int] = None,
         local_k_slice: Optional[slice] = None,
+        position_ids: Optional[torch.Tensor] = None,
         pos_sin: Optional[torch.Tensor] = None,
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
@@ -608,15 +611,32 @@ class Attention(SequenceMixer):
                 k = self.k_norm(k)
 
         if self.rope is not None:
+            if self.kv_cache_manager is not None and position_ids is not None:
+                raise RuntimeError("position_ids are not supported with KV caching")
             # In context-parallel mode we must be given pre-sharded buffers
-            if self.cp_enabled and pos_sin is None and pos_cos is None and freqs_cis is None:
+            if (
+                self.cp_enabled
+                and position_ids is None
+                and pos_sin is None
+                and pos_cos is None
+                and freqs_cis is None
+            ):
                 raise RuntimeError(
-                    "RoPE buffers must be passed through to attention after being properly "
-                    "sharded by the context parallel load balancer"
+                    "RoPE buffers or position_ids must be passed through to attention after "
+                    "being properly sharded by the context parallel load balancer"
                 )
 
             start_pos = self.kv_cache_manager.current_position() if self.kv_cache_manager else None
-            q, k = self._apply_rope(q, k, start_pos, pos_sin, pos_cos, freqs_cis, cu_doc_lens)
+            q, k = self._apply_rope(
+                q,
+                k,
+                start_pos=start_pos,
+                pos_sin=pos_sin,
+                pos_cos=pos_cos,
+                freqs_cis=freqs_cis,
+                cu_doc_lens=cu_doc_lens,
+                position_ids=position_ids,
+            )
 
         # shape: (batch_size, seq_len, n_heads, head_dim)
         att = self.sdpa(
@@ -875,6 +895,7 @@ class NormalizedAttention(Attention):
         max_doc_len_q: Optional[int] = None,
         max_doc_len_k: Optional[int] = None,
         local_k_slice: Optional[slice] = None,
+        position_ids: Optional[torch.Tensor] = None,
         pos_sin: Optional[torch.Tensor] = None,
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
@@ -910,14 +931,31 @@ class NormalizedAttention(Attention):
         v = v.view(B, T, self.n_kv_heads, self.head_dim)
 
         if self.rope is not None:
-            if self.cp_enabled and pos_sin is None and pos_cos is None and freqs_cis is None:
+            if self.kv_cache_manager is not None and position_ids is not None:
+                raise RuntimeError("position_ids are not supported with KV caching")
+            if (
+                self.cp_enabled
+                and position_ids is None
+                and pos_sin is None
+                and pos_cos is None
+                and freqs_cis is None
+            ):
                 raise RuntimeError(
-                    "RoPE buffers must be passed through to attention after being properly "
-                    "sharded by the context parallel load balancer"
+                    "RoPE buffers or position_ids must be passed through to attention after "
+                    "being properly sharded by the context parallel load balancer"
                 )
 
             start_pos = self.kv_cache_manager.current_position() if self.kv_cache_manager else None
-            q, k = self._apply_rope(q, k, start_pos, pos_sin, pos_cos, freqs_cis, cu_doc_lens)
+            q, k = self._apply_rope(
+                q,
+                k,
+                start_pos=start_pos,
+                pos_sin=pos_sin,
+                pos_cos=pos_cos,
+                freqs_cis=freqs_cis,
+                cu_doc_lens=cu_doc_lens,
+                position_ids=position_ids,
+            )
 
         # shape: (batch_size, seq_len, n_heads, head_dim)
         att = self.sdpa(
@@ -1041,6 +1079,7 @@ class FusedAttention(SequenceMixer):
         x: torch.Tensor,
         max_doc_len: Optional[int] = None,
         cu_doc_lens: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
         pos_sin: Optional[torch.Tensor] = None,
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
@@ -1077,12 +1116,20 @@ class FusedAttention(SequenceMixer):
             qkv.clamp_(min=-self.clip_qkv, max=self.clip_qkv)
 
         if self.rope is not None:
+            if position_ids is not None:
+                raise NotImplementedError("position_ids are not yet supported for fused RoPE")
             if self.cp_enabled and pos_sin is None and pos_cos is None and freqs_cis is None:
                 raise RuntimeError(
                     "RoPE buffers must be passed through to attention after being properly "
                     "sharded by the context parallel load balancer"
                 )
-            qkv = self.rope(qkv, pos_sin=pos_sin, pos_cos=pos_cos, freqs_cis=freqs_cis)
+            qkv = self.rope(
+                qkv,
+                position_ids=position_ids,
+                pos_sin=pos_sin,
+                pos_cos=pos_cos,
+                freqs_cis=freqs_cis,
+            )
 
         att = self.backend(
             qkv,

--- a/src/olmo_core/nn/rope.py
+++ b/src/olmo_core/nn/rope.py
@@ -50,6 +50,36 @@ def compute_inv_freqs(theta: int, dim: int, device: torch.device) -> "torch.Tens
     return inv_freq
 
 
+def _validate_position_ids(
+    position_ids: torch.Tensor,
+    *,
+    batch_size: int,
+    q_len: int,
+    k_len: int,
+    start_pos: Optional[int],
+    invalid_input_message: Optional[str],
+    device: torch.device,
+    class_name: str,
+) -> torch.Tensor:
+    if start_pos is not None:
+        raise RuntimeError(f"'start_pos' is invalid when using 'position_ids' with {class_name}")
+    if invalid_input_message is not None:
+        raise RuntimeError(invalid_input_message)
+    if q_len > k_len:
+        raise RuntimeError(
+            f"'position_ids' requires q_len <= k_len (got q_len={q_len}, k_len={k_len})"
+        )
+    if position_ids.ndim != 2 or position_ids.shape != (batch_size, k_len):
+        raise RuntimeError(
+            f"expected 'position_ids' to have shape {(batch_size, k_len)}, "
+            f"got {tuple(position_ids.shape)}"
+        )
+    if position_ids.numel() and int(position_ids.min().item()) < 0:
+        raise RuntimeError("'position_ids' must be non-negative")
+
+    return position_ids.to(device=device, dtype=torch.long)
+
+
 @dataclass
 class RoPEScalingConfig(Config):
     """
@@ -525,41 +555,35 @@ class RotaryEmbedding(RotaryEmbeddingBase):
                         f"'cu_doc_lens' is invalid when using 'position_ids' with "
                         f"{self.__class__.__name__}"
                     )
-                if start_pos is not None:
-                    raise RuntimeError(
-                        f"'start_pos' is invalid when using 'position_ids' with {self.__class__.__name__}"
-                    )
-                if pos_sin is not None or pos_cos is not None:
-                    raise RuntimeError(
+                position_ids = _validate_position_ids(
+                    position_ids,
+                    batch_size=q_.shape[0],
+                    q_len=q_len,
+                    k_len=k_len,
+                    start_pos=start_pos,
+                    invalid_input_message=(
                         f"'pos_sin' and 'pos_cos' are invalid when using 'position_ids' with "
                         f"{self.__class__.__name__}"
-                    )
-                if q_len > k_len:
-                    raise RuntimeError(
-                        f"'position_ids' requires q_len <= k_len (got q_len={q_len}, k_len={k_len})"
-                    )
+                        if pos_sin is not None or pos_cos is not None
+                        else None
+                    ),
+                    device=q_.device,
+                    class_name=self.__class__.__name__,
+                )
 
-                position_ids = position_ids.to(device=q_.device, dtype=torch.long)
-                if position_ids.ndim != 2 or position_ids.shape != (q_.shape[0], k_len):
-                    raise RuntimeError(
-                        f"expected 'position_ids' to have shape {(q_.shape[0], k_len)}, "
-                        f"got {tuple(position_ids.shape)}"
-                    )
-                if position_ids.numel() and int(position_ids.min().item()) < 0:
-                    raise RuntimeError("'position_ids' must be non-negative")
-
-                seq_len_needed = int(position_ids.max().item()) + 1 if position_ids.numel() else 0
+                seq_len_needed = int(position_ids.max().item()) + 1 if position_ids.numel() else 1
                 pos_sin, pos_cos = self._get_rotary_embedding(seq_len_needed, q_.device)
                 pos_sin, pos_cos = pos_sin.type_as(q_), pos_cos.type_as(q_)
+                q_position_ids = position_ids[:, k_len - q_len :]
 
                 if head_first:
-                    sin_q = pos_sin[position_ids[:, k_len - q_len :]].unsqueeze(1)
-                    cos_q = pos_cos[position_ids[:, k_len - q_len :]].unsqueeze(1)
+                    sin_q = pos_sin[q_position_ids].unsqueeze(1)
+                    cos_q = pos_cos[q_position_ids].unsqueeze(1)
                     sin_k = pos_sin[position_ids].unsqueeze(1)
                     cos_k = pos_cos[position_ids].unsqueeze(1)
                 else:
-                    sin_q = pos_sin[position_ids[:, k_len - q_len :]].unsqueeze(2)
-                    cos_q = pos_cos[position_ids[:, k_len - q_len :]].unsqueeze(2)
+                    sin_q = pos_sin[q_position_ids].unsqueeze(2)
+                    cos_q = pos_cos[q_position_ids].unsqueeze(2)
                     sin_k = pos_sin[position_ids].unsqueeze(2)
                     cos_k = pos_cos[position_ids].unsqueeze(2)
 
@@ -714,6 +738,7 @@ class FusedRotaryEmbedding(RotaryEmbeddingBase):
             ``(batch_size, seq_len, 3, n_heads, head_size)``.
         :param start_pos: The absolute position of the first query token (eg for decoding
             where the first query token is just the most recently decoded token).
+        :param position_ids: Explicit position ids. This fused implementation does not support them.
         :return: The qkv tensor after applying RoPE, of the same shape and dtype as the input.
         """
         if freqs_cis is not None:
@@ -846,41 +871,31 @@ class ComplexRotaryEmbedding(RotaryEmbeddingBase):
 
         with torch.autocast(q.device.type, enabled=False):
             if position_ids is not None:
-                if start_pos is not None:
-                    raise RuntimeError(
-                        f"'start_pos' is invalid when using 'position_ids' with {self.__class__.__name__}"
-                    )
-                if freqs_cis is not None:
-                    raise RuntimeError(
+                position_ids = _validate_position_ids(
+                    position_ids,
+                    batch_size=q_.shape[0],
+                    q_len=q_len,
+                    k_len=k_len,
+                    start_pos=start_pos,
+                    invalid_input_message=(
                         f"'freqs_cis' is invalid when using 'position_ids' with "
                         f"{self.__class__.__name__}"
-                    )
-                if q_len > k_len:
-                    raise RuntimeError(
-                        f"'position_ids' requires q_len <= k_len (got q_len={q_len}, k_len={k_len})"
-                    )
+                        if freqs_cis is not None
+                        else None
+                    ),
+                    device=q_.device,
+                    class_name=self.__class__.__name__,
+                )
 
-                position_ids = position_ids.to(device=q_.device, dtype=torch.long)
-                if position_ids.ndim != 2 or position_ids.shape != (q_.shape[0], k_len):
-                    raise RuntimeError(
-                        f"expected 'position_ids' to have shape {(q_.shape[0], k_len)}, "
-                        f"got {tuple(position_ids.shape)}"
-                    )
-                if position_ids.numel() and int(position_ids.min().item()) < 0:
-                    raise RuntimeError("'position_ids' must be non-negative")
-
-                seq_len_needed = int(position_ids.max().item()) + 1
+                seq_len_needed = int(position_ids.max().item()) + 1 if position_ids.numel() else 1
                 freqs_cis = self._get_rotary_embedding(seq_len_needed, q_.device)
+                q_position_ids = position_ids[:, k_len - q_len :]
 
                 if head_first:
-                    q_ = self._apply_rotary_pos_emb(
-                        freqs_cis[position_ids[:, k_len - q_len :]].unsqueeze(1), q_
-                    )
+                    q_ = self._apply_rotary_pos_emb(freqs_cis[q_position_ids].unsqueeze(1), q_)
                     k_ = self._apply_rotary_pos_emb(freqs_cis[position_ids].unsqueeze(1), k_)
                 else:
-                    q_ = self._apply_rotary_pos_emb(
-                        freqs_cis[position_ids[:, k_len - q_len :]].unsqueeze(2), q_
-                    )
+                    q_ = self._apply_rotary_pos_emb(freqs_cis[q_position_ids].unsqueeze(2), q_)
                     k_ = self._apply_rotary_pos_emb(freqs_cis[position_ids].unsqueeze(2), k_)
             else:
                 # shape: (T, hs // 2)

--- a/src/olmo_core/nn/rope.py
+++ b/src/olmo_core/nn/rope.py
@@ -475,6 +475,7 @@ class RotaryEmbedding(RotaryEmbeddingBase):
         k: torch.Tensor,
         head_first: bool = True,
         start_pos: Optional[int] = None,
+        position_ids: Optional[torch.Tensor] = None,
         pos_sin: Optional[torch.Tensor] = None,
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
@@ -491,6 +492,8 @@ class RotaryEmbedding(RotaryEmbeddingBase):
         :param head_first: If the head dim comes before the sequence dim.
         :param start_pos: The absolute position of the first query token (eg for decoding
             where the first query token is just the most recently decoded token).
+        :param position_ids: Explicit per-token RoPE positions with shape
+            ``(batch_size, seq_len)``.
         :param cu_doc_lens: Cumulative document lengths for intra-document RoPE in packed
             inputs. When supplied, each document's tokens receive positions starting from 0
             (matching per-document forwards). Mutually exclusive with ``start_pos``.
@@ -516,50 +519,97 @@ class RotaryEmbedding(RotaryEmbeddingBase):
             q_, k_ = q, k
 
         with torch.autocast(q.device.type, enabled=False):
-            seq_len_needed = (start_pos + k_len) if start_pos is not None else k_len
-            if pos_sin is None or pos_cos is None:
-                pos_sin, pos_cos = self._get_rotary_embedding(seq_len_needed, q_.device)
-            pos_sin, pos_cos = pos_sin.type_as(q_), pos_cos.type_as(q_)
-
-            if pos_sin.size(-2) < seq_len_needed or pos_cos.size(-2) < seq_len_needed:
-                raise RuntimeError(
-                    f"RoPE buffers shorter than required: need {seq_len_needed}, "
-                    f"have {pos_sin.size(-2)}."
-                )
-
-            def _broadcast(t: torch.Tensor) -> torch.Tensor:
-                return t[None, None, :, :] if head_first else t[None, :, None, :]
-
-            if cu_doc_lens is not None:
-                if q_len != k_len:
+            if position_ids is not None:
+                if cu_doc_lens is not None:
                     raise RuntimeError(
-                        "'cu_doc_lens' requires q_len == k_len (no kv-cache packed mode)"
+                        f"'cu_doc_lens' is invalid when using 'position_ids' with "
+                        f"{self.__class__.__name__}"
                     )
-                B = q_.size(0)
-                flat_idx = torch.arange(B * k_len, device=q_.device, dtype=cu_doc_lens.dtype)
-                doc_id = torch.bucketize(flat_idx, cu_doc_lens[1:], right=True)
-                pos_idx = (flat_idx - cu_doc_lens[doc_id]).view(B, k_len)
-                sin_sel = pos_sin.index_select(0, pos_idx.reshape(-1)).view(B, k_len, -1)
-                cos_sel = pos_cos.index_select(0, pos_idx.reshape(-1)).view(B, k_len, -1)
-                if head_first:
-                    sin_qk = sin_sel.unsqueeze(1)
-                    cos_qk = cos_sel.unsqueeze(1)
-                else:
-                    sin_qk = sin_sel.unsqueeze(2)
-                    cos_qk = cos_sel.unsqueeze(2)
-                q_ = self._apply_rotary_pos_emb(sin_qk, cos_qk, q_)
-                k_ = self._apply_rotary_pos_emb(sin_qk, cos_qk, k_)
-            else:
-                q_abs_start = start_pos if start_pos is not None else (k_len - q_len)
-                k_abs_start = start_pos if start_pos is not None else 0
+                if start_pos is not None:
+                    raise RuntimeError(
+                        f"'start_pos' is invalid when using 'position_ids' with {self.__class__.__name__}"
+                    )
+                if pos_sin is not None or pos_cos is not None:
+                    raise RuntimeError(
+                        f"'pos_sin' and 'pos_cos' are invalid when using 'position_ids' with "
+                        f"{self.__class__.__name__}"
+                    )
+                if q_len > k_len:
+                    raise RuntimeError(
+                        f"'position_ids' requires q_len <= k_len (got q_len={q_len}, k_len={k_len})"
+                    )
 
-                sin_q = _broadcast(pos_sin[q_abs_start : q_abs_start + q_len, :])
-                cos_q = _broadcast(pos_cos[q_abs_start : q_abs_start + q_len, :])
-                sin_k = _broadcast(pos_sin[k_abs_start : k_abs_start + k_len, :])
-                cos_k = _broadcast(pos_cos[k_abs_start : k_abs_start + k_len, :])
+                position_ids = position_ids.to(device=q_.device, dtype=torch.long)
+                if position_ids.ndim != 2 or position_ids.shape != (q_.shape[0], k_len):
+                    raise RuntimeError(
+                        f"expected 'position_ids' to have shape {(q_.shape[0], k_len)}, "
+                        f"got {tuple(position_ids.shape)}"
+                    )
+                if position_ids.numel() and int(position_ids.min().item()) < 0:
+                    raise RuntimeError("'position_ids' must be non-negative")
+
+                seq_len_needed = int(position_ids.max().item()) + 1 if position_ids.numel() else 0
+                pos_sin, pos_cos = self._get_rotary_embedding(seq_len_needed, q_.device)
+                pos_sin, pos_cos = pos_sin.type_as(q_), pos_cos.type_as(q_)
+
+                if head_first:
+                    sin_q = pos_sin[position_ids[:, k_len - q_len :]].unsqueeze(1)
+                    cos_q = pos_cos[position_ids[:, k_len - q_len :]].unsqueeze(1)
+                    sin_k = pos_sin[position_ids].unsqueeze(1)
+                    cos_k = pos_cos[position_ids].unsqueeze(1)
+                else:
+                    sin_q = pos_sin[position_ids[:, k_len - q_len :]].unsqueeze(2)
+                    cos_q = pos_cos[position_ids[:, k_len - q_len :]].unsqueeze(2)
+                    sin_k = pos_sin[position_ids].unsqueeze(2)
+                    cos_k = pos_cos[position_ids].unsqueeze(2)
 
                 q_ = self._apply_rotary_pos_emb(sin_q, cos_q, q_)
                 k_ = self._apply_rotary_pos_emb(sin_k, cos_k, k_)
+            else:
+                seq_len_needed = (start_pos + k_len) if start_pos is not None else k_len
+                if pos_sin is None or pos_cos is None:
+                    pos_sin, pos_cos = self._get_rotary_embedding(seq_len_needed, q_.device)
+                pos_sin, pos_cos = pos_sin.type_as(q_), pos_cos.type_as(q_)
+
+                if pos_sin.size(-2) < seq_len_needed or pos_cos.size(-2) < seq_len_needed:
+                    raise RuntimeError(
+                        f"RoPE buffers shorter than required: need {seq_len_needed}, "
+                        f"have {pos_sin.size(-2)}."
+                    )
+
+                def _broadcast(t: torch.Tensor) -> torch.Tensor:
+                    return t[None, None, :, :] if head_first else t[None, :, None, :]
+
+                if cu_doc_lens is not None:
+                    if q_len != k_len:
+                        raise RuntimeError(
+                            "'cu_doc_lens' requires q_len == k_len (no kv-cache packed mode)"
+                        )
+                    B = q_.size(0)
+                    flat_idx = torch.arange(B * k_len, device=q_.device, dtype=cu_doc_lens.dtype)
+                    doc_id = torch.bucketize(flat_idx, cu_doc_lens[1:], right=True)
+                    pos_idx = (flat_idx - cu_doc_lens[doc_id]).view(B, k_len)
+                    sin_sel = pos_sin.index_select(0, pos_idx.reshape(-1)).view(B, k_len, -1)
+                    cos_sel = pos_cos.index_select(0, pos_idx.reshape(-1)).view(B, k_len, -1)
+                    if head_first:
+                        sin_qk = sin_sel.unsqueeze(1)
+                        cos_qk = cos_sel.unsqueeze(1)
+                    else:
+                        sin_qk = sin_sel.unsqueeze(2)
+                        cos_qk = cos_sel.unsqueeze(2)
+                    q_ = self._apply_rotary_pos_emb(sin_qk, cos_qk, q_)
+                    k_ = self._apply_rotary_pos_emb(sin_qk, cos_qk, k_)
+                else:
+                    q_abs_start = start_pos if start_pos is not None else (k_len - q_len)
+                    k_abs_start = start_pos if start_pos is not None else 0
+
+                    sin_q = _broadcast(pos_sin[q_abs_start : q_abs_start + q_len, :])
+                    cos_q = _broadcast(pos_cos[q_abs_start : q_abs_start + q_len, :])
+                    sin_k = _broadcast(pos_sin[k_abs_start : k_abs_start + k_len, :])
+                    cos_k = _broadcast(pos_cos[k_abs_start : k_abs_start + k_len, :])
+
+                    q_ = self._apply_rotary_pos_emb(sin_q, cos_q, q_)
+                    k_ = self._apply_rotary_pos_emb(sin_k, cos_k, k_)
 
         return q_.type_as(q), k_.type_as(k)
 
@@ -648,6 +698,7 @@ class FusedRotaryEmbedding(RotaryEmbeddingBase):
         self,
         qkv: torch.Tensor,
         start_pos: Optional[int] = None,
+        position_ids: Optional[torch.Tensor] = None,
         pos_sin: Optional[torch.Tensor] = None,
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
@@ -667,6 +718,8 @@ class FusedRotaryEmbedding(RotaryEmbeddingBase):
         """
         if freqs_cis is not None:
             raise RuntimeError(f"'freqs_cis' is invalid for {self.__class__.__name__}")
+        if position_ids is not None:
+            raise RuntimeError(f"'position_ids' is invalid for {self.__class__.__name__}")
 
         if self.full_precision:
             qkv_ = qkv.float()
@@ -750,6 +803,7 @@ class ComplexRotaryEmbedding(RotaryEmbeddingBase):
         k: torch.Tensor,
         head_first: bool = True,
         start_pos: Optional[int] = None,
+        position_ids: Optional[torch.Tensor] = None,
         pos_sin: Optional[torch.Tensor] = None,
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
@@ -765,6 +819,7 @@ class ComplexRotaryEmbedding(RotaryEmbeddingBase):
         :param head_first: If the head dim comes before the sequence dim.
         :param start_pos: The absolute position of the first query token (eg for decoding
             where the first query token is just the most recently decoded token).
+        :param position_ids: Explicit per-token RoPE positions with shape ``(batch_size, seq_len)``.
 
         :returns: The query and key matrices after RoPE has been applied.
         """
@@ -790,26 +845,64 @@ class ComplexRotaryEmbedding(RotaryEmbeddingBase):
         k_ = torch.view_as_complex(k_.reshape(*k_.shape[:-1], -1, 2))
 
         with torch.autocast(q.device.type, enabled=False):
-            # shape: (T, hs // 2)
-            seq_len_needed = (start_pos + k_len) if start_pos is not None else k_len
-            if freqs_cis is None:
-                freqs_cis = self._get_rotary_embedding(seq_len_needed, q_.device)
-            q_abs_start = start_pos if start_pos is not None else (k_len - q_len)
-            k_abs_start = start_pos if start_pos is not None else 0
+            if position_ids is not None:
+                if start_pos is not None:
+                    raise RuntimeError(
+                        f"'start_pos' is invalid when using 'position_ids' with {self.__class__.__name__}"
+                    )
+                if freqs_cis is not None:
+                    raise RuntimeError(
+                        f"'freqs_cis' is invalid when using 'position_ids' with "
+                        f"{self.__class__.__name__}"
+                    )
+                if q_len > k_len:
+                    raise RuntimeError(
+                        f"'position_ids' requires q_len <= k_len (got q_len={q_len}, k_len={k_len})"
+                    )
 
-            if head_first:
-                q_ = self._apply_rotary_pos_emb(
-                    freqs_cis[None, None, q_abs_start : q_abs_start + q_len, :], q_
-                )
-                k_ = self._apply_rotary_pos_emb(
-                    freqs_cis[None, None, k_abs_start : k_abs_start + k_len, :], k_
-                )
+                position_ids = position_ids.to(device=q_.device, dtype=torch.long)
+                if position_ids.ndim != 2 or position_ids.shape != (q_.shape[0], k_len):
+                    raise RuntimeError(
+                        f"expected 'position_ids' to have shape {(q_.shape[0], k_len)}, "
+                        f"got {tuple(position_ids.shape)}"
+                    )
+                if position_ids.numel() and int(position_ids.min().item()) < 0:
+                    raise RuntimeError("'position_ids' must be non-negative")
+
+                seq_len_needed = int(position_ids.max().item()) + 1
+                freqs_cis = self._get_rotary_embedding(seq_len_needed, q_.device)
+
+                if head_first:
+                    q_ = self._apply_rotary_pos_emb(
+                        freqs_cis[position_ids[:, k_len - q_len :]].unsqueeze(1), q_
+                    )
+                    k_ = self._apply_rotary_pos_emb(freqs_cis[position_ids].unsqueeze(1), k_)
+                else:
+                    q_ = self._apply_rotary_pos_emb(
+                        freqs_cis[position_ids[:, k_len - q_len :]].unsqueeze(2), q_
+                    )
+                    k_ = self._apply_rotary_pos_emb(freqs_cis[position_ids].unsqueeze(2), k_)
             else:
-                q_ = self._apply_rotary_pos_emb(
-                    freqs_cis[None, q_abs_start : q_abs_start + q_len, None, :], q_
-                )
-                k_ = self._apply_rotary_pos_emb(
-                    freqs_cis[None, k_abs_start : k_abs_start + k_len, None, :], k_
-                )
+                # shape: (T, hs // 2)
+                seq_len_needed = (start_pos + k_len) if start_pos is not None else k_len
+                if freqs_cis is None:
+                    freqs_cis = self._get_rotary_embedding(seq_len_needed, q_.device)
+                q_abs_start = start_pos if start_pos is not None else (k_len - q_len)
+                k_abs_start = start_pos if start_pos is not None else 0
+
+                if head_first:
+                    q_ = self._apply_rotary_pos_emb(
+                        freqs_cis[None, None, q_abs_start : q_abs_start + q_len, :], q_
+                    )
+                    k_ = self._apply_rotary_pos_emb(
+                        freqs_cis[None, None, k_abs_start : k_abs_start + k_len, :], k_
+                    )
+                else:
+                    q_ = self._apply_rotary_pos_emb(
+                        freqs_cis[None, q_abs_start : q_abs_start + q_len, None, :], q_
+                    )
+                    k_ = self._apply_rotary_pos_emb(
+                        freqs_cis[None, k_abs_start : k_abs_start + k_len, None, :], k_
+                    )
 
         return q_.type_as(q), k_.type_as(k)

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -25,7 +25,7 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
 )
 
-from olmo_core.data.utils import get_cumulative_document_lengths
+from olmo_core.data.utils import get_cumulative_document_lengths, get_position_ids_from_doc_lens
 from olmo_core.distributed.parallel import get_pp_mesh
 from olmo_core.distributed.utils import hide_from_torch, unhide_from_torch
 from olmo_core.doc_utils import beta_feature
@@ -391,13 +391,31 @@ class Transformer(nn.Module):
         max_doc_len: Optional[int] = None
         cu_doc_lens: Optional[torch.Tensor] = None
         doc_lens: Optional[torch.Tensor] = None
+        position_ids: Optional[torch.Tensor] = kwargs.pop("position_ids", None)
         cache_leftpad: Optional[torch.Tensor] = kwargs.pop("cache_leftpad", None)
 
-        if (doc_lens := kwargs.pop("doc_lens", None)) is not None and (
-            max_doc_lens := kwargs.pop("max_doc_lens", None)
-        ) is not None:
-            max_doc_len = max(max_doc_lens)
-            cu_doc_lens = get_cumulative_document_lengths(doc_lens)
+        doc_lens = kwargs.pop("doc_lens", None)
+        max_doc_lens = kwargs.pop("max_doc_lens", None)
+        if doc_lens is not None:
+            if position_ids is None:
+                position_ids = get_position_ids_from_doc_lens(doc_lens, S)
+            if max_doc_lens is not None:
+                max_doc_len = max(max_doc_lens)
+                cu_doc_lens = get_cumulative_document_lengths(doc_lens)
+        elif max_doc_lens is not None:
+            raise ValueError("'max_doc_lens' is invalid without 'doc_lens'")
+
+        if position_ids is not None:
+            position_ids = position_ids.to(device=input_ids.device, dtype=torch.long)
+            if position_ids.ndim != 2 or position_ids.shape != (B, S):
+                raise ValueError(
+                    f"'position_ids' must have shape {(B, S)} (got {tuple(position_ids.shape)})"
+                )
+
+            for block in self.blocks.values():
+                if not isinstance(block.attention, FusedAttention) or block.attention.rope is None:
+                    continue
+                raise NotImplementedError("position_ids are not yet supported with fused RoPE")
 
         # Shard inputs and RoPE buffers on sequence dimension if using context parallelism.
         if (cp_load_balancer := self._cp_load_balancer) is not None:
@@ -406,25 +424,33 @@ class Transformer(nn.Module):
             pad_values: List[Union[int, float]] = [0]
             keys = ["input_ids"]
 
-            # NOTE: initialize buffer(s) on CPU to avoid possible host-device sync when sharding.
-            for block_idx, rope_buffers in self.get_rope_buffers(S, torch.device("cpu")).items():
-                if rope_buffers is not None:
-                    # Also shard RoPE buffers based on the context parallelism load balancer.
-                    if rope_buffers.pos_sin is not None:
-                        inputs.append(rope_buffers.pos_sin)
-                        seq_dims.append(0)
-                        pad_values.append(0.0)
-                        keys.append(f"block_{block_idx}.pos_sin")
-                    if rope_buffers.pos_cos is not None:
-                        inputs.append(rope_buffers.pos_cos)
-                        seq_dims.append(0)
-                        pad_values.append(0.0)
-                        keys.append(f"block_{block_idx}.pos_cos")
-                    if rope_buffers.freqs_cis is not None:
-                        inputs.append(rope_buffers.freqs_cis)
-                        seq_dims.append(0)
-                        pad_values.append(0.0)
-                        keys.append(f"block_{block_idx}.freqs_cis")
+            if position_ids is not None:
+                inputs.append(position_ids)
+                seq_dims.append(1)
+                pad_values.append(0)
+                keys.append("position_ids")
+            else:
+                # NOTE: initialize buffer(s) on CPU to avoid possible host-device sync when sharding.
+                for block_idx, rope_buffers in self.get_rope_buffers(
+                    S, torch.device("cpu")
+                ).items():
+                    if rope_buffers is not None:
+                        # Also shard RoPE buffers based on the context parallelism load balancer.
+                        if rope_buffers.pos_sin is not None:
+                            inputs.append(rope_buffers.pos_sin)
+                            seq_dims.append(0)
+                            pad_values.append(0.0)
+                            keys.append(f"block_{block_idx}.pos_sin")
+                        if rope_buffers.pos_cos is not None:
+                            inputs.append(rope_buffers.pos_cos)
+                            seq_dims.append(0)
+                            pad_values.append(0.0)
+                            keys.append(f"block_{block_idx}.pos_cos")
+                        if rope_buffers.freqs_cis is not None:
+                            inputs.append(rope_buffers.freqs_cis)
+                            seq_dims.append(0)
+                            pad_values.append(0.0)
+                            keys.append(f"block_{block_idx}.freqs_cis")
 
             if labels is not None:
                 inputs.append(labels)
@@ -482,11 +508,15 @@ class Transformer(nn.Module):
             if max_doc_len is not None or cu_doc_lens is not None:
                 all_block_kwargs["max_doc_len"] = max_doc_len
                 all_block_kwargs["cu_doc_lens"] = move_to_device(cu_doc_lens, self.device)
+            if position_ids is not None:
+                all_block_kwargs["position_ids"] = move_to_device(position_ids, self.device)
             if cache_leftpad is not None:
                 all_block_kwargs["cache_leftpad"] = move_to_device(cache_leftpad, self.device)
 
         if "cu_doc_lens" in all_block_kwargs:
             mark_dynamic(all_block_kwargs["cu_doc_lens"], 0, strict=False)  # type: ignore[arg-type]
+        if "position_ids" in all_block_kwargs:
+            mark_dynamic(all_block_kwargs["position_ids"], (0, 1), strict=False)
 
         return (
             input_ids,

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -26,7 +26,10 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
 )
 
-from olmo_core.data.utils import get_cumulative_document_lengths, get_position_ids_from_doc_lens
+from olmo_core.data.utils import (
+    get_cumulative_document_lengths,
+    get_position_ids_from_doc_lens,
+)
 from olmo_core.distributed.parallel import get_pp_mesh
 from olmo_core.distributed.utils import hide_from_torch, unhide_from_torch
 from olmo_core.doc_utils import beta_feature

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Iterable,
     List,
     Literal,
     Optional,
@@ -247,6 +248,41 @@ class Transformer(nn.Module):
                 rope_buffers[int(key)] = None
         return rope_buffers
 
+    def _iter_context_parallel_rope_inputs(
+        self, seq_len: int
+    ) -> Iterable[Tuple[str, torch.Tensor, int, float]]:
+        # NOTE: initialize buffer(s) on CPU to avoid possible host-device sync when sharding.
+        for block_idx, rope_buffers in self.get_rope_buffers(seq_len, torch.device("cpu")).items():
+            if rope_buffers is None:
+                continue
+            if rope_buffers.pos_sin is not None:
+                yield f"block_{block_idx}.pos_sin", rope_buffers.pos_sin, 0, 0.0
+            if rope_buffers.pos_cos is not None:
+                yield f"block_{block_idx}.pos_cos", rope_buffers.pos_cos, 0, 0.0
+            if rope_buffers.freqs_cis is not None:
+                yield f"block_{block_idx}.freqs_cis", rope_buffers.freqs_cis, 0, 0.0
+
+    def _has_rope(self) -> bool:
+        return any(
+            isinstance(block.attention, (Attention, FusedAttention))
+            and block.attention.rope is not None
+            for block in self.blocks.values()
+        )
+
+    def _validate_position_ids(
+        self, position_ids: torch.Tensor, batch_size: int, seq_len: int
+    ) -> None:
+        if position_ids.ndim != 2 or position_ids.shape != (batch_size, seq_len):
+            raise ValueError(
+                f"'position_ids' must have shape {(batch_size, seq_len)} "
+                f"(got {tuple(position_ids.shape)})"
+            )
+
+        for block in self.blocks.values():
+            if not isinstance(block.attention, FusedAttention) or block.attention.rope is None:
+                continue
+            raise NotImplementedError("position_ids are not yet supported with fused RoPE")
+
     @torch.no_grad()
     def init_weights(
         self,
@@ -397,7 +433,7 @@ class Transformer(nn.Module):
         doc_lens = kwargs.pop("doc_lens", None)
         max_doc_lens = kwargs.pop("max_doc_lens", None)
         if doc_lens is not None:
-            if position_ids is None:
+            if position_ids is None and self._has_rope():
                 position_ids = get_position_ids_from_doc_lens(doc_lens, S)
             if max_doc_lens is not None:
                 max_doc_len = max(max_doc_lens)
@@ -406,16 +442,8 @@ class Transformer(nn.Module):
             raise ValueError("'max_doc_lens' is invalid without 'doc_lens'")
 
         if position_ids is not None:
+            self._validate_position_ids(position_ids, B, S)
             position_ids = position_ids.to(device=input_ids.device, dtype=torch.long)
-            if position_ids.ndim != 2 or position_ids.shape != (B, S):
-                raise ValueError(
-                    f"'position_ids' must have shape {(B, S)} (got {tuple(position_ids.shape)})"
-                )
-
-            for block in self.blocks.values():
-                if not isinstance(block.attention, FusedAttention) or block.attention.rope is None:
-                    continue
-                raise NotImplementedError("position_ids are not yet supported with fused RoPE")
 
         # Shard inputs and RoPE buffers on sequence dimension if using context parallelism.
         if (cp_load_balancer := self._cp_load_balancer) is not None:
@@ -430,27 +458,13 @@ class Transformer(nn.Module):
                 pad_values.append(0)
                 keys.append("position_ids")
             else:
-                # NOTE: initialize buffer(s) on CPU to avoid possible host-device sync when sharding.
-                for block_idx, rope_buffers in self.get_rope_buffers(
-                    S, torch.device("cpu")
-                ).items():
-                    if rope_buffers is not None:
-                        # Also shard RoPE buffers based on the context parallelism load balancer.
-                        if rope_buffers.pos_sin is not None:
-                            inputs.append(rope_buffers.pos_sin)
-                            seq_dims.append(0)
-                            pad_values.append(0.0)
-                            keys.append(f"block_{block_idx}.pos_sin")
-                        if rope_buffers.pos_cos is not None:
-                            inputs.append(rope_buffers.pos_cos)
-                            seq_dims.append(0)
-                            pad_values.append(0.0)
-                            keys.append(f"block_{block_idx}.pos_cos")
-                        if rope_buffers.freqs_cis is not None:
-                            inputs.append(rope_buffers.freqs_cis)
-                            seq_dims.append(0)
-                            pad_values.append(0.0)
-                            keys.append(f"block_{block_idx}.freqs_cis")
+                for key, rope_input, seq_dim, pad_value in self._iter_context_parallel_rope_inputs(
+                    S
+                ):
+                    inputs.append(rope_input)
+                    seq_dims.append(seq_dim)
+                    pad_values.append(pad_value)
+                    keys.append(key)
 
             if labels is not None:
                 inputs.append(labels)

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -426,20 +426,21 @@ class Transformer(nn.Module):
         # Prepare document length inputs.
         max_doc_len: Optional[int] = None
         cu_doc_lens: Optional[torch.Tensor] = None
-        doc_lens: Optional[torch.Tensor] = None
         position_ids: Optional[torch.Tensor] = kwargs.pop("position_ids", None)
         cache_leftpad: Optional[torch.Tensor] = kwargs.pop("cache_leftpad", None)
 
-        doc_lens = kwargs.pop("doc_lens", None)
+        doc_lens: Optional[torch.Tensor] = kwargs.pop("doc_lens", None)
         max_doc_lens = kwargs.pop("max_doc_lens", None)
-        if doc_lens is not None:
-            if position_ids is None and self._has_rope():
-                position_ids = get_position_ids_from_doc_lens(doc_lens, S)
-            if max_doc_lens is not None:
-                max_doc_len = max(max_doc_lens)
-                cu_doc_lens = get_cumulative_document_lengths(doc_lens)
-        elif max_doc_lens is not None:
+
+        if max_doc_lens is not None and doc_lens is None:
             raise ValueError("'max_doc_lens' is invalid without 'doc_lens'")
+
+        if doc_lens is not None and position_ids is None and self._has_rope():
+            position_ids = get_position_ids_from_doc_lens(doc_lens, S)
+
+        if max_doc_lens is not None:
+            max_doc_len = max(max_doc_lens)
+            cu_doc_lens = get_cumulative_document_lengths(cast(torch.Tensor, doc_lens))
 
         if position_ids is not None:
             self._validate_position_ids(position_ids, B, S)

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from functools import partial
 from typing import Generator
@@ -24,9 +25,18 @@ def unique_name() -> str:
     return uuid.uuid4().hex
 
 
+def _has_aws_credentials() -> bool:
+    return bool(os.environ.get("AWS_ACCESS_KEY_ID")) and bool(
+        os.environ.get("AWS_SECRET_ACCESS_KEY")
+    )
+
+
 @pytest.fixture
 def s3_checkpoint_dir(bucket_name, unique_name) -> Generator[str, None, None]:
     from botocore.exceptions import NoCredentialsError
+
+    if not _has_aws_credentials():
+        pytest.skip("Requires AWS credentials")
 
     folder = f"s3://{bucket_name}/checkpoints/{unique_name}"
     yield folder

--- a/src/test/data/mixes_test.py
+++ b/src/test/data/mixes_test.py
@@ -1,7 +1,14 @@
+import os
+
 import pytest
 
 from olmo_core.data import DataMix, TokenizerName
 from olmo_core.io import file_exists
+
+
+def _skip_without_aws_credentials() -> None:
+    if not os.environ.get("AWS_ACCESS_KEY_ID") or not os.environ.get("AWS_SECRET_ACCESS_KEY"):
+        pytest.skip("Requires AWS credentials")
 
 
 def test_olmoe_mix():
@@ -14,6 +21,7 @@ def test_olmoe_mix():
         == "s3://ai2-llm/preprocessed/olmo-mix/danyh-compiled-v1_7/documents/wiki/allenai/dolma2-tokenizer/part-1-00000.npy"
     )
 
+    _skip_without_aws_credentials()
     try:
         assert file_exists(paths[-1])
     except NoCredentialsError:
@@ -30,6 +38,7 @@ def test_dolma17_mix():
         == "s3://ai2-llm/preprocessed/olmo-mix/v1_7-dd_ngram_dp_030-qc_cc_en_bin_001/cc_en_tail/gpt-neox-olmo-dolma-v1_5/part-092-00000.npy"
     )
 
+    _skip_without_aws_credentials()
     try:
         assert file_exists(paths[-1])
     except NoCredentialsError:
@@ -47,6 +56,7 @@ def test_v3_small_ppl_validation_mix():
     )
     assert labels[0] == "c4_en-validation"
 
+    _skip_without_aws_credentials()
     try:
         assert file_exists(paths[-1])
     except NoCredentialsError:

--- a/src/test/data/utils_test.py
+++ b/src/test/data/utils_test.py
@@ -185,31 +185,40 @@ def test_get_cumulative_document_lengths():
     ).tolist() == [0, 1, 6, 9, 11, 16, 19, 22]
 
 
-def test_get_position_ids_from_doc_lens():
-    assert get_position_ids_from_doc_lens(
-        torch.tensor(
+@pytest.mark.parametrize(
+    ("doc_lens", "seq_len", "expected"),
+    [
+        pytest.param(
+            torch.tensor(
+                [
+                    [2, 3, 0],
+                    [1, 2, 1],
+                ],
+                dtype=torch.int32,
+            ),
+            6,
             [
-                [2, 3, 0],
-                [1, 2, 1],
+                [0, 1, 0, 1, 2, 0],
+                [0, 0, 1, 0, 0, 0],
             ],
-            dtype=torch.int32,
+            id="batched",
         ),
-        seq_len=6,
-    ).tolist() == [
-        [0, 1, 0, 1, 2, 0],
-        [0, 0, 1, 0, 0, 0],
-    ]
-
-    assert get_position_ids_from_doc_lens(
-        torch.tensor([3, 2, 0], dtype=torch.int32), seq_len=6
-    ).tolist() == [
-        0,
-        1,
-        2,
-        0,
-        1,
-        0,
-    ]
+        pytest.param(
+            torch.tensor([3, 2, 0], dtype=torch.int32),
+            6,
+            [0, 1, 2, 0, 1, 0],
+            id="single-instance",
+        ),
+        pytest.param(
+            torch.tensor([[2, 0, 3]], dtype=torch.int32),
+            6,
+            [[0, 1, 0, 1, 2, 0]],
+            id="internal-zero-length-doc",
+        ),
+    ],
+)
+def test_get_position_ids_from_doc_lens(doc_lens: torch.Tensor, seq_len: int, expected):
+    assert get_position_ids_from_doc_lens(doc_lens, seq_len=seq_len).tolist() == expected
 
 
 def test_get_position_ids_from_doc_lens_errors():

--- a/src/test/data/utils_test.py
+++ b/src/test/data/utils_test.py
@@ -11,6 +11,7 @@ from olmo_core.data.utils import (
     bucket_documents,
     get_cumulative_document_lengths,
     get_document_lengths,
+    get_position_ids_from_doc_lens,
     iter_batched,
     iter_document_indices,
     melt_batch,
@@ -182,6 +183,44 @@ def test_get_cumulative_document_lengths():
             dtype=torch.int32,
         )
     ).tolist() == [0, 1, 6, 9, 11, 16, 19, 22]
+
+
+def test_get_position_ids_from_doc_lens():
+    assert get_position_ids_from_doc_lens(
+        torch.tensor(
+            [
+                [2, 3, 0],
+                [1, 2, 1],
+            ],
+            dtype=torch.int32,
+        ),
+        seq_len=6,
+    ).tolist() == [
+        [0, 1, 0, 1, 2, 0],
+        [0, 0, 1, 0, 0, 0],
+    ]
+
+    assert get_position_ids_from_doc_lens(
+        torch.tensor([3, 2, 0], dtype=torch.int32), seq_len=6
+    ).tolist() == [
+        0,
+        1,
+        2,
+        0,
+        1,
+        0,
+    ]
+
+
+def test_get_position_ids_from_doc_lens_errors():
+    with pytest.raises(ValueError, match="non-negative"):
+        get_position_ids_from_doc_lens(torch.tensor([[2, -1]], dtype=torch.int32), seq_len=4)
+
+    with pytest.raises(ValueError, match="exceeds seq_len"):
+        get_position_ids_from_doc_lens(torch.tensor([[2, 3]], dtype=torch.int32), seq_len=4)
+
+    with pytest.raises(ValueError, match="must be 1D or 2D"):
+        get_position_ids_from_doc_lens(torch.ones(1, 1, 1, dtype=torch.int32), seq_len=1)
 
 
 def test_iter_batched():

--- a/src/test/launch/beaker_test.py
+++ b/src/test/launch/beaker_test.py
@@ -4,7 +4,12 @@ import pytest
 
 from olmo_core.launch.beaker import OLMoCoreBeakerImage, get_beaker_client
 
+requires_beaker_token = pytest.mark.skipif(
+    os.environ.get("BEAKER_TOKEN", "") == "", reason="Missing 'BEAKER_TOKEN' env var"
+)
 
+
+@requires_beaker_token
 def test_get_beaker_client_caching():
     with get_beaker_client(workspace="ai2/OLMo-core") as beaker1:
         # Should get the same client since we're requesting the same workspace.
@@ -37,9 +42,7 @@ def beaker():
         yield beaker
 
 
-@pytest.mark.skipif(
-    os.environ.get("BEAKER_TOKEN", "") == "", reason="Missing 'BEAKER_TOKEN' env var"
-)
+@requires_beaker_token
 @pytest.mark.parametrize("image", list(OLMoCoreBeakerImage))
 def test_official_images_exist(image, beaker):
     beaker.image.get(image)

--- a/src/test/nn/attention/attention_test.py
+++ b/src/test/nn/attention/attention_test.py
@@ -489,6 +489,28 @@ def test_fused_attention_rejects_position_ids_with_rope():
 
 
 @requires_gpu
+def test_attention_rejects_position_ids_with_kv_cache():
+    seed_all(0)
+
+    d_model = 128
+    seq_len = 8
+    attention = Attention(
+        d_model=d_model,
+        n_heads=8,
+        rope=RoPEConfig(),
+        backend=AttentionBackendName.torch,
+        init_device="cuda",
+    )
+    attention.init_kv_cache_manager(batch_size=1, max_seq_len=16)
+    x = torch.randn(1, seq_len, d_model, dtype=torch.bfloat16, device="cuda")
+    position_ids = torch.arange(seq_len, device="cuda").unsqueeze(0)
+
+    with pytest.raises(RuntimeError, match="KV caching"):
+        with torch.no_grad(), torch.autocast("cuda", dtype=torch.bfloat16):
+            attention(x, position_ids=position_ids)
+
+
+@requires_gpu
 @requires_compute_capability(min_cc=9)  # flash-attn bf16 precision is worse on A100s (cc=8)
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize(

--- a/src/test/nn/attention/attention_test.py
+++ b/src/test/nn/attention/attention_test.py
@@ -5,7 +5,10 @@ import torch
 import torch.nn.functional as F
 from torch.distributed.tensor import Shard, init_device_mesh
 
-from olmo_core.data.utils import attention_mask_to_cache_leftpad, get_position_ids_from_doc_lens
+from olmo_core.data.utils import (
+    attention_mask_to_cache_leftpad,
+    get_position_ids_from_doc_lens,
+)
 from olmo_core.distributed.checkpoint import (
     load_model_and_optim_state,
     save_model_and_optim_state,

--- a/src/test/nn/attention/attention_test.py
+++ b/src/test/nn/attention/attention_test.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch.distributed.tensor import Shard, init_device_mesh
 
-from olmo_core.data.utils import attention_mask_to_cache_leftpad
+from olmo_core.data.utils import attention_mask_to_cache_leftpad, get_position_ids_from_doc_lens
 from olmo_core.distributed.checkpoint import (
     load_model_and_optim_state,
     save_model_and_optim_state,
@@ -424,6 +424,68 @@ def test_attention_with_intra_document_masking():
     torch.testing.assert_close(y1_fused, y2_fused)
     torch.testing.assert_close(y1, y1_fused)
     torch.testing.assert_close(y2, y2_fused)
+
+
+@requires_gpu
+@requires_flash_attn_2
+def test_attention_rope_position_ids_match_document_reference():
+    seed_all(0)
+
+    d_model = 128
+    n_heads = 8
+    doc_lens = torch.tensor([[3, 4, 5]], dtype=torch.int32)
+    seq_len = int(doc_lens.sum())
+    position_ids = get_position_ids_from_doc_lens(doc_lens, seq_len).to("cuda")
+    cu_doc_lens = torch.cat(
+        [
+            torch.tensor([0], dtype=torch.int32),
+            torch.cumsum(doc_lens.flatten(), dim=0, dtype=torch.int32),
+        ]
+    ).to("cuda")
+
+    attention = Attention(
+        d_model=d_model,
+        n_heads=n_heads,
+        rope=RoPEConfig(),
+        backend=AttentionBackendName.flash_2,
+        init_device="cuda",
+    )
+    x = torch.randn(1, seq_len, d_model, dtype=torch.bfloat16, device="cuda")
+
+    with torch.no_grad(), torch.autocast("cuda", dtype=torch.bfloat16):
+        y_packed = attention(
+            x,
+            max_doc_len=int(doc_lens.max()),
+            cu_doc_lens=cu_doc_lens,
+            position_ids=position_ids,
+        )
+
+        y_reference_parts = []
+        start = 0
+        for doc_len in doc_lens[0].tolist():
+            y_reference_parts.append(attention(x[:, start : start + doc_len, :]))
+            start += doc_len
+        y_reference = torch.cat(y_reference_parts, dim=1)
+
+    torch.testing.assert_close(y_packed, y_reference, rtol=BF16_RTOL, atol=BF16_ATOL)
+
+
+@requires_gpu
+@requires_flash_attn_2
+def test_fused_attention_rejects_position_ids_with_rope():
+    seed_all(0)
+
+    d_model = 128
+    seq_len = 16
+    fused_att = FusedAttention(
+        d_model=d_model, n_heads=8, rope=RoPEConfig(name=RoPEType.fused), init_device="cuda"
+    )
+    x = torch.randn(1, seq_len, d_model, dtype=torch.bfloat16, device="cuda")
+    position_ids = torch.arange(seq_len, device="cuda").unsqueeze(0)
+
+    with pytest.raises(NotImplementedError, match="position_ids"):
+        with torch.no_grad(), torch.autocast("cuda", dtype=torch.bfloat16):
+            fused_att(x, position_ids=position_ids)
 
 
 @requires_gpu

--- a/src/test/nn/rope_test.py
+++ b/src/test/nn/rope_test.py
@@ -528,3 +528,145 @@ def test_rope_tensor_start_pos(device, head_first):
 
         torch.testing.assert_close(q2, q_expected)
         torch.testing.assert_close(k2, k_expected)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize(
+    "head_first",
+    [pytest.param(True, id="head_first"), pytest.param(False, id="seq_first")],
+)
+@pytest.mark.parametrize(
+    "rope_cls",
+    [
+        pytest.param(RotaryEmbedding, id="default"),
+        pytest.param(ComplexRotaryEmbedding, id="complex"),
+    ],
+)
+def test_rope_position_ids_match_default_for_contiguous_positions(device, head_first, rope_cls):
+    B, T, d_model, n_heads = 2, 8, 16, 4
+    head_size = d_model // n_heads
+    rope = rope_cls(head_size=head_size)
+    position_ids = torch.arange(T, device=device).unsqueeze(0).expand(B, -1)
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+        if not head_first:
+            q, k = q.transpose(1, 2), k.transpose(1, 2)
+
+        q_default, k_default = rope(q.clone(), k.clone(), head_first=head_first)
+        q_pos, k_pos = rope(q.clone(), k.clone(), head_first=head_first, position_ids=position_ids)
+
+        torch.testing.assert_close(q_default, q_pos)
+        torch.testing.assert_close(k_default, k_pos)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+@pytest.mark.parametrize(
+    "head_first",
+    [pytest.param(True, id="head_first"), pytest.param(False, id="seq_first")],
+)
+@pytest.mark.parametrize(
+    "rope_cls",
+    [
+        pytest.param(RotaryEmbedding, id="default"),
+        pytest.param(ComplexRotaryEmbedding, id="complex"),
+    ],
+)
+def test_rope_position_ids_reset_per_document(device, head_first, rope_cls):
+    B, d_model, n_heads = 1, 16, 4
+    doc_lens = [2, 3, 4]
+    T = sum(doc_lens)
+    head_size = d_model // n_heads
+    rope = rope_cls(head_size=head_size)
+    position_ids = torch.tensor([[0, 1, 0, 1, 2, 0, 1, 2, 3]], device=device, dtype=torch.long)
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+        if not head_first:
+            q, k = q.transpose(1, 2), k.transpose(1, 2)
+
+        q_out, k_out = rope(q.clone(), k.clone(), head_first=head_first, position_ids=position_ids)
+
+        q_expected_parts = []
+        k_expected_parts = []
+        start = 0
+        for doc_len in doc_lens:
+            if head_first:
+                q_doc = q[:, :, start : start + doc_len, :]
+                k_doc = k[:, :, start : start + doc_len, :]
+            else:
+                q_doc = q[:, start : start + doc_len, :, :]
+                k_doc = k[:, start : start + doc_len, :, :]
+
+            q_doc_out, k_doc_out = rope(q_doc.clone(), k_doc.clone(), head_first=head_first)
+            q_expected_parts.append(q_doc_out)
+            k_expected_parts.append(k_doc_out)
+            start += doc_len
+
+        cat_dim = 2 if head_first else 1
+        q_expected = torch.cat(q_expected_parts, dim=cat_dim)
+        k_expected = torch.cat(k_expected_parts, dim=cat_dim)
+
+        torch.testing.assert_close(q_out, q_expected)
+        torch.testing.assert_close(k_out, k_expected)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_rope_position_ids_with_scaling_matches_default(device):
+    B, T, d_model, n_heads = 2, 8, 16, 4
+    head_size = d_model // n_heads
+    rope = RotaryEmbedding(head_size=head_size, scaling=PIRoPEScalingConfig(factor=2.0))
+    position_ids = torch.arange(T, device=device).unsqueeze(0).expand(B, -1)
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+
+        q_default, k_default = rope(q.clone(), k.clone())
+        q_pos, k_pos = rope(q.clone(), k.clone(), position_ids=position_ids)
+
+        torch.testing.assert_close(q_default, q_pos)
+        torch.testing.assert_close(k_default, k_pos)
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_rope_position_ids_invalid_combinations(device):
+    B, T, d_model, n_heads = 2, 8, 16, 4
+    head_size = d_model // n_heads
+    position_ids = torch.arange(T, device=device).unsqueeze(0).expand(B, -1)
+
+    with torch.no_grad():
+        q = torch.rand(B, n_heads, T, head_size, device=device)
+        k = torch.rand(B, n_heads, T, head_size, device=device)
+
+        rope = RotaryEmbedding(head_size=head_size)
+        with pytest.raises(RuntimeError, match="start_pos"):
+            rope(q.clone(), k.clone(), position_ids=position_ids, start_pos=0)
+
+        buffers = rope.get_buffers(T, device)
+        assert buffers.pos_sin is not None
+        assert buffers.pos_cos is not None
+        with pytest.raises(RuntimeError, match="pos_sin"):
+            rope(
+                q.clone(),
+                k.clone(),
+                position_ids=position_ids,
+                pos_sin=buffers.pos_sin,
+                pos_cos=buffers.pos_cos,
+            )
+
+        complex_rope = ComplexRotaryEmbedding(head_size=head_size)
+        with pytest.raises(RuntimeError, match="start_pos"):
+            complex_rope(q.clone(), k.clone(), position_ids=position_ids, start_pos=0)
+
+        complex_buffers = complex_rope.get_buffers(T, device)
+        assert complex_buffers.freqs_cis is not None
+        with pytest.raises(RuntimeError, match="freqs_cis"):
+            complex_rope(
+                q.clone(),
+                k.clone(),
+                position_ids=position_ids,
+                freqs_cis=complex_buffers.freqs_cis,
+            )

--- a/src/test/nn/transformer/model_test.py
+++ b/src/test/nn/transformer/model_test.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 from torch.distributed.tensor import DTensor, Shard, init_device_mesh
 
 from olmo_core.config import DType
+from olmo_core.data.utils import get_position_ids_from_doc_lens
 from olmo_core.distributed.checkpoint import (
     load_model_and_optim_state,
     save_model_and_optim_state,
@@ -52,6 +53,7 @@ from olmo_core.testing import (
     GPU_MARKS,
     TE_MARKS,
     requires_flash_attn_2,
+    requires_gpu,
     requires_multi_gpu,
     run_distributed_test,
 )
@@ -216,6 +218,55 @@ def get_transformer_config(
 
 def get_transformer_inputs() -> torch.Tensor:
     return torch.arange(0, 128).unsqueeze(0)
+
+
+@requires_gpu
+@requires_flash_attn_2
+def test_transformer_auto_derives_position_ids_from_doc_lens():
+    seed_all(0)
+
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, bias=False)
+    config = TransformerConfig(
+        d_model=64,
+        vocab_size=128,
+        n_layers=2,
+        block=TransformerBlockConfig(
+            sequence_mixer=AttentionConfig(
+                n_heads=4,
+                rope=RoPEConfig(),
+                backend=AttentionBackendName.flash_2,
+                bias=False,
+            ),
+            layer_norm=layer_norm,
+            feed_forward=FeedForwardConfig(hidden_size=128, bias=False),
+        ),
+        lm_head=LMHeadConfig(layer_norm=layer_norm, bias=False),
+    )
+
+    device = torch.device("cuda")
+    model = config.build(init_device="cuda")
+    model.init_weights(device=device, max_seq_len=12)
+    model.eval()
+
+    doc_lens = torch.tensor([[3, 4, 5]], dtype=torch.int32)
+    input_ids = torch.randint(0, config.vocab_size, (1, 12), device=device)
+    position_ids = get_position_ids_from_doc_lens(doc_lens, input_ids.size(1)).to(device)
+
+    with torch.no_grad(), torch.autocast("cuda", dtype=torch.bfloat16):
+        logits_auto = model(input_ids, doc_lens=doc_lens, max_doc_lens=[5])
+        logits_explicit = model(
+            input_ids, doc_lens=doc_lens, max_doc_lens=[5], position_ids=position_ids
+        )
+
+        logits_reference_parts = []
+        start = 0
+        for doc_len in doc_lens[0].tolist():
+            logits_reference_parts.append(model(input_ids[:, start : start + doc_len]))
+            start += doc_len
+        logits_reference = torch.cat(logits_reference_parts, dim=1)
+
+    torch.testing.assert_close(logits_auto, logits_explicit, rtol=BF16_RTOL, atol=BF16_ATOL)
+    torch.testing.assert_close(logits_auto, logits_reference, rtol=BF16_RTOL, atol=BF16_ATOL)
 
 
 def run_tensor_parallel_transformer(checkpoint_dir, outputs_path, architecture: str):

--- a/src/test/nn/transformer/model_test.py
+++ b/src/test/nn/transformer/model_test.py
@@ -31,6 +31,7 @@ from olmo_core.nn.attention import (
 from olmo_core.nn.attention.ring import (
     RingContextParallelStyle,
     UlyssesContextParallelStyle,
+    UlyssesLoadBalancer,
 )
 from olmo_core.nn.feed_forward import ActivationFunction, FeedForwardConfig
 from olmo_core.nn.layer_norm import LayerNorm, LayerNormConfig, LayerNormType
@@ -267,6 +268,45 @@ def test_transformer_auto_derives_position_ids_from_doc_lens():
 
     torch.testing.assert_close(logits_auto, logits_explicit, rtol=BF16_RTOL, atol=BF16_ATOL)
     torch.testing.assert_close(logits_auto, logits_reference, rtol=BF16_RTOL, atol=BF16_ATOL)
+
+
+def test_transformer_context_parallel_shards_position_ids_from_doc_lens():
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, bias=False)
+    config = TransformerConfig(
+        d_model=64,
+        vocab_size=128,
+        n_layers=2,
+        block=TransformerBlockConfig(
+            sequence_mixer=AttentionConfig(
+                n_heads=4,
+                rope=RoPEConfig(),
+                backend=AttentionBackendName.torch,
+                bias=False,
+            ),
+            layer_norm=layer_norm,
+            feed_forward=FeedForwardConfig(hidden_size=128, bias=False),
+        ),
+        lm_head=LMHeadConfig(layer_norm=layer_norm, bias=False),
+    )
+
+    model = config.build(init_device="cpu")
+    model._cp_load_balancer = UlyssesLoadBalancer(cp_rank=1, cp_world_size=2)
+
+    input_ids = torch.arange(9).unsqueeze(0)
+    doc_lens = torch.tensor([[3, 4, 2]], dtype=torch.int32)
+    (
+        input_ids_local,
+        _,
+        all_block_kwargs,
+        per_block_kwargs,
+        _,
+    ) = model._prepare_inputs(input_ids=input_ids, doc_lens=doc_lens, max_doc_lens=[4])
+
+    assert input_ids_local.tolist() == [[8, 0, 0, 0, 0, 0, 0, 0]]
+    assert all_block_kwargs["position_ids"].tolist() == [[1, 0, 0, 0, 0, 0, 0, 0]]
+    assert all_block_kwargs["cu_doc_lens"].tolist() == [0, 3, 7, 9, 16]
+    assert all_block_kwargs["max_doc_len"] == 7
+    assert per_block_kwargs == {}
 
 
 def run_tensor_parallel_transformer(checkpoint_dir, outputs_path, architecture: str):


### PR DESCRIPTION
## Summary
- add native varlen RoPE support via explicit `position_ids`
- auto-derive `position_ids` from `doc_lens` in the transformer input path for packed and intra-document-masked batches
- thread `position_ids` through attention and RoPE while preserving existing contiguous and decode-offset behavior
- add direct helper coverage plus rope, attention, and transformer regression tests

## Design
This change follows the minimal design from issue #503: `position_ids` is the advanced RoPE API, while the common packed-training path can continue passing `doc_lens` and let the transformer derive positions automatically.

The implementation intentionally keeps unsupported paths loud instead of adding partial behavior:
- `position_ids` with fused RoPE raises `NotImplementedError`
- `position_ids` with KV caching raises `RuntimeError`
- context-parallel attention now accepts either pre-sharded RoPE buffers or pre-sharded `position_ids`

## Implementation details
- add `get_position_ids_from_doc_lens()` to build per-token RoPE positions that reset at document boundaries
- update `RotaryEmbedding` and `ComplexRotaryEmbedding` to gather RoPE values from explicit per-token positions
- keep the existing `start_pos` and contiguous-sequence path unchanged when `position_ids` are not provided
- plumb `position_ids` through `Attention`, `NormalizedAttention`, and `Transformer`
- auto-derive `position_ids` from `doc_lens` before CP sharding so the same abstraction works in regular and CP input preparation

## Tests
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest src/test/data/utils_test.py src/test/nn/rope_test.py src/test/nn/attention/attention_test.py src/test/nn/transformer/model_test.py -q`
  - `198 passed, 1073 skipped`

Closes #503