### PR TITLE
Fix qwen3_32B and qwen3_14B factory dims to match the official Qwen3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed Qwen3-14B and Qwen3-32B factory dimensions to match the official model configurations.
+
 ## [v2.6.0](https://github.com/allenai/OLMo-core/releases/tag/v2.6.0) - 2026-08-11
 
 ### Added

--- a/src/olmo_core/nn/transformer/config.py
+++ b/src/olmo_core/nn/transformer/config.py
@@ -1437,7 +1437,7 @@ class TransformerConfig(ModelConfig):
         return cls.llama_like(
             d_model=5120,
             vocab_size=vocab_size,
-            n_layers=kwargs.pop("n_layers", 48),
+            n_layers=kwargs.pop("n_layers", 40),
             n_heads=kwargs.pop("n_heads", 40),
             n_kv_heads=kwargs.pop("n_kv_heads", 8),
             head_dim=kwargs.pop("head_dim", 128),
@@ -1459,7 +1459,7 @@ class TransformerConfig(ModelConfig):
             d_model=5120,
             vocab_size=vocab_size,
             n_layers=kwargs.pop("n_layers", 64),
-            n_heads=kwargs.pop("n_heads", 40),
+            n_heads=kwargs.pop("n_heads", 64),
             n_kv_heads=kwargs.pop("n_kv_heads", 8),
             head_dim=kwargs.pop("head_dim", 128),
             rope_theta=kwargs.pop("rope_theta", 1_000_000),

--- a/src/olmo_core/nn/transformer/config.py
+++ b/src/olmo_core/nn/transformer/config.py
@@ -1417,7 +1417,7 @@ class TransformerConfig(ModelConfig):
         return cls.llama_like(
             d_model=5120,
             vocab_size=vocab_size,
-            n_layers=kwargs.pop("n_layers", 48),
+            n_layers=kwargs.pop("n_layers", 40),
             n_heads=kwargs.pop("n_heads", 40),
             n_kv_heads=kwargs.pop("n_kv_heads", 8),
             head_dim=kwargs.pop("head_dim", 128),
@@ -1439,7 +1439,7 @@ class TransformerConfig(ModelConfig):
             d_model=5120,
             vocab_size=vocab_size,
             n_layers=kwargs.pop("n_layers", 64),
-            n_heads=kwargs.pop("n_heads", 40),
+            n_heads=kwargs.pop("n_heads", 64),
             n_kv_heads=kwargs.pop("n_kv_heads", 8),
             head_dim=kwargs.pop("head_dim", 128),
             rope_theta=kwargs.pop("rope_theta", 1_000_000),

--- a/src/test/nn/transformer/model_test.py
+++ b/src/test/nn/transformer/model_test.py
@@ -686,6 +686,62 @@ def test_qwen3_builder_configs(config_builder, expected_d_model):
 
 
 @pytest.mark.parametrize(
+    "config_builder,expected_n_layers,expected_n_heads,expected_query_dim,expected_num_params",
+    [
+        pytest.param(
+            TransformerConfig.qwen3_14B,
+            40,
+            40,
+            5120,
+            14_768_307_200,
+            id="qwen3_14B",
+        ),
+        pytest.param(
+            TransformerConfig.qwen3_32B,
+            64,
+            64,
+            8192,
+            32_762_123_264,
+            id="qwen3_32B",
+        ),
+    ],
+)
+def test_qwen3_large_builder_default_dimensions(
+    config_builder,
+    expected_n_layers,
+    expected_n_heads,
+    expected_query_dim,
+    expected_num_params,
+):
+    config = config_builder(vocab_size=151936)
+
+    assert config.n_layers == expected_n_layers
+    assert len(config.resolved_block_configs) == expected_n_layers
+    assert config.num_params == expected_num_params
+
+    attention_config = config.block.sequence_mixer
+    assert isinstance(attention_config, AttentionConfig)
+    assert attention_config.n_heads == expected_n_heads
+    assert attention_config.n_kv_heads == 8
+    assert attention_config.head_dim == 128
+
+    attention = attention_config.build(
+        config.d_model,
+        layer_idx=0,
+        n_layers=config.n_layers,
+        init_device="meta",
+    )
+    expected_kv_dim = 8 * 128
+    assert attention.w_q.weight.shape == (expected_query_dim, config.d_model)
+    assert attention.w_k.weight.shape == (expected_kv_dim, config.d_model)
+    assert attention.w_v.weight.shape == (expected_kv_dim, config.d_model)
+    assert attention.w_out.weight.shape == (config.d_model, expected_query_dim)
+    assert sum(p.numel() for p in attention.parameters()) == attention_config.num_params(
+        config.d_model
+    )
+
+
+@pytest.mark.parametrize(
     "config_builder,expected_d_model,expected_n_heads,expected_gdn_v_heads",
     [
         pytest.param(TransformerConfig.qwen3_5_0_8B, 1024, 8, 16, id="qwen3_5_0_8B"),


### PR DESCRIPTION
Just fixed some shapes, you can try with this, you can find the official shapes in the config.json files for each model in https://huggingface.co/collections/Qwen/qwen3

```python
from olmo_core.nn.transformer import TransformerConfig

OFFICIAL = {
    "qwen3_0_6B": (28, 16, 8, 128, 1024, 3072),
    "qwen3_1_7B": (28, 16, 8, 128, 2048, 6144),
    "qwen3_4B": (36, 32, 8, 128, 2560, 9728),
    "qwen3_8B": (36, 32, 8, 128, 4096, 12288),
    "qwen3_14B": (40, 40, 8, 128, 5120, 17408),
    "qwen3_32B": (64, 64, 8, 128, 5120, 25600),
}

failures = []
for name, official in OFFICIAL.items():
    cfg = getattr(TransformerConfig, name)(vocab_size=151936)
    att = cfg.block.attention or cfg.block.sequence_mixer
    got = (cfg.n_layers, att.n_heads, att.n_kv_heads, att.head_dim, cfg.d_model, cfg.block.feed_forward.hidden_size)
    print(f"{name:12s} factory={got}  official={official}  {'OK' if got == official else 'MISMATCH'}")
    if got != official:
        failures.append(name)

if "qwen3_32B" in failures:
    model = TransformerConfig.qwen3_32B(vocab_size=151936).build(init_device="meta")
    att = model.blocks["0"].attention
    print(f"qwen3_32B w_q built as {tuple(att.w_q.weight.shape)}, checkpoint tensor is (8192, 5120)")

print("PASS")
```

You'll find what fails and that the PR fixes it