### PR TITLE
Add nvtx as an optional dependency with a no-op fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,11 @@ dion = ["dion @ git+https://github.com/microsoft/dion.git@7452a5823cf9655b93c3f1
 eval = ["ai2-olmo-eval==0.9.0"]
 fa4 = ["flash-attn-4>=4.0.0b4 ; sys_platform == 'linux'"]
 fla = ["flash-linear-attention==0.4.1"]
+profiling = ["nvtx"]
 torchao = ["torchao==0.15.0"]
 transformers = ["transformers"]
 wandb = ["wandb"]
-all = ["ai2-olmo-core[dev,beaker,comet,dion,eval,fa4,fla,torchao,transformers,wandb]"]
+all = ["ai2-olmo-core[dev,beaker,comet,dion,eval,fa4,fla,profiling,torchao,transformers,wandb]"]
 
 [tool.uv]
 environments = [

--- a/src/olmo_core/_nvtx.py
+++ b/src/olmo_core/_nvtx.py
@@ -1,0 +1,43 @@
+"""
+No-op fallback for the optional ``nvtx`` profiling dependency.
+
+``nvtx`` (NVIDIA Tools Extension) is only needed to emit profiler ranges under a
+profiler such as Nsight Systems, so it is declared as an optional dependency (the
+``profiling`` extra). Modules that annotate hot paths import it defensively::
+
+    try:
+        import nvtx
+    except ImportError:
+        from olmo_core._nvtx import nvtx
+
+so the ``@nvtx.annotate(...)`` annotations become no-ops when nvtx is not installed.
+"""
+
+from __future__ import annotations
+
+from contextlib import ContextDecorator
+from typing import Any
+
+__all__ = ["nvtx"]
+
+
+class _NoOpRange(ContextDecorator):
+    """A do-nothing range usable as both a decorator and a context manager."""
+
+    def __enter__(self) -> "_NoOpRange":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        # Returning None (falsy) means we never suppress exceptions.
+        return None
+
+
+class _NoOpNvtx:
+    """Drop-in stand-in exposing the (sole) ``nvtx.annotate`` API as a no-op."""
+
+    @staticmethod
+    def annotate(*args: Any, **kwargs: Any) -> _NoOpRange:
+        return _NoOpRange()
+
+
+nvtx = _NoOpNvtx()

--- a/src/test/nvtx_test.py
+++ b/src/test/nvtx_test.py
@@ -1,0 +1,15 @@
+from olmo_core._nvtx import nvtx
+
+
+def test_noop_nvtx_as_decorator():
+    @nvtx.annotate("range", color="red")
+    def add(a, b):
+        return a + b
+
+    assert add(2, 3) == 5
+
+
+def test_noop_nvtx_as_context_manager():
+    with nvtx.annotate("range"):
+        result = 21 * 2
+    assert result == 42


### PR DESCRIPTION
## What this adds

Makes `nvtx` (NVIDIA Tools Extension) an **optional** dependency instead of a hard requirement. nvtx is only used to emit profiler ranges (`@nvtx.annotate(...)`), so code shouldn't fail to import when it isn't installed. This is setup for future use.

- New `profiling` extra in `pyproject.toml` (`pip install ai2-olmo-core[profiling]`), also rolled into the `all` extra.
- New `olmo_core._nvtx` module exposing a no-op `nvtx` stand-in whose `annotate` works as both a decorator and a context manager. Modules that annotate hot paths import defensively:

  ```python
  try:
      import nvtx
  except ImportError:
      from olmo_core._nvtx import nvtx
  ```

  so the annotations become no-ops when nvtx isn't installed.

## Testing

`src/test/nvtx_test.py` exercises the no-op shim as both a decorator and a context manager. Pure-Python, CPU-only.
