### PR TITLE
Fix fused_linear_cross_entropy_loss adding the z-loss term to the loss when compute_z_loss=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Disabled z-loss no longer contributes to `fused_linear_cross_entropy_loss`.
+
 ## [v2.6.0](https://github.com/allenai/OLMo-core/releases/tag/v2.6.0) - 2026-08-11
 
 ### Added

--- a/src/olmo_core/nn/functional/cross_entropy_loss.py
+++ b/src/olmo_core/nn/functional/cross_entropy_loss.py
@@ -110,7 +110,7 @@ def fused_linear_cross_entropy_loss(
         bias,
         ce_weight,
         ignore_index,
-        z_loss_multiplier,
+        z_loss_multiplier if compute_z_loss else 0.0,
         label_smoothing,
         reduction,
         softcap,

--- a/src/test/nn/functional/cross_entropy_loss_test.py
+++ b/src/test/nn/functional/cross_entropy_loss_test.py
@@ -1,7 +1,9 @@
+import importlib
+
 import pytest
 import torch
 
-from olmo_core.nn.functional import cross_entropy_loss
+from olmo_core.nn.functional import cross_entropy_loss, fused_linear_cross_entropy_loss
 from olmo_core.testing import DEVICES
 
 
@@ -29,3 +31,55 @@ def test_cross_entropy_loss(device, reduction):
     )
     torch.testing.assert_close(ce_loss, ce_loss1)
     torch.testing.assert_close(z_loss, z_loss1)
+
+
+@pytest.mark.parametrize(
+    ("compute_z_loss", "expected_lse_square_scale"),
+    [
+        pytest.param(False, 0.0, id="disabled"),
+        pytest.param(True, 0.125, id="enabled"),
+    ],
+)
+def test_fused_linear_cross_entropy_loss_z_loss_contract(
+    monkeypatch, compute_z_loss, expected_lse_square_scale
+):
+    loss_module = importlib.import_module("olmo_core.nn.functional.cross_entropy_loss")
+    liger_call = {}
+    ce_loss = torch.tensor(1.5)
+    kernel_z_loss = torch.tensor(0.25)
+
+    def mock_fused_loss(
+        _input,
+        _weight,
+        _labels,
+        _bias,
+        _ce_weight,
+        _ignore_index,
+        lse_square_scale,
+        _label_smoothing,
+        _reduction,
+        _softcap,
+        return_z_loss,
+        _accum_dtype,
+    ):
+        liger_call["lse_square_scale"] = lse_square_scale
+        liger_call["return_z_loss"] = return_z_loss
+        return ce_loss, kernel_z_loss, torch.tensor(1.0)
+
+    monkeypatch.setattr(loss_module, "_fused_linear_cross_entropy_loss", mock_fused_loss)
+
+    actual_ce_loss, actual_z_loss = fused_linear_cross_entropy_loss(
+        torch.zeros(1, 2),
+        torch.zeros(3, 2),
+        torch.zeros(1, dtype=torch.long),
+        compute_z_loss=compute_z_loss,
+        z_loss_multiplier=0.125,
+    )
+
+    assert liger_call["lse_square_scale"] == expected_lse_square_scale
+    assert liger_call["return_z_loss"] is compute_z_loss
+    assert actual_ce_loss is ce_loss
+    if compute_z_loss:
+        assert actual_z_loss is kernel_z_loss
+    else:
+        assert actual_z_loss is None


### PR DESCRIPTION
liger's `lse_square_scale` folds m * lse^2 into the returned loss whenever it's non-zero. `return_z_loss` only controls the separate return. Since `LMHead.forward` passes `z_loss_multiplier or 1e-4`, fused-loss runs with z-loss off return ce + 1e-4 * lse^2. The `compute_z_loss=True` path is unaffected.

Try this with:
```python
import torch
import torch.nn.functional as F
from olmo_core.nn.functional.cross_entropy_loss import fused_linear_cross_entropy_loss

torch.manual_seed(1234)
h = torch.randn(4096, 1024, device="cuda")
w = torch.randn(151936, 1024, device="cuda") * 0.02
labels = torch.randint(0, 151936, (4096,), device="cuda")
labels[torch.rand(4096, device="cuda") < 0.4] = -100

logits = h @ w.t()
ce = F.cross_entropy(logits, labels, ignore_index=-100)
mask = labels != -100
z_term = 1e-4 * (logits.logsumexp(-1).pow(2) * mask).sum() / mask.sum()

loss, _ = fused_linear_cross_entropy_loss(
    h, w, labels, ignore_index=-100, reduction="mean",
    compute_z_loss=False, z_loss_multiplier=1e-4, accum_dtype=torch.float32,
)

print(f"plain CE         = {ce.item():.6f}")
print(f"fused, z off     = {loss.item():.6f}")
print(f"1e-4*mean(lse^2) = {z_term.item():.6f}")

if abs(loss.item() - ce.item()) > 1e-5 * ce.item():
    print("FAIL: the no-z fused loss includes the z-loss term")
else:
    print("PASS")
```

I tried it on a cluster on 1 A100:
```
Before:
plain CE         = 12.137142
fused, z off     = 12.151872
1e-4*mean(lse^2) = 0.014729
FAIL: the no-z fused loss includes the z-loss term
After:
plain CE         = 12.137142
fused, z off     = 12.137142
1e-4*mean(lse^2) = 0.014729
PASS
```