### PR TITLE
Fix LR schedulers when warmup/decay rounds to zero

### DIFF
--- a/src/olmo_core/optim/scheduler.py
+++ b/src/olmo_core/optim/scheduler.py
@@ -149,7 +149,7 @@ class ConstantWithWarmup(Scheduler):
         else:
             warmup = self.warmup
 
-        if current <= warmup:
+        if warmup > 0 and current <= warmup:
             return _linear_warmup(initial_lr, current, warmup, self.warmup_min_lr)
 
         return initial_lr
@@ -214,7 +214,7 @@ class WSD(Scheduler):
         else:
             warmup = self.warmup
 
-        if current <= warmup:
+        if warmup > 0 and current <= warmup:
             return _linear_warmup(initial_lr, current, warmup, self.warmup_min_lr)
 
         if self.decay is None:
@@ -223,7 +223,7 @@ class WSD(Scheduler):
         else:
             decay = self.decay
 
-        if current >= t_max - decay:
+        if decay > 0 and current >= t_max - decay:
             return _linear_decay(initial_lr, t_max - current, decay, self.decay_min_lr)
 
         return initial_lr
@@ -481,7 +481,7 @@ class CosWithWarmupAndLinearDecay(CosWithWarmup):
         else:
             decay = self.decay
 
-        if current >= t_max - decay:
+        if decay > 0 and current >= t_max - decay:
             final_cosine_lr = super().get_lr(initial_lr, t_max - decay, t_max)
             return _linear_decay(final_cosine_lr, t_max - current, decay, self.decay_min_lr)
 
@@ -706,6 +706,8 @@ class WSDS(Scheduler):
             return self._get_peak_lr(initial_lr, pidx)
         else:
             t = pos - S
+            if D == 0:
+                return self.decay_min_lr
             return _linear_decay(self._get_peak_lr(initial_lr, pidx), D - t, D, self.decay_min_lr)
 
 

--- a/src/test/optim/scheduler_test.py
+++ b/src/test/optim/scheduler_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.optim import (
+    WSD,
     WSDS,
     ConstantWithWarmup,
     CosWithWarmup,
@@ -97,6 +98,32 @@ def test_sequential_scheduler():
     assert scheduler.get_lr(initial_lr, 7_500, max_steps) == third_scheduler.get_lr(
         second_scheduler_final_lr, 1_000, max_steps - 6_500
     )
+
+
+def test_constant_with_warmup_zero_warmup():
+    initial_lr = 10.0
+    max_steps = 10_000
+    scheduler = ConstantWithWarmup(warmup=0)
+    assert scheduler.get_lr(initial_lr, 0, max_steps) == initial_lr
+    assert scheduler.get_lr(initial_lr, 1, max_steps) == initial_lr
+    assert scheduler.get_lr(initial_lr, max_steps, max_steps) == initial_lr
+
+
+def test_constant_with_warmup_rounding_to_zero_warmup():
+    initial_lr = 10.0
+    max_steps = 1_000
+    scheduler = ConstantWithWarmup(warmup_fraction=0.0004)
+    assert scheduler.get_lr(initial_lr, 0, max_steps) == initial_lr
+    assert scheduler.get_lr(initial_lr, 1, max_steps) == initial_lr
+
+
+def test_wsd_zero_warmup_and_decay():
+    initial_lr = 10.0
+    max_steps = 10_000
+    scheduler = WSD(warmup=0, decay=0, decay_fraction=None)
+    assert scheduler.get_lr(initial_lr, 0, max_steps) == initial_lr
+    assert scheduler.get_lr(initial_lr, 1, max_steps) == initial_lr
+    assert scheduler.get_lr(initial_lr, max_steps, max_steps) == initial_lr
 
 
 class TestWSDSScheduler:


### PR DESCRIPTION
Summary This PR makes LR schedulers robust to warmup=0 / decay=0 (and fraction-based warmup/decay that rounds to 0). Previously, these configurations could lead to division-by-zero in the linear warmup/decay helpers.

Changes
- Treat warmup=0 as “no warmup” and avoid entering linear warmup when warmup == 0 :
  - ConstantWithWarmup
  - WSD
- Treat decay=0 as “no decay” and avoid entering linear decay when decay == 0 :
  - WSD
  - CosWithWarmupAndLinearDecay
- Handle WSDS period decay steps D == 0 by returning decay_min_lr directly to avoid division-by-zero.
Tests

- Added unit tests covering:
  - ConstantWithWarmup(warmup=0)
  - ConstantWithWarmup(warmup_fraction=...) that rounds to zero warmup
  - WSD(warmup=0, decay=0)
- Ran: python -m pytest -q src/test/optim/scheduler_test.py (all passed)
Behavioral Impact

- No behavior change for configurations with warmup > 0 and decay > 0 .
- Configurations with warmup=0 / decay=0 now behave as “disabled phase” instead of raising due to division-by-zero.