### PR TITLE
[1/n] Add vision transformer, connector, and MultimodalLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added vision transformer encoder (`VisionTransformer`, `SiglipVisionTransformer`), vision-to-LM connector (`VisionConnector`), and `MultimodalTransformer` — a composite vision-language model that fuses image patch tokens into the LM token stream. Supports OpenAI CLIP, SigLIP, and SigLIP2 backbone variants with factory configs for all standard Molmo2 checkpoints.
+- Added a configurable vision transformer encoder (`VisionTransformer`, configured via `VisionEncoderConfig`), vision-to-LM connector (`VisionConnector`), and `MultimodalLM` — a composite vision-language model that fuses image patch tokens into the LM token stream. Supports OpenAI CLIP, SigLIP, and SigLIP2 encoder variants with factory configs for all standard Molmo2 checkpoints.
 - Added `HFConverterCallback`, which can be used to convert models to huggingface format at the end of the training run.
 - Trainer now records checkpoint save and load durations as `train/checkpoint_save_duration_s` and `train/checkpoint_load_duration_s` metrics.
 - Added `PowerLR`, a power-law learning rate scheduler with linear warmup, power-decay phase (`lr = initial_lr * (current / warmup) ** b` for negative `b`, making the LR independent of the training horizon), and an optional linear decay tail. Registered as `"power_lr"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added vision transformer encoder (`VisionTransformer`, `SiglipVisionTransformer`), vision-to-LM connector (`VisionConnector`), and `MultimodalTransformer` — a composite vision-language model that fuses image patch tokens into the LM token stream. Supports OpenAI CLIP, SigLIP, and SigLIP2 backbone variants with factory configs for all standard Molmo2 checkpoints.
 - Added `HFConverterCallback`, which can be used to convert models to huggingface format at the end of the training run.
 - Trainer now records checkpoint save and load durations as `train/checkpoint_save_duration_s` and `train/checkpoint_load_duration_s` metrics.
 - Added `PowerLR`, a power-law learning rate scheduler with linear warmup, power-decay phase (`lr = initial_lr * (current / warmup) ** b` for negative `b`, making the LR independent of the training horizon), and an optional linear decay tail. Registered as `"power_lr"`.

--- a/src/olmo_core/nn/__init__.py
+++ b/src/olmo_core/nn/__init__.py
@@ -5,25 +5,23 @@ Common :class:`torch.nn.Module` implementations.
 from .vision import (
     ImagePoolingType,
     ImageProjectorType,
-    MultimodalTransformer,
-    MultimodalTransformerConfig,
-    SiglipVisionTransformer,
-    VisionBackboneConfig,
-    VisionBackboneType,
+    MultimodalLM,
+    MultimodalLMConfig,
     VisionConnector,
     VisionConnectorConfig,
+    VisionEncoderConfig,
+    VisionEncoderType,
     VisionTransformer,
 )
 
 __all__ = [
-    "VisionBackboneType",
-    "VisionBackboneConfig",
+    "VisionEncoderType",
+    "VisionEncoderConfig",
     "VisionTransformer",
-    "SiglipVisionTransformer",
     "ImagePoolingType",
     "ImageProjectorType",
     "VisionConnectorConfig",
     "VisionConnector",
-    "MultimodalTransformerConfig",
-    "MultimodalTransformer",
+    "MultimodalLMConfig",
+    "MultimodalLM",
 ]

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -506,6 +506,7 @@ class Transformer(nn.Module):
         self,
         input_ids: torch.Tensor,
         *,
+        input_embeddings: Optional[torch.Tensor] = None,
         labels: Optional[torch.Tensor] = None,
         ignore_index: int = -100,
         loss_reduction: Literal["mean", "sum", "none"] = "mean",
@@ -519,6 +520,12 @@ class Transformer(nn.Module):
         Run the transformer on the token input IDs.
 
         :param input_ids: The token input IDs, shape ``(batch_size, seq_len)``.
+        :param input_embeddings: Pre-computed embeddings to use instead of looking up
+            ``input_ids`` in the embedding table, shape
+            ``(batch_size, seq_len, d_model)``.  When provided the embedding lookup,
+            scale, and norm steps are all skipped.  Intended for multimodal use-cases
+            where image features have already been spliced into the embedding sequence.
+            Not supported with context parallelism.
         :param labels: The token labels, shape ``(batch_size, seq_len)``.
         :param ignore_index: The index to ignore in the loss computation. Default is -100.
         :param loss_reduction: The reduction method for the loss. Can be "mean", "sum", or "none".
@@ -550,11 +557,14 @@ class Transformer(nn.Module):
 
         # Get embeddings but pass-through for non-existent layers to allow easy
         # pipeline parallel configuration.
-        h = self.embeddings(input_ids) if self.embeddings is not None else input_ids
-        if self.embeddings is not None and self.embed_scale is not None:
-            h = h * self.embed_scale
-        if self.embedding_norm is not None:
-            h = self.embedding_norm(h)
+        if input_embeddings is not None:
+            h = move_to_device(input_embeddings, self.device)
+        else:
+            h = self.embeddings(input_ids) if self.embeddings is not None else input_ids
+            if self.embeddings is not None and self.embed_scale is not None:
+                h = h * self.embed_scale
+            if self.embedding_norm is not None:
+                h = self.embedding_norm(h)
 
         # Run each block.
         for block_key, block in self.blocks.items():

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -537,6 +537,13 @@ class Transformer(nn.Module):
 
         :returns: The logits if ``labels`` is ``None`` or the losses if ``labels`` is not ``None``.
         """
+        if input_embeddings is not None and self._cp_load_balancer is not None:
+            raise RuntimeError(
+                "`input_embeddings` is not supported with context parallelism: `_prepare_inputs` "
+                "shards `input_ids`/`labels`/RoPE while `input_embeddings` stays full-size, which "
+                "would misalign the hidden states."
+            )
+
         (
             input_ids,
             labels,

--- a/src/olmo_core/nn/vision/__init__.py
+++ b/src/olmo_core/nn/vision/__init__.py
@@ -1,19 +1,16 @@
 """
-Common :class:`torch.nn.Module` implementations.
+Vision encoder modules for multimodal (VLM) training.
 """
 
-from .vision import (
+from .config import VisionBackboneConfig, VisionBackboneType
+from .connector import (
     ImagePoolingType,
     ImageProjectorType,
-    MultimodalTransformer,
-    MultimodalTransformerConfig,
-    SiglipVisionTransformer,
-    VisionBackboneConfig,
-    VisionBackboneType,
     VisionConnector,
     VisionConnectorConfig,
-    VisionTransformer,
 )
+from .image_vit import SiglipVisionTransformer, VisionTransformer
+from .multimodal import MultimodalTransformer, MultimodalTransformerConfig
 
 __all__ = [
     "VisionBackboneType",

--- a/src/olmo_core/nn/vision/__init__.py
+++ b/src/olmo_core/nn/vision/__init__.py
@@ -3,10 +3,10 @@ Vision encoder modules for multimodal (VLM) training.
 """
 
 from .config import (
-    VisionBackboneConfig,
-    VisionBackboneType,
     VisionBlockConfig,
     VisionBlockType,
+    VisionEncoderConfig,
+    VisionEncoderType,
 )
 from .connector import (
     ImagePoolingType,
@@ -14,29 +14,22 @@ from .connector import (
     VisionConnector,
     VisionConnectorConfig,
 )
-from .image_vit import (
-    SiglipVisionTransformer,
-    VisionTransformer,
-    ViTAttention,
-    ViTBlock,
-    ViTMLP,
-)
-from .multimodal import MultimodalTransformer, MultimodalTransformerConfig
+from .image_vit import VisionTransformer, ViTAttention, ViTBlock, ViTMLP
+from .multimodal import MultimodalLM, MultimodalLMConfig
 
 __all__ = [
-    "VisionBackboneType",
-    "VisionBackboneConfig",
+    "VisionEncoderType",
+    "VisionEncoderConfig",
     "VisionBlockType",
     "VisionBlockConfig",
     "ViTAttention",
     "ViTMLP",
     "ViTBlock",
     "VisionTransformer",
-    "SiglipVisionTransformer",
     "ImagePoolingType",
     "ImageProjectorType",
     "VisionConnectorConfig",
     "VisionConnector",
-    "MultimodalTransformerConfig",
-    "MultimodalTransformer",
+    "MultimodalLMConfig",
+    "MultimodalLM",
 ]

--- a/src/olmo_core/nn/vision/__init__.py
+++ b/src/olmo_core/nn/vision/__init__.py
@@ -2,19 +2,35 @@
 Vision encoder modules for multimodal (VLM) training.
 """
 
-from .config import VisionBackboneConfig, VisionBackboneType
+from .config import (
+    VisionBackboneConfig,
+    VisionBackboneType,
+    VisionBlockConfig,
+    VisionBlockType,
+)
 from .connector import (
     ImagePoolingType,
     ImageProjectorType,
     VisionConnector,
     VisionConnectorConfig,
 )
-from .image_vit import SiglipVisionTransformer, VisionTransformer
+from .image_vit import (
+    SiglipVisionTransformer,
+    VisionTransformer,
+    ViTAttention,
+    ViTBlock,
+    ViTMLP,
+)
 from .multimodal import MultimodalTransformer, MultimodalTransformerConfig
 
 __all__ = [
     "VisionBackboneType",
     "VisionBackboneConfig",
+    "VisionBlockType",
+    "VisionBlockConfig",
+    "ViTAttention",
+    "ViTMLP",
+    "ViTBlock",
     "VisionTransformer",
     "SiglipVisionTransformer",
     "ImagePoolingType",

--- a/src/olmo_core/nn/vision/config.py
+++ b/src/olmo_core/nn/vision/config.py
@@ -8,14 +8,14 @@ from olmo_core.config import DType, StrEnum
 from olmo_core.nn.config import ModuleConfig
 
 __all__ = [
-    "VisionBackboneType",
+    "VisionEncoderType",
     "VisionBlockType",
     "VisionBlockConfig",
-    "VisionBackboneConfig",
+    "VisionEncoderConfig",
 ]
 
 
-class VisionBackboneType(StrEnum):
+class VisionEncoderType(StrEnum):
     """
     An enumeration of supported vision encoder architectures.
     """
@@ -31,13 +31,13 @@ class VisionBackboneType(StrEnum):
     """
     SigLIP-style encoder (no CLS token).
     Default config matches SigLIP-SO400M-14-378.
-    ➡️ :class:`~olmo_core.nn.vision.SiglipVisionTransformer`
+    ➡️ :class:`~olmo_core.nn.vision.VisionTransformer`
     """
 
     siglip2 = "siglip2"
     """
     SigLIP2-style encoder (no CLS token; same architecture as SigLIP, improved training).
-    ➡️ :class:`~olmo_core.nn.vision.SiglipVisionTransformer`
+    ➡️ :class:`~olmo_core.nn.vision.VisionTransformer`
     """
 
 
@@ -64,18 +64,18 @@ class VisionBlockConfig(ModuleConfig):
     :attr:`VisionBlockType.standard` is available; additional block variants can be
     registered here as they are added.
 
-    The block reads its layer dimensions from the parent :class:`VisionBackboneConfig`
+    The block reads its layer dimensions from the parent :class:`VisionEncoderConfig`
     passed to :meth:`build`.
     """
 
     name: VisionBlockType = VisionBlockType.standard
     """The vision block implementation to use."""
 
-    def build(self, cfg: "VisionBackboneConfig", init_device: str = "cpu") -> nn.Module:
+    def build(self, cfg: "VisionEncoderConfig", init_device: str = "cpu") -> nn.Module:
         """
         Instantiate the block.
 
-        :param cfg: The parent vision backbone configuration supplying layer dimensions.
+        :param cfg: The parent vision encoder configuration supplying layer dimensions.
         :param init_device: Device on which to initialise parameters.
         :returns: A :class:`~olmo_core.nn.vision.ViTBlock` instance.
         """
@@ -88,7 +88,7 @@ class VisionBlockConfig(ModuleConfig):
 
 
 @dataclass
-class VisionBackboneConfig(ModuleConfig):
+class VisionEncoderConfig(ModuleConfig):
     """
     Configuration for a vision transformer encoder.
 
@@ -98,7 +98,7 @@ class VisionBackboneConfig(ModuleConfig):
     ==========================================  =======================
     Factory                                     Checkpoint
     ==========================================  =======================
-    :meth:`VisionBackboneConfig`                CLIP ViT-L/14-336
+    :meth:`VisionEncoderConfig`                CLIP ViT-L/14-336
     :meth:`siglip_b16_224`                      SigLIP B/16-224
     :meth:`siglip_l16_384`                      SigLIP L/16-384
     :meth:`siglip_so400m_patch14_224`           SigLIP SO400M/14-224
@@ -111,14 +111,14 @@ class VisionBackboneConfig(ModuleConfig):
 
     Example usage::
 
-        cfg = VisionBackboneConfig()           # CLIP ViT-L/14-336
-        cfg = VisionBackboneConfig.siglip2_so400m_patch14_378()
+        cfg = VisionEncoderConfig()           # CLIP ViT-L/14-336
+        cfg = VisionEncoderConfig.siglip2_so400m_patch14_378()
         vit = cfg.build(init_device="cpu")
         # images: (B, n_patches, patch_size**2 * 3)  -- pre-patchified
         # outputs: list of per-layer hidden states
     """
 
-    name: VisionBackboneType = VisionBackboneType.openai
+    name: VisionEncoderType = VisionEncoderType.openai
     """The vision encoder architecture."""
 
     image_default_input_size: Tuple[int, int] = (336, 336)
@@ -167,6 +167,24 @@ class VisionBackboneConfig(ModuleConfig):
     residual_dropout: float = 0.0
     """Dropout probability applied after the attention output projection."""
 
+    use_cls_token: bool = True
+    """
+    Whether to prepend a learnable CLS token (CLIP-style). SigLIP-style encoders set
+    this to ``False``.
+    """
+
+    patch_embedding_bias: bool = False
+    """
+    Whether the patch-embedding projection has a bias term. CLIP omits it; SigLIP
+    includes it.
+    """
+
+    use_pre_ln: bool = True
+    """
+    Whether a LayerNorm is applied to the embeddings before the transformer blocks
+    (CLIP-style). SigLIP-style encoders set this to ``False``.
+    """
+
     block: VisionBlockConfig = field(default_factory=VisionBlockConfig)
     """
     Configuration selecting the transformer block implementation. Defaults to the
@@ -192,11 +210,14 @@ class VisionBackboneConfig(ModuleConfig):
     @classmethod
     def siglip_b16_224(cls) -> Self:
         """
-        Returns a :class:`VisionBackboneConfig` matching SigLIP ViT-B/16-224
+        Returns a :class:`VisionEncoderConfig` matching SigLIP ViT-B/16-224
         (``google/siglip-base-patch16-224``).
         """
         return cls(
-            name=VisionBackboneType.siglip,
+            name=VisionEncoderType.siglip,
+            use_cls_token=False,
+            patch_embedding_bias=True,
+            use_pre_ln=False,
             image_default_input_size=(224, 224),
             image_patch_size=16,
             image_emb_dim=768,
@@ -213,11 +234,14 @@ class VisionBackboneConfig(ModuleConfig):
     @classmethod
     def siglip_l16_384(cls) -> Self:
         """
-        Returns a :class:`VisionBackboneConfig` matching SigLIP ViT-L/16-384
+        Returns a :class:`VisionEncoderConfig` matching SigLIP ViT-L/16-384
         (``google/siglip-large-patch16-384``).
         """
         return cls(
-            name=VisionBackboneType.siglip,
+            name=VisionEncoderType.siglip,
+            use_cls_token=False,
+            patch_embedding_bias=True,
+            use_pre_ln=False,
             image_default_input_size=(384, 384),
             image_patch_size=16,
             image_emb_dim=1024,
@@ -234,11 +258,14 @@ class VisionBackboneConfig(ModuleConfig):
     @classmethod
     def siglip_so400m_patch14_224(cls) -> Self:
         """
-        Returns a :class:`VisionBackboneConfig` matching SigLIP SO400M/14-224
+        Returns a :class:`VisionEncoderConfig` matching SigLIP SO400M/14-224
         (``google/siglip-so400m-patch14-224``).
         """
         return cls(
-            name=VisionBackboneType.siglip,
+            name=VisionEncoderType.siglip,
+            use_cls_token=False,
+            patch_embedding_bias=True,
+            use_pre_ln=False,
             image_default_input_size=(224, 224),
             image_patch_size=14,
             image_emb_dim=1152,
@@ -255,11 +282,14 @@ class VisionBackboneConfig(ModuleConfig):
     @classmethod
     def siglip_so400m(cls) -> Self:
         """
-        Returns a :class:`VisionBackboneConfig` matching SigLIP SO400M/14-378
+        Returns a :class:`VisionEncoderConfig` matching SigLIP SO400M/14-378
         (``google/siglip-so400m-patch14-378``).
         """
         return cls(
-            name=VisionBackboneType.siglip,
+            name=VisionEncoderType.siglip,
+            use_cls_token=False,
+            patch_embedding_bias=True,
+            use_pre_ln=False,
             image_default_input_size=(378, 378),
             image_patch_size=14,
             image_emb_dim=1152,
@@ -280,11 +310,14 @@ class VisionBackboneConfig(ModuleConfig):
     @classmethod
     def siglip2_b16_256(cls) -> Self:
         """
-        Returns a :class:`VisionBackboneConfig` matching SigLIP2 ViT-B/16-256
+        Returns a :class:`VisionEncoderConfig` matching SigLIP2 ViT-B/16-256
         (``google/siglip2-base-patch16-256``).
         """
         return cls(
-            name=VisionBackboneType.siglip2,
+            name=VisionEncoderType.siglip2,
+            use_cls_token=False,
+            patch_embedding_bias=True,
+            use_pre_ln=False,
             image_default_input_size=(256, 256),
             image_patch_size=16,
             image_emb_dim=768,
@@ -301,11 +334,14 @@ class VisionBackboneConfig(ModuleConfig):
     @classmethod
     def siglip2_l16_256(cls) -> Self:
         """
-        Returns a :class:`VisionBackboneConfig` matching SigLIP2 ViT-L/16-256
+        Returns a :class:`VisionEncoderConfig` matching SigLIP2 ViT-L/16-256
         (``google/siglip2-large-patch16-256``).
         """
         return cls(
-            name=VisionBackboneType.siglip2,
+            name=VisionEncoderType.siglip2,
+            use_cls_token=False,
+            patch_embedding_bias=True,
+            use_pre_ln=False,
             image_default_input_size=(256, 256),
             image_patch_size=16,
             image_emb_dim=1024,
@@ -322,11 +358,14 @@ class VisionBackboneConfig(ModuleConfig):
     @classmethod
     def siglip2_so400m_patch14_378(cls) -> Self:
         """
-        Returns a :class:`VisionBackboneConfig` matching SigLIP2 SO400M/14-378
+        Returns a :class:`VisionEncoderConfig` matching SigLIP2 SO400M/14-378
         (``google/siglip2-so400m-patch14-378``).
         """
         return cls(
-            name=VisionBackboneType.siglip2,
+            name=VisionEncoderType.siglip2,
+            use_cls_token=False,
+            patch_embedding_bias=True,
+            use_pre_ln=False,
             image_default_input_size=(378, 378),
             image_patch_size=14,
             image_emb_dim=1152,
@@ -343,11 +382,14 @@ class VisionBackboneConfig(ModuleConfig):
     @classmethod
     def siglip2_so400m_patch16_256(cls) -> Self:
         """
-        Returns a :class:`VisionBackboneConfig` matching SigLIP2 SO400M/16-256
+        Returns a :class:`VisionEncoderConfig` matching SigLIP2 SO400M/16-256
         (``google/siglip2-so400m-patch16-256``).
         """
         return cls(
-            name=VisionBackboneType.siglip2,
+            name=VisionEncoderType.siglip2,
+            use_cls_token=False,
+            patch_embedding_bias=True,
+            use_pre_ln=False,
             image_default_input_size=(256, 256),
             image_patch_size=16,
             image_emb_dim=1152,
@@ -366,14 +408,9 @@ class VisionBackboneConfig(ModuleConfig):
         Instantiate the vision encoder on ``init_device``.
 
         :param init_device: Device string (e.g. ``"cpu"``, ``"meta"``).
-        :returns: A :class:`~olmo_core.nn.vision.VisionTransformer` or
-            :class:`~olmo_core.nn.vision.SiglipVisionTransformer` instance.
+        :returns: A :class:`~olmo_core.nn.vision.VisionTransformer` instance configured
+            for the selected encoder variant.
         """
-        from .image_vit import SiglipVisionTransformer, VisionTransformer
+        from .image_vit import VisionTransformer
 
-        if self.name == VisionBackboneType.openai:
-            return VisionTransformer(self, init_device=init_device)
-        elif self.name in (VisionBackboneType.siglip, VisionBackboneType.siglip2):
-            return SiglipVisionTransformer(self, init_device=init_device)
-        else:
-            raise NotImplementedError(f"Vision backbone type '{self.name}' is not supported.")
+        return VisionTransformer(self, init_device=init_device)

--- a/src/olmo_core/nn/vision/config.py
+++ b/src/olmo_core/nn/vision/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Tuple
 
 import torch.nn as nn
@@ -9,6 +9,8 @@ from olmo_core.nn.config import ModuleConfig
 
 __all__ = [
     "VisionBackboneType",
+    "VisionBlockType",
+    "VisionBlockConfig",
     "VisionBackboneConfig",
 ]
 
@@ -37,6 +39,52 @@ class VisionBackboneType(StrEnum):
     SigLIP2-style encoder (no CLS token; same architecture as SigLIP, improved training).
     ➡️ :class:`~olmo_core.nn.vision.SiglipVisionTransformer`
     """
+
+
+class VisionBlockType(StrEnum):
+    """
+    An enumeration of the different vision transformer block implementations.
+    """
+
+    standard = "standard"
+    """
+    Standard pre-LN ViT block (multi-head attention + MLP).
+    ➡️ :class:`~olmo_core.nn.vision.ViTBlock`
+    """
+
+
+@dataclass
+class VisionBlockConfig(ModuleConfig):
+    """
+    Configuration for a single vision transformer block.
+
+    Mirrors the language-model :class:`~olmo_core.nn.transformer.TransformerBlockConfig`
+    pattern: the block implementation is selected via :attr:`name` and :meth:`build`
+    dispatches to the matching public block class. Today only
+    :attr:`VisionBlockType.standard` is available; additional block variants can be
+    registered here as they are added.
+
+    The block reads its layer dimensions from the parent :class:`VisionBackboneConfig`
+    passed to :meth:`build`.
+    """
+
+    name: VisionBlockType = VisionBlockType.standard
+    """The vision block implementation to use."""
+
+    def build(self, cfg: "VisionBackboneConfig", init_device: str = "cpu") -> nn.Module:
+        """
+        Instantiate the block.
+
+        :param cfg: The parent vision backbone configuration supplying layer dimensions.
+        :param init_device: Device on which to initialise parameters.
+        :returns: A :class:`~olmo_core.nn.vision.ViTBlock` instance.
+        """
+        from .image_vit import ViTBlock
+
+        if self.name == VisionBlockType.standard:
+            return ViTBlock(cfg, init_device=init_device)
+        else:
+            raise NotImplementedError(self.name)
 
 
 @dataclass
@@ -118,6 +166,12 @@ class VisionBackboneConfig(ModuleConfig):
 
     residual_dropout: float = 0.0
     """Dropout probability applied after the attention output projection."""
+
+    block: VisionBlockConfig = field(default_factory=VisionBlockConfig)
+    """
+    Configuration selecting the transformer block implementation. Defaults to the
+    standard pre-LN ViT block; see :class:`VisionBlockConfig`.
+    """
 
     initializer_range: float = 0.02
     """Std dev for normal-distribution weight initialisation."""

--- a/src/olmo_core/nn/vision/config.py
+++ b/src/olmo_core/nn/vision/config.py
@@ -1,0 +1,317 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch.nn as nn
+
+from ...config import DType, StrEnum
+from ..config import ModuleConfig
+
+__all__ = [
+    "VisionBackboneType",
+    "VisionBackboneConfig",
+]
+
+
+class VisionBackboneType(StrEnum):
+    """
+    An enumeration of supported vision encoder architectures.
+    """
+
+    openai = "openai"
+    """
+    OpenAI CLIP ViT-style encoder (with CLS token).
+    Default config matches ViT-L/14-336.
+    ➡️ :class:`~olmo_core.nn.vision.VisionTransformer`
+    """
+
+    siglip = "siglip"
+    """
+    SigLIP-style encoder (no CLS token).
+    Default config matches SigLIP-SO400M-14-378.
+    ➡️ :class:`~olmo_core.nn.vision.SiglipVisionTransformer`
+    """
+
+    siglip2 = "siglip2"
+    """
+    SigLIP2-style encoder (no CLS token; same architecture as SigLIP, improved training).
+    ➡️ :class:`~olmo_core.nn.vision.SiglipVisionTransformer`
+    """
+
+
+@dataclass
+class VisionBackboneConfig(ModuleConfig):
+    """
+    Configuration for a vision transformer encoder.
+
+    Default field values correspond to OpenAI CLIP ViT-L/14-336.
+    Use the class-method factories for other standard checkpoints:
+
+    ==========================================  =======================
+    Factory                                     Checkpoint
+    ==========================================  =======================
+    :meth:`VisionBackboneConfig`                CLIP ViT-L/14-336
+    :meth:`siglip_b16_224`                      SigLIP B/16-224
+    :meth:`siglip_l16_384`                      SigLIP L/16-384
+    :meth:`siglip_so400m_patch14_224`           SigLIP SO400M/14-224
+    :meth:`siglip_so400m`                       SigLIP SO400M/14-378
+    :meth:`siglip2_b16_256`                     SigLIP2 B/16-256
+    :meth:`siglip2_l16_256`                     SigLIP2 L/16-256
+    :meth:`siglip2_so400m_patch14_378`          SigLIP2 SO400M/14-378
+    :meth:`siglip2_so400m_patch16_256`          SigLIP2 SO400M/16-256
+    ==========================================  =======================
+
+    Example usage::
+
+        cfg = VisionBackboneConfig()           # CLIP ViT-L/14-336
+        cfg = VisionBackboneConfig.siglip2_so400m_patch14_378()
+        vit = cfg.build(init_device="cpu")
+        # images: (B, n_patches, patch_size**2 * 3)  -- pre-patchified
+        # outputs: list of per-layer hidden states
+    """
+
+    name: VisionBackboneType = VisionBackboneType.openai
+    """The vision encoder architecture."""
+
+    image_default_input_size: Tuple[int, int] = (336, 336)
+    """Default (height, width) of input images in pixels."""
+
+    image_patch_size: int = 14
+    """Patch size in pixels (square patches assumed)."""
+
+    image_emb_dim: int = 1024
+    """Hidden dimension of the vision transformer."""
+
+    image_num_heads: int = 16
+    """Number of attention heads."""
+
+    image_num_key_value_heads: int = 16
+    """Number of key/value heads. Equal to ``image_num_heads`` for MHA; less for GQA."""
+
+    image_num_layers: int = 23
+    """Number of transformer blocks. CLIP ViT-L/14 uses 23 (not 24) since Molmo extracts from layer -2."""
+
+    image_head_dim: int = 64
+    """Per-head dimension. Must satisfy ``image_emb_dim == image_num_heads * image_head_dim``."""
+
+    image_mlp_dim: int = 4096
+    """Hidden size of the per-block feed-forward network."""
+
+    image_mlp_activations: str = "quick_gelu"
+    """Activation name for the ViT FFN, passed to ``transformers.activations.get_activation``."""
+
+    image_num_pos: int = 577
+    """Number of positional embedding slots. For CLIP ViT-L/14-336: 24*24 patches + 1 CLS = 577."""
+
+    image_norm_eps: float = 1e-5
+    """Epsilon for layer normalisation inside the vision transformer."""
+
+    attention_dropout: float = 0.0
+    """Dropout probability for attention weights."""
+
+    residual_dropout: float = 0.0
+    """Dropout probability applied after the attention output projection."""
+
+    initializer_range: float = 0.02
+    """Std dev for normal-distribution weight initialisation."""
+
+    dtype: DType = DType.float32
+    """Default parameter dtype."""
+
+    @property
+    def image_num_patch(self) -> Tuple[int, int]:
+        """Number of patches along (height, width) for the default input size."""
+        h, w = self.image_default_input_size
+        return h // self.image_patch_size, w // self.image_patch_size
+
+    # ------------------------------------------------------------------
+    # SigLIP factory methods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def siglip_b16_224(cls) -> "VisionBackboneConfig":
+        """
+        Returns a :class:`VisionBackboneConfig` matching SigLIP ViT-B/16-224
+        (``google/siglip-base-patch16-224``).
+        """
+        return cls(
+            name=VisionBackboneType.siglip,
+            image_default_input_size=(224, 224),
+            image_patch_size=16,
+            image_emb_dim=768,
+            image_num_heads=12,
+            image_num_key_value_heads=12,
+            image_num_layers=12,
+            image_head_dim=64,
+            image_mlp_dim=3072,
+            image_mlp_activations="gelu_pytorch_tanh",
+            image_num_pos=196,  # 14*14 = 196, no CLS
+            image_norm_eps=1e-6,
+        )
+
+    @classmethod
+    def siglip_l16_384(cls) -> "VisionBackboneConfig":
+        """
+        Returns a :class:`VisionBackboneConfig` matching SigLIP ViT-L/16-384
+        (``google/siglip-large-patch16-384``).
+        """
+        return cls(
+            name=VisionBackboneType.siglip,
+            image_default_input_size=(384, 384),
+            image_patch_size=16,
+            image_emb_dim=1024,
+            image_num_heads=16,
+            image_num_key_value_heads=16,
+            image_num_layers=24,
+            image_head_dim=64,
+            image_mlp_dim=4096,
+            image_mlp_activations="gelu_pytorch_tanh",
+            image_num_pos=576,  # 24*24 = 576, no CLS
+            image_norm_eps=1e-6,
+        )
+
+    @classmethod
+    def siglip_so400m_patch14_224(cls) -> "VisionBackboneConfig":
+        """
+        Returns a :class:`VisionBackboneConfig` matching SigLIP SO400M/14-224
+        (``google/siglip-so400m-patch14-224``).
+        """
+        return cls(
+            name=VisionBackboneType.siglip,
+            image_default_input_size=(224, 224),
+            image_patch_size=14,
+            image_emb_dim=1152,
+            image_num_heads=16,
+            image_num_key_value_heads=16,
+            image_num_layers=27,
+            image_head_dim=72,
+            image_mlp_dim=4304,
+            image_mlp_activations="gelu_pytorch_tanh",
+            image_num_pos=256,  # 16*16 = 256, no CLS
+            image_norm_eps=1e-6,
+        )
+
+    @classmethod
+    def siglip_so400m(cls) -> "VisionBackboneConfig":
+        """
+        Returns a :class:`VisionBackboneConfig` matching SigLIP SO400M/14-378
+        (``google/siglip-so400m-patch14-378``).
+        """
+        return cls(
+            name=VisionBackboneType.siglip,
+            image_default_input_size=(378, 378),
+            image_patch_size=14,
+            image_emb_dim=1152,
+            image_num_heads=16,
+            image_num_key_value_heads=16,
+            image_num_layers=27,
+            image_head_dim=72,
+            image_mlp_dim=4304,
+            image_mlp_activations="gelu_pytorch_tanh",
+            image_num_pos=729,  # 27*27 = 729, no CLS
+            image_norm_eps=1e-6,
+        )
+
+    # ------------------------------------------------------------------
+    # SigLIP2 factory methods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def siglip2_b16_256(cls) -> "VisionBackboneConfig":
+        """
+        Returns a :class:`VisionBackboneConfig` matching SigLIP2 ViT-B/16-256
+        (``google/siglip2-base-patch16-256``).
+        """
+        return cls(
+            name=VisionBackboneType.siglip2,
+            image_default_input_size=(256, 256),
+            image_patch_size=16,
+            image_emb_dim=768,
+            image_num_heads=12,
+            image_num_key_value_heads=12,
+            image_num_layers=12,
+            image_head_dim=64,
+            image_mlp_dim=3072,
+            image_mlp_activations="gelu_pytorch_tanh",
+            image_num_pos=256,  # 16*16 = 256, no CLS
+            image_norm_eps=1e-6,
+        )
+
+    @classmethod
+    def siglip2_l16_256(cls) -> "VisionBackboneConfig":
+        """
+        Returns a :class:`VisionBackboneConfig` matching SigLIP2 ViT-L/16-256
+        (``google/siglip2-large-patch16-256``).
+        """
+        return cls(
+            name=VisionBackboneType.siglip2,
+            image_default_input_size=(256, 256),
+            image_patch_size=16,
+            image_emb_dim=1024,
+            image_num_heads=16,
+            image_num_key_value_heads=16,
+            image_num_layers=24,
+            image_head_dim=64,
+            image_mlp_dim=4096,
+            image_mlp_activations="gelu_pytorch_tanh",
+            image_num_pos=256,  # 16*16 = 256, no CLS
+            image_norm_eps=1e-6,
+        )
+
+    @classmethod
+    def siglip2_so400m_patch14_378(cls) -> "VisionBackboneConfig":
+        """
+        Returns a :class:`VisionBackboneConfig` matching SigLIP2 SO400M/14-378
+        (``google/siglip2-so400m-patch14-378``).
+        """
+        return cls(
+            name=VisionBackboneType.siglip2,
+            image_default_input_size=(378, 378),
+            image_patch_size=14,
+            image_emb_dim=1152,
+            image_num_heads=16,
+            image_num_key_value_heads=16,
+            image_num_layers=27,
+            image_head_dim=72,
+            image_mlp_dim=4304,
+            image_mlp_activations="gelu_pytorch_tanh",
+            image_num_pos=729,  # 27*27 = 729, no CLS
+            image_norm_eps=1e-6,
+        )
+
+    @classmethod
+    def siglip2_so400m_patch16_256(cls) -> "VisionBackboneConfig":
+        """
+        Returns a :class:`VisionBackboneConfig` matching SigLIP2 SO400M/16-256
+        (``google/siglip2-so400m-patch16-256``).
+        """
+        return cls(
+            name=VisionBackboneType.siglip2,
+            image_default_input_size=(256, 256),
+            image_patch_size=16,
+            image_emb_dim=1152,
+            image_num_heads=16,
+            image_num_key_value_heads=16,
+            image_num_layers=27,
+            image_head_dim=72,
+            image_mlp_dim=4304,
+            image_mlp_activations="gelu_pytorch_tanh",
+            image_num_pos=256,  # 16*16 = 256, no CLS
+            image_norm_eps=1e-6,
+        )
+
+    def build(self, init_device: str = "cpu") -> nn.Module:
+        """
+        Instantiate the vision encoder on ``init_device``.
+
+        :param init_device: Device string (e.g. ``"cpu"``, ``"meta"``).
+        :returns: A :class:`~olmo_core.nn.vision.VisionTransformer` or
+            :class:`~olmo_core.nn.vision.SiglipVisionTransformer` instance.
+        """
+        from .image_vit import SiglipVisionTransformer, VisionTransformer
+
+        if self.name == VisionBackboneType.openai:
+            return VisionTransformer(self, init_device=init_device)
+        elif self.name in (VisionBackboneType.siglip, VisionBackboneType.siglip2):
+            return SiglipVisionTransformer(self, init_device=init_device)
+        else:
+            raise NotImplementedError(f"Vision backbone type '{self.name}' is not supported.")

--- a/src/olmo_core/nn/vision/config.py
+++ b/src/olmo_core/nn/vision/config.py
@@ -2,9 +2,10 @@ from dataclasses import dataclass
 from typing import Tuple
 
 import torch.nn as nn
+from typing_extensions import Self
 
-from ...config import DType, StrEnum
-from ..config import ModuleConfig
+from olmo_core.config import DType, StrEnum
+from olmo_core.nn.config import ModuleConfig
 
 __all__ = [
     "VisionBackboneType",
@@ -88,7 +89,11 @@ class VisionBackboneConfig(ModuleConfig):
     """Number of key/value heads. Equal to ``image_num_heads`` for MHA; less for GQA."""
 
     image_num_layers: int = 23
-    """Number of transformer blocks. CLIP ViT-L/14 uses 23 (not 24) since Molmo extracts from layer -2."""
+    """
+    Number of transformer blocks to instantiate. The full HF CLIP ViT-L/14 tower has
+    24 layers; the default of 23 keeps only the layers needed when features are read
+    from the second-to-last layer (index ``-2``), dropping the unused final block.
+    """
 
     image_head_dim: int = 64
     """Per-head dimension. Must satisfy ``image_emb_dim == image_num_heads * image_head_dim``."""
@@ -97,7 +102,10 @@ class VisionBackboneConfig(ModuleConfig):
     """Hidden size of the per-block feed-forward network."""
 
     image_mlp_activations: str = "quick_gelu"
-    """Activation name for the ViT FFN, passed to ``transformers.activations.get_activation``."""
+    """
+    Activation name for the ViT FFN. One of ``quick_gelu`` (CLIP),
+    ``gelu_pytorch_tanh`` (SigLIP), or ``gelu``.
+    """
 
     image_num_pos: int = 577
     """Number of positional embedding slots. For CLIP ViT-L/14-336: 24*24 patches + 1 CLS = 577."""
@@ -128,7 +136,7 @@ class VisionBackboneConfig(ModuleConfig):
     # ------------------------------------------------------------------
 
     @classmethod
-    def siglip_b16_224(cls) -> "VisionBackboneConfig":
+    def siglip_b16_224(cls) -> Self:
         """
         Returns a :class:`VisionBackboneConfig` matching SigLIP ViT-B/16-224
         (``google/siglip-base-patch16-224``).
@@ -149,7 +157,7 @@ class VisionBackboneConfig(ModuleConfig):
         )
 
     @classmethod
-    def siglip_l16_384(cls) -> "VisionBackboneConfig":
+    def siglip_l16_384(cls) -> Self:
         """
         Returns a :class:`VisionBackboneConfig` matching SigLIP ViT-L/16-384
         (``google/siglip-large-patch16-384``).
@@ -170,7 +178,7 @@ class VisionBackboneConfig(ModuleConfig):
         )
 
     @classmethod
-    def siglip_so400m_patch14_224(cls) -> "VisionBackboneConfig":
+    def siglip_so400m_patch14_224(cls) -> Self:
         """
         Returns a :class:`VisionBackboneConfig` matching SigLIP SO400M/14-224
         (``google/siglip-so400m-patch14-224``).
@@ -191,7 +199,7 @@ class VisionBackboneConfig(ModuleConfig):
         )
 
     @classmethod
-    def siglip_so400m(cls) -> "VisionBackboneConfig":
+    def siglip_so400m(cls) -> Self:
         """
         Returns a :class:`VisionBackboneConfig` matching SigLIP SO400M/14-378
         (``google/siglip-so400m-patch14-378``).
@@ -216,7 +224,7 @@ class VisionBackboneConfig(ModuleConfig):
     # ------------------------------------------------------------------
 
     @classmethod
-    def siglip2_b16_256(cls) -> "VisionBackboneConfig":
+    def siglip2_b16_256(cls) -> Self:
         """
         Returns a :class:`VisionBackboneConfig` matching SigLIP2 ViT-B/16-256
         (``google/siglip2-base-patch16-256``).
@@ -237,7 +245,7 @@ class VisionBackboneConfig(ModuleConfig):
         )
 
     @classmethod
-    def siglip2_l16_256(cls) -> "VisionBackboneConfig":
+    def siglip2_l16_256(cls) -> Self:
         """
         Returns a :class:`VisionBackboneConfig` matching SigLIP2 ViT-L/16-256
         (``google/siglip2-large-patch16-256``).
@@ -258,7 +266,7 @@ class VisionBackboneConfig(ModuleConfig):
         )
 
     @classmethod
-    def siglip2_so400m_patch14_378(cls) -> "VisionBackboneConfig":
+    def siglip2_so400m_patch14_378(cls) -> Self:
         """
         Returns a :class:`VisionBackboneConfig` matching SigLIP2 SO400M/14-378
         (``google/siglip2-so400m-patch14-378``).
@@ -279,7 +287,7 @@ class VisionBackboneConfig(ModuleConfig):
         )
 
     @classmethod
-    def siglip2_so400m_patch16_256(cls) -> "VisionBackboneConfig":
+    def siglip2_so400m_patch16_256(cls) -> Self:
         """
         Returns a :class:`VisionBackboneConfig` matching SigLIP2 SO400M/16-256
         (``google/siglip2-so400m-patch16-256``).

--- a/src/olmo_core/nn/vision/connector.py
+++ b/src/olmo_core/nn/vision/connector.py
@@ -5,9 +5,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from ...config import DType, StrEnum
-from ..config import ModuleConfig
-from .config import VisionBackboneConfig
+from olmo_core.config import DType, StrEnum
+from olmo_core.nn.config import ModuleConfig
+from olmo_core.nn.vision.config import VisionBackboneConfig
 
 __all__ = [
     "ImagePoolingType",
@@ -29,8 +29,8 @@ class ImagePoolingType(StrEnum):
     attention_meanq = "attention_meanq"
     """
     For each group, use the mean of its patch features as the query and
-    cross-attend over all patches in the group as keys/values. This is Molmo's
-    default; with a 4-patch group it reduces patch count 4×.
+    cross-attend over all patches in the group as keys/values. With a 4-patch
+    group it reduces patch count 4×.
     """
 
     none = "none"
@@ -48,7 +48,6 @@ class ImageProjectorType(StrEnum):
     mlp = "mlp"
     """
     SwiGLU two-stream MLP: ``w2(silu(w1(x)) * w3(x))``.
-    Matches Molmo's ``ImageProjectorMLP`` with ``llama_swiglu`` activation.
     """
 
     linear = "linear"
@@ -142,8 +141,7 @@ class _PoolingCrossAttention(nn.Module):
 class _ConnectorMLP(nn.Module):
     """SwiGLU MLP that projects vision features to LM embedding dimension.
 
-    Computes ``w2(silu(w1(x)) * w3(x))``, matching Molmo's ``ImageProjectorMLP``
-    with ``llama_swiglu`` activation.
+    Computes ``w2(silu(w1(x)) * w3(x))``.
     """
 
     def __init__(

--- a/src/olmo_core/nn/vision/connector.py
+++ b/src/olmo_core/nn/vision/connector.py
@@ -1,0 +1,409 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from ...config import DType, StrEnum
+from ..config import ModuleConfig
+from .config import VisionBackboneConfig
+
+__all__ = [
+    "ImagePoolingType",
+    "ImageProjectorType",
+    "VisionConnectorConfig",
+    "VisionConnector",
+]
+
+
+class ImagePoolingType(StrEnum):
+    """
+    How to pool patch groups before projection.
+
+    Each pool group is defined by the data preprocessor's ``pooled_patches_idx``
+    tensor (a per-group list of patch indices, with ``-1`` marking padded
+    slots). The same pool size is applied to every group in a batch.
+    """
+
+    attention_meanq = "attention_meanq"
+    """
+    For each group, use the mean of its patch features as the query and
+    cross-attend over all patches in the group as keys/values. This is Molmo's
+    default; with a 4-patch group it reduces patch count 4×.
+    """
+
+    none = "none"
+    """
+    No pooling — pass the gathered features directly to the projector. ``pool_size``
+    must be 1 for this mode.
+    """
+
+
+class ImageProjectorType(StrEnum):
+    """
+    How to project pooled vision features into the LM embedding space.
+    """
+
+    mlp = "mlp"
+    """
+    SwiGLU two-stream MLP: ``w2(silu(w1(x)) * w3(x))``.
+    Matches Molmo's ``ImageProjectorMLP`` with ``llama_swiglu`` activation.
+    """
+
+    linear = "linear"
+    """
+    Single bias-free linear layer.
+    """
+
+
+class _PoolingCrossAttention(nn.Module):
+    """Cross-attention used for patch-group pooling.
+
+    Q is the mean of the group's patches; K/V are all patches in the group.
+    Maps ``num_input_layers * image_emb_dim`` → ``image_emb_dim``.
+    """
+
+    def __init__(
+        self,
+        *,
+        input_dim: int,
+        emb_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        initializer_range: float = 0.02,
+        dtype: torch.dtype = torch.float32,
+        init_device: str = "cpu",
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.num_kv_groups = num_heads // num_kv_heads
+        self.head_dim = head_dim
+        self.emb_dim = emb_dim
+        self.initializer_range = initializer_range
+
+        self.wq = nn.Linear(
+            input_dim, num_heads * head_dim, bias=True, device=init_device, dtype=dtype
+        )
+        self.wk = nn.Linear(
+            input_dim, num_kv_heads * head_dim, bias=True, device=init_device, dtype=dtype
+        )
+        self.wv = nn.Linear(
+            input_dim, num_kv_heads * head_dim, bias=True, device=init_device, dtype=dtype
+        )
+        self.wo = nn.Linear(
+            num_heads * head_dim, emb_dim, bias=True, device=init_device, dtype=dtype
+        )
+
+    def reset_parameters(self):
+        for w in (self.wq, self.wk, self.wv, self.wo):
+            nn.init.normal_(w.weight, std=self.initializer_range)
+            nn.init.zeros_(w.bias)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        context: torch.Tensor,
+        attn_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        :param query: ``(B, 1, input_dim)`` — mean of the group's patch features.
+        :param context: ``(B, pool_size, input_dim)`` — all patches in the group.
+        :param attn_mask: Optional bool mask ``(B, 1, 1, pool_size)`` where ``True``
+            allows attention. Used to ignore padded patches (where the
+            ``pooled_patches_idx`` entry was ``-1``).
+        :returns: ``(B, 1, emb_dim)``
+        """
+        B = query.shape[0]
+        q = self.wq(query).reshape(B, 1, self.num_heads, self.head_dim)
+        k = self.wk(context).reshape(B, context.shape[1], self.num_kv_heads, self.head_dim)
+        v = self.wv(context).reshape(B, context.shape[1], self.num_kv_heads, self.head_dim)
+
+        if self.num_kv_groups > 1:
+            k = k.repeat_interleave(self.num_kv_groups, dim=2)
+            v = v.repeat_interleave(self.num_kv_groups, dim=2)
+
+        out = F.scaled_dot_product_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+            attn_mask=attn_mask,
+            is_causal=False,
+        ).transpose(
+            1, 2
+        )  # (B, 1, num_heads * head_dim)
+
+        out = out.reshape(B, 1, self.num_heads * self.head_dim)
+        return self.wo(out)
+
+
+class _ConnectorMLP(nn.Module):
+    """SwiGLU MLP that projects vision features to LM embedding dimension.
+
+    Computes ``w2(silu(w1(x)) * w3(x))``, matching Molmo's ``ImageProjectorMLP``
+    with ``llama_swiglu`` activation.
+    """
+
+    def __init__(
+        self,
+        *,
+        input_dim: int,
+        output_dim: int,
+        hidden_size: int,
+        initializer_range: float = 0.02,
+        dtype: torch.dtype = torch.float32,
+        init_device: str = "cpu",
+    ):
+        super().__init__()
+        self.initializer_range = initializer_range
+        # SwiGLU: two parallel gates → one output
+        self.w1 = nn.Linear(input_dim, hidden_size, bias=False, device=init_device, dtype=dtype)
+        self.w3 = nn.Linear(input_dim, hidden_size, bias=False, device=init_device, dtype=dtype)
+        self.w2 = nn.Linear(hidden_size, output_dim, bias=False, device=init_device, dtype=dtype)
+
+    def reset_parameters(self):
+        for w in (self.w1, self.w2, self.w3):
+            nn.init.normal_(w.weight, std=self.initializer_range)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+@dataclass
+class VisionConnectorConfig(ModuleConfig):
+    """
+    Configuration for the vision-to-language connector.
+
+    The connector sits between the vision encoder and the LM backbone. For each
+    group described by ``pooled_patches_idx`` it gathers a fixed-size patch
+    set, applies attention pooling, and projects the result into the LM's
+    embedding space.
+
+    Pool size and spatial layout are determined entirely by the data
+    preprocessor (which builds ``pooled_patches_idx``). The connector only
+    needs to know the pooling and projection style.
+
+    Use :meth:`from_vision_backbone` to build a config from a
+    :class:`~olmo_core.nn.vision.VisionBackboneConfig` and an LM ``d_model``.
+    """
+
+    image_emb_dim: int = 1024
+    """Vision encoder hidden dimension (from :attr:`VisionBackboneConfig.image_emb_dim`)."""
+
+    image_num_heads: int = 16
+    """Number of attention heads for pooling cross-attention."""
+
+    image_num_key_value_heads: int = 16
+    """Number of KV heads for pooling cross-attention."""
+
+    image_head_dim: int = 64
+    """Per-head dimension for pooling cross-attention."""
+
+    output_dim: int = 4096
+    """LM ``d_model`` — target dimension after projection."""
+
+    num_input_layers: int = 1
+    """
+    Number of ViT layer outputs concatenated before pooling (e.g. ``2`` for
+    ``vit_layers=[-2, -9]``). The pooling cross-attention's input dimension
+    becomes ``num_input_layers * image_emb_dim``.
+    """
+
+    pooling_type: ImagePoolingType = ImagePoolingType.attention_meanq
+    """Pooling strategy applied before projection."""
+
+    pooling_attention_mask: bool = False
+    """
+    If ``True``, mask out patches with ``pooled_patches_idx == -1`` from the
+    pooling attention so they don't contribute. Recommended whenever the data
+    preprocessor pads groups (e.g. multi-crop with non-aligned grids).
+    """
+
+    projector_type: ImageProjectorType = ImageProjectorType.mlp
+    """Projection architecture."""
+
+    mlp_hidden_size: Optional[int] = None
+    """
+    Hidden size for the SwiGLU MLP projector. Defaults to
+    ``4 * image_emb_dim`` when ``None``.
+    """
+
+    initializer_range: float = 0.02
+    """Standard deviation for normal-distribution weight initialisation."""
+
+    dtype: DType = DType.float32
+    """Default parameter dtype."""
+
+    @classmethod
+    def from_vision_backbone(
+        cls,
+        vision_cfg: VisionBackboneConfig,
+        output_dim: int,
+        num_input_layers: int = 1,
+        **kwargs,
+    ) -> "VisionConnectorConfig":
+        """
+        Convenience factory that copies attention hyperparameters from a
+        :class:`~olmo_core.nn.vision.VisionBackboneConfig`.
+
+        :param vision_cfg: Vision backbone configuration.
+        :param output_dim: LM ``d_model``.
+        :param num_input_layers: Number of ViT layer outputs to concatenate
+            before pooling (default 1 = last layer only).
+        """
+        return cls(
+            image_emb_dim=vision_cfg.image_emb_dim,
+            image_num_heads=vision_cfg.image_num_heads,
+            image_num_key_value_heads=vision_cfg.image_num_key_value_heads,
+            image_head_dim=vision_cfg.image_head_dim,
+            output_dim=output_dim,
+            num_input_layers=num_input_layers,
+            dtype=vision_cfg.dtype,
+            **kwargs,
+        )
+
+    @property
+    def pooling_input_dim(self) -> int:
+        """Input dim to pooling cross-attention = ``num_input_layers * image_emb_dim``."""
+        return self.num_input_layers * self.image_emb_dim
+
+    @property
+    def projector_input_dim(self) -> int:
+        """Input dim to the MLP projector.
+
+        Equals ``image_emb_dim`` after pooling, or ``pooling_input_dim`` when
+        :attr:`pooling_type` is ``none``.
+        """
+        if self.pooling_type == ImagePoolingType.none:
+            return self.pooling_input_dim
+        return self.image_emb_dim
+
+    def build(self, init_device: str = "cpu") -> "VisionConnector":
+        """
+        Instantiate the connector on ``init_device``.
+
+        :param init_device: Device string (e.g. ``"cpu"``, ``"meta"``).
+        :returns: A :class:`VisionConnector`.
+        """
+        return VisionConnector(self, init_device=init_device)
+
+
+class VisionConnector(nn.Module):
+    """
+    Vision-to-language connector: gather-based group pooling + projection.
+
+    Each group of patches (defined by a row of ``pooled_patches_idx``) is
+    gathered from the per-image patch features, optionally attention-pooled
+    into a single token, and projected into LM embedding space.
+
+    :param cfg: Connector configuration.
+    :param init_device: Device on which to initialise parameters.
+    """
+
+    def __init__(self, cfg: VisionConnectorConfig, init_device: str = "cpu"):
+        super().__init__()
+        self.cfg = cfg
+        dtype = cfg.dtype.as_pt()
+
+        self.pooling: Optional[_PoolingCrossAttention] = None
+        if cfg.pooling_type == ImagePoolingType.attention_meanq:
+            self.pooling = _PoolingCrossAttention(
+                input_dim=cfg.pooling_input_dim,
+                emb_dim=cfg.image_emb_dim,
+                num_heads=cfg.image_num_heads,
+                num_kv_heads=cfg.image_num_key_value_heads,
+                head_dim=cfg.image_head_dim,
+                initializer_range=cfg.initializer_range,
+                dtype=dtype,
+                init_device=init_device,
+            )
+
+        proj_in = cfg.projector_input_dim
+        if cfg.projector_type == ImageProjectorType.mlp:
+            hidden = cfg.mlp_hidden_size or 4 * cfg.image_emb_dim
+            self.projector: nn.Module = _ConnectorMLP(
+                input_dim=proj_in,
+                output_dim=cfg.output_dim,
+                hidden_size=hidden,
+                initializer_range=cfg.initializer_range,
+                dtype=dtype,
+                init_device=init_device,
+            )
+        elif cfg.projector_type == ImageProjectorType.linear:
+            self.projector = nn.Linear(
+                proj_in, cfg.output_dim, bias=False, device=init_device, dtype=dtype
+            )
+        else:
+            raise NotImplementedError(f"Unsupported projector type: {cfg.projector_type}")
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Re-initialise all parameters."""
+        if self.pooling is not None:
+            self.pooling.reset_parameters()
+        if isinstance(self.projector, _ConnectorMLP):
+            self.projector.reset_parameters()
+        elif isinstance(self.projector, nn.Linear):
+            nn.init.normal_(self.projector.weight, std=self.cfg.initializer_range)
+
+    def forward(
+        self,
+        image_features: torch.Tensor,
+        pooled_patches_idx: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Pool and project patch features by gathering through ``pooled_patches_idx``.
+
+        :param image_features: Float tensor of shape
+            ``(B, n_total_patches, pooling_input_dim)``. ``n_total_patches``
+            covers all crops for each batch element flattened together
+            (e.g. ``n_crops * n_patches_per_crop``).
+        :param pooled_patches_idx: Long tensor of shape
+            ``(B, n_pooled, pool_size)``. Each row lists ``pool_size`` indices
+            into ``image_features`` (along the second axis) that should be
+            pooled into a single output token. Entries equal to ``-1`` mark
+            padding within a group and are zeroed out (and masked from the
+            pooling attention if :attr:`cfg.pooling_attention_mask` is set).
+        :returns: ``(B, n_pooled, output_dim)``.
+        """
+        cfg = self.cfg
+        B, _, dim = image_features.shape
+        n_pooled, pool_size = pooled_patches_idx.shape[1], pooled_patches_idx.shape[2]
+        valid = pooled_patches_idx >= 0
+
+        # Gather pool_size patches per group.
+        batch_idx = (
+            torch.arange(B, device=pooled_patches_idx.device)
+            .view(B, 1, 1)
+            .expand(B, n_pooled, pool_size)
+        )
+        # (B, n_pooled, pool_size, dim)
+        to_pool = image_features[batch_idx, pooled_patches_idx.clamp(min=0)]
+        # Zero out features at padded slots (idx == -1).
+        to_pool = to_pool * valid.unsqueeze(-1).to(to_pool.dtype)
+
+        if cfg.pooling_type == ImagePoolingType.attention_meanq:
+            assert self.pooling is not None
+            # Flatten group dim into the cross-attention batch.
+            flat = to_pool.reshape(B * n_pooled, pool_size, dim)
+            attn_mask: Optional[torch.Tensor] = None
+            if cfg.pooling_attention_mask:
+                attn_mask = valid.reshape(B * n_pooled, 1, 1, pool_size)
+                # Build query as masked mean over valid slots only.
+                denom = valid.reshape(B * n_pooled, pool_size).sum(-1).clamp(min=1).unsqueeze(-1)
+                query = flat.sum(dim=1, keepdim=True) / denom.unsqueeze(-1).to(flat.dtype)
+            else:
+                query = flat.mean(dim=1, keepdim=True)
+            pooled = self.pooling(query, flat, attn_mask=attn_mask)  # (B*n_pooled, 1, emb_dim)
+            pooled = pooled.reshape(B, n_pooled, cfg.image_emb_dim)
+        elif cfg.pooling_type == ImagePoolingType.none:
+            # No pooling: pool_size must be 1, just squeeze.
+            assert pool_size == 1, "pool_size must be 1 when pooling_type=none"
+            pooled = to_pool.reshape(B, n_pooled, dim)
+        else:
+            raise NotImplementedError(f"Unsupported pooling type: {cfg.pooling_type}")
+
+        return self.projector(pooled)

--- a/src/olmo_core/nn/vision/connector.py
+++ b/src/olmo_core/nn/vision/connector.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 
 from olmo_core.config import DType, StrEnum
 from olmo_core.nn.config import ModuleConfig
-from olmo_core.nn.vision.config import VisionBackboneConfig
+from olmo_core.nn.vision.config import VisionEncoderConfig
 
 __all__ = [
     "ImagePoolingType",
@@ -183,12 +183,12 @@ class VisionConnectorConfig(ModuleConfig):
     preprocessor (which builds ``pooled_patches_idx``). The connector only
     needs to know the pooling and projection style.
 
-    Use :meth:`from_vision_backbone` to build a config from a
-    :class:`~olmo_core.nn.vision.VisionBackboneConfig` and an LM ``d_model``.
+    Use :meth:`from_vision_encoder` to build a config from a
+    :class:`~olmo_core.nn.vision.VisionEncoderConfig` and an LM ``d_model``.
     """
 
     image_emb_dim: int = 1024
-    """Vision encoder hidden dimension (from :attr:`VisionBackboneConfig.image_emb_dim`)."""
+    """Vision encoder hidden dimension (from :attr:`VisionEncoderConfig.image_emb_dim`)."""
 
     image_num_heads: int = 16
     """Number of attention heads for pooling cross-attention."""
@@ -235,18 +235,18 @@ class VisionConnectorConfig(ModuleConfig):
     """Default parameter dtype."""
 
     @classmethod
-    def from_vision_backbone(
+    def from_vision_encoder(
         cls,
-        vision_cfg: VisionBackboneConfig,
+        vision_cfg: VisionEncoderConfig,
         output_dim: int,
         num_input_layers: int = 1,
         **kwargs,
     ) -> "VisionConnectorConfig":
         """
         Convenience factory that copies attention hyperparameters from a
-        :class:`~olmo_core.nn.vision.VisionBackboneConfig`.
+        :class:`~olmo_core.nn.vision.VisionEncoderConfig`.
 
-        :param vision_cfg: Vision backbone configuration.
+        :param vision_cfg: Vision encoder configuration.
         :param output_dim: LM ``d_model``.
         :param num_input_layers: Number of ViT layer outputs to concatenate
             before pooling (default 1 = last layer only).

--- a/src/olmo_core/nn/vision/image_vit.py
+++ b/src/olmo_core/nn/vision/image_vit.py
@@ -1,0 +1,333 @@
+import math
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.activations import get_activation
+
+from .config import VisionBackboneConfig
+
+__all__ = [
+    "VisionTransformer",
+    "SiglipVisionTransformer",
+]
+
+
+class _ViTAttention(nn.Module):
+    """Multi-head dot-product attention for a vision transformer block."""
+
+    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
+        super().__init__()
+        self.embed_dim = cfg.image_emb_dim
+        self.num_heads = cfg.image_num_heads
+        self.head_dim = cfg.image_head_dim
+        self.num_kv_heads = cfg.image_num_key_value_heads
+        self.num_kv_groups = self.num_heads // self.num_kv_heads
+        self.initializer_range = cfg.initializer_range
+        dtype = cfg.dtype.as_pt()
+
+        self.wq = nn.Linear(
+            self.embed_dim,
+            self.num_heads * self.head_dim,
+            bias=True,
+            device=init_device,
+            dtype=dtype,
+        )
+        self.wk = nn.Linear(
+            self.embed_dim,
+            self.num_kv_heads * self.head_dim,
+            bias=True,
+            device=init_device,
+            dtype=dtype,
+        )
+        self.wv = nn.Linear(
+            self.embed_dim,
+            self.num_kv_heads * self.head_dim,
+            bias=True,
+            device=init_device,
+            dtype=dtype,
+        )
+        self.wo = nn.Linear(
+            self.num_heads * self.head_dim,
+            self.embed_dim,
+            bias=True,
+            device=init_device,
+            dtype=dtype,
+        )
+
+        self.attn_drop = nn.Dropout(cfg.attention_dropout) if cfg.attention_dropout > 0 else None
+        self.resid_drop = nn.Dropout(cfg.residual_dropout)
+
+    def reset_parameters(self):
+        for w in (self.wq, self.wk, self.wv, self.wo):
+            nn.init.normal_(w.weight, std=self.initializer_range)
+            nn.init.zeros_(w.bias)
+
+    def forward(self, x: torch.Tensor, kv: Optional[torch.Tensor] = None) -> torch.Tensor:
+        B, N, _ = x.shape
+        src = x if kv is None else kv
+
+        q = self.wq(x).reshape(B, N, self.num_heads, self.head_dim)
+        k = self.wk(src).reshape(B, src.shape[1], self.num_kv_heads, self.head_dim)
+        v = self.wv(src).reshape(B, src.shape[1], self.num_kv_heads, self.head_dim)
+
+        if self.num_kv_groups > 1:
+            k = k.repeat_interleave(self.num_kv_groups, dim=2)
+            v = v.repeat_interleave(self.num_kv_groups, dim=2)
+
+        out = F.scaled_dot_product_attention(
+            q.transpose(1, 2).contiguous(),
+            k.transpose(1, 2).contiguous(),
+            v.transpose(1, 2).contiguous(),
+            is_causal=False,
+            dropout_p=self.attn_drop.p if self.attn_drop is not None and self.training else 0.0,
+        ).transpose(1, 2)
+
+        out = out.reshape(B, N, self.embed_dim)
+        out = self.wo(out)
+        out = self.resid_drop(out)
+        return out
+
+
+class _ViTMLP(nn.Module):
+    """Two-layer feed-forward network used inside each ViT block."""
+
+    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
+        super().__init__()
+        dtype = cfg.dtype.as_pt()
+        self.w1 = nn.Linear(
+            cfg.image_emb_dim, cfg.image_mlp_dim, bias=True, device=init_device, dtype=dtype
+        )
+        self.w2 = nn.Linear(
+            cfg.image_mlp_dim, cfg.image_emb_dim, bias=True, device=init_device, dtype=dtype
+        )
+        self.act = get_activation(cfg.image_mlp_activations)
+        self._emb_dim = cfg.image_emb_dim
+        self._mlp_dim = cfg.image_mlp_dim
+
+    def reset_parameters(self):
+        nn.init.trunc_normal_(self.w1.weight, std=math.sqrt(1 / self._emb_dim), a=-2.0, b=2.0)
+        nn.init.trunc_normal_(self.w2.weight, std=math.sqrt(1 / self._mlp_dim), a=-2.0, b=2.0)
+        nn.init.zeros_(self.w1.bias)
+        nn.init.zeros_(self.w2.bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.w2(self.act(self.w1(x)))
+
+
+class _ViTBlock(nn.Module):
+    """Standard pre-LN ViT residual block (attention + MLP)."""
+
+    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
+        super().__init__()
+        dtype = cfg.dtype.as_pt()
+        self.attn_norm = nn.LayerNorm(
+            cfg.image_emb_dim, eps=cfg.image_norm_eps, device=init_device, dtype=dtype
+        )
+        self.ffn_norm = nn.LayerNorm(
+            cfg.image_emb_dim, eps=cfg.image_norm_eps, device=init_device, dtype=dtype
+        )
+        self.attn = _ViTAttention(cfg, init_device=init_device)
+        self.ffn = _ViTMLP(cfg, init_device=init_device)
+
+    def reset_parameters(self):
+        self.attn_norm.reset_parameters()
+        self.ffn_norm.reset_parameters()
+        self.attn.reset_parameters()
+        self.ffn.reset_parameters()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.attn_norm(x))
+        x = x + self.ffn(self.ffn_norm(x))
+        return x
+
+
+def _interpolate_pos_emb(
+    pos_emb: torch.Tensor,  # (num_pos, emb_dim)
+    target_patch_num: Tuple[int, int],
+    num_prefix: int = 1,
+) -> torch.Tensor:
+    """Bicubic-interpolate positional embeddings to a different spatial resolution."""
+    cls_emb = pos_emb[:num_prefix]  # (num_prefix, emb_dim)
+    patch_emb = pos_emb[num_prefix:]  # (H0*W0, emb_dim)
+
+    h0 = w0 = int(math.sqrt(patch_emb.shape[0]))
+    h1, w1 = target_patch_num
+
+    if h0 == h1 and w0 == w1:
+        return pos_emb
+
+    patch_emb = patch_emb.reshape(1, h0, w0, -1).permute(0, 3, 1, 2)  # (1, D, H0, W0)
+    patch_emb = F.interpolate(
+        patch_emb, size=(h1, w1), mode="bicubic", align_corners=False, antialias=True
+    )
+    patch_emb = patch_emb.permute(0, 2, 3, 1).reshape(h1 * w1, -1)  # (H1*W1, D)
+
+    return torch.cat([cls_emb, patch_emb], dim=0)
+
+
+class VisionTransformer(nn.Module):
+    """
+    OpenAI CLIP-style vision transformer with a prepended CLS token.
+
+    Matches ``VisionTransformer`` in the Molmo reference implementation and is
+    suitable for weights from OpenAI CLIP ViT-L/14-336.
+
+    The forward pass accepts pre-patchified images and returns the hidden states
+    from every block, so callers can select specific layers (e.g. ``[-2, -9]``).
+
+    :param cfg: Vision backbone configuration.
+    :param init_device: Device on which to initialise parameters.
+    """
+
+    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
+        super().__init__()
+        self.cfg = cfg
+        dtype = cfg.dtype.as_pt()
+
+        # Patch embedding: flattened patch pixels → emb_dim.
+        patch_pixels = cfg.image_patch_size * cfg.image_patch_size * 3
+        self.patch_embedding = nn.Linear(
+            patch_pixels, cfg.image_emb_dim, bias=False, device=init_device, dtype=dtype
+        )
+
+        # CLS token and positional embeddings.
+        self.num_prefix_tokens: int = 1
+        self.class_embedding = nn.Parameter(
+            torch.zeros(cfg.image_emb_dim, device=init_device, dtype=dtype)
+        )
+        self.positional_embedding = nn.Parameter(
+            torch.zeros(cfg.image_num_pos, cfg.image_emb_dim, device=init_device, dtype=dtype)
+        )
+
+        self.pre_ln = nn.LayerNorm(
+            cfg.image_emb_dim, eps=cfg.image_norm_eps, device=init_device, dtype=dtype
+        )
+        self.blocks = nn.ModuleList(
+            [_ViTBlock(cfg, init_device=init_device) for _ in range(cfg.image_num_layers)]
+        )
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Re-initialise all parameters."""
+        scale = self.cfg.image_emb_dim**-0.5
+        nn.init.normal_(self.class_embedding, std=scale)
+        nn.init.normal_(self.positional_embedding, std=scale)
+        nn.init.normal_(self.patch_embedding.weight, std=0.02)
+        self.pre_ln.reset_parameters()
+        for block in self.blocks:
+            block.reset_parameters()
+
+    def _add_pos_emb(self, x: torch.Tensor, patch_num: Tuple[int, int]) -> torch.Tensor:
+        pos_emb = _interpolate_pos_emb(
+            self.positional_embedding, patch_num, num_prefix=self.num_prefix_tokens
+        )
+        return x + pos_emb[None, :, :].to(x.dtype)
+
+    def forward(
+        self, x: torch.Tensor, patch_num: Optional[Tuple[int, int]] = None
+    ) -> List[torch.Tensor]:
+        """
+        Encode pre-patchified images.
+
+        :param x: Float tensor of shape ``(batch, n_patches, patch_size**2 * 3)``.
+        :param patch_num: Spatial grid ``(H, W)`` of patches. Defaults to
+            ``cfg.image_num_patch``.
+        :returns: List of length ``image_num_layers``, each element a tensor of shape
+            ``(batch, 1 + n_patches, image_emb_dim)``.
+        """
+        if patch_num is None:
+            patch_num = self.cfg.image_num_patch
+
+        B, N, _ = x.shape
+        x = self.patch_embedding(x)
+
+        # Prepend CLS token.
+        cls = self.class_embedding[None, None, :].expand(B, 1, -1).to(x.dtype)
+        x = torch.cat([cls, x], dim=1)  # (B, 1+N, D)
+        x = self._add_pos_emb(x, patch_num)
+        x = self.pre_ln(x)
+
+        hidden_states: List[torch.Tensor] = []
+        for block in self.blocks:
+            x = block(x)
+            hidden_states.append(x)
+        return hidden_states
+
+
+class SiglipVisionTransformer(nn.Module):
+    """
+    SigLIP-style vision transformer without a CLS token.
+
+    Matches ``SiglipVisionTransformer`` in the Molmo reference implementation and is
+    suitable for weights from SigLIP-SO400M-14-378.
+
+    Like :class:`VisionTransformer`, the forward pass returns hidden states from every
+    block. There is no CLS token, so each output tensor has shape
+    ``(batch, n_patches, image_emb_dim)``.
+
+    :param cfg: Vision backbone configuration. Use :meth:`VisionBackboneConfig.siglip_so400m`
+        for the SigLIP-SO400M defaults.
+    :param init_device: Device on which to initialise parameters.
+    """
+
+    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
+        super().__init__()
+        self.cfg = cfg
+        dtype = cfg.dtype.as_pt()
+
+        patch_pixels = cfg.image_patch_size * cfg.image_patch_size * 3
+        self.patch_embedding = nn.Linear(
+            patch_pixels, cfg.image_emb_dim, bias=True, device=init_device, dtype=dtype
+        )
+
+        self.num_prefix_tokens: int = 0  # no CLS token
+        self.positional_embedding = nn.Parameter(
+            torch.zeros(cfg.image_num_pos, cfg.image_emb_dim, device=init_device, dtype=dtype)
+        )
+
+        self.blocks = nn.ModuleList(
+            [_ViTBlock(cfg, init_device=init_device) for _ in range(cfg.image_num_layers)]
+        )
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Re-initialise all parameters."""
+        scale = self.cfg.image_emb_dim**-0.5
+        nn.init.normal_(self.positional_embedding, std=scale)
+        nn.init.normal_(self.patch_embedding.weight, std=0.02)
+        nn.init.zeros_(self.patch_embedding.bias)
+        for block in self.blocks:
+            block.reset_parameters()
+
+    def _add_pos_emb(self, x: torch.Tensor, patch_num: Tuple[int, int]) -> torch.Tensor:
+        pos_emb = _interpolate_pos_emb(self.positional_embedding, patch_num, num_prefix=0)
+        return x + pos_emb[None, :, :].to(x.dtype)
+
+    def forward(
+        self, x: torch.Tensor, patch_num: Optional[Tuple[int, int]] = None
+    ) -> List[torch.Tensor]:
+        """
+        Encode pre-patchified images.
+
+        :param x: Float tensor of shape ``(batch, n_patches, patch_size**2 * 3)``.
+        :param patch_num: Spatial grid ``(H, W)`` of patches. Defaults to
+            ``cfg.image_num_patch``.
+        :returns: List of length ``image_num_layers``, each element a tensor of shape
+            ``(batch, n_patches, image_emb_dim)``.
+        """
+        if patch_num is None:
+            patch_num = self.cfg.image_num_patch
+
+        B, N, _ = x.shape
+        x = self.patch_embedding(x)
+        x = self._add_pos_emb(x, patch_num)
+
+        hidden_states: List[torch.Tensor] = []
+        for block in self.blocks:
+            x = block(x)
+            hidden_states.append(x)
+        return hidden_states

--- a/src/olmo_core/nn/vision/image_vit.py
+++ b/src/olmo_core/nn/vision/image_vit.py
@@ -8,6 +8,9 @@ import torch.nn.functional as F
 from olmo_core.nn.vision.config import VisionBackboneConfig
 
 __all__ = [
+    "ViTAttention",
+    "ViTMLP",
+    "ViTBlock",
     "VisionTransformer",
     "SiglipVisionTransformer",
 ]
@@ -35,7 +38,7 @@ def _get_activation(name: str) -> Callable[[torch.Tensor], torch.Tensor]:
     return _ACTIVATIONS[name]
 
 
-class _ViTAttention(nn.Module):
+class ViTAttention(nn.Module):
     """Multi-head dot-product attention for a vision transformer block."""
 
     def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
@@ -111,7 +114,7 @@ class _ViTAttention(nn.Module):
         return out
 
 
-class _ViTMLP(nn.Module):
+class ViTMLP(nn.Module):
     """Two-layer feed-forward network used inside each ViT block."""
 
     def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
@@ -137,7 +140,7 @@ class _ViTMLP(nn.Module):
         return self.w2(self.act(self.w1(x)))
 
 
-class _ViTBlock(nn.Module):
+class ViTBlock(nn.Module):
     """Standard pre-LN ViT residual block (attention + MLP)."""
 
     def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
@@ -149,8 +152,8 @@ class _ViTBlock(nn.Module):
         self.ffn_norm = nn.LayerNorm(
             cfg.image_emb_dim, eps=cfg.image_norm_eps, device=init_device, dtype=dtype
         )
-        self.attn = _ViTAttention(cfg, init_device=init_device)
-        self.ffn = _ViTMLP(cfg, init_device=init_device)
+        self.attn = ViTAttention(cfg, init_device=init_device)
+        self.ffn = ViTMLP(cfg, init_device=init_device)
 
     def reset_parameters(self):
         self.attn_norm.reset_parameters()
@@ -225,7 +228,7 @@ class VisionTransformer(nn.Module):
             cfg.image_emb_dim, eps=cfg.image_norm_eps, device=init_device, dtype=dtype
         )
         self.blocks = nn.ModuleList(
-            [_ViTBlock(cfg, init_device=init_device) for _ in range(cfg.image_num_layers)]
+            [cfg.block.build(cfg, init_device=init_device) for _ in range(cfg.image_num_layers)]
         )
 
         self.reset_parameters()
@@ -308,7 +311,7 @@ class SiglipVisionTransformer(nn.Module):
         )
 
         self.blocks = nn.ModuleList(
-            [_ViTBlock(cfg, init_device=init_device) for _ in range(cfg.image_num_layers)]
+            [cfg.block.build(cfg, init_device=init_device) for _ in range(cfg.image_num_layers)]
         )
 
         self.reset_parameters()

--- a/src/olmo_core/nn/vision/image_vit.py
+++ b/src/olmo_core/nn/vision/image_vit.py
@@ -1,17 +1,38 @@
 import math
-from typing import List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers.activations import get_activation
 
-from .config import VisionBackboneConfig
+from olmo_core.nn.vision.config import VisionBackboneConfig
 
 __all__ = [
     "VisionTransformer",
     "SiglipVisionTransformer",
 ]
+
+
+def _quick_gelu(x: torch.Tensor) -> torch.Tensor:
+    # OpenAI CLIP's "QuickGELU"; not available as a PyTorch built-in.
+    return x * torch.sigmoid(1.702 * x)
+
+
+# Activations used by the supported vision encoders, implemented with plain
+# PyTorch ops. Names follow the HF convention so configs map directly onto
+# HF checkpoint configs.
+_ACTIVATIONS: Dict[str, Callable[[torch.Tensor], torch.Tensor]] = {
+    "quick_gelu": _quick_gelu,
+    "gelu_pytorch_tanh": lambda x: F.gelu(x, approximate="tanh"),
+    "gelu": F.gelu,
+}
+
+
+def _get_activation(name: str) -> Callable[[torch.Tensor], torch.Tensor]:
+    """Resolve an activation function by name."""
+    if name not in _ACTIVATIONS:
+        raise ValueError(f"Unknown activation {name!r}; expected one of {sorted(_ACTIVATIONS)}.")
+    return _ACTIVATIONS[name]
 
 
 class _ViTAttention(nn.Module):
@@ -102,7 +123,7 @@ class _ViTMLP(nn.Module):
         self.w2 = nn.Linear(
             cfg.image_mlp_dim, cfg.image_emb_dim, bias=True, device=init_device, dtype=dtype
         )
-        self.act = get_activation(cfg.image_mlp_activations)
+        self.act = _get_activation(cfg.image_mlp_activations)
         self._emb_dim = cfg.image_emb_dim
         self._mlp_dim = cfg.image_mlp_dim
 
@@ -169,10 +190,9 @@ def _interpolate_pos_emb(
 
 class VisionTransformer(nn.Module):
     """
-    OpenAI CLIP-style vision transformer with a prepended CLS token.
+    CLIP-style vision transformer with a prepended CLS token.
 
-    Matches ``VisionTransformer`` in the Molmo reference implementation and is
-    suitable for weights from OpenAI CLIP ViT-L/14-336.
+    Compatible with OpenAI CLIP ViT-L/14-336 weights.
 
     The forward pass accepts pre-patchified images and returns the hidden states
     from every block, so callers can select specific layers (e.g. ``[-2, -9]``).
@@ -261,8 +281,7 @@ class SiglipVisionTransformer(nn.Module):
     """
     SigLIP-style vision transformer without a CLS token.
 
-    Matches ``SiglipVisionTransformer`` in the Molmo reference implementation and is
-    suitable for weights from SigLIP-SO400M-14-378.
+    Compatible with SigLIP-SO400M-14-378 weights.
 
     Like :class:`VisionTransformer`, the forward pass returns hidden states from every
     block. There is no CLS token, so each output tensor has shape

--- a/src/olmo_core/nn/vision/image_vit.py
+++ b/src/olmo_core/nn/vision/image_vit.py
@@ -5,14 +5,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from olmo_core.nn.vision.config import VisionBackboneConfig
+from olmo_core.nn.vision.config import VisionEncoderConfig
 
 __all__ = [
     "ViTAttention",
     "ViTMLP",
     "ViTBlock",
     "VisionTransformer",
-    "SiglipVisionTransformer",
 ]
 
 
@@ -41,7 +40,7 @@ def _get_activation(name: str) -> Callable[[torch.Tensor], torch.Tensor]:
 class ViTAttention(nn.Module):
     """Multi-head dot-product attention for a vision transformer block."""
 
-    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
+    def __init__(self, cfg: VisionEncoderConfig, init_device: str = "cpu"):
         super().__init__()
         self.embed_dim = cfg.image_emb_dim
         self.num_heads = cfg.image_num_heads
@@ -117,7 +116,7 @@ class ViTAttention(nn.Module):
 class ViTMLP(nn.Module):
     """Two-layer feed-forward network used inside each ViT block."""
 
-    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
+    def __init__(self, cfg: VisionEncoderConfig, init_device: str = "cpu"):
         super().__init__()
         dtype = cfg.dtype.as_pt()
         self.w1 = nn.Linear(
@@ -143,7 +142,7 @@ class ViTMLP(nn.Module):
 class ViTBlock(nn.Module):
     """Standard pre-LN ViT residual block (attention + MLP)."""
 
-    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
+    def __init__(self, cfg: VisionEncoderConfig, init_device: str = "cpu"):
         super().__init__()
         dtype = cfg.dtype.as_pt()
         self.attn_norm = nn.LayerNorm(
@@ -193,40 +192,64 @@ def _interpolate_pos_emb(
 
 class VisionTransformer(nn.Module):
     """
-    CLIP-style vision transformer with a prepended CLS token.
+    Configurable vision transformer encoder.
 
-    Compatible with OpenAI CLIP ViT-L/14-336 weights.
+    A single implementation that covers the supported encoder families; the
+    architectural variant is selected entirely through :class:`VisionEncoderConfig`:
 
-    The forward pass accepts pre-patchified images and returns the hidden states
-    from every block, so callers can select specific layers (e.g. ``[-2, -9]``).
+    - :attr:`~VisionEncoderConfig.use_cls_token` — prepend a learnable CLS token
+      (CLIP-style) vs. patches only (SigLIP-style).
+    - :attr:`~VisionEncoderConfig.patch_embedding_bias` — whether the patch-embedding
+      projection has a bias term.
+    - :attr:`~VisionEncoderConfig.use_pre_ln` — apply a LayerNorm to the embeddings
+      before the transformer blocks (CLIP-style).
 
-    :param cfg: Vision backbone configuration.
+    The defaults match OpenAI CLIP ViT-L/14-336; the
+    :meth:`VisionEncoderConfig.siglip_so400m` family of factories configures the
+    SigLIP variants. Use whichever factory matches your checkpoint.
+
+    The forward pass accepts pre-patchified images and returns the hidden states from
+    every block, so callers can select specific layers (e.g. ``[-2, -9]``).
+
+    :param cfg: Vision encoder configuration.
     :param init_device: Device on which to initialise parameters.
     """
 
-    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
+    def __init__(self, cfg: VisionEncoderConfig, init_device: str = "cpu"):
         super().__init__()
         self.cfg = cfg
         dtype = cfg.dtype.as_pt()
 
+        self.num_prefix_tokens: int = 1 if cfg.use_cls_token else 0
+
         # Patch embedding: flattened patch pixels → emb_dim.
         patch_pixels = cfg.image_patch_size * cfg.image_patch_size * 3
         self.patch_embedding = nn.Linear(
-            patch_pixels, cfg.image_emb_dim, bias=False, device=init_device, dtype=dtype
+            patch_pixels,
+            cfg.image_emb_dim,
+            bias=cfg.patch_embedding_bias,
+            device=init_device,
+            dtype=dtype,
         )
 
-        # CLS token and positional embeddings.
-        self.num_prefix_tokens: int = 1
-        self.class_embedding = nn.Parameter(
-            torch.zeros(cfg.image_emb_dim, device=init_device, dtype=dtype)
-        )
+        # Optional prepended CLS / prefix token (CLIP-style).
+        self.class_embedding: Optional[nn.Parameter] = None
+        if cfg.use_cls_token:
+            self.class_embedding = nn.Parameter(
+                torch.zeros(cfg.image_emb_dim, device=init_device, dtype=dtype)
+            )
+
         self.positional_embedding = nn.Parameter(
             torch.zeros(cfg.image_num_pos, cfg.image_emb_dim, device=init_device, dtype=dtype)
         )
 
-        self.pre_ln = nn.LayerNorm(
-            cfg.image_emb_dim, eps=cfg.image_norm_eps, device=init_device, dtype=dtype
-        )
+        # Optional pre-LayerNorm applied before the blocks (CLIP-style).
+        self.pre_ln: Optional[nn.LayerNorm] = None
+        if cfg.use_pre_ln:
+            self.pre_ln = nn.LayerNorm(
+                cfg.image_emb_dim, eps=cfg.image_norm_eps, device=init_device, dtype=dtype
+            )
+
         self.blocks = nn.ModuleList(
             [cfg.block.build(cfg, init_device=init_device) for _ in range(cfg.image_num_layers)]
         )
@@ -236,10 +259,14 @@ class VisionTransformer(nn.Module):
     def reset_parameters(self):
         """Re-initialise all parameters."""
         scale = self.cfg.image_emb_dim**-0.5
-        nn.init.normal_(self.class_embedding, std=scale)
+        if self.class_embedding is not None:
+            nn.init.normal_(self.class_embedding, std=scale)
         nn.init.normal_(self.positional_embedding, std=scale)
         nn.init.normal_(self.patch_embedding.weight, std=0.02)
-        self.pre_ln.reset_parameters()
+        if self.patch_embedding.bias is not None:
+            nn.init.zeros_(self.patch_embedding.bias)
+        if self.pre_ln is not None:
+            self.pre_ln.reset_parameters()
         for block in self.blocks:
             block.reset_parameters()
 
@@ -259,7 +286,7 @@ class VisionTransformer(nn.Module):
         :param patch_num: Spatial grid ``(H, W)`` of patches. Defaults to
             ``cfg.image_num_patch``.
         :returns: List of length ``image_num_layers``, each element a tensor of shape
-            ``(batch, 1 + n_patches, image_emb_dim)``.
+            ``(batch, num_prefix_tokens + n_patches, image_emb_dim)``.
         """
         if patch_num is None:
             patch_num = self.cfg.image_num_patch
@@ -267,86 +294,15 @@ class VisionTransformer(nn.Module):
         B, N, _ = x.shape
         x = self.patch_embedding(x)
 
-        # Prepend CLS token.
-        cls = self.class_embedding[None, None, :].expand(B, 1, -1).to(x.dtype)
-        x = torch.cat([cls, x], dim=1)  # (B, 1+N, D)
+        # Prepend CLS / prefix token when configured.
+        if self.class_embedding is not None:
+            cls = self.class_embedding[None, None, :].expand(B, 1, -1).to(x.dtype)
+            x = torch.cat([cls, x], dim=1)  # (B, num_prefix + N, D)
+
         x = self._add_pos_emb(x, patch_num)
-        x = self.pre_ln(x)
 
-        hidden_states: List[torch.Tensor] = []
-        for block in self.blocks:
-            x = block(x)
-            hidden_states.append(x)
-        return hidden_states
-
-
-class SiglipVisionTransformer(nn.Module):
-    """
-    SigLIP-style vision transformer without a CLS token.
-
-    Compatible with SigLIP-SO400M-14-378 weights.
-
-    Like :class:`VisionTransformer`, the forward pass returns hidden states from every
-    block. There is no CLS token, so each output tensor has shape
-    ``(batch, n_patches, image_emb_dim)``.
-
-    :param cfg: Vision backbone configuration. Use :meth:`VisionBackboneConfig.siglip_so400m`
-        for the SigLIP-SO400M defaults.
-    :param init_device: Device on which to initialise parameters.
-    """
-
-    def __init__(self, cfg: VisionBackboneConfig, init_device: str = "cpu"):
-        super().__init__()
-        self.cfg = cfg
-        dtype = cfg.dtype.as_pt()
-
-        patch_pixels = cfg.image_patch_size * cfg.image_patch_size * 3
-        self.patch_embedding = nn.Linear(
-            patch_pixels, cfg.image_emb_dim, bias=True, device=init_device, dtype=dtype
-        )
-
-        self.num_prefix_tokens: int = 0  # no CLS token
-        self.positional_embedding = nn.Parameter(
-            torch.zeros(cfg.image_num_pos, cfg.image_emb_dim, device=init_device, dtype=dtype)
-        )
-
-        self.blocks = nn.ModuleList(
-            [cfg.block.build(cfg, init_device=init_device) for _ in range(cfg.image_num_layers)]
-        )
-
-        self.reset_parameters()
-
-    def reset_parameters(self):
-        """Re-initialise all parameters."""
-        scale = self.cfg.image_emb_dim**-0.5
-        nn.init.normal_(self.positional_embedding, std=scale)
-        nn.init.normal_(self.patch_embedding.weight, std=0.02)
-        nn.init.zeros_(self.patch_embedding.bias)
-        for block in self.blocks:
-            block.reset_parameters()
-
-    def _add_pos_emb(self, x: torch.Tensor, patch_num: Tuple[int, int]) -> torch.Tensor:
-        pos_emb = _interpolate_pos_emb(self.positional_embedding, patch_num, num_prefix=0)
-        return x + pos_emb[None, :, :].to(x.dtype)
-
-    def forward(
-        self, x: torch.Tensor, patch_num: Optional[Tuple[int, int]] = None
-    ) -> List[torch.Tensor]:
-        """
-        Encode pre-patchified images.
-
-        :param x: Float tensor of shape ``(batch, n_patches, patch_size**2 * 3)``.
-        :param patch_num: Spatial grid ``(H, W)`` of patches. Defaults to
-            ``cfg.image_num_patch``.
-        :returns: List of length ``image_num_layers``, each element a tensor of shape
-            ``(batch, n_patches, image_emb_dim)``.
-        """
-        if patch_num is None:
-            patch_num = self.cfg.image_num_patch
-
-        B, N, _ = x.shape
-        x = self.patch_embedding(x)
-        x = self._add_pos_emb(x, patch_num)
+        if self.pre_ln is not None:
+            x = self.pre_ln(x)
 
         hidden_states: List[torch.Tensor] = []
         for block in self.blocks:

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -4,11 +4,11 @@ from typing import List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 
-from ...config import Config
-from ..lm_head import LMOutputWithLoss
-from ..transformer.config import TransformerConfig
-from .config import VisionBackboneConfig
-from .connector import VisionConnectorConfig
+from olmo_core.config import Config
+from olmo_core.nn.lm_head import LMOutputWithLoss
+from olmo_core.nn.transformer.config import TransformerConfig
+from olmo_core.nn.vision.config import VisionBackboneConfig
+from olmo_core.nn.vision.connector import VisionConnectorConfig
 
 __all__ = [
     "MultimodalTransformerConfig",
@@ -25,7 +25,7 @@ class MultimodalTransformerConfig(Config):
     a vision encoder (:class:`~olmo_core.nn.vision.VisionBackboneConfig`), and
     a vision-to-language connector
     (:class:`~olmo_core.nn.vision.VisionConnectorConfig`) into a single module
-    matching Molmo's image-feature splice mechanics.
+    that splices projected image features into the LM embedding stream.
 
     Example::
 
@@ -60,8 +60,8 @@ class MultimodalTransformerConfig(Config):
     """
     Indices of the ViT hidden-state layers to extract and concatenate before
     the connector. Negative indices count from the last layer. For example,
-    ``(-1,)`` uses only the final layer; ``(-2, -9)`` matches Molmo's two-layer
-    extraction and requires :attr:`connector.num_input_layers` to be ``2``.
+    ``(-1,)`` uses only the final layer; a two-layer selection such as ``(-2, -9)``
+    requires :attr:`connector.num_input_layers` to be ``2``.
     """
 
     def build(self, init_device: str = "cpu") -> "MultimodalTransformer":
@@ -78,7 +78,7 @@ class MultimodalTransformer(nn.Module):
     """
     Vision-language model: vision encoder + connector + language model.
 
-    Forward pass flow (matching Molmo's reference implementation):
+    Forward pass flow:
 
     1. Look up LM token embeddings for ``input_ids``.
     2. If images are provided, run them through the vision tower, extract the
@@ -187,8 +187,11 @@ class MultimodalTransformer(nn.Module):
                     f"preprocessor must insert exactly one <im_patch> per pooled feature."
                 )
             d = h.shape[-1]
-            h.view(-1, d)[is_image_patch] = h.view(-1, d)[is_image_patch] + image_features.reshape(
-                -1, d
-            )
+            # ``.contiguous()`` guards against a non-contiguous ``h`` (e.g. from a fused
+            # embedding_norm), for which ``.view()`` would raise. ``flat`` is a view of
+            # the contiguous ``h``, so the in-place add below propagates back into ``h``.
+            h = h.contiguous()
+            flat = h.view(-1, d)
+            flat[is_image_patch] = flat[is_image_patch] + image_features.reshape(-1, d)
 
         return self.lm(input_ids, input_embeddings=h, labels=labels, **kwargs)

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -163,6 +163,11 @@ class MultimodalTransformer(nn.Module):
             self.lm.embeddings is not None
         ), "MultimodalTransformer requires the LM to have an embedding table"
 
+        device = self.lm.device
+        input_ids = input_ids.to(device)
+        if labels is not None:
+            labels = labels.to(device)
+
         # Compute LM token embeddings with any configured scale / norm.
         h = self.lm.embeddings(input_ids)
         if self.lm.embed_scale is not None:
@@ -173,6 +178,9 @@ class MultimodalTransformer(nn.Module):
         if images is not None:
             if pooled_patches_idx is None:
                 raise ValueError("`pooled_patches_idx` is required when `images` is provided")
+
+            images = images.to(device)
+            pooled_patches_idx = pooled_patches_idx.to(device)
 
             image_features = self._encode_images(images, pooled_patches_idx)  # (B, n_pooled, d)
 

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -1,0 +1,194 @@
+from dataclasses import dataclass
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+
+from ...config import Config
+from ..lm_head import LMOutputWithLoss
+from ..transformer.config import TransformerConfig
+from .config import VisionBackboneConfig
+from .connector import VisionConnectorConfig
+
+__all__ = [
+    "MultimodalTransformerConfig",
+    "MultimodalTransformer",
+]
+
+
+@dataclass
+class MultimodalTransformerConfig(Config):
+    """
+    Configuration for a multimodal (vision-language) transformer.
+
+    Composes a language model (:class:`~olmo_core.nn.transformer.TransformerConfig`),
+    a vision encoder (:class:`~olmo_core.nn.vision.VisionBackboneConfig`), and
+    a vision-to-language connector
+    (:class:`~olmo_core.nn.vision.VisionConnectorConfig`) into a single module
+    matching Molmo's image-feature splice mechanics.
+
+    Example::
+
+        lm_cfg = TransformerConfig.olmo2_1M(vocab_size=50000)
+        vis_cfg = VisionBackboneConfig()           # CLIP ViT-L/14-336
+        conn_cfg = VisionConnectorConfig.from_vision_backbone(vis_cfg, output_dim=lm_cfg.d_model)
+        cfg = MultimodalTransformerConfig(
+            lm=lm_cfg, vision=vis_cfg, connector=conn_cfg, image_patch_token_id=49152,
+        )
+        model = cfg.build()
+    """
+
+    lm: TransformerConfig
+    """Language model configuration."""
+
+    vision: VisionBackboneConfig
+    """Vision encoder configuration."""
+
+    connector: VisionConnectorConfig
+    """Vision-to-language connector configuration."""
+
+    image_patch_token_id: int = 0
+    """
+    LM vocabulary ID of the ``<im_patch>`` placeholder token. Positions in
+    ``input_ids`` matching this ID receive projected image features via ``+=``
+    during the forward pass. The data preprocessor is responsible for ensuring
+    the number of occurrences of this token in the sequence matches the number
+    of pooled image features the connector produces.
+    """
+
+    vit_layers: Tuple[int, ...] = (-1,)
+    """
+    Indices of the ViT hidden-state layers to extract and concatenate before
+    the connector. Negative indices count from the last layer. For example,
+    ``(-1,)`` uses only the final layer; ``(-2, -9)`` matches Molmo's two-layer
+    extraction and requires :attr:`connector.num_input_layers` to be ``2``.
+    """
+
+    def build(self, init_device: str = "cpu") -> "MultimodalTransformer":
+        """
+        Instantiate the multimodal model on ``init_device``.
+
+        :param init_device: Device string (e.g. ``"cpu"``, ``"meta"``).
+        :returns: A :class:`MultimodalTransformer`.
+        """
+        return MultimodalTransformer(self, init_device=init_device)
+
+
+class MultimodalTransformer(nn.Module):
+    """
+    Vision-language model: vision encoder + connector + language model.
+
+    Forward pass flow (matching Molmo's reference implementation):
+
+    1. Look up LM token embeddings for ``input_ids``.
+    2. If images are provided, run them through the vision tower, extract the
+       configured ViT layers, optionally strip the CLS / register prefix, and
+       gather/pool/project via the connector to produce one feature per
+       ``<im_patch>`` placeholder token.
+    3. Add the projected image features back into the LM embedding sequence
+       at every position where ``input_ids == image_patch_token_id``.
+    4. Run the LM with the modified embeddings.
+
+    :param cfg: Multimodal model configuration.
+    :param init_device: Device on which to initialise parameters.
+    """
+
+    def __init__(self, cfg: MultimodalTransformerConfig, init_device: str = "cpu"):
+        super().__init__()
+        self.cfg = cfg
+        self.lm = cfg.lm.build(init_device=init_device)
+        self.vision = cfg.vision.build(init_device=init_device)
+        self.connector = cfg.connector.build(init_device=init_device)
+
+    def _encode_images(
+        self,
+        images: torch.Tensor,
+        pooled_patches_idx: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Encode pre-patchified images into LM-space pooled features.
+
+        :param images: Shape ``(B, n_crops, n_patches, patch_dim)``.
+        :param pooled_patches_idx: Shape ``(B, n_pooled, pool_size)`` —
+            indices into the flattened ``(n_crops * n_patches)`` patch axis
+            for each pool group, with ``-1`` marking padded slots.
+        :returns: Shape ``(B, n_pooled, lm_d_model)``.
+        """
+        B, T, N, _ = images.shape
+
+        # Flatten crop dim into batch dim for the ViT.
+        hidden_states: List[torch.Tensor] = self.vision(images.reshape(B * T, N, -1))
+
+        # Select configured layers and concat along feature dim.
+        selected = [hidden_states[i] for i in self.cfg.vit_layers]
+        features = torch.cat(selected, dim=-1) if len(selected) > 1 else selected[0]
+
+        # Strip prefix tokens (CLS for CLIP-style).
+        num_prefix = getattr(self.vision, "num_prefix_tokens", 0)
+        if num_prefix > 0:
+            features = features[:, num_prefix:]
+
+        # Reshape back to (B, T*N, dim) — the connector indexes into the
+        # flat crop-patch axis.
+        features = features.reshape(B, T * features.shape[1], features.shape[-1])
+
+        return self.connector(features, pooled_patches_idx)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        images: Optional[torch.Tensor] = None,
+        pooled_patches_idx: Optional[torch.Tensor] = None,
+        labels: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Union[torch.Tensor, LMOutputWithLoss]:
+        """
+        Run the vision-language forward pass.
+
+        :param input_ids: Token IDs, shape ``(B, seq_len)``. Positions equal to
+            :attr:`cfg.image_patch_token_id` will be overwritten (via ``+=``)
+            with projected image features.
+        :param images: Pre-patchified image patches, shape
+            ``(B, n_crops, n_patches, patch_dim)``. Pass ``None`` for
+            text-only batches.
+        :param pooled_patches_idx: Per-group patch indices,
+            shape ``(B, n_pooled, pool_size)``. Required when *images* is not
+            ``None``. ``n_pooled`` must equal the number of
+            ``<im_patch>`` tokens per sequence.
+        :param labels: Target token IDs, shape ``(B, seq_len)``.
+        :returns: Logits or loss (same as
+            :meth:`~olmo_core.nn.transformer.Transformer.forward`).
+        """
+        assert (
+            self.lm.embeddings is not None
+        ), "MultimodalTransformer requires the LM to have an embedding table"
+
+        # Compute LM token embeddings with any configured scale / norm.
+        h = self.lm.embeddings(input_ids)
+        if self.lm.embed_scale is not None:
+            h = h * self.lm.embed_scale
+        if self.lm.embedding_norm is not None:
+            h = self.lm.embedding_norm(h)
+
+        if images is not None:
+            if pooled_patches_idx is None:
+                raise ValueError("`pooled_patches_idx` is required when `images` is provided")
+
+            image_features = self._encode_images(images, pooled_patches_idx)  # (B, n_pooled, d)
+
+            # Splice into LM embeddings at every <im_patch> position.
+            is_image_patch = input_ids.view(-1) == self.cfg.image_patch_token_id
+            n_patches_in_seq = int(is_image_patch.sum())
+            n_features = image_features.shape[0] * image_features.shape[1]
+            if n_patches_in_seq != n_features:
+                raise ValueError(
+                    f"Number of <im_patch> tokens in input_ids ({n_patches_in_seq}) does not "
+                    f"match the number of projected image features ({n_features}). The data "
+                    f"preprocessor must insert exactly one <im_patch> per pooled feature."
+                )
+            d = h.shape[-1]
+            h.view(-1, d)[is_image_patch] = h.view(-1, d)[is_image_patch] + image_features.reshape(
+                -1, d
+            )
+
+        return self.lm(input_ids, input_embeddings=h, labels=labels, **kwargs)

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -7,22 +7,22 @@ import torch.nn as nn
 from olmo_core.config import Config
 from olmo_core.nn.lm_head import LMOutputWithLoss
 from olmo_core.nn.transformer.config import TransformerConfig
-from olmo_core.nn.vision.config import VisionBackboneConfig
+from olmo_core.nn.vision.config import VisionEncoderConfig
 from olmo_core.nn.vision.connector import VisionConnectorConfig
 
 __all__ = [
-    "MultimodalTransformerConfig",
-    "MultimodalTransformer",
+    "MultimodalLMConfig",
+    "MultimodalLM",
 ]
 
 
 @dataclass
-class MultimodalTransformerConfig(Config):
+class MultimodalLMConfig(Config):
     """
     Configuration for a multimodal (vision-language) transformer.
 
     Composes a language model (:class:`~olmo_core.nn.transformer.TransformerConfig`),
-    a vision encoder (:class:`~olmo_core.nn.vision.VisionBackboneConfig`), and
+    a vision encoder (:class:`~olmo_core.nn.vision.VisionEncoderConfig`), and
     a vision-to-language connector
     (:class:`~olmo_core.nn.vision.VisionConnectorConfig`) into a single module
     that splices projected image features into the LM embedding stream.
@@ -30,9 +30,9 @@ class MultimodalTransformerConfig(Config):
     Example::
 
         lm_cfg = TransformerConfig.olmo2_1M(vocab_size=50000)
-        vis_cfg = VisionBackboneConfig()           # CLIP ViT-L/14-336
-        conn_cfg = VisionConnectorConfig.from_vision_backbone(vis_cfg, output_dim=lm_cfg.d_model)
-        cfg = MultimodalTransformerConfig(
+        vis_cfg = VisionEncoderConfig()           # CLIP ViT-L/14-336
+        conn_cfg = VisionConnectorConfig.from_vision_encoder(vis_cfg, output_dim=lm_cfg.d_model)
+        cfg = MultimodalLMConfig(
             lm=lm_cfg, vision=vis_cfg, connector=conn_cfg, image_patch_token_id=49152,
         )
         model = cfg.build()
@@ -41,7 +41,7 @@ class MultimodalTransformerConfig(Config):
     lm: TransformerConfig
     """Language model configuration."""
 
-    vision: VisionBackboneConfig
+    vision: VisionEncoderConfig
     """Vision encoder configuration."""
 
     connector: VisionConnectorConfig
@@ -64,17 +64,17 @@ class MultimodalTransformerConfig(Config):
     requires :attr:`connector.num_input_layers` to be ``2``.
     """
 
-    def build(self, init_device: str = "cpu") -> "MultimodalTransformer":
+    def build(self, init_device: str = "cpu") -> "MultimodalLM":
         """
         Instantiate the multimodal model on ``init_device``.
 
         :param init_device: Device string (e.g. ``"cpu"``, ``"meta"``).
-        :returns: A :class:`MultimodalTransformer`.
+        :returns: A :class:`MultimodalLM`.
         """
-        return MultimodalTransformer(self, init_device=init_device)
+        return MultimodalLM(self, init_device=init_device)
 
 
-class MultimodalTransformer(nn.Module):
+class MultimodalLM(nn.Module):
     """
     Vision-language model: vision encoder + connector + language model.
 
@@ -93,7 +93,7 @@ class MultimodalTransformer(nn.Module):
     :param init_device: Device on which to initialise parameters.
     """
 
-    def __init__(self, cfg: MultimodalTransformerConfig, init_device: str = "cpu"):
+    def __init__(self, cfg: MultimodalLMConfig, init_device: str = "cpu"):
         super().__init__()
         self.cfg = cfg
         self.lm = cfg.lm.build(init_device=init_device)
@@ -161,7 +161,7 @@ class MultimodalTransformer(nn.Module):
         """
         assert (
             self.lm.embeddings is not None
-        ), "MultimodalTransformer requires the LM to have an embedding table"
+        ), "MultimodalLM requires the LM to have an embedding table"
 
         device = self.lm.device
         input_ids = input_ids.to(device)

--- a/src/test/nn/vision/config_test.py
+++ b/src/test/nn/vision/config_test.py
@@ -1,0 +1,154 @@
+"""Tests for VisionBackboneConfig factory methods and build()."""
+
+import pytest
+
+from olmo_core.nn.vision.config import VisionBackboneConfig, VisionBackboneType
+from olmo_core.nn.vision.image_vit import SiglipVisionTransformer, VisionTransformer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SIGLIP_FACTORIES = [
+    ("siglip_b16_224", VisionBackboneConfig.siglip_b16_224, 768, 12, 196),
+    ("siglip_l16_384", VisionBackboneConfig.siglip_l16_384, 1024, 24, 576),
+    (
+        "siglip_so400m_patch14_224",
+        VisionBackboneConfig.siglip_so400m_patch14_224,
+        1152,
+        27,
+        256,
+    ),
+    ("siglip_so400m", VisionBackboneConfig.siglip_so400m, 1152, 27, 729),
+]
+
+_SIGLIP2_FACTORIES = [
+    ("siglip2_b16_256", VisionBackboneConfig.siglip2_b16_256, 768, 12, 256),
+    ("siglip2_l16_256", VisionBackboneConfig.siglip2_l16_256, 1024, 24, 256),
+    (
+        "siglip2_so400m_patch14_378",
+        VisionBackboneConfig.siglip2_so400m_patch14_378,
+        1152,
+        27,
+        729,
+    ),
+    (
+        "siglip2_so400m_patch16_256",
+        VisionBackboneConfig.siglip2_so400m_patch16_256,
+        1152,
+        27,
+        256,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Field-value tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,factory,emb_dim,n_layers,num_pos",
+    _SIGLIP_FACTORIES + _SIGLIP2_FACTORIES,
+    ids=[row[0] for row in _SIGLIP_FACTORIES + _SIGLIP2_FACTORIES],
+)
+def test_factory_fields(name, factory, emb_dim, n_layers, num_pos):
+    cfg = factory()
+    assert cfg.image_emb_dim == emb_dim, f"{name}: emb_dim"
+    assert cfg.image_num_layers == n_layers, f"{name}: n_layers"
+    assert cfg.image_num_pos == num_pos, f"{name}: num_pos"
+    # head_dim must satisfy emb_dim == heads * head_dim
+    assert (
+        cfg.image_emb_dim == cfg.image_num_heads * cfg.image_head_dim
+    ), f"{name}: head_dim consistency"
+
+
+def test_clip_default_fields():
+    cfg = VisionBackboneConfig()
+    assert cfg.name == VisionBackboneType.openai
+    assert cfg.image_emb_dim == 1024
+    assert cfg.image_num_layers == 23
+    assert cfg.image_num_pos == 577
+    assert cfg.image_emb_dim == cfg.image_num_heads * cfg.image_head_dim
+
+
+# ---------------------------------------------------------------------------
+# build() returns the correct class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory,expected_cls",
+    [
+        (VisionBackboneConfig, VisionTransformer),
+        (VisionBackboneConfig.siglip_so400m, SiglipVisionTransformer),
+        (VisionBackboneConfig.siglip_b16_224, SiglipVisionTransformer),
+        (VisionBackboneConfig.siglip2_b16_256, SiglipVisionTransformer),
+        (VisionBackboneConfig.siglip2_so400m_patch14_378, SiglipVisionTransformer),
+    ],
+    ids=["clip", "siglip_so400m", "siglip_b16", "siglip2_b16", "siglip2_so400m"],
+)
+def test_build_returns_correct_class(factory, expected_cls):
+    cfg = factory()
+    model = cfg.build(init_device="meta")
+    assert isinstance(model, expected_cls)
+
+
+# ---------------------------------------------------------------------------
+# CLIP has CLS token, SigLIP / SigLIP2 do not
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory,expect_cls_token",
+    [
+        (VisionBackboneConfig, True),
+        (VisionBackboneConfig.siglip_so400m, False),
+        (VisionBackboneConfig.siglip2_b16_256, False),
+    ],
+    ids=["clip", "siglip", "siglip2"],
+)
+def test_cls_token_presence(factory, expect_cls_token):
+    model = factory().build(init_device="meta")
+    if expect_cls_token:
+        assert hasattr(model, "class_embedding")
+        assert model.num_prefix_tokens == 1
+    else:
+        assert not hasattr(model, "class_embedding")
+        assert model.num_prefix_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# image_num_patch property
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory,expected_patch_num",
+    [
+        (VisionBackboneConfig, (24, 24)),  # 336/14
+        (VisionBackboneConfig.siglip_b16_224, (14, 14)),  # 224/16
+        (VisionBackboneConfig.siglip_l16_384, (24, 24)),  # 384/16
+        (VisionBackboneConfig.siglip2_b16_256, (16, 16)),  # 256/16
+    ],
+    ids=["clip", "siglip_b16", "siglip_l16", "siglip2_b16"],
+)
+def test_image_num_patch(factory, expected_patch_num):
+    cfg = factory()
+    assert cfg.image_num_patch == expected_patch_num
+
+
+# ---------------------------------------------------------------------------
+# SigLIP2 and SigLIP SO400M share architecture; differ only by type
+# ---------------------------------------------------------------------------
+
+
+def test_siglip2_so400m_shares_arch_with_siglip_so400m():
+    s1 = VisionBackboneConfig.siglip_so400m()
+    s2 = VisionBackboneConfig.siglip2_so400m_patch14_378()
+    assert s1.image_emb_dim == s2.image_emb_dim
+    assert s1.image_num_heads == s2.image_num_heads
+    assert s1.image_num_layers == s2.image_num_layers
+    assert s1.name != s2.name
+    assert s1.name == VisionBackboneType.siglip
+    assert s2.name == VisionBackboneType.siglip2

--- a/src/test/nn/vision/config_test.py
+++ b/src/test/nn/vision/config_test.py
@@ -1,40 +1,40 @@
-"""Tests for VisionBackboneConfig factory methods and build()."""
+"""Tests for VisionEncoderConfig factory methods and build()."""
 
 import pytest
 
-from olmo_core.nn.vision.config import VisionBackboneConfig, VisionBackboneType
-from olmo_core.nn.vision.image_vit import SiglipVisionTransformer, VisionTransformer
+from olmo_core.nn.vision.config import VisionEncoderConfig, VisionEncoderType
+from olmo_core.nn.vision.image_vit import VisionTransformer
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 _SIGLIP_FACTORIES = [
-    ("siglip_b16_224", VisionBackboneConfig.siglip_b16_224, 768, 12, 196),
-    ("siglip_l16_384", VisionBackboneConfig.siglip_l16_384, 1024, 24, 576),
+    ("siglip_b16_224", VisionEncoderConfig.siglip_b16_224, 768, 12, 196),
+    ("siglip_l16_384", VisionEncoderConfig.siglip_l16_384, 1024, 24, 576),
     (
         "siglip_so400m_patch14_224",
-        VisionBackboneConfig.siglip_so400m_patch14_224,
+        VisionEncoderConfig.siglip_so400m_patch14_224,
         1152,
         27,
         256,
     ),
-    ("siglip_so400m", VisionBackboneConfig.siglip_so400m, 1152, 27, 729),
+    ("siglip_so400m", VisionEncoderConfig.siglip_so400m, 1152, 27, 729),
 ]
 
 _SIGLIP2_FACTORIES = [
-    ("siglip2_b16_256", VisionBackboneConfig.siglip2_b16_256, 768, 12, 256),
-    ("siglip2_l16_256", VisionBackboneConfig.siglip2_l16_256, 1024, 24, 256),
+    ("siglip2_b16_256", VisionEncoderConfig.siglip2_b16_256, 768, 12, 256),
+    ("siglip2_l16_256", VisionEncoderConfig.siglip2_l16_256, 1024, 24, 256),
     (
         "siglip2_so400m_patch14_378",
-        VisionBackboneConfig.siglip2_so400m_patch14_378,
+        VisionEncoderConfig.siglip2_so400m_patch14_378,
         1152,
         27,
         729,
     ),
     (
         "siglip2_so400m_patch16_256",
-        VisionBackboneConfig.siglip2_so400m_patch16_256,
+        VisionEncoderConfig.siglip2_so400m_patch16_256,
         1152,
         27,
         256,
@@ -64,8 +64,8 @@ def test_factory_fields(name, factory, emb_dim, n_layers, num_pos):
 
 
 def test_clip_default_fields():
-    cfg = VisionBackboneConfig()
-    assert cfg.name == VisionBackboneType.openai
+    cfg = VisionEncoderConfig()
+    assert cfg.name == VisionEncoderType.openai
     assert cfg.image_emb_dim == 1024
     assert cfg.image_num_layers == 23
     assert cfg.image_num_pos == 577
@@ -78,20 +78,24 @@ def test_clip_default_fields():
 
 
 @pytest.mark.parametrize(
-    "factory,expected_cls",
+    "factory,expect_cls_token",
     [
-        (VisionBackboneConfig, VisionTransformer),
-        (VisionBackboneConfig.siglip_so400m, SiglipVisionTransformer),
-        (VisionBackboneConfig.siglip_b16_224, SiglipVisionTransformer),
-        (VisionBackboneConfig.siglip2_b16_256, SiglipVisionTransformer),
-        (VisionBackboneConfig.siglip2_so400m_patch14_378, SiglipVisionTransformer),
+        (VisionEncoderConfig, True),
+        (VisionEncoderConfig.siglip_so400m, False),
+        (VisionEncoderConfig.siglip_b16_224, False),
+        (VisionEncoderConfig.siglip2_b16_256, False),
+        (VisionEncoderConfig.siglip2_so400m_patch14_378, False),
     ],
     ids=["clip", "siglip_so400m", "siglip_b16", "siglip2_b16", "siglip2_so400m"],
 )
-def test_build_returns_correct_class(factory, expected_cls):
-    cfg = factory()
-    model = cfg.build(init_device="meta")
-    assert isinstance(model, expected_cls)
+def test_build_returns_configured_variant(factory, expect_cls_token):
+    model = factory().build(init_device="meta")
+    assert isinstance(model, VisionTransformer)
+    # CLIP prepends a CLS token, applies a pre-LN, and uses a bias-free patch
+    # projection; the SigLIP families are the inverse on all three switches.
+    assert (model.class_embedding is not None) == expect_cls_token
+    assert (model.pre_ln is not None) == expect_cls_token
+    assert (model.patch_embedding.bias is not None) == (not expect_cls_token)
 
 
 # ---------------------------------------------------------------------------
@@ -102,19 +106,19 @@ def test_build_returns_correct_class(factory, expected_cls):
 @pytest.mark.parametrize(
     "factory,expect_cls_token",
     [
-        (VisionBackboneConfig, True),
-        (VisionBackboneConfig.siglip_so400m, False),
-        (VisionBackboneConfig.siglip2_b16_256, False),
+        (VisionEncoderConfig, True),
+        (VisionEncoderConfig.siglip_so400m, False),
+        (VisionEncoderConfig.siglip2_b16_256, False),
     ],
     ids=["clip", "siglip", "siglip2"],
 )
 def test_cls_token_presence(factory, expect_cls_token):
     model = factory().build(init_device="meta")
     if expect_cls_token:
-        assert hasattr(model, "class_embedding")
+        assert model.class_embedding is not None
         assert model.num_prefix_tokens == 1
     else:
-        assert not hasattr(model, "class_embedding")
+        assert model.class_embedding is None
         assert model.num_prefix_tokens == 0
 
 
@@ -126,10 +130,10 @@ def test_cls_token_presence(factory, expect_cls_token):
 @pytest.mark.parametrize(
     "factory,expected_patch_num",
     [
-        (VisionBackboneConfig, (24, 24)),  # 336/14
-        (VisionBackboneConfig.siglip_b16_224, (14, 14)),  # 224/16
-        (VisionBackboneConfig.siglip_l16_384, (24, 24)),  # 384/16
-        (VisionBackboneConfig.siglip2_b16_256, (16, 16)),  # 256/16
+        (VisionEncoderConfig, (24, 24)),  # 336/14
+        (VisionEncoderConfig.siglip_b16_224, (14, 14)),  # 224/16
+        (VisionEncoderConfig.siglip_l16_384, (24, 24)),  # 384/16
+        (VisionEncoderConfig.siglip2_b16_256, (16, 16)),  # 256/16
     ],
     ids=["clip", "siglip_b16", "siglip_l16", "siglip2_b16"],
 )
@@ -144,11 +148,31 @@ def test_image_num_patch(factory, expected_patch_num):
 
 
 def test_siglip2_so400m_shares_arch_with_siglip_so400m():
-    s1 = VisionBackboneConfig.siglip_so400m()
-    s2 = VisionBackboneConfig.siglip2_so400m_patch14_378()
+    s1 = VisionEncoderConfig.siglip_so400m()
+    s2 = VisionEncoderConfig.siglip2_so400m_patch14_378()
     assert s1.image_emb_dim == s2.image_emb_dim
     assert s1.image_num_heads == s2.image_num_heads
     assert s1.image_num_layers == s2.image_num_layers
     assert s1.name != s2.name
-    assert s1.name == VisionBackboneType.siglip
-    assert s2.name == VisionBackboneType.siglip2
+    assert s1.name == VisionEncoderType.siglip
+    assert s2.name == VisionEncoderType.siglip2
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_config_round_trip():
+    # A SigLIP config exercises the non-default variant switches.
+    cfg = VisionEncoderConfig.siglip_b16_224()
+    dumped = cfg.as_config_dict()
+    assert dumped["name"] == "siglip"
+
+    restored = VisionEncoderConfig.from_dict(dumped)
+    assert restored.name == VisionEncoderType.siglip
+    # The variant switches must survive the round-trip.
+    assert restored.use_cls_token is False
+    assert restored.patch_embedding_bias is True
+    assert restored.use_pre_ln is False
+    assert restored.image_emb_dim == cfg.image_emb_dim

--- a/src/test/nn/vision/connector_test.py
+++ b/src/test/nn/vision/connector_test.py
@@ -4,9 +4,9 @@ import torch
 from olmo_core.nn.vision import (
     ImagePoolingType,
     ImageProjectorType,
-    VisionBackboneConfig,
     VisionConnector,
     VisionConnectorConfig,
+    VisionEncoderConfig,
 )
 
 # ---------------------------------------------------------------------------
@@ -75,14 +75,14 @@ def _row_major_pooled_idx(
 # ---------------------------------------------------------------------------
 
 
-def test_from_vision_backbone():
-    vis_cfg = VisionBackboneConfig(
+def test_from_vision_encoder():
+    vis_cfg = VisionEncoderConfig(
         image_emb_dim=64,
         image_num_heads=4,
         image_num_key_value_heads=4,
         image_head_dim=16,
     )
-    conn_cfg = VisionConnectorConfig.from_vision_backbone(vis_cfg, output_dim=256)
+    conn_cfg = VisionConnectorConfig.from_vision_encoder(vis_cfg, output_dim=256)
     assert conn_cfg.image_emb_dim == 64
     assert conn_cfg.output_dim == 256
     assert conn_cfg.num_input_layers == 1

--- a/src/test/nn/vision/connector_test.py
+++ b/src/test/nn/vision/connector_test.py
@@ -1,0 +1,267 @@
+import pytest
+import torch
+
+from olmo_core.nn.vision import (
+    ImagePoolingType,
+    ImageProjectorType,
+    VisionBackboneConfig,
+    VisionConnector,
+    VisionConnectorConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _small_cfg(
+    pooling_type: ImagePoolingType = ImagePoolingType.attention_meanq,
+    projector_type: ImageProjectorType = ImageProjectorType.mlp,
+    num_input_layers: int = 1,
+    output_dim: int = 128,
+    pooling_attention_mask: bool = False,
+) -> VisionConnectorConfig:
+    return VisionConnectorConfig(
+        image_emb_dim=64,
+        image_num_heads=4,
+        image_num_key_value_heads=4,
+        image_head_dim=16,
+        output_dim=output_dim,
+        num_input_layers=num_input_layers,
+        pooling_type=pooling_type,
+        pooling_attention_mask=pooling_attention_mask,
+        projector_type=projector_type,
+        mlp_hidden_size=64,
+    )
+
+
+def _features(
+    batch: int, n_total_patches: int, num_layers: int = 1, emb_dim: int = 64
+) -> torch.Tensor:
+    return torch.randn(batch, n_total_patches, num_layers * emb_dim)
+
+
+def _row_major_pooled_idx(
+    batch: int,
+    grid_h: int,
+    grid_w: int,
+    pool_h: int = 2,
+    pool_w: int = 2,
+) -> torch.Tensor:
+    """Build a ``pooled_patches_idx`` for a single-crop ``grid_h × grid_w`` grid.
+
+    Groups patches into ``pool_h × pool_w`` non-overlapping windows in
+    row-major order. No padding (``-1``) entries.
+    """
+    assert grid_h % pool_h == 0 and grid_w % pool_w == 0
+    nH, nW = grid_h // pool_h, grid_w // pool_w
+    pool_size = pool_h * pool_w
+    idx = torch.zeros(nH * nW, pool_size, dtype=torch.long)
+    for i in range(nH):
+        for j in range(nW):
+            group = i * nW + j
+            slot = 0
+            for di in range(pool_h):
+                for dj in range(pool_w):
+                    patch_row = i * pool_h + di
+                    patch_col = j * pool_w + dj
+                    idx[group, slot] = patch_row * grid_w + patch_col
+                    slot += 1
+    return idx.unsqueeze(0).expand(batch, -1, -1).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# VisionConnectorConfig
+# ---------------------------------------------------------------------------
+
+
+def test_from_vision_backbone():
+    vis_cfg = VisionBackboneConfig(
+        image_emb_dim=64,
+        image_num_heads=4,
+        image_num_key_value_heads=4,
+        image_head_dim=16,
+    )
+    conn_cfg = VisionConnectorConfig.from_vision_backbone(vis_cfg, output_dim=256)
+    assert conn_cfg.image_emb_dim == 64
+    assert conn_cfg.output_dim == 256
+    assert conn_cfg.num_input_layers == 1
+
+
+def test_pooling_input_dim_single_layer():
+    cfg = _small_cfg()
+    assert cfg.pooling_input_dim == 64  # 1 * image_emb_dim
+
+
+def test_pooling_input_dim_multi_layer():
+    cfg = _small_cfg(num_input_layers=2)
+    assert cfg.pooling_input_dim == 128  # 2 * image_emb_dim
+
+
+def test_projector_input_dim_after_pooling():
+    cfg = _small_cfg(pooling_type=ImagePoolingType.attention_meanq)
+    assert cfg.projector_input_dim == 64  # image_emb_dim after pooling
+
+
+def test_projector_input_dim_no_pooling():
+    cfg = _small_cfg(pooling_type=ImagePoolingType.none)
+    assert cfg.projector_input_dim == 64  # equals pooling_input_dim when no pooling
+
+
+def test_build_returns_vision_connector():
+    cfg = _small_cfg()
+    conn = cfg.build(init_device="cpu")
+    assert isinstance(conn, VisionConnector)
+
+
+# ---------------------------------------------------------------------------
+# VisionConnector — attention_meanq pooling + mlp projector
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorAttentionMLP:
+    def setup_method(self):
+        self.cfg = _small_cfg()
+        self.conn = self.cfg.build(init_device="cpu")
+
+    def test_output_shape_4x_patch_reduction(self):
+        # 4×4 = 16 patches → 2×2 pool = 4 pooled tokens with pool_size=4
+        x = _features(2, 16)
+        idx = _row_major_pooled_idx(2, 4, 4)
+        out = self.conn(x, idx)
+        assert out.shape == (2, 4, self.cfg.output_dim)
+
+    def test_output_shape_single_patch_grid(self):
+        # 2×2 grid → 1 pooled token
+        x = _features(1, 4)
+        idx = _row_major_pooled_idx(1, 2, 2)
+        out = self.conn(x, idx)
+        assert out.shape == (1, 1, self.cfg.output_dim)
+
+    def test_output_dtype_matches_input(self):
+        x = _features(1, 16).to(torch.float32)
+        idx = _row_major_pooled_idx(1, 4, 4)
+        out = self.conn(x, idx)
+        assert out.dtype == torch.float32
+
+    def test_pooling_module_present(self):
+        assert self.conn.pooling is not None
+
+    @pytest.mark.parametrize("batch", [1, 3])
+    def test_various_batch_sizes(self, batch: int):
+        x = _features(batch, 16)
+        idx = _row_major_pooled_idx(batch, 4, 4)
+        out = self.conn(x, idx)
+        assert out.shape == (batch, 4, self.cfg.output_dim)
+
+    def test_deterministic_eval(self):
+        x = _features(2, 16)
+        idx = _row_major_pooled_idx(2, 4, 4)
+        self.conn.eval()
+        out1 = self.conn(x, idx)
+        out2 = self.conn(x, idx)
+        assert torch.allclose(out1, out2)
+
+    def test_meta_device(self):
+        conn = _small_cfg().build(init_device="meta")
+        assert next(iter(conn.parameters())).device.type == "meta"
+
+
+# ---------------------------------------------------------------------------
+# VisionConnector — multi-crop layout
+# ---------------------------------------------------------------------------
+
+
+def test_multi_crop_via_flat_patch_index():
+    """Two crops worth of patches concatenated, single set of pool groups."""
+    cfg = _small_cfg()
+    conn = cfg.build(init_device="cpu")
+    # 2 crops × 16 patches = 32 patches total; pool into 8 groups of 4.
+    x = _features(1, 32)
+    # Two stacked 4×4 row-major grids: first crop is patches 0..15, second 16..31.
+    idx_crop0 = _row_major_pooled_idx(1, 4, 4)  # (1, 4, 4) indices 0..15
+    idx_crop1 = _row_major_pooled_idx(1, 4, 4) + 16  # shift to second crop
+    idx = torch.cat([idx_crop0, idx_crop1], dim=1)  # (1, 8, 4)
+    out = conn(x, idx)
+    assert out.shape == (1, 8, cfg.output_dim)
+
+
+# ---------------------------------------------------------------------------
+# VisionConnector — padding via -1 indices
+# ---------------------------------------------------------------------------
+
+
+def test_padding_indices_zero_out_features():
+    """Pool groups with -1 entries should ignore those slots when masked."""
+    cfg = _small_cfg(pooling_attention_mask=True)
+    conn = cfg.build(init_device="cpu")
+    x = _features(1, 4)
+    # One group with two real patches and two padded entries.
+    idx = torch.tensor([[[0, 1, -1, -1]]], dtype=torch.long)
+    out = conn(x, idx)
+    assert out.shape == (1, 1, cfg.output_dim)
+    assert torch.isfinite(out).all()
+
+
+# ---------------------------------------------------------------------------
+# VisionConnector — multi-layer input
+# ---------------------------------------------------------------------------
+
+
+def test_multi_layer_input():
+    cfg = _small_cfg(num_input_layers=2)
+    conn = cfg.build(init_device="cpu")
+    x = _features(2, 16, num_layers=2)  # (2, 16, 128)
+    idx = _row_major_pooled_idx(2, 4, 4)
+    out = conn(x, idx)
+    assert out.shape == (2, 4, cfg.output_dim)
+
+
+# ---------------------------------------------------------------------------
+# VisionConnector — no pooling variant (pool_size=1)
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorNoPooling:
+    def setup_method(self):
+        self.cfg = _small_cfg(pooling_type=ImagePoolingType.none)
+        self.conn = self.cfg.build(init_device="cpu")
+
+    def test_no_pooling_module(self):
+        assert self.conn.pooling is None
+
+    def test_output_shape_unchanged_patch_count(self):
+        # With pool_size=1, each patch becomes its own pooled token.
+        x = _features(2, 16)
+        idx = torch.arange(16, dtype=torch.long).view(1, 16, 1).expand(2, -1, -1).contiguous()
+        out = self.conn(x, idx)
+        assert out.shape == (2, 16, self.cfg.output_dim)
+
+
+# ---------------------------------------------------------------------------
+# VisionConnector — linear projector
+# ---------------------------------------------------------------------------
+
+
+def test_linear_projector():
+    cfg = _small_cfg(projector_type=ImageProjectorType.linear, pooling_type=ImagePoolingType.none)
+    conn = cfg.build(init_device="cpu")
+    x = _features(2, 16)
+    idx = torch.arange(16, dtype=torch.long).view(1, 16, 1).expand(2, -1, -1).contiguous()
+    out = conn(x, idx)
+    assert out.shape == (2, 16, cfg.output_dim)
+
+
+# ---------------------------------------------------------------------------
+# Config round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_config_round_trip():
+    from olmo_core.config import Config
+
+    cfg = _small_cfg()
+    assert isinstance(cfg, Config)
+    d = cfg.as_config_dict()
+    assert d["pooling_type"] == "attention_meanq"
+    assert d["projector_type"] == "mlp"

--- a/src/test/nn/vision/image_vit_test.py
+++ b/src/test/nn/vision/image_vit_test.py
@@ -1,0 +1,194 @@
+import pytest
+import torch
+
+from olmo_core.nn.vision import (
+    SiglipVisionTransformer,
+    VisionBackboneConfig,
+    VisionBackboneType,
+    VisionTransformer,
+)
+
+# ---------------------------------------------------------------------------
+# Tiny configs for fast CPU tests
+# ---------------------------------------------------------------------------
+
+
+def _tiny_clip_cfg(**kwargs) -> VisionBackboneConfig:
+    """Minimal CLIP-style config: 2 layers, small dims."""
+    return VisionBackboneConfig(
+        name=VisionBackboneType.openai,
+        image_default_input_size=(28, 28),
+        image_patch_size=14,
+        image_emb_dim=64,
+        image_num_heads=4,
+        image_num_key_value_heads=4,
+        image_num_layers=2,
+        image_head_dim=16,
+        image_mlp_dim=128,
+        image_mlp_activations="quick_gelu",
+        image_num_pos=5,  # 2*2 patches + 1 CLS
+        **kwargs,
+    )
+
+
+def _tiny_siglip_cfg(**kwargs) -> VisionBackboneConfig:
+    """Minimal SigLIP-style config: 2 layers, small dims."""
+    return VisionBackboneConfig(
+        name=VisionBackboneType.siglip,
+        image_default_input_size=(28, 28),
+        image_patch_size=14,
+        image_emb_dim=64,
+        image_num_heads=4,
+        image_num_key_value_heads=4,
+        image_num_layers=2,
+        image_head_dim=16,
+        image_mlp_dim=128,
+        image_mlp_activations="gelu_pytorch_tanh",
+        image_num_pos=4,  # 2*2 patches, no CLS
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# VisionBackboneConfig.build()
+# ---------------------------------------------------------------------------
+
+
+def test_clip_build_returns_correct_type():
+    cfg = _tiny_clip_cfg()
+    vit = cfg.build(init_device="cpu")
+    assert isinstance(vit, VisionTransformer)
+
+
+def test_siglip_build_returns_correct_type():
+    cfg = _tiny_siglip_cfg()
+    vit = cfg.build(init_device="cpu")
+    assert isinstance(vit, SiglipVisionTransformer)
+
+
+# ---------------------------------------------------------------------------
+# VisionTransformer (CLIP-style)
+# ---------------------------------------------------------------------------
+
+
+class TestVisionTransformer:
+    def setup_method(self):
+        self.cfg = _tiny_clip_cfg()
+        self.vit = VisionTransformer(self.cfg, init_device="cpu")
+
+    def _make_input(self, batch: int = 2) -> torch.Tensor:
+        n_patches = 2 * 2  # 28px / 14px = 2 per side
+        patch_pixels = 14 * 14 * 3
+        return torch.randn(batch, n_patches, patch_pixels)
+
+    def test_forward_returns_list_of_length_num_layers(self):
+        x = self._make_input()
+        out = self.vit(x)
+        assert len(out) == self.cfg.image_num_layers
+
+    def test_output_shape_includes_cls_token(self):
+        batch = 3
+        x = self._make_input(batch)
+        out = self.vit(x)
+        n_patches = 2 * 2
+        expected = (batch, 1 + n_patches, self.cfg.image_emb_dim)
+        for layer_out in out:
+            assert layer_out.shape == expected, f"Got {layer_out.shape}, expected {expected}"
+
+    def test_forward_deterministic(self):
+        x = self._make_input()
+        self.vit.eval()
+        out1 = self.vit(x)
+        out2 = self.vit(x)
+        assert torch.allclose(out1[-1], out2[-1])
+
+    def test_patch_num_override(self):
+        """Positional embeddings should interpolate to a different resolution."""
+        cfg = _tiny_clip_cfg()
+        cfg.image_default_input_size = (42, 42)  # 3x3 patches
+        cfg.image_num_pos = 5  # still sized for 2x2 — must interpolate
+        vit = VisionTransformer(cfg, init_device="cpu")
+
+        n_patches = 3 * 3
+        patch_pixels = 14 * 14 * 3
+        x = torch.randn(1, n_patches, patch_pixels)
+        out = vit(x, patch_num=(3, 3))
+        assert out[-1].shape == (1, 1 + n_patches, cfg.image_emb_dim)
+
+    def test_num_prefix_tokens(self):
+        assert self.vit.num_prefix_tokens == 1
+
+    def test_meta_device_build(self):
+        vit = VisionTransformer(_tiny_clip_cfg(), init_device="meta")
+        assert next(iter(vit.parameters())).device.type == "meta"
+
+    @pytest.mark.parametrize("batch", [1, 4])
+    def test_various_batch_sizes(self, batch: int):
+        x = self._make_input(batch)
+        out = self.vit(x)
+        assert out[-1].shape[0] == batch
+
+
+# ---------------------------------------------------------------------------
+# SiglipVisionTransformer
+# ---------------------------------------------------------------------------
+
+
+class TestSiglipVisionTransformer:
+    def setup_method(self):
+        self.cfg = _tiny_siglip_cfg()
+        self.vit = SiglipVisionTransformer(self.cfg, init_device="cpu")
+
+    def _make_input(self, batch: int = 2) -> torch.Tensor:
+        n_patches = 2 * 2
+        patch_pixels = 14 * 14 * 3
+        return torch.randn(batch, n_patches, patch_pixels)
+
+    def test_forward_returns_list_of_length_num_layers(self):
+        x = self._make_input()
+        out = self.vit(x)
+        assert len(out) == self.cfg.image_num_layers
+
+    def test_output_shape_no_cls_token(self):
+        batch = 2
+        x = self._make_input(batch)
+        out = self.vit(x)
+        n_patches = 2 * 2
+        expected = (batch, n_patches, self.cfg.image_emb_dim)
+        for layer_out in out:
+            assert layer_out.shape == expected
+
+    def test_num_prefix_tokens(self):
+        assert self.vit.num_prefix_tokens == 0
+
+    def test_meta_device_build(self):
+        vit = SiglipVisionTransformer(_tiny_siglip_cfg(), init_device="meta")
+        assert next(iter(vit.parameters())).device.type == "meta"
+
+
+# ---------------------------------------------------------------------------
+# VisionBackboneConfig helpers
+# ---------------------------------------------------------------------------
+
+
+def test_siglip_so400m_factory():
+    cfg = VisionBackboneConfig.siglip_so400m()
+    assert cfg.name == VisionBackboneType.siglip
+    assert cfg.image_default_input_size == (378, 378)
+    assert cfg.image_emb_dim == 1152
+    assert cfg.image_num_layers == 27
+    assert cfg.image_num_pos == 729
+
+
+def test_image_num_patch_property():
+    cfg = _tiny_clip_cfg()
+    assert cfg.image_num_patch == (2, 2)
+
+
+def test_config_round_trip_yaml():
+    from olmo_core.config import Config
+
+    cfg = _tiny_clip_cfg()
+    assert isinstance(cfg, Config)
+    dumped = cfg.as_config_dict()
+    assert dumped["name"] == "openai"

--- a/src/test/nn/vision/image_vit_test.py
+++ b/src/test/nn/vision/image_vit_test.py
@@ -2,9 +2,8 @@ import pytest
 import torch
 
 from olmo_core.nn.vision import (
-    SiglipVisionTransformer,
-    VisionBackboneConfig,
-    VisionBackboneType,
+    VisionEncoderConfig,
+    VisionEncoderType,
     VisionTransformer,
 )
 
@@ -13,10 +12,10 @@ from olmo_core.nn.vision import (
 # ---------------------------------------------------------------------------
 
 
-def _tiny_clip_cfg(**kwargs) -> VisionBackboneConfig:
+def _tiny_clip_cfg(**kwargs) -> VisionEncoderConfig:
     """Minimal CLIP-style config: 2 layers, small dims."""
-    return VisionBackboneConfig(
-        name=VisionBackboneType.openai,
+    return VisionEncoderConfig(
+        name=VisionEncoderType.openai,
         image_default_input_size=(28, 28),
         image_patch_size=14,
         image_emb_dim=64,
@@ -31,10 +30,13 @@ def _tiny_clip_cfg(**kwargs) -> VisionBackboneConfig:
     )
 
 
-def _tiny_siglip_cfg(**kwargs) -> VisionBackboneConfig:
+def _tiny_siglip_cfg(**kwargs) -> VisionEncoderConfig:
     """Minimal SigLIP-style config: 2 layers, small dims."""
-    return VisionBackboneConfig(
-        name=VisionBackboneType.siglip,
+    return VisionEncoderConfig(
+        name=VisionEncoderType.siglip,
+        use_cls_token=False,
+        patch_embedding_bias=True,
+        use_pre_ln=False,
         image_default_input_size=(28, 28),
         image_patch_size=14,
         image_emb_dim=64,
@@ -50,24 +52,11 @@ def _tiny_siglip_cfg(**kwargs) -> VisionBackboneConfig:
 
 
 # ---------------------------------------------------------------------------
-# VisionBackboneConfig.build()
-# ---------------------------------------------------------------------------
-
-
-def test_clip_build_returns_correct_type():
-    cfg = _tiny_clip_cfg()
-    vit = cfg.build(init_device="cpu")
-    assert isinstance(vit, VisionTransformer)
-
-
-def test_siglip_build_returns_correct_type():
-    cfg = _tiny_siglip_cfg()
-    vit = cfg.build(init_device="cpu")
-    assert isinstance(vit, SiglipVisionTransformer)
-
-
-# ---------------------------------------------------------------------------
 # VisionTransformer (CLIP-style)
+#
+# NOTE: config-layer concerns (factory fields, build() dispatch, CLS-token
+# presence, image_num_patch, serialization round-trip) live in config_test.py.
+# These tests cover only forward-pass behavior of the encoder module.
 # ---------------------------------------------------------------------------
 
 
@@ -115,9 +104,6 @@ class TestVisionTransformer:
         out = vit(x, patch_num=(3, 3))
         assert out[-1].shape == (1, 1 + n_patches, cfg.image_emb_dim)
 
-    def test_num_prefix_tokens(self):
-        assert self.vit.num_prefix_tokens == 1
-
     def test_meta_device_build(self):
         vit = VisionTransformer(_tiny_clip_cfg(), init_device="meta")
         assert next(iter(vit.parameters())).device.type == "meta"
@@ -137,7 +123,7 @@ class TestVisionTransformer:
 class TestSiglipVisionTransformer:
     def setup_method(self):
         self.cfg = _tiny_siglip_cfg()
-        self.vit = SiglipVisionTransformer(self.cfg, init_device="cpu")
+        self.vit = VisionTransformer(self.cfg, init_device="cpu")
 
     def _make_input(self, batch: int = 2) -> torch.Tensor:
         n_patches = 2 * 2
@@ -158,37 +144,6 @@ class TestSiglipVisionTransformer:
         for layer_out in out:
             assert layer_out.shape == expected
 
-    def test_num_prefix_tokens(self):
-        assert self.vit.num_prefix_tokens == 0
-
     def test_meta_device_build(self):
-        vit = SiglipVisionTransformer(_tiny_siglip_cfg(), init_device="meta")
+        vit = VisionTransformer(_tiny_siglip_cfg(), init_device="meta")
         assert next(iter(vit.parameters())).device.type == "meta"
-
-
-# ---------------------------------------------------------------------------
-# VisionBackboneConfig helpers
-# ---------------------------------------------------------------------------
-
-
-def test_siglip_so400m_factory():
-    cfg = VisionBackboneConfig.siglip_so400m()
-    assert cfg.name == VisionBackboneType.siglip
-    assert cfg.image_default_input_size == (378, 378)
-    assert cfg.image_emb_dim == 1152
-    assert cfg.image_num_layers == 27
-    assert cfg.image_num_pos == 729
-
-
-def test_image_num_patch_property():
-    cfg = _tiny_clip_cfg()
-    assert cfg.image_num_patch == (2, 2)
-
-
-def test_config_round_trip_yaml():
-    from olmo_core.config import Config
-
-    cfg = _tiny_clip_cfg()
-    assert isinstance(cfg, Config)
-    dumped = cfg.as_config_dict()
-    assert dumped["name"] == "openai"

--- a/src/test/nn/vision/multimodal_test.py
+++ b/src/test/nn/vision/multimodal_test.py
@@ -3,11 +3,11 @@ import torch
 
 from olmo_core.nn.transformer.config import TransformerConfig
 from olmo_core.nn.vision import (
-    MultimodalTransformer,
-    MultimodalTransformerConfig,
-    VisionBackboneConfig,
-    VisionBackboneType,
+    MultimodalLM,
+    MultimodalLMConfig,
     VisionConnectorConfig,
+    VisionEncoderConfig,
+    VisionEncoderType,
 )
 
 # ---------------------------------------------------------------------------
@@ -23,10 +23,10 @@ def _tiny_lm_cfg() -> TransformerConfig:
     return TransformerConfig.olmo2_1M(vocab_size=_LM_VOCAB)
 
 
-def _tiny_vision_cfg() -> VisionBackboneConfig:
+def _tiny_vision_cfg() -> VisionEncoderConfig:
     """Tiny CLIP-style ViT: 2×2 patch grid (28px / 14px), 2 layers, emb_dim=32."""
-    return VisionBackboneConfig(
-        name=VisionBackboneType.openai,
+    return VisionEncoderConfig(
+        name=VisionEncoderType.openai,
         image_default_input_size=(28, 28),
         image_patch_size=14,
         image_emb_dim=32,
@@ -40,15 +40,15 @@ def _tiny_vision_cfg() -> VisionBackboneConfig:
     )
 
 
-def _tiny_multimodal_cfg(vit_layers=(-1,)) -> MultimodalTransformerConfig:
+def _tiny_multimodal_cfg(vit_layers=(-1,)) -> MultimodalLMConfig:
     lm_cfg = _tiny_lm_cfg()
     vis_cfg = _tiny_vision_cfg()
-    conn_cfg = VisionConnectorConfig.from_vision_backbone(
+    conn_cfg = VisionConnectorConfig.from_vision_encoder(
         vis_cfg,
         output_dim=_LM_D_MODEL,
         mlp_hidden_size=32,
     )
-    return MultimodalTransformerConfig(
+    return MultimodalLMConfig(
         lm=lm_cfg,
         vision=vis_cfg,
         connector=conn_cfg,
@@ -88,14 +88,14 @@ def _make_inputs(
 
 
 # ---------------------------------------------------------------------------
-# MultimodalTransformerConfig
+# MultimodalLMConfig
 # ---------------------------------------------------------------------------
 
 
-def test_build_returns_multimodal_transformer():
+def test_build_returns_multimodal_lm():
     cfg = _tiny_multimodal_cfg()
     model = cfg.build(init_device="cpu")
-    assert isinstance(model, MultimodalTransformer)
+    assert isinstance(model, MultimodalLM)
 
 
 def test_config_has_expected_fields():
@@ -221,13 +221,13 @@ def test_multi_layer_vit():
     """Two-layer extraction: connector must have num_input_layers=2."""
     lm_cfg = _tiny_lm_cfg()
     vis_cfg = _tiny_vision_cfg()
-    conn_cfg = VisionConnectorConfig.from_vision_backbone(
+    conn_cfg = VisionConnectorConfig.from_vision_encoder(
         vis_cfg,
         output_dim=_LM_D_MODEL,
         num_input_layers=2,
         mlp_hidden_size=32,
     )
-    cfg = MultimodalTransformerConfig(
+    cfg = MultimodalLMConfig(
         lm=lm_cfg,
         vision=vis_cfg,
         connector=conn_cfg,

--- a/src/test/nn/vision/multimodal_test.py
+++ b/src/test/nn/vision/multimodal_test.py
@@ -1,0 +1,241 @@
+import pytest
+import torch
+
+from olmo_core.nn.transformer.config import TransformerConfig
+from olmo_core.nn.vision import (
+    MultimodalTransformer,
+    MultimodalTransformerConfig,
+    VisionBackboneConfig,
+    VisionBackboneType,
+    VisionConnectorConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_LM_VOCAB = 256
+_LM_D_MODEL = 12  # olmo2_1M d_model
+_IMAGE_PATCH_TOKEN = 1  # arbitrary reserved ID for <im_patch>
+
+
+def _tiny_lm_cfg() -> TransformerConfig:
+    return TransformerConfig.olmo2_1M(vocab_size=_LM_VOCAB)
+
+
+def _tiny_vision_cfg() -> VisionBackboneConfig:
+    """Tiny CLIP-style ViT: 2×2 patch grid (28px / 14px), 2 layers, emb_dim=32."""
+    return VisionBackboneConfig(
+        name=VisionBackboneType.openai,
+        image_default_input_size=(28, 28),
+        image_patch_size=14,
+        image_emb_dim=32,
+        image_num_heads=2,
+        image_num_key_value_heads=2,
+        image_num_layers=2,
+        image_head_dim=16,
+        image_mlp_dim=64,
+        image_num_pos=5,  # 1 CLS + 4 patches
+        image_norm_eps=1e-5,
+    )
+
+
+def _tiny_multimodal_cfg(vit_layers=(-1,)) -> MultimodalTransformerConfig:
+    lm_cfg = _tiny_lm_cfg()
+    vis_cfg = _tiny_vision_cfg()
+    conn_cfg = VisionConnectorConfig.from_vision_backbone(
+        vis_cfg,
+        output_dim=_LM_D_MODEL,
+        mlp_hidden_size=32,
+    )
+    return MultimodalTransformerConfig(
+        lm=lm_cfg,
+        vision=vis_cfg,
+        connector=conn_cfg,
+        image_patch_token_id=_IMAGE_PATCH_TOKEN,
+        vit_layers=vit_layers,
+    )
+
+
+def _make_inputs(
+    batch: int,
+    seq_len: int,
+    n_crops: int = 1,
+    n_patches_per_crop: int = 4,
+    pool_size: int = 4,
+):
+    """Build (input_ids, images, pooled_patches_idx) with the right counts."""
+    total_patches = n_crops * n_patches_per_crop
+    assert total_patches % pool_size == 0
+    n_pooled = total_patches // pool_size
+
+    # Place `n_pooled` <im_patch> tokens at the front; fill the rest with random non-image tokens.
+    image_token_ids = torch.full((batch, n_pooled), _IMAGE_PATCH_TOKEN, dtype=torch.long)
+    text_ids = torch.randint(2, _LM_VOCAB, (batch, seq_len - n_pooled))
+    input_ids = torch.cat([image_token_ids, text_ids], dim=1)
+
+    images = torch.randn(batch, n_crops, n_patches_per_crop, 14 * 14 * 3)
+
+    # Row-major non-overlapping pools across the total patch axis.
+    idx = (
+        torch.arange(total_patches, dtype=torch.long)
+        .view(n_pooled, pool_size)
+        .unsqueeze(0)
+        .expand(batch, -1, -1)
+        .contiguous()
+    )
+    return input_ids, images, idx
+
+
+# ---------------------------------------------------------------------------
+# MultimodalTransformerConfig
+# ---------------------------------------------------------------------------
+
+
+def test_build_returns_multimodal_transformer():
+    cfg = _tiny_multimodal_cfg()
+    model = cfg.build(init_device="cpu")
+    assert isinstance(model, MultimodalTransformer)
+
+
+def test_config_has_expected_fields():
+    cfg = _tiny_multimodal_cfg()
+    assert cfg.vit_layers == (-1,)
+    assert cfg.lm.d_model == _LM_D_MODEL
+    assert cfg.vision.image_emb_dim == 32
+    assert cfg.connector.output_dim == _LM_D_MODEL
+    assert cfg.image_patch_token_id == _IMAGE_PATCH_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# Text-only forward pass
+# ---------------------------------------------------------------------------
+
+
+class TestTextOnlyForward:
+    def setup_method(self):
+        self.cfg = _tiny_multimodal_cfg()
+        self.model = self.cfg.build(init_device="cpu")
+        self.model.eval()
+
+    def test_output_shape(self):
+        input_ids = torch.randint(2, _LM_VOCAB, (2, 16))
+        out = self.model(input_ids)
+        assert out.shape == (2, 16, _LM_VOCAB)
+
+    def test_batch_size_1(self):
+        input_ids = torch.randint(2, _LM_VOCAB, (1, 8))
+        out = self.model(input_ids)
+        assert out.shape == (1, 8, _LM_VOCAB)
+
+    def test_deterministic_eval(self):
+        input_ids = torch.randint(2, _LM_VOCAB, (2, 8))
+        out1 = self.model(input_ids)
+        out2 = self.model(input_ids)
+        assert torch.allclose(out1, out2)
+
+    def test_with_labels_returns_loss(self):
+        from olmo_core.nn.lm_head import LMOutputWithLoss
+
+        input_ids = torch.randint(2, _LM_VOCAB, (2, 8))
+        labels = torch.randint(2, _LM_VOCAB, (2, 8))
+        out = self.model(input_ids, labels=labels)
+        assert isinstance(out, LMOutputWithLoss)
+        assert out.loss.shape == ()
+
+
+# ---------------------------------------------------------------------------
+# Image forward pass (1 crop, 2×2 pool → 1 pooled token per batch element)
+# ---------------------------------------------------------------------------
+
+
+class TestImageForward:
+    def setup_method(self):
+        self.cfg = _tiny_multimodal_cfg()
+        self.model = self.cfg.build(init_device="cpu")
+        self.model.eval()
+
+    def test_output_shape(self):
+        input_ids, images, idx = _make_inputs(batch=2, seq_len=16)
+        out = self.model(input_ids, images=images, pooled_patches_idx=idx)
+        assert out.shape == (2, 16, _LM_VOCAB)
+
+    def test_image_injection_changes_output(self):
+        """Output differs from text-only when image features are injected."""
+        torch.manual_seed(42)
+        input_ids, images, idx = _make_inputs(batch=1, seq_len=16)
+        out_text = self.model(input_ids)
+        out_img = self.model(input_ids, images=images, pooled_patches_idx=idx)
+        assert not torch.allclose(out_text, out_img)
+
+    def test_missing_idx_raises(self):
+        input_ids, images, _ = _make_inputs(batch=1, seq_len=16)
+        with pytest.raises(ValueError, match="pooled_patches_idx"):
+            self.model(input_ids, images=images)
+
+    def test_mismatched_image_patch_count_raises(self):
+        """Wrong number of <im_patch> tokens in input_ids should raise."""
+        input_ids, images, idx = _make_inputs(batch=1, seq_len=16)
+        # Drop one <im_patch>: replace with a non-image token.
+        input_ids[0, 0] = 7
+        with pytest.raises(ValueError, match="match the number of projected image features"):
+            self.model(input_ids, images=images, pooled_patches_idx=idx)
+
+
+# ---------------------------------------------------------------------------
+# Multi-crop image input
+# ---------------------------------------------------------------------------
+
+
+def test_multi_crop():
+    cfg = _tiny_multimodal_cfg()
+    model = cfg.build(init_device="cpu")
+    model.eval()
+    # 2 crops × 4 patches = 8 total, pool=4 → 2 pooled tokens per batch element.
+    input_ids, images, idx = _make_inputs(
+        batch=2, seq_len=16, n_crops=2, n_patches_per_crop=4, pool_size=4
+    )
+    out = model(input_ids, images=images, pooled_patches_idx=idx)
+    assert out.shape == (2, 16, _LM_VOCAB)
+
+
+# ---------------------------------------------------------------------------
+# Meta device
+# ---------------------------------------------------------------------------
+
+
+def test_meta_device():
+    cfg = _tiny_multimodal_cfg()
+    model = cfg.build(init_device="meta")
+    for p in model.parameters():
+        assert p.device.type == "meta"
+        break
+
+
+# ---------------------------------------------------------------------------
+# Multi-layer ViT extraction
+# ---------------------------------------------------------------------------
+
+
+def test_multi_layer_vit():
+    """Two-layer extraction: connector must have num_input_layers=2."""
+    lm_cfg = _tiny_lm_cfg()
+    vis_cfg = _tiny_vision_cfg()
+    conn_cfg = VisionConnectorConfig.from_vision_backbone(
+        vis_cfg,
+        output_dim=_LM_D_MODEL,
+        num_input_layers=2,
+        mlp_hidden_size=32,
+    )
+    cfg = MultimodalTransformerConfig(
+        lm=lm_cfg,
+        vision=vis_cfg,
+        connector=conn_cfg,
+        image_patch_token_id=_IMAGE_PATCH_TOKEN,
+        vit_layers=(-1, -2),
+    )
+    model = cfg.build(init_device="cpu")
+    model.eval()
+    input_ids, images, idx = _make_inputs(batch=2, seq_len=16)
+    out = model(input_ids, images=images, pooled_patches_idx=idx)
+    assert out.shape == (2, 16, _LM_VOCAB)

--- a/src/test/nn/vision/parity_test.py
+++ b/src/test/nn/vision/parity_test.py
@@ -16,9 +16,8 @@ import pytest
 import torch
 
 from olmo_core.nn.vision import (
-    SiglipVisionTransformer,
-    VisionBackboneConfig,
-    VisionBackboneType,
+    VisionEncoderConfig,
+    VisionEncoderType,
     VisionTransformer,
 )
 
@@ -169,8 +168,8 @@ def test_clip_parity():
     """
     hf = _try_load_hf(transformers.CLIPVisionModel, "openai/clip-vit-large-patch14-336")
 
-    cfg = VisionBackboneConfig(image_num_layers=24)  # match HF's 24-layer checkpoint
-    assert cfg.name == VisionBackboneType.openai
+    cfg = VisionEncoderConfig(image_num_layers=24)  # match HF's 24-layer checkpoint
+    assert cfg.name == VisionEncoderType.openai
     ours = VisionTransformer(cfg, init_device="cpu").eval()
     ours.load_state_dict(_convert_clip_state_dict(hf.state_dict()))
 
@@ -195,10 +194,10 @@ def test_clip_parity():
 
 
 def test_siglip_parity():
-    """Our :class:`SiglipVisionTransformer` matches HF's ``SiglipVisionModel``.
+    """Our :class:`VisionTransformer` matches HF's ``SiglipVisionModel``.
 
     Uses ``google/siglip-so400m-patch14-384``, which truncates to a 27×27
-    patch grid (floor(384/14) = 27). Our :meth:`VisionBackboneConfig.siglip_so400m`
+    patch grid (floor(384/14) = 27). Our :meth:`VisionEncoderConfig.siglip_so400m`
     config uses input size 378 (= 27×14) to match the same 27×27 grid exactly.
 
     ``SiglipVisionModel`` exposes ``forward(pixel_values=…)`` directly; it does
@@ -206,8 +205,8 @@ def test_siglip_parity():
     """
     hf = _try_load_hf(transformers.SiglipVisionModel, "google/siglip-so400m-patch14-384")
 
-    cfg = VisionBackboneConfig.siglip_so400m()
-    ours = SiglipVisionTransformer(cfg, init_device="cpu").eval()
+    cfg = VisionEncoderConfig.siglip_so400m()
+    ours = VisionTransformer(cfg, init_device="cpu").eval()
     ours.load_state_dict(_convert_siglip_state_dict(hf.state_dict()))
 
     torch.manual_seed(0)
@@ -230,7 +229,7 @@ def test_siglip_parity():
 
 
 def test_siglip2_parity():
-    """Our :class:`SiglipVisionTransformer` matches HF's SigLIP2 checkpoint.
+    """Our :class:`VisionTransformer` matches HF's SigLIP2 checkpoint.
 
     Uses ``google/siglip2-so400m-patch14-384``.  Despite the "384" in the
     model ID, both 378×378 and 384×384 inputs produce a 27×27 patch grid
@@ -243,8 +242,8 @@ def test_siglip2_parity():
     """
     hf = _try_load_hf(transformers.SiglipVisionModel, "google/siglip2-so400m-patch14-384")
 
-    cfg = VisionBackboneConfig.siglip2_so400m_patch14_378()
-    ours = SiglipVisionTransformer(cfg, init_device="cpu").eval()
+    cfg = VisionEncoderConfig.siglip2_so400m_patch14_378()
+    ours = VisionTransformer(cfg, init_device="cpu").eval()
     ours.load_state_dict(_convert_siglip_state_dict(hf.state_dict()))
 
     torch.manual_seed(0)

--- a/src/test/nn/vision/parity_test.py
+++ b/src/test/nn/vision/parity_test.py
@@ -1,0 +1,251 @@
+"""
+Numerical-parity tests between our vision encoders and the HuggingFace
+reference implementations.
+
+These tests load real checkpoints (``openai/clip-vit-large-patch14-336``,
+``google/siglip-so400m-patch14-384``, ``google/siglip2-so400m-patch14-384``)
+and assert that running the same pixel input through both models produces
+matching pre-``post_layernorm`` hidden states.  Requires the ``transformers``
+package and the checkpoints to be available locally (or downloadable) —
+otherwise the tests skip.
+"""
+
+from typing import Dict
+
+import pytest
+import torch
+
+from olmo_core.nn.vision import (
+    SiglipVisionTransformer,
+    VisionBackboneConfig,
+    VisionBackboneType,
+    VisionTransformer,
+)
+
+transformers = pytest.importorskip("transformers")
+
+# Float32 accumulation error across 24–27 transformer layers.  Two independent
+# implementations of identical ops can differ by O(1e-4)–O(1e-3) due to kernel
+# fusion differences and activation approximations — not from any precision loss.
+# Measured worst-cases: CLIP 5e-4, SigLIP 2.8e-3, SigLIP2 3e-4.
+# These tolerances verify fp32-level equivalence; they would NOT pass fp16
+# inference (errors ~1e-2), which is intentional.
+_RTOL = 1e-3
+_ATOL = 3e-3  # SigLIP 27-layer worst case; CLIP and SigLIP2 are ~10x lower
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patchify(image: torch.Tensor, patch_size: int) -> torch.Tensor:
+    """Pixel ``(B, 3, H, W)`` → patches ``(B, N, 3 * p * p)``.
+
+    Uses the C-major flatten order that matches a HuggingFace ``Conv2d`` patch
+    embedding with ``kernel_size = stride = patch_size``: each output channel's
+    ``Conv2d`` weight, reshaped to ``(D, -1)``, dotted with the flat patch
+    pixels equals the convolution at that spatial location.
+    """
+    B, C, H, W = image.shape
+    p = patch_size
+    assert H % p == 0 and W % p == 0
+    x = image.reshape(B, C, H // p, p, W // p, p)
+    x = x.permute(0, 2, 4, 1, 3, 5).contiguous()  # (B, H/p, W/p, C, p, p)
+    return x.reshape(B, (H // p) * (W // p), C * p * p)
+
+
+def _convert_clip_state_dict(hf_sd: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    """Map a HuggingFace ``CLIPVisionTransformer`` state dict to ours."""
+    out: Dict[str, torch.Tensor] = {}
+    out["class_embedding"] = hf_sd["embeddings.class_embedding"]
+    # Conv2d (D, 3, p, p) → Linear (D, 3*p*p), C-major flatten.
+    out["patch_embedding.weight"] = hf_sd["embeddings.patch_embedding.weight"].reshape(
+        hf_sd["embeddings.patch_embedding.weight"].shape[0], -1
+    )
+    out["positional_embedding"] = hf_sd["embeddings.position_embedding.weight"]
+    out["pre_ln.weight"] = hf_sd["pre_layrnorm.weight"]
+    out["pre_ln.bias"] = hf_sd["pre_layrnorm.bias"]
+
+    # Per-layer projections.
+    n_layers = (
+        max(int(k.split(".")[2]) for k in hf_sd.keys() if k.startswith("encoder.layers.")) + 1
+    )
+    for i in range(n_layers):
+        src = f"encoder.layers.{i}"
+        dst = f"blocks.{i}"
+        for hf_name, our_name in (
+            ("layer_norm1", "attn_norm"),
+            ("layer_norm2", "ffn_norm"),
+        ):
+            out[f"{dst}.{our_name}.weight"] = hf_sd[f"{src}.{hf_name}.weight"]
+            out[f"{dst}.{our_name}.bias"] = hf_sd[f"{src}.{hf_name}.bias"]
+        for hf_name, our_name in (
+            ("q_proj", "wq"),
+            ("k_proj", "wk"),
+            ("v_proj", "wv"),
+            ("out_proj", "wo"),
+        ):
+            out[f"{dst}.attn.{our_name}.weight"] = hf_sd[f"{src}.self_attn.{hf_name}.weight"]
+            out[f"{dst}.attn.{our_name}.bias"] = hf_sd[f"{src}.self_attn.{hf_name}.bias"]
+        for hf_name, our_name in (("fc1", "w1"), ("fc2", "w2")):
+            out[f"{dst}.ffn.{our_name}.weight"] = hf_sd[f"{src}.mlp.{hf_name}.weight"]
+            out[f"{dst}.ffn.{our_name}.bias"] = hf_sd[f"{src}.mlp.{hf_name}.bias"]
+    return out
+
+
+def _convert_siglip_state_dict(hf_sd: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    """Map a HuggingFace ``SiglipVisionTransformer`` state dict to ours.
+
+    Skips ``post_layernorm`` and ``head.*`` since we compare at the
+    pre-``post_layernorm`` boundary and don't model the pooling head.
+    """
+    out: Dict[str, torch.Tensor] = {}
+    out["patch_embedding.weight"] = hf_sd["embeddings.patch_embedding.weight"].reshape(
+        hf_sd["embeddings.patch_embedding.weight"].shape[0], -1
+    )
+    out["patch_embedding.bias"] = hf_sd["embeddings.patch_embedding.bias"]
+    out["positional_embedding"] = hf_sd["embeddings.position_embedding.weight"]
+
+    n_layers = (
+        max(int(k.split(".")[2]) for k in hf_sd.keys() if k.startswith("encoder.layers.")) + 1
+    )
+    for i in range(n_layers):
+        src = f"encoder.layers.{i}"
+        dst = f"blocks.{i}"
+        for hf_name, our_name in (
+            ("layer_norm1", "attn_norm"),
+            ("layer_norm2", "ffn_norm"),
+        ):
+            out[f"{dst}.{our_name}.weight"] = hf_sd[f"{src}.{hf_name}.weight"]
+            out[f"{dst}.{our_name}.bias"] = hf_sd[f"{src}.{hf_name}.bias"]
+        for hf_name, our_name in (
+            ("q_proj", "wq"),
+            ("k_proj", "wk"),
+            ("v_proj", "wv"),
+            ("out_proj", "wo"),
+        ):
+            out[f"{dst}.attn.{our_name}.weight"] = hf_sd[f"{src}.self_attn.{hf_name}.weight"]
+            out[f"{dst}.attn.{our_name}.bias"] = hf_sd[f"{src}.self_attn.{hf_name}.bias"]
+        for hf_name, our_name in (("fc1", "w1"), ("fc2", "w2")):
+            out[f"{dst}.ffn.{our_name}.weight"] = hf_sd[f"{src}.mlp.{hf_name}.weight"]
+            out[f"{dst}.ffn.{our_name}.bias"] = hf_sd[f"{src}.mlp.{hf_name}.bias"]
+    return out
+
+
+def _try_load_hf(model_cls, model_id: str):
+    """Load an HF model offline-first; skip the test if not cached and not downloadable."""
+    try:
+        return model_cls.from_pretrained(model_id).eval()
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"could not load {model_id}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# CLIP parity
+# ---------------------------------------------------------------------------
+
+
+def test_clip_parity():
+    """Our :class:`VisionTransformer` matches HF's ``CLIPVisionModel`` numerically.
+
+    Uses ``openai/clip-vit-large-patch14-336`` (default config). HF has 24
+    blocks; our default config sets ``image_num_layers=23`` (Molmo's choice),
+    so we override to 24 for the parity test.
+
+    ``CLIPVisionModel`` is the vision-only model in ``transformers``; it exposes
+    ``forward(pixel_values=…)`` directly and does not have a nested
+    ``vision_model`` attribute.
+    """
+    hf = _try_load_hf(transformers.CLIPVisionModel, "openai/clip-vit-large-patch14-336")
+
+    cfg = VisionBackboneConfig(image_num_layers=24)  # match HF's 24-layer checkpoint
+    assert cfg.name == VisionBackboneType.openai
+    ours = VisionTransformer(cfg, init_device="cpu").eval()
+    ours.load_state_dict(_convert_clip_state_dict(hf.state_dict()))
+
+    torch.manual_seed(0)
+    pixel_values = torch.randn(1, 3, 336, 336)
+
+    with torch.inference_mode():
+        # hidden_states[0] is the patch-embedding output; hidden_states[-1] is
+        # the output of the final encoder block, i.e. pre-post_layernorm.
+        hf_out = hf(pixel_values=pixel_values, output_hidden_states=True)
+        hf_last = hf_out.hidden_states[-1]
+
+        patches = _patchify(pixel_values, cfg.image_patch_size)
+        ours_last = ours(patches, cfg.image_num_patch)[-1]
+
+    torch.testing.assert_close(ours_last, hf_last, rtol=_RTOL, atol=_ATOL)
+
+
+# ---------------------------------------------------------------------------
+# SigLIP parity
+# ---------------------------------------------------------------------------
+
+
+def test_siglip_parity():
+    """Our :class:`SiglipVisionTransformer` matches HF's ``SiglipVisionModel``.
+
+    Uses ``google/siglip-so400m-patch14-384``, which truncates to a 27×27
+    patch grid (floor(384/14) = 27). Our :meth:`VisionBackboneConfig.siglip_so400m`
+    config uses input size 378 (= 27×14) to match the same 27×27 grid exactly.
+
+    ``SiglipVisionModel`` exposes ``forward(pixel_values=…)`` directly; it does
+    not have a nested ``vision_model`` attribute.
+    """
+    hf = _try_load_hf(transformers.SiglipVisionModel, "google/siglip-so400m-patch14-384")
+
+    cfg = VisionBackboneConfig.siglip_so400m()
+    ours = SiglipVisionTransformer(cfg, init_device="cpu").eval()
+    ours.load_state_dict(_convert_siglip_state_dict(hf.state_dict()))
+
+    torch.manual_seed(0)
+    # 378 = 27×14: both HF and our model produce a 27×27 patch grid.
+    pixel_values = torch.randn(1, 3, 378, 378)
+
+    with torch.inference_mode():
+        hf_out = hf(pixel_values=pixel_values, output_hidden_states=True)
+        hf_last = hf_out.hidden_states[-1]  # output of final encoder block
+
+        patches = _patchify(pixel_values, cfg.image_patch_size)
+        ours_last = ours(patches, cfg.image_num_patch)[-1]
+
+    torch.testing.assert_close(ours_last, hf_last, rtol=_RTOL, atol=_ATOL)
+
+
+# ---------------------------------------------------------------------------
+# SigLIP2 parity
+# ---------------------------------------------------------------------------
+
+
+def test_siglip2_parity():
+    """Our :class:`SiglipVisionTransformer` matches HF's SigLIP2 checkpoint.
+
+    Uses ``google/siglip2-so400m-patch14-384``.  Despite the "384" in the
+    model ID, both 378×378 and 384×384 inputs produce a 27×27 patch grid
+    (floor(378/14) = floor(384/14) = 27).  We use 378 to match our config's
+    ``image_default_input_size``.
+
+    SigLIP2 shares the same ``SiglipVisionModel`` class in ``transformers`` as
+    SigLIP — only the training recipe differs — so the same state-dict
+    converter applies.
+    """
+    hf = _try_load_hf(transformers.SiglipVisionModel, "google/siglip2-so400m-patch14-384")
+
+    cfg = VisionBackboneConfig.siglip2_so400m_patch14_378()
+    ours = SiglipVisionTransformer(cfg, init_device="cpu").eval()
+    ours.load_state_dict(_convert_siglip_state_dict(hf.state_dict()))
+
+    torch.manual_seed(0)
+    # 378 = 27×14: both HF and our model produce a 27×27 = 729 patch grid.
+    pixel_values = torch.randn(1, 3, 378, 378)
+
+    with torch.inference_mode():
+        hf_out = hf(pixel_values=pixel_values, output_hidden_states=True)
+        hf_last = hf_out.hidden_states[-1]  # output of final encoder block
+
+        patches = _patchify(pixel_values, cfg.image_patch_size)
+        ours_last = ours(patches, cfg.image_num_patch)[-1]
+
+    torch.testing.assert_close(ours_last, hf_last, rtol=_RTOL, atol=_ATOL)

--- a/src/test/nn/vision/parity_test.py
+++ b/src/test/nn/vision/parity_test.py
@@ -134,7 +134,17 @@ def _convert_siglip_state_dict(hf_sd: Dict[str, torch.Tensor]) -> Dict[str, torc
 
 
 def _try_load_hf(model_cls, model_id: str):
-    """Load an HF model offline-first; skip the test if not cached and not downloadable."""
+    """Load an HF model, preferring the local cache.
+
+    Tries ``local_files_only=True`` first so a cached checkpoint never triggers a
+    network download (which would turn this unit test into a slow integration
+    download). Only if the checkpoint isn't cached do we fall back to a normal
+    ``from_pretrained`` that may download. Skips the test if neither succeeds.
+    """
+    try:
+        return model_cls.from_pretrained(model_id, local_files_only=True).eval()
+    except Exception:  # noqa: BLE001  # not cached locally; fall back to download
+        pass
     try:
         return model_cls.from_pretrained(model_id).eval()
     except Exception as e:  # noqa: BLE001
@@ -150,8 +160,8 @@ def test_clip_parity():
     """Our :class:`VisionTransformer` matches HF's ``CLIPVisionModel`` numerically.
 
     Uses ``openai/clip-vit-large-patch14-336`` (default config). HF has 24
-    blocks; our default config sets ``image_num_layers=23`` (Molmo's choice),
-    so we override to 24 for the parity test.
+    blocks; our default config sets ``image_num_layers=23`` (the final block is
+    unused when reading from layer ``-2``), so we override to 24 for the parity test.
 
     ``CLIPVisionModel`` is the vision-only model in ``transformers``; it exposes
     ``forward(pixel_values=…)`` directly and does not have a nested


### PR DESCRIPTION
## Summary

This is the first in a series of a few PRs adding VLM/multimodal support to OLMo-core.

---

## What's in this PR

Three new modules under `src/olmo_core/nn/vision/`:

### Vision encoder (`image_vit.py`, `config.py`)

A single, configurable `VisionTransformer` (built from `VisionEncoderConfig`) covering both supported encoder families. There is **one** module class; the architectural variant is selected entirely through config switches rather than separate subclasses:

| Switch | CLIP (`openai`) | SigLIP / SigLIP2 |
|---|---|---|
| `use_cls_token` | `True` (prepends a learnable CLS) | `False` |
| `patch_embedding_bias` | `False` | `True` |
| `use_pre_ln` | `True` (LayerNorm before blocks) | `False` |

| Type | HF checkpoint |
|------|--------------|
| `openai` (CLIP) | `openai/clip-vit-large-patch14-336` |
| `siglip` | `google/siglip-so400m-patch14-384` |
| `siglip2` | `google/siglip2-so400m-patch14-384` |

Key config knobs: `image_default_input_size`, `image_patch_size`, `image_emb_dim`, `image_num_heads`, `image_num_layers`, `image_num_pos`. Factory class-methods cover all standard Molmo2 variants.

The transformer block follows the same pattern as the LM side: `ViTAttention` / `ViTMLP` / `ViTBlock` are public, and the block is selected via `VisionBlockConfig` / `VisionBlockType` (`VisionEncoderConfig.block`), so additional block implementations can be registered as they're added.

### `VisionConnector` (`connector.py`)

Maps variable-length vision embeddings to the LM hidden dimension:
1. 2×2 attention pooling over the patch grid
2. SwiGLU MLP projector → `output_dim = lm.d_model`

Constructed via `VisionConnectorConfig.from_vision_encoder(vis_cfg, output_dim, mlp_hidden_size)`.

### `MultimodalLM` (`multimodal.py`)

Composite model holding `lm: Transformer`, `vision: VisionTransformer`, and `connector: VisionConnector`. It **composes** an LM rather than subclassing `Transformer` — the LM exposes a generic `input_embeddings` entry point (the standard precomputed-embeddings hook), and the multimodal logic lives here. Forward pass:
1. Run the vision encoder on each crop's patch tensor.
2. Project patch embeddings to LM width via `VisionConnector`.
3. Splice patch tokens into the text embedding stream at `image_patch_token_id` positions.
4. Run the standard LM forward pass on the fused sequence.

---

## HF Parity Tests

`src/test/nn/vision/parity_test.py` loads real checkpoints and asserts numerical equivalence between our implementation and HuggingFace's reference models. Tests skip automatically when checkpoints are not cached.

Measured max absolute errors on CPU in float32 (24–27 transformer layers):

| Checkpoint | max abs error | mean abs error | tolerance used |
|---|---|---|---|
| `openai/clip-vit-large-patch14-336` | **4.9e-04** | 3.1e-06 | `atol=3e-3, rtol=1e-3` |
| `google/siglip-so400m-patch14-384` | **2.8e-03** | 7.8e-06 | `atol=3e-3, rtol=1e-3` |
| `google/siglip2-so400m-patch14-384` | **3.1e-04** | 3.0e-06 | `atol=3e-3, rtol=1e-3` |

These errors reflect genuine float32 accumulation across 24–27 attention/MLP layers from independent kernel implementations — not any precision loss. They are ~10–100× tighter than fp16 parity would require. State-dict key layouts are unchanged across the CLIP and SigLIP variants, so all three parity tests pass against the single configurable encoder.

---

## Files changed

```
src/olmo_core/nn/vision/__init__.py        (new)
src/olmo_core/nn/vision/config.py          (new)  VisionEncoderConfig + factories, VisionBlockConfig
src/olmo_core/nn/vision/image_vit.py       (new)  VisionTransformer, ViTBlock/ViTAttention/ViTMLP
src/olmo_core/nn/vision/connector.py       (new)  VisionConnector
src/olmo_core/nn/vision/multimodal.py      (new)  MultimodalLM, MultimodalLMConfig

src/test/nn/vision/__init__.py             (new)
src/test/nn/vision/config_test.py          (new)  config + factory + build dispatch + round-trip
src/test/nn/vision/image_vit_test.py       (new)  encoder forward-pass behavior
src/test/nn/vision/connector_test.py       (new)
src/test/nn/vision/multimodal_test.py      (new)
src/test/nn/vision/parity_test.py          (new)  CLIP + SigLIP + SigLIP2 HF parity
```
