### PR TITLE
Add NumpyFSL pipeline support to ModelLadder

### DIFF
--- a/src/olmo_core/model_ladder/base.py
+++ b/src/olmo_core/model_ladder/base.py
@@ -5,6 +5,7 @@ import math
 import typing
 from abc import ABCMeta, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
+import dataclasses
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, NamedTuple, TypeVar
 
@@ -17,7 +18,13 @@ import olmo_core.io as io
 import olmo_core.train.callbacks as callbacks
 from olmo_core.aliases import PathOrStr
 from olmo_core.config import Config
-from olmo_core.data import DataMix, NumpyPaddedFSLDatasetConfig, TokenizerConfig
+from olmo_core.data import (
+    DataMix,
+    NumpyDataLoaderConfig,
+    NumpyFSLDatasetConfig,
+    NumpyPaddedFSLDatasetConfig,
+    TokenizerConfig,
+)
 from olmo_core.data.composable import (
     ComposableDataLoaderConfig,
     InstanceSourceConfig,
@@ -226,10 +233,14 @@ class ModelLadder(Config):
     """The model configurator to use."""
     run_configurator: RunConfigurator
     """The run configurator to use."""
-    data_loader: ComposableDataLoaderConfig
-    """The data loader configuration to use for each run."""
-    instance_sources: list[InstanceSourceConfig]
-    """The instance sources to use for each run."""
+    data_loader: ComposableDataLoaderConfig | None = None
+    """The composable data loader configuration to use for each run."""
+    instance_sources: list[InstanceSourceConfig] | None = None
+    """The composable instance sources to use for each run."""
+    numpy_dataset: NumpyFSLDatasetConfig | None = None
+    """The NumpyFSL dataset configuration, as an alternative to the composable pipeline."""
+    numpy_data_loader: NumpyDataLoaderConfig | None = None
+    """The NumpyFSL data loader configuration, as an alternative to the composable pipeline."""
     sequence_length: int = 8192
     """The sequence length to train each run on."""
     tokenizer: TokenizerConfig
@@ -239,9 +250,23 @@ class ModelLadder(Config):
     backend: str = "cpu:gloo,cuda:nccl"
     """The distributed backend to use for each run."""
 
+    @property
+    def _uses_composable(self) -> bool:
+        return self.data_loader is not None and self.instance_sources is not None
+
+    @property
+    def _uses_numpy_fsl(self) -> bool:
+        return self.numpy_dataset is not None and self.numpy_data_loader is not None
+
     def __post_init__(self):
         if self.max_devices <= 0:
             raise OLMoConfigurationError("max_devices must be a positive integer.")
+        if self._uses_composable == self._uses_numpy_fsl:
+            raise OLMoConfigurationError(
+                "Exactly one data pipeline must be configured: "
+                "either (data_loader + instance_sources) for composable, "
+                "or (numpy_dataset + numpy_data_loader) for NumpyFSL."
+            )
         for size_spec in self.sizes:
             min_devices, _ = self.model_configurator.configure_minimal_device_mesh_spec(
                 size_spec=size_spec,
@@ -340,21 +365,45 @@ class ModelLadder(Config):
         # Configure trainer.
         trainer_config = self._configure_trainer(size_spec, for_benchmarking=for_benchmarking)
 
-        # Build instance sources and data loader.
-        instance_sources = [
-            source.build(work_dir=self.work_dir) for source in self.instance_sources
-        ]
-        data_loader = self.data_loader.build(
-            *instance_sources,
-            work_dir=self.work_dir,
-            global_batch_size=global_batch_size,
-            tokenizer=self.tokenizer,
-        )
-        if data_loader.sequence_length != self.sequence_length:
-            raise OLMoConfigurationError(
-                f"Data loader sequence of {data_loader.sequence_length} does not match "
-                f"configured sequence length of {self.sequence_length}."
+        # Build data loader.
+        if self._uses_composable:
+            assert self.instance_sources is not None and self.data_loader is not None
+            built_sources = [
+                source.build(work_dir=self.work_dir) for source in self.instance_sources
+            ]
+            data_loader = self.data_loader.build(
+                *built_sources,
+                work_dir=self.work_dir,
+                global_batch_size=global_batch_size,
+                tokenizer=self.tokenizer,
             )
+            if data_loader.sequence_length != self.sequence_length:
+                raise OLMoConfigurationError(
+                    f"Data loader sequence of {data_loader.sequence_length} does not match "
+                    f"configured sequence length of {self.sequence_length}."
+                )
+        else:
+            assert self.numpy_dataset is not None and self.numpy_data_loader is not None
+            dataset_config = self.numpy_dataset
+            # For source mixtures, update global_batch_size and requested_tokens
+            # which vary per model size.
+            if dataset_config.source_mixture_config is not None:
+                max_tokens = self.run_configurator.configure_duration(
+                    num_params, global_batch_size
+                ).value
+                src_mix = dataclasses.replace(
+                    dataset_config.source_mixture_config,
+                    global_batch_size=global_batch_size,
+                    requested_tokens=max_tokens,
+                )
+                dataset_config = dataclasses.replace(
+                    dataset_config, source_mixture_config=src_mix
+                )
+            dataset = dataset_config.build()
+            loader_config = dataclasses.replace(
+                self.numpy_data_loader, global_batch_size=global_batch_size
+            )
+            data_loader = loader_config.build(dataset)
 
         # Build train module.
         train_module = self.model_configurator.build_train_module(
@@ -377,9 +426,17 @@ class ModelLadder(Config):
             "model": model_config.as_config_dict(),
             "optim": optim_config.as_config_dict(),
             "scheduler": scheduler.as_config_dict(),
-            "data_loader": self.data_loader.as_config_dict(),
-            "instance_sources": [s.as_config_dict() for s in self.instance_sources],
         }
+        if self._uses_composable:
+            assert self.data_loader is not None and self.instance_sources is not None
+            config_dict["data_loader"] = self.data_loader.as_config_dict()
+            config_dict["instance_sources"] = [
+                s.as_config_dict() for s in self.instance_sources
+            ]
+        else:
+            assert self.numpy_dataset is not None and self.numpy_data_loader is not None
+            config_dict["numpy_dataset"] = self.numpy_dataset.as_config_dict()
+            config_dict["numpy_data_loader"] = self.numpy_data_loader.as_config_dict()
         typing.cast(
             callbacks.ConfigSaverCallback, trainer.callbacks["config_saver"]
         ).config = config_dict

--- a/src/scripts/train/ladder/2026Q1/old_pipeline_baseline_ladder.py
+++ b/src/scripts/train/ladder/2026Q1/old_pipeline_baseline_ladder.py
@@ -1,0 +1,76 @@
+"""
+Baseline ladder using the old NumpyFSL data pipeline with full attention.
+
+This is the NumpyFSL equivalent of ``baseline_full_attn_ladder.py``, used to test
+whether the data pipeline itself causes performance differences.
+"""
+
+import argparse
+import logging
+
+import olmo_core.io as io
+from olmo_core.data import NumpyDataLoaderConfig, NumpyFSLDatasetConfig, TokenizerConfig
+from olmo_core.internal.common import get_gpu_type, get_root_dir
+from olmo_core.internal.ladder import main
+from olmo_core.model_ladder import (
+    ModelLadder,
+    Olmo3ModelConfigurator,
+    TransformerSize,
+    WSDSChinchillaRunConfigurator,
+)
+
+log = logging.getLogger(__name__)
+
+DOLMA2_BASELINE_PATHS = [
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/all-dressed-snazzy2-fixed/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/arxiv/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/finemath-3plus/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/s2pdf_redacted/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/stack-edu/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/wikipedia/**/*.npy",
+]
+
+
+def configure_ladder(args: argparse.Namespace) -> ModelLadder:
+    tokenizer = TokenizerConfig.dolma2()
+    work_dir = str(
+        io.join_path(get_root_dir(args.cluster), "model-ladders", args.name, "cache")
+    )
+
+    dataset = NumpyFSLDatasetConfig.glob(
+        *DOLMA2_BASELINE_PATHS,
+        sequence_length=args.sequence_length,
+        tokenizer=tokenizer,
+        work_dir=work_dir,
+    )
+
+    ladder = ModelLadder(
+        name=args.name,
+        dir=str(io.join_path(get_root_dir(args.cluster), "model-ladders", args.name)),
+        sizes=[s for s in TransformerSize if s.approx_num_params <= 370e6],
+        max_devices=args.max_gpus,
+        device_type=get_gpu_type(args.cluster),
+        model_configurator=Olmo3ModelConfigurator(
+            model_construction_kwargs={"sliding_window": None},
+            rank_microbatch_size=None
+            if args.rank_mbz is None
+            else args.rank_mbz * args.sequence_length,
+        ),
+        run_configurator=WSDSChinchillaRunConfigurator(
+            chinchilla_multiple=args.chinchilla_multiple
+        ),
+        sequence_length=args.sequence_length,
+        tokenizer=tokenizer,
+        numpy_dataset=dataset,
+        numpy_data_loader=NumpyDataLoaderConfig(
+            global_batch_size=0,  # set by ModelLadder at runtime
+            seed=42,
+            num_workers=4,
+            work_dir=work_dir,
+        ),
+    )
+    return ladder
+
+
+if __name__ == "__main__":
+    main(configure_ladder)

--- a/src/scripts/train/ladder/2026Q1/old_pipeline_icl_overlap_ladder.py
+++ b/src/scripts/train/ladder/2026Q1/old_pipeline_icl_overlap_ladder.py
@@ -1,0 +1,107 @@
+"""
+ICL overlap ladder using the old NumpyFSL data pipeline with full attention.
+
+This is the NumpyFSL equivalent of ``icl_overlap_full_attn_ladder.py``, used to test
+whether the data pipeline itself causes performance differences.
+"""
+
+import argparse
+import logging
+
+import olmo_core.io as io
+from olmo_core.data import NumpyDataLoaderConfig, NumpyFSLDatasetConfig, TokenizerConfig
+from olmo_core.data.source_mixture import (
+    SourceMixtureConfig,
+    SourceMixtureDatasetConfig,
+    SourceMixtureList,
+)
+from olmo_core.internal.common import get_gpu_type, get_root_dir
+from olmo_core.internal.ladder import main
+from olmo_core.model_ladder import (
+    ModelLadder,
+    Olmo3ModelConfigurator,
+    TransformerSize,
+    WSDSChinchillaRunConfigurator,
+)
+
+log = logging.getLogger(__name__)
+
+ICL_OVERLAP_PATHS = [
+    "/weka/oe-training-default/ai2-llm/suffix-arrays/preprocessed/dolma2-0625-v01/icl-overlap-max-suffix-8192-eos-fix/allenai/dolma2-tokenizer/*.npy",
+]
+
+DOLMA2_BASELINE_PATHS = [
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/all-dressed-snazzy2-fixed/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/arxiv/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/finemath-3plus/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/s2pdf_redacted/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/stack-edu/**/*.npy",
+    "/weka/oe-training-default/ai2-llm/preprocessed/dolma2-0625/v0.1/allenai/dolma2-tokenizer/wikipedia/**/*.npy",
+]
+
+SEED = 42
+
+
+def configure_ladder(args: argparse.Namespace) -> ModelLadder:
+    tokenizer = TokenizerConfig.dolma2()
+    work_dir = str(
+        io.join_path(get_root_dir(args.cluster), "model-ladders", args.name, "cache")
+    )
+
+    src_mix = SourceMixtureDatasetConfig(
+        source_list=SourceMixtureList(
+            sources=[
+                SourceMixtureConfig(
+                    source_name="icl-overlap",
+                    paths=ICL_OVERLAP_PATHS,
+                    target_ratio=0.5,
+                ),
+                SourceMixtureConfig(
+                    source_name="baseline",
+                    paths=DOLMA2_BASELINE_PATHS,
+                    target_ratio=0.5,
+                ),
+            ]
+        ),
+        requested_tokens=1,  # placeholder, set by ModelLadder per model size
+        global_batch_size=1,  # placeholder, set by ModelLadder per model size
+        seed=SEED,
+    )
+    dataset = NumpyFSLDatasetConfig.from_src_mix(
+        src_mix,
+        sequence_length=args.sequence_length,
+        tokenizer=tokenizer,
+        work_dir=work_dir,
+        chunk_based_mixture=True,
+    )
+
+    ladder = ModelLadder(
+        name=args.name,
+        dir=str(io.join_path(get_root_dir(args.cluster), "model-ladders", args.name)),
+        sizes=[s for s in TransformerSize if s.approx_num_params <= 370e6],
+        max_devices=args.max_gpus,
+        device_type=get_gpu_type(args.cluster),
+        model_configurator=Olmo3ModelConfigurator(
+            model_construction_kwargs={"sliding_window": None},
+            rank_microbatch_size=None
+            if args.rank_mbz is None
+            else args.rank_mbz * args.sequence_length,
+        ),
+        run_configurator=WSDSChinchillaRunConfigurator(
+            chinchilla_multiple=args.chinchilla_multiple
+        ),
+        sequence_length=args.sequence_length,
+        tokenizer=tokenizer,
+        numpy_dataset=dataset,
+        numpy_data_loader=NumpyDataLoaderConfig(
+            global_batch_size=0,  # set by ModelLadder at runtime
+            seed=SEED,
+            num_workers=4,
+            work_dir=work_dir,
+        ),
+    )
+    return ladder
+
+
+if __name__ == "__main__":
+    main(configure_ladder)


### PR DESCRIPTION
## Summary

Adds NumpyFSL as an alternative data pipeline in `ModelLadder`, enabling experiments that compare old vs new pipelines while keeping all other ladder settings identical.

## Changes

### `src/olmo_core/model_ladder/base.py`
- Made `data_loader` and `instance_sources` optional (default `None`)
- Added `numpy_dataset: NumpyFSLDatasetConfig | None` and `numpy_data_loader: NumpyDataLoaderConfig | None` as alternatives
- Validation ensures exactly one pipeline is configured
- `run()` branches on active pipeline; for NumpyFSL with source mixtures, updates `global_batch_size` and `requested_tokens` per model size before building
- Backward compatible — all existing ladder scripts work unchanged

### New scripts
- `src/scripts/train/ladder/2026Q1/old_pipeline_baseline_ladder.py` — NumpyFSL baseline with full attention, sizes up to 370M
- `src/scripts/train/ladder/2026Q1/old_pipeline_icl_overlap_ladder.py` — NumpyFSL ICL overlap (50/50 mix, 8k suffix data) with full attention

## Context

This is part of an investigation into whether the data pipeline (NumpyFSL vs composable) causes the discrepancy between cookbook results (ICL overlap positive) and ladder results (ICL overlap negative). 4 runs (190M/370M x baseline/ICL overlap) have been launched using these scripts.

https://claude.ai/code/session_01Y7LBjpaPtn6RVzpH4Y5C81