### PR TITLE
Two small transformer core fixes: TE Dynamo + PP init seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed LM in-loop evaluator data-order drift across repeated runs by resetting loader bookkeeping before each pass and making deterministic reshuffling the default.
 - Fixed Qwen3 implementation to match HuggingFace by applying RoPE in the input dtype (bf16) rather than upcasting to fp32.
 - Fixed Beaker secret existence check to use the case-insensitive HTTP endpoint, avoiding spurious "secret not found" errors when secret names differ only in case.
+- Fixed `Transformer.init_weights` so that under interleaved pipeline parallelism (e.g. `Interleaved1F1B`, `InterleavedZeroBubble`) the multiple model chunks owned by a single rank no longer initialize to identical parameters. Adds a `model_part_idx` kwarg incorporated into the seed as `model_part_idx * pp_size`.
+- Disabled `torch.compile` tracing through `TEAttentionBackend.forward`, whose Python/pybind setup is not Dynamo-safe.
 
 ### Changed
 

--- a/src/olmo_core/nn/attention/backend.py
+++ b/src/olmo_core/nn/attention/backend.py
@@ -1083,6 +1083,9 @@ class TEAttentionBackend(AttentionBackend):
         else:
             raise ValueError("One of ring or uly must be specified")
 
+    @torch.compiler.disable(
+        reason="Transformer Engine attention uses Python/pybind setup that Dynamo should not trace"
+    )
     def forward(
         self,
         qkv: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]],

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -255,6 +255,7 @@ class Transformer(nn.Module):
         max_local_microbatch_size: Optional[int] = None,
         device: Optional[torch.device] = None,
         world_mesh: Optional[DeviceMesh] = None,
+        model_part_idx: int = 0,
     ) -> torch.Generator:
         """
         Initialize the model weights.
@@ -264,6 +265,10 @@ class Transformer(nn.Module):
         :param max_local_microbatch_size: The maximum local (rank) micro-batch size (in tokens)
             expected. This is used to warm-up some MoE cache.
         :param device: The device the local copy of the model will be trained on.
+        :param model_part_idx: The local index of this model part on the current rank.
+            With interleaved pipeline schedules a single rank can own multiple model
+            chunks, and each must receive a distinct seed; otherwise their parameters
+            would be identical.
         """
         device = device or self.device
         self.to_empty(device=device)
@@ -274,7 +279,8 @@ class Transformer(nn.Module):
 
         seed = self.init_seed
         if world_mesh is not None and self.pp_enabled:
-            seed += get_pp_mesh(world_mesh).get_local_rank()
+            pp_mesh = get_pp_mesh(world_mesh)
+            seed += pp_mesh.get_local_rank() + model_part_idx * pp_mesh.size()
 
         generator = torch.Generator(device).manual_seed(seed)
 

--- a/src/olmo_core/train/train_module/transformer/common.py
+++ b/src/olmo_core/train/train_module/transformer/common.py
@@ -145,12 +145,13 @@ def parallelize_model(
 
     # Materialize and init parameters.
     log.info("Initializing model weights...")
-    for m in model_parts:
+    for model_part_idx, m in enumerate(model_parts):
         m.init_weights(
             max_seq_len=max_sequence_length,
             max_local_microbatch_size=rank_microbatch_size,
             device=device,
             world_mesh=world_mesh,
+            model_part_idx=model_part_idx,
         )
 
     return model

--- a/src/test/nn/transformer/init_test.py
+++ b/src/test/nn/transformer/init_test.py
@@ -235,15 +235,11 @@ def test_init_weights_diversifies_seed_across_model_parts(monkeypatch):
 
     part_a = _build_tiny_model()
     part_a._pp_enabled = True
-    part_a.init_weights(
-        device=torch.device("cpu"), world_mesh=object(), model_part_idx=0
-    )
+    part_a.init_weights(device=torch.device("cpu"), world_mesh=object(), model_part_idx=0)
 
     part_b = _build_tiny_model()
     part_b._pp_enabled = True
-    part_b.init_weights(
-        device=torch.device("cpu"), world_mesh=object(), model_part_idx=1
-    )
+    part_b.init_weights(device=torch.device("cpu"), world_mesh=object(), model_part_idx=1)
 
     assert not torch.equal(part_a.embeddings.weight, part_b.embeddings.weight)
     assert not torch.equal(
@@ -262,15 +258,11 @@ def test_init_weights_same_model_part_idx_is_deterministic(monkeypatch):
 
     part_a = _build_tiny_model()
     part_a._pp_enabled = True
-    part_a.init_weights(
-        device=torch.device("cpu"), world_mesh=object(), model_part_idx=1
-    )
+    part_a.init_weights(device=torch.device("cpu"), world_mesh=object(), model_part_idx=1)
 
     part_b = _build_tiny_model()
     part_b._pp_enabled = True
-    part_b.init_weights(
-        device=torch.device("cpu"), world_mesh=object(), model_part_idx=1
-    )
+    part_b.init_weights(device=torch.device("cpu"), world_mesh=object(), model_part_idx=1)
 
     assert torch.equal(part_a.embeddings.weight, part_b.embeddings.weight)
     assert torch.equal(

--- a/src/test/nn/transformer/init_test.py
+++ b/src/test/nn/transformer/init_test.py
@@ -198,5 +198,104 @@ def test_fan_in_init_raises_for_gdn():
         model.init_weights(device=torch.device("cpu"))
 
 
+class _FakePPMesh:
+    def __init__(self, local_rank: int, size: int):
+        self._local_rank = local_rank
+        self._size = size
+
+    def get_local_rank(self) -> int:
+        return self._local_rank
+
+    def size(self) -> int:
+        return self._size
+
+
+def _build_tiny_model(init_seed: int = 42):
+    return TransformerConfig.llama_like(
+        d_model=64,
+        vocab_size=128,
+        n_layers=2,
+        n_heads=2,
+        feed_forward=FeedForwardConfig(hidden_size=128, bias=False),
+        init_seed=init_seed,
+    ).build(init_device="meta")
+
+
+def test_init_weights_diversifies_seed_across_model_parts(monkeypatch):
+    """
+    Under interleaved pipeline parallelism a single rank can own multiple model
+    chunks. They must each get a distinct init seed, or their parameters would
+    collide.
+    """
+    fake_pp_mesh = _FakePPMesh(local_rank=0, size=2)
+    monkeypatch.setattr(
+        "olmo_core.nn.transformer.model.get_pp_mesh",
+        lambda _world_mesh: fake_pp_mesh,
+    )
+
+    part_a = _build_tiny_model()
+    part_a._pp_enabled = True
+    part_a.init_weights(
+        device=torch.device("cpu"), world_mesh=object(), model_part_idx=0
+    )
+
+    part_b = _build_tiny_model()
+    part_b._pp_enabled = True
+    part_b.init_weights(
+        device=torch.device("cpu"), world_mesh=object(), model_part_idx=1
+    )
+
+    assert not torch.equal(part_a.embeddings.weight, part_b.embeddings.weight)
+    assert not torch.equal(
+        part_a.blocks["0"].attention.w_q.weight,
+        part_b.blocks["0"].attention.w_q.weight,
+    )
+
+
+def test_init_weights_same_model_part_idx_is_deterministic(monkeypatch):
+    """Two chunks with the same (pp_rank, model_part_idx) must init identically."""
+    fake_pp_mesh = _FakePPMesh(local_rank=0, size=2)
+    monkeypatch.setattr(
+        "olmo_core.nn.transformer.model.get_pp_mesh",
+        lambda _world_mesh: fake_pp_mesh,
+    )
+
+    part_a = _build_tiny_model()
+    part_a._pp_enabled = True
+    part_a.init_weights(
+        device=torch.device("cpu"), world_mesh=object(), model_part_idx=1
+    )
+
+    part_b = _build_tiny_model()
+    part_b._pp_enabled = True
+    part_b.init_weights(
+        device=torch.device("cpu"), world_mesh=object(), model_part_idx=1
+    )
+
+    assert torch.equal(part_a.embeddings.weight, part_b.embeddings.weight)
+    assert torch.equal(
+        part_a.blocks["0"].attention.w_q.weight,
+        part_b.blocks["0"].attention.w_q.weight,
+    )
+
+
+def test_init_weights_model_part_idx_ignored_without_pp():
+    """
+    Without PP enabled, ``model_part_idx`` must not affect initialization —
+    existing non-PP training runs must produce identical RNG streams to before.
+    """
+    part_a = _build_tiny_model()
+    part_a.init_weights(device=torch.device("cpu"), model_part_idx=0)
+
+    part_b = _build_tiny_model()
+    part_b.init_weights(device=torch.device("cpu"), model_part_idx=7)
+
+    assert torch.equal(part_a.embeddings.weight, part_b.embeddings.weight)
+    assert torch.equal(
+        part_a.blocks["0"].attention.w_q.weight,
+        part_b.blocks["0"].attention.w_q.weight,
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Two small, independent fixes.

- **Disable Dynamo tracing through `TEAttentionBackend.forward`** — Transformer Engine attention uses Python/pybind setup that `torch.compile` should not trace. Adds `@torch.compiler.disable` to the forward method.
- **Diversify init seed across model parts under interleaved pipeline parallelism** — With an interleaved PP schedule (e.g. `Interleaved1F1B`, `InterleavedZeroBubble`) a single rank can own multiple model chunks. Previously `init_weights` derived its seed only from `pp_local_rank`, so all chunks on the same rank initialized to identical parameters. Adds a `model_part_idx` kwarg to `Transformer.init_weights` and incorporates it as `model_part_idx * pp_size`, which is collision-free with the PP rank contribution by construction. The caller in `train_module/transformer/common.py` is updated to pass the enumerated index.

## Test plan
- [x] `make checks` (style/lint/type)
- [x] `pytest -v src/test/nn/transformer/` (no GPU)
- [x] Sanity check that an existing non-PP training script's init RNG stream is unchanged (seed contribution is `0` when `model_part_idx=0`)
- [x] Confirm under an interleaved PP run that different chunks on the same rank produce different parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)