### PR TITLE
Improve checkpoint/S3 IO robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- S3 uploads/downloads now also retry on transient SSL errors (`ssl.SSLError`, botocore/urllib3 `SSLError`).
+- Distributed checkpoint writes now clone each tensor before serialization to avoid accidentally writing the full backing storage of a view/shared tensor, with a guard that raises `OLMoCheckpointError` if a written tensor is unexpectedly larger than its `nbytes`.
 - Fixed LM in-loop evaluator data-order drift across repeated runs by resetting loader bookkeeping before each pass and making deterministic reshuffling the default.
 - Fixed Qwen3 implementation to match HuggingFace by applying RoPE in the input dtype (bf16) rather than upcasting to fp32.
 - Fixed Beaker secret existence check to use the case-insensitive HTTP endpoint, avoiding spurious "secret not found" errors when secret names differ only in case.

--- a/src/olmo_core/distributed/checkpoint/__init__.py
+++ b/src/olmo_core/distributed/checkpoint/__init__.py
@@ -177,7 +177,7 @@ def load_state_dict(
     reader = RemoteFileSystemReader(
         dir, thread_count=thread_count, pre_download=pre_download, work_dir=work_dir
     )
-    dist_cp.load(
+    dist_cp.state_dict_loader.load(
         state_dict,
         checkpoint_id=dir,
         storage_reader=reader,

--- a/src/olmo_core/distributed/checkpoint/__init__.py
+++ b/src/olmo_core/distributed/checkpoint/__init__.py
@@ -366,7 +366,7 @@ def load_model_and_optim_state(
     if key_mapping is not None:
         swap_param_keys(state_dict, key_mapping, metadata=metadata)
 
-    dist_cp.load(
+    dist_cp.state_dict_loader.load(
         state_dict,
         checkpoint_id=dir,
         storage_reader=reader,

--- a/src/olmo_core/distributed/checkpoint/filesystem.py
+++ b/src/olmo_core/distributed/checkpoint/filesystem.py
@@ -122,9 +122,17 @@ def _write_items(
             else:
                 assert isinstance(data, torch.Tensor)
                 data = data.cpu()  # should already be on CPU, but just in case
+                data = data.clone()  # avoid serializing unrelated shared storage
                 torch.save(data, tmp_file)
 
             length = tmp_file.tell() - offset
+
+            if isinstance(data, torch.Tensor) and (length - data.nbytes) > 1024 * 1024:
+                raise OLMoCheckpointError(
+                    f"Written byte size mismatch for index {write_item.index}: "
+                    f"expected {data.nbytes}, got {length}. "
+                    "The data might be a view or sharing underlying storage with something else."
+                )
 
             results.append(
                 WriteResult(

--- a/src/olmo_core/io.py
+++ b/src/olmo_core/io.py
@@ -4,6 +4,7 @@ import os
 import pickle
 import re
 import shutil
+import ssl
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -932,9 +933,18 @@ def _get_s3_endpoint_url(scheme: str) -> Optional[str]:
 
 def _s3_retry_condition(err: Exception) -> bool:
     import botocore.exceptions as boto_errors
+    import urllib3.exceptions as urllib3_errors
 
     return isinstance(
-        err, (boto_errors.ClientError, boto_errors.HTTPClientError, boto_errors.ConnectionError)
+        err,
+        (
+            boto_errors.ClientError,
+            boto_errors.HTTPClientError,
+            boto_errors.ConnectionError,
+            boto_errors.SSLError,
+            urllib3_errors.SSLError,
+            ssl.SSLError,
+        ),
     )
 
 

--- a/src/test/io_test.py
+++ b/src/test/io_test.py
@@ -3,6 +3,7 @@ from glob import glob
 import pytest
 
 from olmo_core.io import (
+    _s3_retry_condition,
     copy_dir,
     copy_file,
     deserialize_from_tensor,
@@ -18,6 +19,19 @@ from olmo_core.io import (
 def test_serde_from_tensor():
     data = {"a": (1, 2)}
     assert deserialize_from_tensor(serialize_to_tensor(data)) == data
+
+
+def test_s3_retry_condition_includes_ssl_errors():
+    import ssl
+
+    import botocore.exceptions as boto_errors
+
+    # Transient network/SSL errors should be retried.
+    assert _s3_retry_condition(ssl.SSLError("handshake failure")) is True
+    assert _s3_retry_condition(boto_errors.ConnectionError(error="reset")) is True
+
+    # Non-transient errors should not be retried.
+    assert _s3_retry_condition(ValueError("not a network error")) is False
 
 
 def test_local_functionality(tmp_path):


### PR DESCRIPTION
## Summary

Three small, independent reliability improvements to the IO / distributed-checkpoint paths.

### S3 retries on transient SSL errors (`io.py`)
`_s3_retry_condition` now also treats SSL errors (`ssl.SSLError`, botocore `SSLError`, urllib3 `SSLError`) as retryable, alongside the existing client/HTTP/connection errors. Transient TLS handshake failures during S3 transfers are no longer fatal.

### Distributed checkpoint write correctness (`distributed/checkpoint/filesystem.py`)
Before `torch.save`-ing a tensor, clone it so a **view or storage-sharing tensor** doesn't drag its entire backing storage into the checkpoint shard. A guard raises `OLMoCheckpointError` if a written tensor's byte length exceeds its `nbytes` by more than 1 MiB, surfacing this class of bug loudly instead of silently bloating checkpoints.

### Loader API path (`distributed/checkpoint/__init__.py`)
Call `dist_cp.state_dict_loader.load(...)` instead of the top-level `dist_cp.load` alias.

## Tests
- New unit test for `_s3_retry_condition` covering SSL/connection (retryable) vs. non-network errors (not retryable).
- `pytest src/test/io_test.py` and the CPU `distributed/checkpoint` tests pass. (The `*_to_gcs_*` checkpoint tests require GCS credentials and are environment-gated.)
- `make checks` (isort/black/ruff/mypy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)