### PR TITLE
[DRAFT] Modify CosWithWarmupAndLinearDecay tail-handoff and missing super().__post_init__()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed LM in-loop evaluator data-order drift across repeated runs by resetting loader bookkeeping before each pass and making deterministic reshuffling the default.
 - Fixed Qwen3 implementation to match HuggingFace by applying RoPE in the input dtype (bf16) rather than upcasting to fp32.
 - Fixed Beaker secret existence check to use the case-insensitive HTTP endpoint, avoiding spurious "secret not found" errors when secret names differ only in case.
+- Fixed `CosWithWarmupAndLinearDecay`: now invokes `super().__post_init__()` (so the deprecated `warmup_steps` alias is migrated and parent validations run), and the cosine now completes to `alpha_f * peak` by step `t_max - decay`, with the linear tail carrying from there to `decay_min_lr`. Previously the cosine ran across the full `t_max` and the linear tail attached mid-flight at whatever value the cosine produced at `t_max - decay`.
 
 ### Changed
 

--- a/src/olmo_core/optim/scheduler.py
+++ b/src/olmo_core/optim/scheduler.py
@@ -471,6 +471,8 @@ class CosWithWarmupAndLinearDecay(CosWithWarmup):
 
         if self.decay_fraction is not None and (self.decay_fraction < 0 or self.decay_fraction > 1):
             raise OLMoConfigurationError("'decay_fraction' must be between 0 and 1.")
+        
+        super().__post_init__()
 
     def get_lr(
         self, initial_lr: Union[float, torch.Tensor], current: int, t_max: int
@@ -481,11 +483,14 @@ class CosWithWarmupAndLinearDecay(CosWithWarmup):
         else:
             decay = self.decay
 
+        # linear decay starts after the cosine schedule is *COMPLETE*
         if current >= t_max - decay:
-            final_cosine_lr = super().get_lr(initial_lr, t_max - decay, t_max)
+            # final_cosine_lr = super().get_lr(initial_lr, t_max - decay, t_max)
+            final_cosine_lr = initial_lr * self.alpha_f
             return _linear_decay(final_cosine_lr, t_max - current, decay, self.decay_min_lr)
 
-        return super().get_lr(initial_lr, current, t_max)
+        # return super().get_lr(initial_lr, current, t_max)
+        return super().get_lr(initial_lr, current, t_max - decay)
 
 
 def _linear_warmup(

--- a/src/olmo_core/optim/scheduler.py
+++ b/src/olmo_core/optim/scheduler.py
@@ -471,7 +471,7 @@ class CosWithWarmupAndLinearDecay(CosWithWarmup):
 
         if self.decay_fraction is not None and (self.decay_fraction < 0 or self.decay_fraction > 1):
             raise OLMoConfigurationError("'decay_fraction' must be between 0 and 1.")
-        
+
         super().__post_init__()
 
     def get_lr(
@@ -483,13 +483,13 @@ class CosWithWarmupAndLinearDecay(CosWithWarmup):
         else:
             decay = self.decay
 
-        # linear decay starts after the cosine schedule is *COMPLETE*
+        # The cosine completes (reaches alpha_f * peak) by step `t_max - decay`,
+        # then the linear tail anneals from that value to `decay_min_lr` over
+        # the remaining `decay` steps.
         if current >= t_max - decay:
-            # final_cosine_lr = super().get_lr(initial_lr, t_max - decay, t_max)
             final_cosine_lr = initial_lr * self.alpha_f
             return _linear_decay(final_cosine_lr, t_max - current, decay, self.decay_min_lr)
 
-        # return super().get_lr(initial_lr, current, t_max)
         return super().get_lr(initial_lr, current, t_max - decay)
 
 

--- a/src/test/optim/scheduler_test.py
+++ b/src/test/optim/scheduler_test.py
@@ -7,6 +7,7 @@ from olmo_core.optim import (
     WSDS,
     ConstantWithWarmup,
     CosWithWarmup,
+    CosWithWarmupAndLinearDecay,
     ExponentialScheduler,
     InvSqrtWithWarmup,
     LinearWithWarmup,
@@ -53,6 +54,69 @@ def test_inv_sqrt_with_warmup():
     assert scheduler.get_lr(initial_lr, 3_000, max_steps) == 10.0
     assert scheduler.get_lr(initial_lr, 5_000, max_steps) == 2.0 + 8.0 * math.sqrt(3_000 / 5_000)
     assert scheduler.get_lr(initial_lr, 10_000, max_steps) == 2.0 + 8.0 * math.sqrt(3_000 / 10_000)
+
+
+def test_cos_with_warmup_and_linear_decay():
+    """
+    Schedule: linear warmup -> cosine fully completing to alpha_f * peak by
+    step (t_max - decay) -> linear tail to decay_min_lr over the last `decay`
+    steps.
+    """
+    initial_lr = 10.0
+    warmup_steps = 1_000
+    decay_steps = 2_000
+    max_steps = 10_000
+    alpha_f = 0.1
+    cosine_end = max_steps - decay_steps  # 8_000
+    scheduler = CosWithWarmupAndLinearDecay(
+        warmup=warmup_steps,
+        decay=decay_steps,
+        decay_fraction=None,
+        alpha_f=alpha_f,
+    )
+
+    # Warmup interior.
+    assert scheduler.get_lr(initial_lr, 0, max_steps) == pytest.approx(0.0)
+    assert scheduler.get_lr(initial_lr, 500, max_steps) == pytest.approx(5.0)
+    assert scheduler.get_lr(initial_lr, warmup_steps, max_steps) == pytest.approx(initial_lr)
+
+    # Cosine region: cosine runs over (t_max - warmup - decay) within the
+    # super-class call, which sees t_max == cosine_end. Test that the cosine
+    # value at step `current` matches the bare CosWithWarmup formula.
+    bare_cos = CosWithWarmup(warmup=warmup_steps, alpha_f=alpha_f)
+    for current in (1_500, 4_000, 7_000, cosine_end - 1):
+        assert scheduler.get_lr(initial_lr, current, max_steps) == pytest.approx(
+            bare_cos.get_lr(initial_lr, current, cosine_end)
+        )
+
+    # Boundary: at exactly t_max - decay the tail starts at alpha_f * peak.
+    assert scheduler.get_lr(initial_lr, cosine_end, max_steps) == pytest.approx(
+        initial_lr * alpha_f
+    )
+
+    # Linear decay tail: halfway through tail, halfway from alpha_f*peak to 0.
+    mid_tail = cosine_end + decay_steps // 2
+    assert scheduler.get_lr(initial_lr, mid_tail, max_steps) == pytest.approx(
+        initial_lr * alpha_f * 0.5
+    )
+
+    # End of schedule: LR reaches decay_min_lr (default 0).
+    assert scheduler.get_lr(initial_lr, max_steps, max_steps) == pytest.approx(0.0)
+
+
+def test_cos_with_warmup_and_linear_decay_migrates_deprecated_warmup_steps():
+    """
+    super().__post_init__() must run so the deprecated 'warmup_steps' alias
+    gets migrated to 'warmup'.
+    """
+    with pytest.warns(DeprecationWarning, match="warmup_steps.*deprecated"):
+        scheduler = CosWithWarmupAndLinearDecay(
+            warmup_steps=500,
+            decay=1_000,
+            decay_fraction=None,
+        )
+    assert scheduler.warmup == 500
+    assert scheduler.warmup_steps is None
 
 
 def test_cos_with_warmup_scheduler():


### PR DESCRIPTION
## Summary

TODO: unclear if we actually want this behavior. 

Rewrites the tail-handoff semantics of `CosWithWarmupAndLinearDecay` and fixes a missing `super().__post_init__()` call. Original work by @Tianhua-Tao; this PR ports just the scheduler portion onto `main` (preserving authorship/date) and adds tests + a CHANGELOG entry.

## What's changed

### 1. Tail starts at the cosine's *terminal* value, not its mid-flight value

**Before:** The cosine ran across the full `t_max`. At step `t_max - decay`, the linear tail attached at *whatever value the cosine happened to produce there* (call that `cos(t_max - decay, t_max)` — a value somewhere between peak and `alpha_f * peak`, depending on horizon and `alpha_f`). The tail then anneals from that mid-flight value to `decay_min_lr`.

**After:** The cosine completes (reaches `alpha_f * peak`) by step `t_max - decay`. Achieved by passing `t_max - decay` to `super().get_lr(...)` for the cosine region, and hard-coding the tail's starting value to `initial_lr * alpha_f`. The linear tail then anneals from `alpha_f * peak` down to `decay_min_lr` over the last `decay` steps.

Net effect: the class now matches the schedule its name promises — "warmup → cosine completing to `alpha_f * peak` by `t_max - decay` → linear tail to `decay_min_lr` over `decay` steps."

### 2. Missing `super().__post_init__()` call

`CosWithWarmupAndLinearDecay.__post_init__` validated its own fields but never invoked `super().__post_init__()`. This meant the parent's deprecated-alias migration (`warmup_steps` → `warmup`) was skipped on the subclass, and the parent's `warmup_fraction` range check ran only via duplicated logic in the child. Now `super().__post_init__()` is called at the end.

## Tests

`src/test/optim/scheduler_test.py` gains:

- `test_cos_with_warmup_and_linear_decay` — verifies the three-phase schedule. The cosine region matches a bare `CosWithWarmup` evaluated against `t_max = (full_t_max - decay)`. The tail starts at `alpha_f * peak` at exactly `t_max - decay`, anneals linearly to `decay_min_lr` by `t_max`.
- `test_cos_with_warmup_and_linear_decay_migrates_deprecated_warmup_steps` — confirms the `super().__post_init__()` call now propagates the `warmup_steps` → `warmup` migration and emits the deprecation warning.

34 tests pass; `make checks` clean (isort, black, ruff, mypy across all 381 source files).

## Commits

| SHA | Author | Subject |
|---|---|---|
| `0dd3f4c5` | Tianhua Tao | Rewrite `CosWithWarmupAndLinearDecay` tail semantics (the core change) |
| `f824210d` | Akshita Bhagia | Clean up leftover `# ...` reference comments and trailing whitespace |
| `b7ab9a43` | Akshita Bhagia | Add tests |
| `8834192c` | Akshita Bhagia | Update CHANGELOG |

## Compatibility note

Existing callers of `CosWithWarmupAndLinearDecay` will see different LR values in the tail region. If you have runs in flight that depend on the old "tail attaches mid-cosine" behavior, this is a behavior change — but the class name already implies the new semantics, and the old behavior was buggy in the sense that the tail start was implicit/non-obvious.

## Test plan

- [x] `pytest src/test/optim/scheduler_test.py` — 34 passed
- [x] `make checks` (isort + black + ruff + mypy) — clean
- [ ] Confirm no existing training scripts on `main` depend on the old tail-attachment behavior of `CosWithWarmupAndLinearDecay`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
