### PR TITLE
Fix LayerNorm Scaling implementation

### DIFF
--- a/src/olmo_core/nn/transformer/block.py
+++ b/src/olmo_core/nn/transformer/block.py
@@ -270,8 +270,7 @@ class LayerNormScaledTransformerBlock(TransformerBlock):
         )
 
         # LayerNorm scaling factor 1/sqrt(layer_id), where layer_id is 1-based.
-        ln_scale_value = 1.0 / math.sqrt(block_idx + 1)
-        self.register_buffer("ln_scale", torch.tensor(ln_scale_value, dtype=torch.float32))
+        self.ln_scale: float = 1.0 / math.sqrt(block_idx + 1)
 
     def forward(
         self,
@@ -281,12 +280,11 @@ class LayerNormScaledTransformerBlock(TransformerBlock):
         **kwargs,
     ) -> torch.Tensor:
         del loss_div_factor
-        scale = self.ln_scale.to(dtype=x.dtype, device=x.device)
         h = self.attention_residual_stream(
-            x, self.attention(self.attention_norm(x) * scale, **kwargs)
+            x, self.attention(self.attention_norm(x) * self.ln_scale, **kwargs)
         )
         return self.feed_forward_residual_stream(
-            h, self.feed_forward(self.feed_forward_norm(h) * scale)
+            h, self.feed_forward(self.feed_forward_norm(h) * self.ln_scale)
         )
 
 


### PR DESCRIPTION
## Issue
The current LayerNorm Scaling implementation has a silent bug when used in the training pipeline.

The scale is implemented as a buffer and initialized in the `__init__` method of `LayerNormScaledTransformerBlock`. However, model initialization in `src/olmo_core/nn/transformer/model.py` calls `to_empty` before initializing each module’s weights individually. This effectively erases the contents of the `ln_scale` buffer and causes incorrect behavior during training.

## Fix
There are two possible fixes. The first is to keep using a buffer and implement a custom initialization function. The second is to implement the scale as a Python scalar, which is simpler and is the approach taken in this PR.