### PR TITLE
Add max_checkpoints to limit permanent checkpoint retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `max_checkpoints` parameter to `CheckpointerCallback` (default: 3) to limit the number of permanent checkpoints retained. Oldest checkpoints are removed automatically when the limit is exceeded. Set to `None` to keep all (previous behavior).
 - Added `HFConverterCallback`, which can be used to convert models to huggingface format at the end of the training run.
 - Trainer now records checkpoint save and load durations as `train/checkpoint_save_duration_s` and `train/checkpoint_load_duration_s` metrics.
 - Added `PowerLR`, a power-law learning rate scheduler with linear warmup, power-decay phase (`lr = initial_lr * (current / warmup) ** b` for negative `b`, making the LR independent of the training horizon), and an optional linear decay tail. Registered as `"power_lr"`.

--- a/src/olmo_core/train/callbacks/checkpointer.py
+++ b/src/olmo_core/train/callbacks/checkpointer.py
@@ -99,6 +99,16 @@ class CheckpointerCallback(Callback):
     A list of fixed steps at which to save additional permanent checkpoints.
     """
 
+    max_checkpoints: Optional[int] = 3
+    """
+    Maximum number of permanent checkpoints to keep. When a new permanent checkpoint
+    is saved and the count exceeds this limit, the oldest is removed.
+    Set to ``None`` to keep all checkpoints (previous behavior).
+
+    .. note::
+        Checkpoints saved at :data:`fixed_steps` are counted toward this limit.
+    """
+
     enabled: bool = True
 
     # Bookkeeping
@@ -125,6 +135,8 @@ class CheckpointerCallback(Callback):
                 raise OLMoConfigurationError(
                     "'ephemeral_save_interval' must be less than 'save_interval'"
                 )
+        if self.max_checkpoints is not None and self.max_checkpoints < 1:
+            raise OLMoConfigurationError("'max_checkpoints' must be at least 1")
 
     @property
     def checkpointer(self) -> Checkpointer:
@@ -195,6 +207,12 @@ class CheckpointerCallback(Callback):
         for path in self._checkpoints_to_remove:
             self._remove_checkpoint(path)
         self._checkpoints_to_remove.clear()
+
+    def _trim_checkpoints(self):
+        if self.max_checkpoints is not None:
+            while len(self._checkpoints) > self.max_checkpoints:
+                oldest_path = self._checkpoints.pop(0)
+                self._schedule_for_removal(oldest_path)
 
     def pre_train(self):
         if not self.enabled:
@@ -272,9 +290,11 @@ class CheckpointerCallback(Callback):
         if self.fixed_steps is not None and self.step in self.fixed_steps:
             # Save permanent checkpoint.
             self._checkpoints.append(self._save_checkpoint())
+            self._trim_checkpoints()
         elif self.save_interval is not None and self.step % self.save_interval == 0:
             # Save permanent checkpoint.
             self._checkpoints.append(self._save_checkpoint())
+            self._trim_checkpoints()
         elif (
             self.ephemeral_save_interval is not None
             and self.step % self.ephemeral_save_interval == 0
@@ -300,5 +320,6 @@ class CheckpointerCallback(Callback):
 
         if self.step > self._latest_checkpoint_step:
             self._checkpoints.append(self._save_checkpoint(save_async=False))
+            self._trim_checkpoints()
 
         self._await_last_checkpoint()


### PR DESCRIPTION
## Summary
- Adds a `max_checkpoints` parameter to `CheckpointerCallback` (default: 3) that trims the oldest permanent checkpoints after each save
- Uses the existing `_schedule_for_removal` / `_remove_checkpoint` infrastructure — no new deletion code needed
- Set to `None` to preserve the previous keep-all behavior
- Includes input validation (`max_checkpoints >= 1`)

## Motivation
Permanent checkpoints accumulate indefinitely because there is no retention limit — the `_checkpoints` list is appended to on every save but never trimmed. On AI2's WEKA storage, this has produced ~143 TB of checkpoint waste across the oe-adapt partition (42.6% of used space). A single GRPO run on a 32B model with `checkpoint_state_freq=200` creates 50 checkpoints totaling 4.4 TB; with `max_checkpoints=3`, this caps at ~264 GB.

The older OLMo v1 framework had `save_num_checkpoints_to_keep` with working cleanup logic. When OLMo-core replaced it, the feature was not carried over. Ephemeral checkpoints already have retention (keep latest 1) — this applies the same pattern to permanent checkpoints.

Every downstream team that overrides checkpoint defaults sets `save_num_checkpoints_to_keep=1` (molmo, molmo2, molmoact, MolmoBot). A default of 3 covers the common use cases (latest for resume, a few intermediates for model selection).

## Test plan
- [ ] Verify existing checkpoint tests pass (`src/test/train/callbacks/`, integration tests)
- [ ] Confirm `max_checkpoints=None` preserves old behavior (no trimming)
- [ ] Confirm `max_checkpoints=3` trims oldest after the 4th permanent checkpoint save
- [ ] Verify `fixed_steps` checkpoints are also subject to the limit