### PR TITLE
Misc training-utility improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `PowerLR`, a power-law learning rate scheduler with linear warmup, power-decay phase (`lr = initial_lr * (current / warmup) ** b` for negative `b`, making the LR independent of the training horizon), and an optional linear decay tail. Registered as `"power_lr"`.
 - Added `ComposableScheduler`, a piecewise LR scheduler built from `ComposableSchedulerStage` segments (linear/cosine interpolation between endpoint LRs) on an absolute time axis. Registered as `"composable"`. Note: `ComposableScheduler` ignores the `t_max` passed to `get_lr` and emits a once-per-instance `UserWarning` to that effect.
 - Added `OverrideDecay`, a late-stage decay override usable on both `ComposableScheduler` and `SequentialScheduler` via an `override_decay` field. When `current >= override_decay.start`, the main schedule is interrupted mid-flight and the LR decays from the value the main schedule would have produced at `start` to a target LR over `duration` (linear or cosine). `SequentialScheduler` additionally warns that `t_max` is ignored once the override becomes active.
+- `OLMO_RICH_LOGGING` can now explicitly enable *or* disable rich console logging (`0`/`false`/`no`/`off` disables it); previously setting it to any value only force-enabled rich logging.
+- `init_distributed()` now bootstraps a minimal single-process environment (`RANK=0`, `WORLD_SIZE=1`, `MASTER_ADDR`/`MASTER_PORT`) when launch env vars are absent, so scripts can be run directly (without `torchrun`) for single-process debugging.
 
 
 ### Fixed
 
+- Excluded `mark_dynamic` from `torch.compile` tracing (`@torch.compiler.disable`).
+- Clearer error messages (now include the offending values) when a rank batch size isn't divisible by the sequence length, or `max_target_sequence_length` isn't a multiple of `sequence_length`.
 - Fixed LM in-loop evaluator data-order drift across repeated runs by resetting loader bookkeeping before each pass and making deterministic reshuffling the default.
 - Fixed Qwen3 implementation to match HuggingFace by applying RoPE in the input dtype (bf16) rather than upcasting to fp32.
 - Fixed Beaker secret existence check to use the case-insensitive HTTP endpoint, avoiding spurious "secret not found" errors when secret names differ only in case.

--- a/src/olmo_core/data/data_loader.py
+++ b/src/olmo_core/data/data_loader.py
@@ -635,7 +635,7 @@ class NumpyFSLDataLoader(NumpyDataLoaderBase):
         assert isinstance(self.dataset, NumpyFSLDatasetBase)
         if self.rank_batch_size % self.dataset.sequence_length != 0:
             raise OLMoConfigurationError(
-                "rank batch size (in tokens) must be divisible by sequence length"
+                f"rank batch size (in tokens) {self.rank_batch_size} must be divisible by sequence length {self.dataset.sequence_length}"
             )
 
     @property

--- a/src/olmo_core/data/numpy_dataset.py
+++ b/src/olmo_core/data/numpy_dataset.py
@@ -521,7 +521,7 @@ class NumpyFSLDataset(NumpyFSLDatasetBase):
             or max_target_sequence_length % sequence_length != 0
         ):
             raise OLMoConfigurationError(
-                "'max_target_sequence_length' should be a multiple of 'sequence_length'"
+                f"'max_target_sequence_length'({max_target_sequence_length}) should be a multiple of 'sequence_length'({sequence_length})"
             )
 
         self._max_target_sequence_length = max_target_sequence_length
@@ -716,7 +716,7 @@ class NumpyFSLDatasetMixture(NumpyFSLDataset):
             or max_target_sequence_length % sequence_length != 0
         ):
             raise OLMoConfigurationError(
-                "'max_target_sequence_length' should be a multiple of 'sequence_length'"
+                f"'max_target_sequence_length'({max_target_sequence_length}) should be a multiple of 'sequence_length'({sequence_length})"
             )
 
         super().__init__(

--- a/src/olmo_core/distributed/utils.py
+++ b/src/olmo_core/distributed/utils.py
@@ -5,6 +5,7 @@ Distributed helpers, most of which work in a non-distributed context as well for
 import logging
 import math
 import os
+import socket
 from datetime import timedelta
 from typing import Callable, List, Optional, TypeVar, Union, cast
 
@@ -22,9 +23,50 @@ OLMO_LOCAL_RANK_ENV_VAR = "LOCAL_RANK"
 OLMO_NUM_NODES_ENV_VAR = "NUM_NODES"
 OLMO_LOCAL_WORLD_SIZE_ENV_VAR = "LOCAL_WORLD_SIZE"
 BEAKER_HOSTNAME_ENV_VAR = "BEAKER_NODE_HOSTNAME"
+TORCH_RANK_ENV_VAR = "RANK"
+TORCH_WORLD_SIZE_ENV_VAR = "WORLD_SIZE"
+TORCH_MASTER_ADDR_ENV_VAR = "MASTER_ADDR"
+TORCH_MASTER_PORT_ENV_VAR = "MASTER_PORT"
 
 
 log = logging.getLogger(__name__)
+
+
+def _find_free_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _bootstrap_single_process_distributed_env() -> None:
+    """
+    Fill in the minimal torchrun-style environment for direct single-process runs.
+    """
+    missing_rank_env = (
+        TORCH_RANK_ENV_VAR not in os.environ and TORCH_WORLD_SIZE_ENV_VAR not in os.environ
+    )
+    explicit_singleton = (
+        os.environ.get(TORCH_WORLD_SIZE_ENV_VAR) == "1"
+        and os.environ.get(TORCH_RANK_ENV_VAR, "0") == "0"
+    )
+
+    if not missing_rank_env and not explicit_singleton:
+        return
+
+    if missing_rank_env:
+        log_or_print(
+            log,
+            "Distributed launch env vars not found; bootstrapping a single-process distributed setup.",
+        )
+
+    set_env_var(TORCH_RANK_ENV_VAR, "0")
+    set_env_var(TORCH_WORLD_SIZE_ENV_VAR, "1")
+    set_env_var(OLMO_LOCAL_RANK_ENV_VAR, "0")
+    set_env_var(OLMO_LOCAL_WORLD_SIZE_ENV_VAR, "1")
+    set_env_var(OLMO_NUM_NODES_ENV_VAR, "1")
+    set_env_var(TORCH_MASTER_ADDR_ENV_VAR, "127.0.0.1")
+    if TORCH_MASTER_PORT_ENV_VAR not in os.environ:
+        set_env_var(TORCH_MASTER_PORT_ENV_VAR, str(_find_free_local_port()))
 
 
 def init_distributed(
@@ -49,6 +91,8 @@ def init_distributed(
 
     # Force processes to synchronize at init process group.
     set_env_var("TORCH_DIST_INIT_BARRIER", "1")
+
+    _bootstrap_single_process_distributed_env()
 
     if shared_filesytem:
         set_env_var(OLMO_SHARED_FS_ENV_VAR, "1")

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -30,6 +30,7 @@ from .exceptions import OLMoCLIError, OLMoEnvironmentError, OLMoError, OLMoThrea
 
 OLMO_NUM_THREADS_ENV_VAR = "OLMO_NUM_THREADS"
 LOG_FILTER_TYPE_ENV_VAR = "LOG_FILTER_TYPE"
+RICH_LOGGING_ENV_VAR = "OLMO_RICH_LOGGING"
 
 
 _log_extra_fields: Dict[str, Any] = {}
@@ -115,6 +116,7 @@ def move_to_device(o: T, device: torch.device, non_blocking: Optional[bool] = No
         return o
 
 
+@torch.compiler.disable
 def mark_dynamic(x: torch.Tensor, dim: Union[int, Sequence[int]], strict: bool = True):
     """
     Mark a tensor as having dynamic sizes for ``torch.compile()``.
@@ -311,12 +313,20 @@ def setup_logging(
     logging.setLogRecordFactory(log_record_factory)
 
     handler: logging.Handler
-    # NOTE: Beaker supports rich logging now.
-    if (
-        os.environ.get("OLMO_RICH_LOGGING") is None
-        and os.environ.get("BEAKER_EXPERIMENT_ID") is None
-        and (os.environ.get("DEBIAN_FRONTEND", None) == "noninteractive" or not sys.stdout.isatty())
-    ):
+    rich_logging_env = os.environ.get(RICH_LOGGING_ENV_VAR)
+    if rich_logging_env is not None:
+        use_rich_logging = rich_logging_env.lower() not in ("0", "false", "no", "off")
+    else:
+        # NOTE: Beaker supports rich logging now.
+        use_rich_logging = not (
+            os.environ.get("BEAKER_EXPERIMENT_ID") is None
+            and (
+                os.environ.get("DEBIAN_FRONTEND", None) == "noninteractive"
+                or not sys.stdout.isatty()
+            )
+        )
+
+    if not use_rich_logging:
         handler = logging.StreamHandler(sys.stdout)
         formatter = logging.Formatter(
             "%(asctime)s\t%(hostname)s:%(local_rank)s\t%(name)s:%(lineno)s\t%(levelname)s\t%(message)s"
@@ -796,6 +806,9 @@ _CUDA_STREAMS: Dict[str, torch.cuda.Stream] = {}
 
 
 def get_or_init_stream(id: str, priority: int = 0) -> torch.cuda.Stream:
+    # NOTE: pri_idx = std::clamp(-priority, 0, max_stream_priorities - 1)
+    # pytorch/c10/cuda/CUDAStream.cpp
+    # it turns out priority>=0 is the same as default priority=0
     global _CUDA_STREAMS
     if id in _CUDA_STREAMS:
         return _CUDA_STREAMS[id]


### PR DESCRIPTION
## Summary

A handful of small, independent quality-of-life improvements to the training utilities. No behavior change to existing default paths beyond what's noted.

### `OLMO_RICH_LOGGING` becomes a real toggle (`utils.py`)
`setup_logging` now treats `OLMO_RICH_LOGGING` as an explicit on/off switch — `0`/`false`/`no`/`off` disables rich logging, anything else enables it. Previously, setting the var to *any* value (even `0`) only force-*enabled* rich logging. When the var is unset, behavior is unchanged.

### Single-process distributed bootstrap (`distributed/utils.py`)
`init_distributed()` now fills in a minimal torchrun-style environment (`RANK=0`, `WORLD_SIZE=1`, `MASTER_ADDR`, a free `MASTER_PORT`) when those launch env vars are absent, so a training/debug script can be run directly without `torchrun` for single-process work. Only activates when the rank env is missing or an explicit singleton (`WORLD_SIZE=1`).

### `mark_dynamic` excluded from `torch.compile` tracing (`utils.py`)
`@torch.compiler.disable` on `mark_dynamic`, so the dynamic-shape marking helper isn't traced by Dynamo.

### Clearer error messages (`data/data_loader.py`, `data/numpy_dataset.py`)
The rank-batch-size / `max_target_sequence_length` divisibility errors now include the actual offending values.

## Tests
`pytest src/test/utils_test.py src/test/distributed/utils_test.py` → 23 passed, 1 skipped. `make checks` (isort/black/ruff/mypy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)