### PR TITLE
Add grouped_mm kernel wrapper

### DIFF
--- a/src/olmo_core/kernels/__init__.py
+++ b/src/olmo_core/kernels/__init__.py
@@ -1,0 +1,13 @@
+"""
+Low-level CUDA/C++ kernels and their Python wrappers.
+
+The wrappers are import-safe on CPU: the CUDA/C++ extensions are built lazily on first
+use (see :mod:`olmo_core.kernels.cuda_extension_utils`), so importing this package does
+not require a GPU or a compiler.
+"""
+
+from .grouped_mm import grouped_mm
+
+__all__ = [
+    "grouped_mm",
+]

--- a/src/olmo_core/kernels/cuda/grouped_mm_out.cpp
+++ b/src/olmo_core/kernels/cuda/grouped_mm_out.cpp
@@ -1,0 +1,188 @@
+#include <torch/extension.h>
+
+#include <ATen/core/Tensor.h>
+#include <ATen/native/GroupedMMUtils.h>
+#include <ATen/native/cuda/GroupMM.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace py = pybind11;
+
+namespace {
+
+std::optional<at::Tensor> normalize_optional_tensor(
+    const c10::optional<at::Tensor>& tensor) {
+  if (tensor.has_value() && tensor->defined()) {
+    return std::optional<at::Tensor>(tensor.value());
+  }
+  return std::nullopt;
+}
+
+std::vector<int64_t> grouped_mm_expected_output_size(
+    const at::Tensor& mat_a,
+    const at::Tensor& mat_b,
+    const std::optional<at::Tensor>& offs) {
+  const bool a_is_2d = mat_a.dim() == 2;
+  const bool b_is_2d = mat_b.dim() == 2;
+
+  if (a_is_2d) {
+    if (b_is_2d) {
+      TORCH_CHECK(offs.has_value(), "offs is required for 2D/2D grouped_mm");
+      return {offs->size(0), mat_a.size(0), mat_b.size(1)};
+    } else {
+      TORCH_CHECK(offs.has_value(), "offs is required for 2D/3D grouped_mm");
+      TORCH_CHECK(
+          offs->size(0) == mat_b.size(0),
+          "matrix batch sizes have to match");
+      return {mat_a.size(0), mat_b.size(-1)};
+    }
+  } else {
+    if (b_is_2d) {
+      TORCH_CHECK(offs.has_value(), "offs is required for 3D/2D grouped_mm");
+      TORCH_CHECK(
+          offs->size(0) == mat_a.size(0),
+          "matrix batch sizes have to match");
+      return {mat_a.size(1), mat_b.size(1)};
+    }
+
+    TORCH_CHECK(
+        mat_a.size(0) == mat_b.size(0), "batched dimension has to match");
+    return {mat_a.size(0), mat_a.size(1), mat_b.size(-1)};
+  }
+}
+
+void check_out_tensor_shape(
+    const at::Tensor& out,
+    const std::vector<int64_t>& expected_sizes) {
+  TORCH_CHECK(
+      out.dim() == static_cast<int64_t>(expected_sizes.size()),
+      "out rank mismatch: expected ",
+      expected_sizes.size(),
+      "D but got ",
+      out.dim(),
+      "D");
+  for (size_t i = 0; i < expected_sizes.size(); ++i) {
+    TORCH_CHECK(
+        out.size(static_cast<int64_t>(i)) == expected_sizes[i],
+        "out shape mismatch at dim ",
+        i,
+        ": expected ",
+        expected_sizes[i],
+        " but got ",
+        out.size(static_cast<int64_t>(i)));
+  }
+}
+
+bool has_fast_path_output_layout(
+    const at::Tensor& out,
+    const std::vector<int64_t>& expected_sizes,
+    const bool a_is_2d,
+    const bool b_is_2d) {
+  if (reinterpret_cast<uintptr_t>(out.data_ptr()) % 16 != 0) {
+    return false;
+  }
+  const int alignment = 16 / out.element_size();
+  const auto last_dim = static_cast<int64_t>(expected_sizes.size() - 1);
+  const int64_t size_padded =
+      (expected_sizes[last_dim] + alignment - 1) / alignment * alignment;
+
+  if (a_is_2d != b_is_2d) {
+    return out.stride(0) == size_padded && out.stride(1) == 1;
+  }
+
+  return out.stride(0) == expected_sizes[1] * size_padded &&
+      out.stride(1) == size_padded && out.stride(2) == 1;
+}
+
+bool should_use_fast_path(
+    const at::Tensor& mat_a,
+    const at::Tensor& mat_b,
+    const at::Tensor& out,
+    const std::vector<int64_t>& expected_sizes,
+    const bool a_is_2d,
+    const bool b_is_2d) {
+  if (mat_a.scalar_type() != at::kBFloat16 ||
+      mat_b.scalar_type() != at::kBFloat16 ||
+      out.scalar_type() != at::kBFloat16) {
+    return false;
+  }
+
+#ifdef USE_ROCM
+  return false;
+#else
+  return has_fast_path_output_layout(out, expected_sizes, a_is_2d, b_is_2d);
+#endif
+}
+
+} // namespace
+
+at::Tensor grouped_mm_out_cuda(
+    const at::Tensor& mat_a,
+    const at::Tensor& mat_b,
+    at::Tensor out,
+    const c10::optional<at::Tensor>& offs_opt,
+    const c10::optional<at::Tensor>& bias_opt) {
+  TORCH_CHECK(mat_a.is_cuda(), "mat_a must be CUDA");
+  TORCH_CHECK(mat_b.is_cuda(), "mat_b must be CUDA");
+  TORCH_CHECK(out.is_cuda(), "out must be CUDA");
+  TORCH_CHECK(
+      mat_a.device() == mat_b.device(),
+      "mat_a/mat_b device mismatch: ",
+      mat_a.device(),
+      " vs ",
+      mat_b.device());
+  TORCH_CHECK(
+      out.device() == mat_a.device(),
+      "out/mat_a device mismatch: ",
+      out.device(),
+      " vs ",
+      mat_a.device());
+
+  const auto offs = normalize_optional_tensor(offs_opt);
+  const auto bias = normalize_optional_tensor(bias_opt);
+
+  const std::optional<c10::ScalarType> out_dtype = out.scalar_type();
+  at::native::_grouped_mm_validate_inputs(mat_a, mat_b, offs, bias, out_dtype);
+  const auto resolved_out_dtype =
+      at::native::_resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
+  TORCH_CHECK(
+      out.scalar_type() == resolved_out_dtype,
+      "out dtype must match grouped_mm resolved dtype. got out=",
+      out.scalar_type(),
+      ", expected=",
+      resolved_out_dtype);
+
+  const auto expected_sizes = grouped_mm_expected_output_size(mat_a, mat_b, offs);
+  check_out_tensor_shape(out, expected_sizes);
+
+  const bool a_is_2d = mat_a.dim() == 2;
+  const bool b_is_2d = mat_b.dim() == 2;
+  const bool use_fast_path = should_use_fast_path(
+      mat_a, mat_b, out, expected_sizes, a_is_2d, b_is_2d);
+
+  if (use_fast_path) {
+    try {
+      at::cuda::detail::bf16bf16_grouped_mm(mat_a, mat_b, offs, bias, out);
+      return out;
+    } catch (const c10::Error&) {
+      // Fall back if the fast kernel is unavailable for the current build/device.
+    }
+  }
+
+  at::native::_grouped_mm_fallback(mat_a, mat_b, offs, bias, out_dtype, out);
+  return out;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+      "grouped_mm_out_cuda",
+      &grouped_mm_out_cuda,
+      "GroupedMM with explicit output buffer (CUDA)",
+      py::arg("mat_a"),
+      py::arg("mat_b"),
+      py::arg("out"),
+      py::arg("offs") = py::none(),
+      py::arg("bias") = py::none());
+}

--- a/src/olmo_core/kernels/grouped_mm.py
+++ b/src/olmo_core/kernels/grouped_mm.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+from .cuda_extension_utils import load_cuda_extension
+
+_CUDA_EXTENSION = None
+_CUDA_EXTENSION_ATTEMPTED = False
+_CUDA_EXTENSION_ERROR: Optional[Exception] = None
+
+
+def _load_cuda_extension():
+    global _CUDA_EXTENSION
+    global _CUDA_EXTENSION_ATTEMPTED
+    global _CUDA_EXTENSION_ERROR
+    if _CUDA_EXTENSION is not None:
+        return _CUDA_EXTENSION
+    if _CUDA_EXTENSION_ATTEMPTED and _CUDA_EXTENSION is None:
+        raise RuntimeError("CUDA grouped_mm extension is unavailable") from _CUDA_EXTENSION_ERROR
+
+    _CUDA_EXTENSION_ATTEMPTED = True
+    try:
+        this_dir = Path(__file__).resolve().parent
+        cpp_src = this_dir / "cuda" / "grouped_mm_out.cpp"
+        _CUDA_EXTENSION = load_cuda_extension(
+            base_name="olmo_grouped_mm_out_ext",
+            sources=[cpp_src],
+            extra_cflags=["-O3"],
+            verbose_env_names=("OLMO_GROUPED_MM_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
+            force_rebuild_env_names=(
+                "OLMO_GROUPED_MM_FORCE_REBUILD",
+                "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
+            ),
+            stale_lock_timeout_env_names=("OLMO_MOE_EXT_STALE_LOCK_TIMEOUT_SEC",),
+            with_arch_suffix=True,
+        )
+    except Exception as e:
+        _CUDA_EXTENSION_ERROR = e
+        raise RuntimeError(f"Failed to build/load CUDA grouped_mm extension: {e}") from e
+
+    return _CUDA_EXTENSION
+
+
+@torch.compiler.disable
+def _grouped_mm_out_cuda(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    *,
+    out: torch.Tensor,
+    offs: Optional[torch.Tensor],
+    bias: Optional[torch.Tensor],
+) -> torch.Tensor:
+    ext = _load_cuda_extension()
+    return ext.grouped_mm_out_cuda(mat_a, mat_b, out, offs, bias)
+
+
+def _expected_grouped_mm_output_shape(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    offs: Optional[torch.Tensor],
+) -> tuple[int, ...]:
+    a_is_2d = mat_a.ndim == 2
+    b_is_2d = mat_b.ndim == 2
+
+    if a_is_2d:
+        if b_is_2d:
+            if offs is None:
+                raise ValueError("offs is required for 2D/2D grouped_mm")
+            return (int(offs.shape[0]), int(mat_a.shape[0]), int(mat_b.shape[1]))
+        if offs is None:
+            raise ValueError("offs is required for 2D/3D grouped_mm")
+        return (int(mat_a.shape[0]), int(mat_b.shape[-1]))
+
+    if b_is_2d:
+        if offs is None:
+            raise ValueError("offs is required for 3D/2D grouped_mm")
+        return (int(mat_a.shape[1]), int(mat_b.shape[1]))
+    return (int(mat_a.shape[0]), int(mat_a.shape[1]), int(mat_b.shape[-1]))
+
+
+def _check_out_buffer(
+    *,
+    out: torch.Tensor,
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    offs: Optional[torch.Tensor],
+    out_dtype: Optional[torch.dtype],
+) -> None:
+    if not out.is_cuda:
+        raise ValueError("out must be CUDA")
+    if out.device != mat_a.device:
+        raise ValueError(f"out/mat_a device mismatch: {out.device} vs {mat_a.device}")
+    if mat_b.device != mat_a.device:
+        raise ValueError(f"mat_b/mat_a device mismatch: {mat_b.device} vs {mat_a.device}")
+
+    expected_dtype = out_dtype if out_dtype is not None else mat_a.dtype
+    if out.dtype != expected_dtype:
+        raise ValueError(f"out dtype mismatch: expected {expected_dtype}, got {out.dtype}")
+
+    expected_shape = _expected_grouped_mm_output_shape(mat_a, mat_b, offs)
+    if tuple(out.shape) != expected_shape:
+        raise ValueError(f"out shape mismatch: expected {expected_shape}, got {tuple(out.shape)}")
+
+
+def _check_input_grad_out_buffer(
+    *,
+    input_grad_out: torch.Tensor,
+    mat_a: torch.Tensor,
+) -> None:
+    if not input_grad_out.is_cuda:
+        raise ValueError("input_grad_out must be CUDA")
+    if input_grad_out.device != mat_a.device:
+        raise ValueError(
+            f"input_grad_out/mat_a device mismatch: {input_grad_out.device} vs {mat_a.device}"
+        )
+    if input_grad_out.dtype != mat_a.dtype:
+        raise ValueError(
+            f"input_grad_out/mat_a dtype mismatch: {input_grad_out.dtype} vs {mat_a.dtype}"
+        )
+    if tuple(input_grad_out.shape) != tuple(mat_a.shape):
+        raise ValueError(
+            "input_grad_out shape mismatch: "
+            f"expected {tuple(mat_a.shape)}, got {tuple(input_grad_out.shape)}"
+        )
+
+
+def _is_col_major_last2(x: torch.Tensor) -> bool:
+    if x.ndim < 2:
+        return False
+    strides = x.stride()
+    sizes = x.shape
+    return strides[-2] == 1 and strides[-1] == sizes[-2]
+
+
+def _grouped_mm_mat1_backward(
+    grad: torch.Tensor,
+    mat2: torch.Tensor,
+    offs: Optional[torch.Tensor],
+    *,
+    mat1_was_col_major: bool,
+    out: Optional[torch.Tensor],
+) -> torch.Tensor:
+    if mat1_was_col_major:
+        if out is None:
+            return F.grouped_mm(mat2, grad.transpose(-2, -1), offs=offs).transpose(-2, -1)
+        out_t = out.transpose(-2, -1)
+        _grouped_mm_out_cuda(mat2, grad.transpose(-2, -1), out=out_t, offs=offs, bias=None)
+        return out
+
+    if out is None:
+        return F.grouped_mm(grad, mat2.transpose(-2, -1), offs=offs)
+    return _grouped_mm_out_cuda(grad, mat2.transpose(-2, -1), out=out, offs=offs, bias=None)
+
+
+def _grouped_mm_mat2_backward(
+    grad: torch.Tensor,
+    mat1: torch.Tensor,
+    offs: Optional[torch.Tensor],
+    *,
+    mat2_was_col_major: bool,
+) -> torch.Tensor:
+    if mat2_was_col_major:
+        return F.grouped_mm(grad.transpose(-2, -1), mat1, offs=offs).transpose(-2, -1)
+    return F.grouped_mm(mat1.transpose(-2, -1), grad, offs=offs)
+
+
+class _GroupedMMWithBuffersFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        offs: Optional[torch.Tensor],
+        bias: Optional[torch.Tensor],
+        out_dtype: Optional[torch.dtype],
+        out: Optional[torch.Tensor],
+        input_grad_out: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if out is not None:
+            _check_out_buffer(out=out, mat_a=mat_a, mat_b=mat_b, offs=offs, out_dtype=out_dtype)
+            result = _grouped_mm_out_cuda(mat_a, mat_b, out=out, offs=offs, bias=bias)
+            if result is out:
+                ctx.mark_dirty(result)
+        else:
+            result = F.grouped_mm(mat_a, mat_b, offs=offs, bias=bias, out_dtype=out_dtype)
+
+        if input_grad_out is not None:
+            _check_input_grad_out_buffer(input_grad_out=input_grad_out, mat_a=mat_a)
+
+        ctx.mat_a = mat_a if ctx.needs_input_grad[1] else None
+        ctx.mat_b = mat_b if ctx.needs_input_grad[0] else None
+        ctx.offs = offs
+        ctx.mat_a_was_col_major = _is_col_major_last2(mat_a)
+        ctx.mat_b_was_col_major = _is_col_major_last2(mat_b)
+        ctx.input_grad_out = input_grad_out
+        return result
+
+    @staticmethod
+    def backward(ctx, grad_out: torch.Tensor):  # type: ignore[override]
+        grad_mat_a = None
+        grad_mat_b = None
+        offs = ctx.offs
+
+        # Wgrad
+        if ctx.needs_input_grad[1]:
+            if ctx.mat_a is None:
+                raise RuntimeError("Missing saved mat_a for grouped_mm backward")
+            grad_mat_b = _grouped_mm_mat2_backward(
+                grad_out,
+                ctx.mat_a,
+                offs,
+                mat2_was_col_major=ctx.mat_b_was_col_major,
+            )
+
+        # Dgrad
+        # Compute grad(mat_a) after grad(mat_b), because input_grad_out can alias mat_a storage.
+        if ctx.needs_input_grad[0]:
+            if ctx.mat_b is None:
+                raise RuntimeError("Missing saved mat_b for grouped_mm backward")
+            grad_mat_a = _grouped_mm_mat1_backward(
+                grad_out,
+                ctx.mat_b,
+                offs,
+                mat1_was_col_major=ctx.mat_a_was_col_major,
+                out=ctx.input_grad_out,
+            )
+            if ctx.input_grad_out is not None and grad_mat_a is not ctx.input_grad_out:
+                raise RuntimeError(
+                    "Expected grad(mat_a) to be written into the provided input_grad_out buffer"
+                )
+
+        return grad_mat_a, grad_mat_b, None, None, None, None, None
+
+
+def grouped_mm(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    *,
+    offs: Optional[torch.Tensor] = None,
+    bias: Optional[torch.Tensor] = None,
+    out_dtype: Optional[torch.dtype] = None,
+    out: Optional[torch.Tensor] = None,
+    input_grad_out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    grouped_mm(mat_a, mat_b, *, offs=None, bias=None, out_dtype=None, out=None, input_grad_out=None)
+
+    Equivalent to torch.nn.functional.grouped_mm with two extra buffers:
+    - `out`: if provided, forward writes the result in-place into this tensor and returns it.
+    - `input_grad_out`: if provided, backward writes grad(mat_a) into this buffer and returns it.
+    """
+    if out is not None or input_grad_out is not None:
+        if not mat_a.is_cuda or not mat_b.is_cuda:
+            raise ValueError("grouped_mm with explicit buffers requires CUDA tensors")
+    return _GroupedMMWithBuffersFunction.apply(
+        mat_a,
+        mat_b,
+        offs,
+        bias,
+        out_dtype,
+        out,
+        input_grad_out,
+    )
+
+
+__all__ = ["grouped_mm"]

--- a/src/olmo_core/testing/__init__.py
+++ b/src/olmo_core/testing/__init__.py
@@ -17,6 +17,7 @@ from .utils import (
     has_grouped_gemm,
     has_multiple_gpus,
     has_quack,
+    has_torch_grouped_mm,
     has_torchao,
     requires_flash_attn_2,
     requires_flash_attn_4,
@@ -25,6 +26,7 @@ from .utils import (
     requires_multi_gpu,
     requires_quack,
     requires_te,
+    requires_torch_grouped_mm,
 )
 
 __all__ = [
@@ -44,6 +46,7 @@ __all__ = [
     "has_flash_attn_4",
     "has_grouped_gemm",
     "has_multiple_gpus",
+    "has_torch_grouped_mm",
     "has_torchao",
     "has_quack",
     "requires_flash_attn_2",
@@ -51,6 +54,7 @@ __all__ = [
     "requires_te",
     "requires_gpu",
     "requires_grouped_gemm",
+    "requires_torch_grouped_mm",
     "requires_quack",
     "requires_multi_gpu",
     "run_distributed_test",

--- a/src/olmo_core/testing/utils.py
+++ b/src/olmo_core/testing/utils.py
@@ -15,6 +15,10 @@ has_cuda = torch.cuda.is_available()
 has_multiple_gpus = has_cuda and torch.cuda.device_count() > 1
 has_mps = torch.mps.is_available()
 compute_capability = torch.cuda.get_device_capability()[0] if has_cuda else None
+# torch.nn.functional.grouped_mm (and the F.ScalingType / F.SwizzleType enums used by the
+# scaled/FP8 path) were added in torch 2.10; the MoE-v2 kernels require them. Note this is
+# distinct from `has_grouped_gemm`, which checks for the third-party `grouped_gemm` package.
+has_torch_grouped_mm = hasattr(torch.nn.functional, "grouped_mm")
 has_flash_attn_2 = flash_attn_api.has_flash_attn_2()
 has_flash_attn_3 = flash_attn_api.has_flash_attn_3()
 has_flash_attn_4 = flash_attn_api.has_flash_attn_4()
@@ -154,6 +158,22 @@ GROUPED_GEMM_MARKS = (
 
 def requires_grouped_gemm(func):
     for mark in GROUPED_GEMM_MARKS:
+        func = mark(func)
+    return func
+
+
+TORCH_GROUPED_MM_MARKS = (
+    pytest.mark.gpu,
+    pytest.mark.skipif(not has_cuda, reason="Requires a GPU"),
+    pytest.mark.skipif(
+        not has_torch_grouped_mm,
+        reason="Requires torch.nn.functional.grouped_mm (torch>=2.10)",
+    ),
+)
+
+
+def requires_torch_grouped_mm(func):
+    for mark in TORCH_GROUPED_MM_MARKS:
         func = mark(func)
     return func
 

--- a/src/test/kernels/grouped_mm_test.py
+++ b/src/test/kernels/grouped_mm_test.py
@@ -1,0 +1,63 @@
+import torch
+import torch.nn.functional as F
+
+from olmo_core.kernels.grouped_mm import grouped_mm
+from olmo_core.testing import requires_gpu
+
+
+def _build_grouped_mm_inputs(
+    *,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(41)
+    group_sizes = torch.tensor([3, 2, 3], device=device, dtype=torch.int32)
+    offs = torch.cumsum(group_sizes, dim=0, dtype=torch.int32)
+    a = torch.randn(int(offs[-1].item()), 512, device=device, dtype=torch.float32)
+    b = torch.randn(group_sizes.numel(), 512, 512, device=device, dtype=torch.float32)
+    return a, b, offs
+
+
+@requires_gpu
+def test_grouped_mm_wrapper_matches_torch_grouped_mm():
+    device = torch.device("cuda")
+    a, b, offs = _build_grouped_mm_inputs(device=device)
+
+    out = grouped_mm(a, b, offs=offs)
+    ref = F.grouped_mm(a, b, offs=offs)
+
+    torch.testing.assert_close(out, ref)
+
+
+@requires_gpu
+def test_grouped_mm_wrapper_writes_forward_out_buffer():
+    device = torch.device("cuda")
+    a, b, offs = _build_grouped_mm_inputs(device=device)
+    out_buffer = torch.empty((a.shape[0], b.shape[-1]), device=device, dtype=a.dtype)
+
+    out = grouped_mm(a, b, offs=offs, out=out_buffer)
+    ref = F.grouped_mm(a, b, offs=offs)
+
+    assert out.untyped_storage().data_ptr() == out_buffer.untyped_storage().data_ptr()
+    torch.testing.assert_close(out, ref)
+
+
+@requires_gpu
+def test_grouped_mm_wrapper_writes_input_grad_out_buffer():
+    device = torch.device("cuda")
+    a, b, offs = _build_grouped_mm_inputs(device=device)
+    a = a.detach().requires_grad_(True)
+    b = b.detach().requires_grad_(True)
+    input_grad_out = torch.empty_like(a)
+
+    out = grouped_mm(a, b, offs=offs, input_grad_out=input_grad_out)
+    grad_out = torch.randn_like(out)
+    grad_a, grad_b = torch.autograd.grad(out, (a, b), grad_outputs=grad_out)
+
+    a_ref = a.detach().clone().requires_grad_(True)
+    b_ref = b.detach().clone().requires_grad_(True)
+    out_ref = F.grouped_mm(a_ref, b_ref, offs=offs)
+    grad_a_ref, grad_b_ref = torch.autograd.grad(out_ref, (a_ref, b_ref), grad_outputs=grad_out)
+
+    assert grad_a.untyped_storage().data_ptr() == input_grad_out.untyped_storage().data_ptr()
+    torch.testing.assert_close(grad_a, grad_a_ref)
+    torch.testing.assert_close(grad_b, grad_b_ref)

--- a/src/test/kernels/grouped_mm_test.py
+++ b/src/test/kernels/grouped_mm_test.py
@@ -61,3 +61,26 @@ def test_grouped_mm_wrapper_writes_input_grad_out_buffer():
     assert grad_a.untyped_storage().data_ptr() == input_grad_out.untyped_storage().data_ptr()
     torch.testing.assert_close(grad_a, grad_a_ref)
     torch.testing.assert_close(grad_b, grad_b_ref)
+
+
+@requires_gpu
+def test_grouped_mm_wrapper_matches_torch_grouped_mm_fwd_bwd():
+    # Default path (no out=/input_grad_out= buffers): the wrapper should be a drop-in for
+    # torch.nn.functional.grouped_mm in both the forward output and the gradients.
+    device = torch.device("cuda")
+    a, b, offs = _build_grouped_mm_inputs(device=device)
+    a = a.detach().requires_grad_(True)
+    b = b.detach().requires_grad_(True)
+
+    a_ref = a.detach().clone().requires_grad_(True)
+    b_ref = b.detach().clone().requires_grad_(True)
+
+    out = grouped_mm(a, b, offs=offs)
+    out_ref = F.grouped_mm(a_ref, b_ref, offs=offs)
+    torch.testing.assert_close(out, out_ref)
+
+    grad_out = torch.randn_like(out)
+    grad_a, grad_b = torch.autograd.grad(out, (a, b), grad_outputs=grad_out)
+    grad_a_ref, grad_b_ref = torch.autograd.grad(out_ref, (a_ref, b_ref), grad_outputs=grad_out)
+    torch.testing.assert_close(grad_a, grad_a_ref)
+    torch.testing.assert_close(grad_b, grad_b_ref)

--- a/src/test/kernels/grouped_mm_test.py
+++ b/src/test/kernels/grouped_mm_test.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 
 from olmo_core.kernels.grouped_mm import grouped_mm
-from olmo_core.testing import requires_gpu
+from olmo_core.testing import requires_torch_grouped_mm
 
 
 def _build_grouped_mm_inputs(
@@ -17,7 +17,7 @@ def _build_grouped_mm_inputs(
     return a, b, offs
 
 
-@requires_gpu
+@requires_torch_grouped_mm
 def test_grouped_mm_wrapper_matches_torch_grouped_mm():
     device = torch.device("cuda")
     a, b, offs = _build_grouped_mm_inputs(device=device)
@@ -28,7 +28,7 @@ def test_grouped_mm_wrapper_matches_torch_grouped_mm():
     torch.testing.assert_close(out, ref)
 
 
-@requires_gpu
+@requires_torch_grouped_mm
 def test_grouped_mm_wrapper_writes_forward_out_buffer():
     device = torch.device("cuda")
     a, b, offs = _build_grouped_mm_inputs(device=device)
@@ -41,7 +41,7 @@ def test_grouped_mm_wrapper_writes_forward_out_buffer():
     torch.testing.assert_close(out, ref)
 
 
-@requires_gpu
+@requires_torch_grouped_mm
 def test_grouped_mm_wrapper_writes_input_grad_out_buffer():
     device = torch.device("cuda")
     a, b, offs = _build_grouped_mm_inputs(device=device)
@@ -63,7 +63,7 @@ def test_grouped_mm_wrapper_writes_input_grad_out_buffer():
     torch.testing.assert_close(grad_b, grad_b_ref)
 
 
-@requires_gpu
+@requires_torch_grouped_mm
 def test_grouped_mm_wrapper_matches_torch_grouped_mm_fwd_bwd():
     # Default path (no out=/input_grad_out= buffers): the wrapper should be a drop-in for
     # torch.nn.functional.grouped_mm in both the forward output and the gradients.


### PR DESCRIPTION
## What this adds

`olmo_core.kernels.grouped_mm` — a thin wrapper over `torch.nn.functional.grouped_mm` (ragged/grouped matmul indexed by an `offs` tensor) that adds two caller-provided buffers:

- **`out=`** — write the forward result in place into a preallocated tensor and return it.
- **`input_grad_out=`** — write `grad(mat_a)` into a preallocated buffer during backward.

These let callers reuse preallocated forward/backward buffers and avoid extra allocations in hot loops. Ships `cuda/grouped_mm_out.cpp` for the in-place output path, loaded lazily via `load_cuda_extension`, and exports `grouped_mm` from `olmo_core.kernels`.

## Import-safety / testing

Pure-Python wrapper; the CUDA extension builds lazily on first use, so the module is import-safe on CPU (no GPU or compiler needed to import). Correctness is covered by GPU tests on hardware.
