### PR TITLE
Add MXFP8 / scaled grouped-matmul FP8 kernels and FP8 weight cache

### DIFF
--- a/src/olmo_core/kernels/__init__.py
+++ b/src/olmo_core/kernels/__init__.py
@@ -7,7 +7,9 @@ not require a GPU or a compiler.
 """
 
 from .grouped_mm import grouped_mm
+from .mxfp8_tensor import OlmoMXFP8Tensor
 
 __all__ = [
     "grouped_mm",
+    "OlmoMXFP8Tensor",
 ]

--- a/src/olmo_core/kernels/__init__.py
+++ b/src/olmo_core/kernels/__init__.py
@@ -8,8 +8,20 @@ not require a GPU or a compiler.
 
 from .grouped_mm import grouped_mm
 from .mxfp8_tensor import OlmoMXFP8Tensor
+from .scaled_grouped_mm import (
+    ScaledGroupedMMPrequantizedLHS,
+    ScaledGroupedMMPrequantizedRHS,
+    prequantize_scaled_grouped_mm_rhs,
+    scaled_grouped_mm_q,
+    scaled_grouped_mm_q_fp8_weight,
+)
 
 __all__ = [
     "grouped_mm",
     "OlmoMXFP8Tensor",
+    "ScaledGroupedMMPrequantizedLHS",
+    "ScaledGroupedMMPrequantizedRHS",
+    "prequantize_scaled_grouped_mm_rhs",
+    "scaled_grouped_mm_q",
+    "scaled_grouped_mm_q_fp8_weight",
 ]

--- a/src/olmo_core/kernels/cuda/scaled_grouped_mm_out.cpp
+++ b/src/olmo_core/kernels/cuda/scaled_grouped_mm_out.cpp
@@ -1,0 +1,110 @@
+#include <torch/extension.h>
+
+#include <ATen/core/Tensor.h>
+
+#include <optional>
+
+namespace py = pybind11;
+
+// Exported by libtorch_cuda when PyTorch is built with USE_FBGEMM_GENAI.
+// We intentionally call this backend directly so we can write into `out`
+// without creating a temporary tensor and copying.
+namespace fbgemm_gpu {
+at::Tensor mx8mx8bf16_grouped_mm(
+    at::Tensor mat_a,
+    at::Tensor mat_b,
+    at::Tensor scale_a,
+    at::Tensor scale_b,
+    at::Tensor offs,
+    std::optional<at::Tensor> out);
+}  // namespace fbgemm_gpu
+
+namespace {
+
+std::optional<at::Tensor> normalize_optional_tensor(
+    const c10::optional<at::Tensor>& tensor) {
+  if (tensor.has_value() && tensor->defined()) {
+    return std::optional<at::Tensor>(tensor.value());
+  }
+  return std::nullopt;
+}
+
+bool is_transposed_last2(const at::Tensor& t) {
+  if (t.dim() < 2) {
+    return false;
+  }
+  return t.stride(-2) == 1 && t.stride(-1) == t.size(-2);
+}
+
+}  // namespace
+
+at::Tensor scaled_grouped_mm_v2_out_cuda(
+    const at::Tensor& mat_a_q,
+    const at::Tensor& mat_b_q,
+    const at::Tensor& scale_a,
+    const at::Tensor& scale_b,
+    at::Tensor out,
+    const c10::optional<at::Tensor>& offs_opt,
+    bool use_fast_accum) {
+  TORCH_CHECK(mat_a_q.is_cuda(), "mat_a_q must be CUDA");
+  TORCH_CHECK(mat_b_q.is_cuda(), "mat_b_q must be CUDA");
+  TORCH_CHECK(scale_a.is_cuda(), "scale_a must be CUDA");
+  TORCH_CHECK(scale_b.is_cuda(), "scale_b must be CUDA");
+  TORCH_CHECK(out.is_cuda(), "out must be CUDA");
+  TORCH_CHECK(mat_a_q.scalar_type() == at::kFloat8_e4m3fn, "mat_a_q must be float8_e4m3fn");
+  TORCH_CHECK(mat_b_q.scalar_type() == at::kFloat8_e4m3fn, "mat_b_q must be float8_e4m3fn");
+  TORCH_CHECK(scale_a.scalar_type() == at::kFloat8_e8m0fnu, "scale_a must be float8_e8m0fnu");
+  TORCH_CHECK(scale_b.scalar_type() == at::kFloat8_e8m0fnu, "scale_b must be float8_e8m0fnu");
+  TORCH_CHECK(out.scalar_type() == at::kBFloat16, "out must be bfloat16");
+  TORCH_CHECK(mat_a_q.dim() == 2, "mat_a_q must be rank-2 [M, K]");
+  TORCH_CHECK(mat_b_q.dim() == 3, "mat_b_q must be rank-3 [G, K, N]");
+  TORCH_CHECK(is_transposed_last2(mat_b_q), "Expected mat_b_q to be transposed in trailing dims");
+  TORCH_CHECK(
+      mat_a_q.size(1) == mat_b_q.size(1),
+      "mat_a_q K dimension must match mat_b_q K dimension, got ",
+      mat_a_q.size(1),
+      " vs ",
+      mat_b_q.size(1));
+  TORCH_CHECK(
+      out.dim() == 2 && out.size(0) == mat_a_q.size(0) && out.size(1) == mat_b_q.size(2),
+      "out shape must be [M, N] = [",
+      mat_a_q.size(0),
+      ", ",
+      mat_b_q.size(2),
+      "], got ",
+      out.sizes());
+  (void)use_fast_accum;
+
+  auto offs = normalize_optional_tensor(offs_opt);
+  TORCH_CHECK(offs.has_value(), "offs is required for MXFP8 grouped mm");
+  TORCH_CHECK(offs->is_cuda(), "offs must be CUDA");
+  TORCH_CHECK(offs->scalar_type() == at::kInt, "offs must be int32");
+  TORCH_CHECK(offs->dim() == 1, "offs must be rank-1");
+
+  auto result = fbgemm_gpu::mx8mx8bf16_grouped_mm(
+      mat_a_q,
+      mat_b_q,
+      scale_a,
+      scale_b,
+      offs.value(),
+      std::optional<at::Tensor>(out));
+  TORCH_CHECK(result.defined(), "mx8mx8bf16_grouped_mm returned undefined tensor");
+  TORCH_CHECK(
+      result.data_ptr() == out.data_ptr(),
+      "mx8mx8bf16_grouped_mm did not write into provided out buffer");
+  return out;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+      "scaled_grouped_mm_v2_out_cuda",
+      &scaled_grouped_mm_v2_out_cuda,
+      "Scaled grouped_mm_v2 with explicit output tensor",
+      py::arg("mat_a_q"),
+      py::arg("mat_b_q"),
+      py::arg("scale_a"),
+      py::arg("scale_b"),
+      py::arg("out"),
+      py::arg("offs") = py::none(),
+      py::arg("use_fast_accum") = true);
+}

--- a/src/olmo_core/kernels/mxfp8_tensor.py
+++ b/src/olmo_core/kernels/mxfp8_tensor.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Tuple
 
 import torch
 
+from ..doc_utils import beta_feature
 from .mxfp8_utils import (
     _quantize_to_mxfp8_torch,
     dequantize_rows_from_mxfp8,
@@ -24,6 +25,7 @@ def _dequantize_rows_from_mxfp8_torch(
     return x.reshape(m, k).to(out_dtype)
 
 
+@beta_feature
 class OlmoMXFP8Tensor(torch.Tensor):
     """
     Prototype tensor subclass for rowwise MXFP8 payloads.

--- a/src/olmo_core/kernels/mxfp8_tensor.py
+++ b/src/olmo_core/kernels/mxfp8_tensor.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+import torch
+
+from .mxfp8_utils import (
+    _quantize_to_mxfp8_torch,
+    dequantize_rows_from_mxfp8,
+    quantize_rows_to_mxfp8,
+)
+
+
+def _dequantize_rows_from_mxfp8_torch(
+    qdata: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    block_size: int = 32,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    m, k = qdata.shape
+    q_blocks = qdata.reshape(m, k // block_size, block_size)
+    x = q_blocks.to(torch.float32) * scales.to(torch.float32).unsqueeze(-1)
+    return x.reshape(m, k).to(out_dtype)
+
+
+class OlmoMXFP8Tensor(torch.Tensor):
+    """
+    Prototype tensor subclass for rowwise MXFP8 payloads.
+
+    This is intentionally narrow:
+    - rank-2 tensors only
+    - e4m3 qdata plus e8m0 row/block scales
+    - wrapper dtype is the original high-precision dtype
+
+    The goal is to test whether qdata + scales can travel as one Tensor-like
+    value through custom autograd boundaries. Generic torch ops conservatively
+    dequantize to a normal high-precision tensor.
+    """
+
+    qdata: torch.Tensor
+    scales: torch.Tensor
+    block_size: int
+    orig_dtype: torch.dtype
+    prefer_triton: bool
+
+    @staticmethod
+    def __new__(
+        cls,
+        qdata: torch.Tensor,
+        scales: torch.Tensor,
+        *,
+        block_size: int = 32,
+        orig_dtype: torch.dtype = torch.bfloat16,
+        prefer_triton: bool = True,
+    ) -> "OlmoMXFP8Tensor":
+        if qdata.ndim != 2 or scales.ndim != 2:
+            raise ValueError(
+                "OlmoMXFP8Tensor expects rank-2 qdata/scales, "
+                f"got qdata={tuple(qdata.shape)} scales={tuple(scales.shape)}"
+            )
+        if block_size != 32:
+            raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+        if qdata.dtype != torch.float8_e4m3fn:
+            raise ValueError(f"qdata must be float8_e4m3fn, got {qdata.dtype}")
+        if scales.dtype != torch.float8_e8m0fnu:
+            raise ValueError(f"scales must be float8_e8m0fnu, got {scales.dtype}")
+        expected_scales_shape = (qdata.shape[0], qdata.shape[1] // block_size)
+        if tuple(scales.shape) != expected_scales_shape:
+            raise ValueError(
+                "scales shape mismatch: "
+                f"expected {expected_scales_shape}, got {tuple(scales.shape)}"
+            )
+        self = torch.Tensor._make_wrapper_subclass(
+            cls,
+            qdata.shape,
+            strides=qdata.stride(),
+            storage_offset=qdata.storage_offset(),
+            dtype=orig_dtype,
+            layout=qdata.layout,
+            device=qdata.device,
+            requires_grad=False,
+        )
+        self.qdata = qdata
+        self.scales = scales
+        self.block_size = int(block_size)
+        self.orig_dtype = orig_dtype
+        self.prefer_triton = bool(prefer_triton)
+        return self
+
+    @staticmethod
+    def from_hp(
+        x: torch.Tensor,
+        *,
+        block_size: int = 32,
+        prefer_triton: bool = True,
+    ) -> "OlmoMXFP8Tensor":
+        if prefer_triton:
+            qdata, scales = quantize_rows_to_mxfp8(x, block_size=block_size)
+        else:
+            qdata, scales = _quantize_to_mxfp8_torch(x, block_size=block_size)
+        return OlmoMXFP8Tensor(
+            qdata,
+            scales,
+            block_size=block_size,
+            orig_dtype=x.dtype,
+            prefer_triton=prefer_triton,
+        )
+
+    @staticmethod
+    def from_qdata_scales(
+        qdata: torch.Tensor,
+        scales: torch.Tensor,
+        *,
+        block_size: int = 32,
+        orig_dtype: torch.dtype = torch.bfloat16,
+        prefer_triton: bool = True,
+    ) -> "OlmoMXFP8Tensor":
+        return OlmoMXFP8Tensor(
+            qdata,
+            scales,
+            block_size=block_size,
+            orig_dtype=orig_dtype,
+            prefer_triton=prefer_triton,
+        )
+
+    def dequantize(self, *, out_dtype: torch.dtype | None = None) -> torch.Tensor:
+        resolved_out_dtype = self.orig_dtype if out_dtype is None else out_dtype
+        if not self.prefer_triton:
+            return _dequantize_rows_from_mxfp8_torch(
+                self.qdata,
+                self.scales,
+                block_size=self.block_size,
+                out_dtype=resolved_out_dtype,
+            )
+        return dequantize_rows_from_mxfp8(
+            self.qdata,
+            self.scales,
+            block_size=self.block_size,
+            out_dtype=resolved_out_dtype,
+        )
+
+    def as_scaled_grouped_mm_prequantized_lhs(self):
+        from .scaled_grouped_mm import ScaledGroupedMMPrequantizedLHS
+
+        return ScaledGroupedMMPrequantizedLHS(
+            mat_a_q=self.qdata,
+            scale_a=self.scales,
+            mat_a_shape=tuple(self.shape),
+            scales_are_blocked=False,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "OlmoMXFP8Tensor("
+            f"shape={tuple(self.shape)}, dtype={self.dtype}, "
+            f"qdata_dtype={self.qdata.dtype}, scales_dtype={self.scales.dtype}, "
+            f"block_size={self.block_size}, prefer_triton={self.prefer_triton})"
+        )
+
+    def __tensor_flatten__(self) -> Tuple[list[str], Dict[str, Any]]:
+        tensor_names = ["qdata", "scales"]
+        return tensor_names, {
+            "block_size": self.block_size,
+            "orig_dtype": self.orig_dtype,
+            "prefer_triton": self.prefer_triton,
+        }
+
+    @staticmethod
+    def __tensor_unflatten__(
+        inner_tensors: Dict[str, torch.Tensor],
+        meta: Dict[str, Any],
+        outer_size: torch.Size,
+        outer_stride: Tuple[int, ...],
+    ) -> "OlmoMXFP8Tensor":
+        del outer_size, outer_stride
+        return OlmoMXFP8Tensor(
+            inner_tensors["qdata"],
+            inner_tensors["scales"],
+            block_size=int(meta["block_size"]),
+            orig_dtype=meta["orig_dtype"],
+            prefer_triton=bool(meta["prefer_triton"]),
+        )
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        del types
+        kwargs = {} if kwargs is None else kwargs
+
+        def unwrap(value):
+            if isinstance(value, OlmoMXFP8Tensor):
+                return value.dequantize()
+            if isinstance(value, tuple):
+                return tuple(unwrap(item) for item in value)
+            if isinstance(value, list):
+                return [unwrap(item) for item in value]
+            if isinstance(value, dict):
+                return {key: unwrap(item) for key, item in value.items()}
+            return value
+
+        return func(*unwrap(args), **unwrap(kwargs))
+
+
+__all__ = ["OlmoMXFP8Tensor"]

--- a/src/olmo_core/kernels/mxfp8_utils.py
+++ b/src/olmo_core/kernels/mxfp8_utils.py
@@ -1,0 +1,2336 @@
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+import torch
+
+try:
+    import nvtx
+except ImportError:
+    from olmo_core._nvtx import nvtx
+
+try:
+    import triton
+    import triton.language as tl
+except Exception:  # pragma: no cover - Triton may be unavailable in some test envs.
+    triton = None
+    tl = None
+
+
+_F8E4M3_LARGEST_POW2 = 8.0
+_F8E8M0_EXP_BIAS = 127.0
+_F8E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+_FP32_TINY = float(torch.finfo(torch.float32).tiny)
+
+# Default launch configs for Triton kernels. Q/DQ can autotune a small set of
+# nearby configs, but these defaults are still used by non-autotuned kernels.
+_MXFP8_Q_BLOCK_M = 32
+_MXFP8_Q_BLOCK_N = 256
+_MXFP8_Q_NUM_WARPS = 4
+_MXFP8_Q_NUM_STAGES = 3
+
+_MXFP8_DQ_BLOCK_M = 32
+_MXFP8_DQ_BLOCK_N = 256
+_MXFP8_DQ_NUM_WARPS = 4
+_MXFP8_DQ_NUM_STAGES = 3
+
+_MXFP8_SWIGLU_BLOCK_M = 8
+_MXFP8_SWIGLU_BLOCK_N = 256
+_MXFP8_SWIGLU_NUM_WARPS = 4
+_MXFP8_SWIGLU_NUM_STAGES = 1
+
+_MXFP8_SWIGLU_FROM_FP8_BLOCK_M = 64
+_MXFP8_SWIGLU_FROM_FP8_BLOCK_N = 64
+_MXFP8_SWIGLU_FROM_FP8_NUM_WARPS = 4
+_MXFP8_SWIGLU_FROM_FP8_NUM_STAGES = 3
+
+_MXFP8_REDUCE_BLOCK_M = 64
+_MXFP8_REDUCE_BLOCK_N = 128
+_MXFP8_REDUCE_NUM_WARPS = 8
+_MXFP8_REDUCE_NUM_STAGES = 3
+
+_MXFP8_DOT_BLOCK_M = 32
+_MXFP8_DOT_BLOCK_N = 256
+_MXFP8_DOT_NUM_WARPS = 4
+_MXFP8_DOT_NUM_STAGES = 2
+
+_TE_MXFP8_IMPORT_ATTEMPTED = False
+_TE_MXFP8_STATE = None
+
+
+def ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _mxfp8_backend(kind: str) -> str:
+    specific_backend = os.environ.get(f"OLMO_MXFP8_{kind}_BACKEND")
+    backend = specific_backend
+    if backend is None:
+        backend = os.environ.get("OLMO_MXFP8_QDQ_BACKEND", "triton")
+    return backend.strip().lower()
+
+
+def _mxfp8_backend_wants_te(kind: str) -> bool:
+    return _mxfp8_backend(kind) in {"te", "transformer_engine"}
+
+
+def _get_te_mxfp8_state():
+    global _TE_MXFP8_IMPORT_ATTEMPTED, _TE_MXFP8_STATE
+    if _TE_MXFP8_IMPORT_ATTEMPTED:
+        return _TE_MXFP8_STATE
+
+    _TE_MXFP8_IMPORT_ATTEMPTED = True
+    try:
+        import transformer_engine.pytorch  # noqa: F401
+        import transformer_engine_torch as tex
+        from transformer_engine.pytorch.tensor.mxfp8_tensor import (
+            MXFP8Quantizer,
+            MXFP8Tensor,
+        )
+    except Exception:
+        _TE_MXFP8_STATE = None
+        return None
+
+    quantizer = MXFP8Quantizer(
+        tex.DType.kFloat8E4M3,
+        rowwise=True,
+        columnwise=False,
+    )
+    _TE_MXFP8_STATE = (tex, MXFP8Tensor, quantizer)
+    return _TE_MXFP8_STATE
+
+
+def _te_mxfp8_compact_scale_layout(rows: int, cols: int, block_size: int) -> bool:
+    scale_cols = cols // block_size
+    return rows % 128 == 0 and scale_cols % 4 == 0
+
+
+def to_blocked(input_matrix: torch.Tensor) -> torch.Tensor:
+    """
+    Rearrange matrix scales to cuBLAS blocked/swizzled layout.
+
+    Input shape is [H, W] where W is per-row scale groups.
+    Output is flattened blocked representation expected by MX kernels.
+    """
+    rows, cols = input_matrix.shape
+    n_row_blocks = ceil_div(rows, 128)
+    n_col_blocks = ceil_div(cols, 4)
+
+    padded_rows = n_row_blocks * 128
+    padded_cols = n_col_blocks * 4
+
+    padded = input_matrix
+    if (rows, cols) != (padded_rows, padded_cols):
+        padded = torch.zeros(
+            (padded_rows, padded_cols), device=input_matrix.device, dtype=input_matrix.dtype
+        )
+        padded[:rows, :cols] = input_matrix
+
+    blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
+    rearranged = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16)
+    return rearranged.flatten().contiguous()
+
+
+if triton is not None:
+    _MXFP8_Q_AUTOTUNE_CONFIGS = [
+        # Keep a broader set while we characterize B200 codegen. Two-chunk Q is
+        # the default for the routed up/gate save path, so wide 2H activations do
+        # not depend on one perfect full-width specialization.
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 256}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 512}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 1024}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 512}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 1024}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 256}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 256}, num_warps=8, num_stages=2),
+    ]
+
+    _MXFP8_DQ_AUTOTUNE_CONFIGS = [
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 256}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 512}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 1024}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 512}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 1024}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 256}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 256}, num_warps=8, num_stages=2),
+    ]
+
+    @triton.jit
+    def _dest_indices_for_block(
+        row_offs,
+        col_offs,
+        BLOCK_ROWS: tl.constexpr,
+        BLOCK_COLS: tl.constexpr,
+    ):
+        # Rearrange (128,4) into the SWIZZLE_32_4_4 destination index pattern.
+        r_div_32 = row_offs // 32
+        r_mod_32 = row_offs % 32
+        dest_indices = r_mod_32 * 16 + r_div_32 * 4 + col_offs
+        return tl.reshape(dest_indices, (BLOCK_ROWS * BLOCK_COLS))
+
+    @triton.jit
+    def _triton_scale_swizzle_m_groups(
+        scales_ptr,
+        scales_stride_dim0,
+        scales_stride_dim1,
+        scale_cols,
+        orig_offsets,
+        output_scales_ptr,
+        output_scales_stride_dim0,
+        output_stride_per_block,
+        output_stride_per_row_of_blocks,
+        num_groups: tl.constexpr,
+        BLOCK_ROWS: tl.constexpr,
+        BLOCK_COLS: tl.constexpr,
+    ):
+        group_pid = tl.program_id(0)
+        block_col_pid = tl.program_id(1)
+
+        input_group_start_row = tl.load(orig_offsets + group_pid - 1, mask=group_pid > 0, other=0)
+        input_group_end_row = tl.load(
+            orig_offsets + group_pid, mask=group_pid < num_groups, other=0
+        )
+        output_group_start_row = 0
+        prev_group_end_for_start = 0
+        for i in tl.static_range(0, num_groups):
+            group_end_for_start = tl.load(orig_offsets + i)
+            group_size = group_end_for_start - prev_group_end_for_start
+            padded_group_size = ((group_size + BLOCK_ROWS - 1) // BLOCK_ROWS) * BLOCK_ROWS
+            output_group_start_row += tl.where(i < group_pid, padded_group_size, 0)
+            prev_group_end_for_start = group_end_for_start
+
+        row_offs = tl.arange(0, BLOCK_ROWS)[:, None]
+        col_offs = tl.arange(0, BLOCK_COLS)[None, :]
+        dest_indices_flat = _dest_indices_for_block(
+            row_offs,
+            col_offs,
+            BLOCK_ROWS=BLOCK_ROWS,
+            BLOCK_COLS=BLOCK_COLS,
+        )
+
+        block_row_id = 0
+        current_start_row = input_group_start_row
+        while current_start_row < input_group_end_row:
+            block_row_offs = current_start_row + row_offs
+            block_col_offs = block_col_pid * BLOCK_COLS + col_offs
+            block_offs = block_row_offs * scales_stride_dim0 + block_col_offs * scales_stride_dim1
+            mask = (block_row_offs < input_group_end_row) & (block_col_offs < scale_cols)
+            input_scales = tl.load(scales_ptr + block_offs, mask=mask, other=0)
+            scales_flat = tl.reshape(input_scales, (BLOCK_ROWS * BLOCK_COLS))
+
+            output_block_offsets = (
+                output_group_start_row * output_scales_stride_dim0
+                + (block_row_id * output_stride_per_row_of_blocks)
+                + (block_col_pid * output_stride_per_block)
+            )
+            tl.store(output_scales_ptr + output_block_offsets + dest_indices_flat, scales_flat)
+
+            block_row_id += 1
+            current_start_row += BLOCK_ROWS
+
+    @triton.jit
+    def _triton_scale_swizzle_per_group_3d(
+        input_ptr,
+        input_stride_dim0,
+        input_stride_dim1,
+        input_stride_dim2,
+        output_ptr,
+        output_stride_dim0,
+        output_block_stride,
+        scale_rows,
+        scale_cols,
+        BLOCK_ROWS: tl.constexpr,
+        BLOCK_COLS: tl.constexpr,
+    ):
+        pid_group = tl.program_id(0)
+        pid_row = tl.program_id(1)
+        pid_col = tl.program_id(2)
+
+        input_ptr += pid_group * input_stride_dim0
+        output_ptr += pid_group * output_stride_dim0
+
+        row_offs = tl.arange(0, BLOCK_ROWS)[:, None]
+        col_offs = tl.arange(0, BLOCK_COLS)[None, :]
+        dest_indices_flat = _dest_indices_for_block(
+            row_offs,
+            col_offs,
+            BLOCK_ROWS=BLOCK_ROWS,
+            BLOCK_COLS=BLOCK_COLS,
+        )
+
+        start_row = pid_row * BLOCK_ROWS
+        start_col = pid_col * BLOCK_COLS
+        global_rows = start_row + row_offs
+        global_cols = start_col + col_offs
+        mask = (global_rows < scale_rows) & (global_cols < scale_cols)
+
+        input_scales = tl.load(
+            input_ptr + global_rows * input_stride_dim1 + global_cols * input_stride_dim2,
+            mask=mask,
+            other=0.0,
+        )
+        scales_flat = tl.reshape(input_scales, (BLOCK_ROWS * BLOCK_COLS))
+
+        local_numel = BLOCK_ROWS * BLOCK_COLS
+        block_offset = pid_col * local_numel + (pid_row * output_block_stride)
+        tl.store(output_ptr + block_offset + dest_indices_flat, scales_flat)
+
+    # Broader Q autotune while we characterize B200 codegen. The routed up/gate
+    # save path defaults to two chunks, so the widest activation no longer
+    # depends on one fragile full-width specialization.
+    @triton.autotune(
+        configs=_MXFP8_Q_AUTOTUNE_CONFIGS,
+        key=["n_rows", "n_cols", "BLOCK_SIZE", "USE_BF16_EXP"],
+    )
+    @triton.jit
+    def _triton_mxfp8_quantize_dim0(
+        x_ptr,
+        x_stride_0,
+        x_stride_1,
+        q_ptr,
+        q_stride_0,
+        q_stride_1,
+        scale_ptr,
+        s_stride_0,
+        s_stride_1,
+        n_rows,
+        n_cols,
+        BLOCK_SIZE: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        USE_BF16_EXP: tl.constexpr,
+    ):
+        # Quantizes contiguous [M, K] to:
+        # - q_ptr: e4m3 values [M, K]
+        # - scale_ptr: e8m0 biased exponents [M, K//BLOCK_SIZE] as uint8
+        FP32_TINY: tl.constexpr = 1.1754943508222875e-38
+        F8E4M3_MAX: tl.constexpr = 448.0
+        E8M0_EXP_BIAS: tl.constexpr = 127.0
+        E8M0_EXP_BIAS_INT: tl.constexpr = 127
+        F8E4M3_LARGEST_POW2: tl.constexpr = 8.0
+        F8E4M3_LARGEST_POW2_INT: tl.constexpr = 8
+        BF16_MBITS: tl.constexpr = 7
+        SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
+
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+
+        row_idx = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+        col_idx = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+
+        x_offsets = row_idx * x_stride_0 + col_idx * x_stride_1
+        q_offsets = row_idx * q_stride_0 + col_idx * q_stride_1
+        q_mask = (row_idx < n_rows) & (col_idx < n_cols)
+        x = tl.load(x_ptr + x_offsets, mask=q_mask, other=0.0)
+
+        x_r = x.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE, BLOCK_SIZE).to(tl.float32)
+        max_abs = tl.max(tl.abs(x_r), axis=1)
+        max_abs = tl.where(max_abs == max_abs, max_abs, 0.0)  # NaN -> 0
+        max_abs = tl.maximum(max_abs, FP32_TINY)
+
+        if USE_BF16_EXP:
+            max_abs_bf16 = max_abs.to(tl.bfloat16)
+            max_abs_i16 = max_abs_bf16.to(tl.int16, bitcast=True)
+            largest_p2 = ((max_abs_i16 >> BF16_MBITS) & 0xFF) - E8M0_EXP_BIAS_INT
+            scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2_INT
+            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS_INT)
+            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS_INT)
+            scale_biased_i32 = (scale_unbiased + E8M0_EXP_BIAS_INT).to(tl.int32)
+            scale_biased_u8 = scale_biased_i32.to(tl.uint8)
+            inv_exp = 254 - scale_biased_i32
+            inv_bits = inv_exp.to(tl.uint32) << 23
+            inv_bits = tl.where(inv_exp == 0, 0x00400000, inv_bits)
+            inv_scale = inv_bits.to(tl.float32, bitcast=True)
+            q_hp = x_r * inv_scale[:, None]
+        else:
+            largest_p2 = tl.floor(tl.log2(max_abs))
+            scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2
+            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
+            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
+
+            scale_biased_u8 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.uint8)
+            dequant_scale = tl.exp2(scale_unbiased).to(tl.float32)
+            q_hp = x_r / dequant_scale[:, None]
+
+        q_hp = tl.where(q_hp == q_hp, q_hp, 0.0)
+        q_hp = tl.maximum(q_hp, -F8E4M3_MAX)
+        q_hp = tl.minimum(q_hp, F8E4M3_MAX)
+
+        q_tile = tl.reshape(q_hp, (BLOCK_M, BLOCK_N)).to(tl.float8e4nv)
+        tl.store(q_ptr + q_offsets, q_tile, mask=q_mask)
+
+        n_scale_cols = tl.cdiv(n_cols, BLOCK_SIZE)
+        scale_col_idx = pid_n * SCALE_BLOCKS_PER_TILE + tl.arange(0, SCALE_BLOCKS_PER_TILE)[None, :]
+        scale_offsets = row_idx * s_stride_0 + scale_col_idx * s_stride_1
+        scale_mask = (row_idx < n_rows) & (scale_col_idx < n_scale_cols)
+        scale_tile = tl.reshape(scale_biased_u8, (BLOCK_M, SCALE_BLOCKS_PER_TILE))
+        tl.store(scale_ptr + scale_offsets, scale_tile, mask=scale_mask)
+
+    # NOTE: Deliberately no @triton.autotune here.
+    @triton.jit
+    def _triton_mxfp8_quantize_grouped_blocked_tiled_dim0(
+        x_ptr,
+        x_stride_0,
+        x_stride_1,
+        q_ptr,
+        q_stride_0,
+        q_stride_1,
+        blocked_scale_ptr,
+        blocked_scale_stride_0,
+        offs,
+        n_rows,
+        n_cols,
+        BLOCK_SIZE: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        NUM_GROUPS: tl.constexpr,
+        USE_BF16_EXP: tl.constexpr,
+    ):
+        # Same quantization tile shape as _triton_mxfp8_quantize_dim0, but
+        # writes scale bytes directly in grouped SWIZZLE_32_4_4 layout.
+        FP32_TINY: tl.constexpr = 1.1754943508222875e-38
+        F8E4M3_MAX: tl.constexpr = 448.0
+        E8M0_EXP_BIAS: tl.constexpr = 127.0
+        E8M0_EXP_BIAS_INT: tl.constexpr = 127
+        F8E4M3_LARGEST_POW2: tl.constexpr = 8.0
+        F8E4M3_LARGEST_POW2_INT: tl.constexpr = 8
+        BF16_MBITS: tl.constexpr = 7
+        SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
+
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+
+        row_idx = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+        col_idx = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+
+        x_offsets = row_idx * x_stride_0 + col_idx * x_stride_1
+        q_offsets = row_idx * q_stride_0 + col_idx * q_stride_1
+        q_mask = (row_idx < n_rows) & (col_idx < n_cols)
+        x = tl.load(x_ptr + x_offsets, mask=q_mask, other=0.0)
+
+        x_r = x.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE, BLOCK_SIZE).to(tl.float32)
+        max_abs = tl.max(tl.abs(x_r), axis=1)
+        max_abs = tl.where(max_abs == max_abs, max_abs, 0.0)  # NaN -> 0
+        max_abs = tl.maximum(max_abs, FP32_TINY)
+
+        if USE_BF16_EXP:
+            max_abs_bf16 = max_abs.to(tl.bfloat16)
+            max_abs_i16 = max_abs_bf16.to(tl.int16, bitcast=True)
+            largest_p2 = ((max_abs_i16 >> BF16_MBITS) & 0xFF) - E8M0_EXP_BIAS_INT
+            scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2_INT
+            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS_INT)
+            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS_INT)
+            scale_biased_i32 = (scale_unbiased + E8M0_EXP_BIAS_INT).to(tl.int32)
+            scale_biased_u8 = scale_biased_i32.to(tl.uint8)
+            inv_exp = 254 - scale_biased_i32
+            inv_bits = inv_exp.to(tl.uint32) << 23
+            inv_bits = tl.where(inv_exp == 0, 0x00400000, inv_bits)
+            inv_scale = inv_bits.to(tl.float32, bitcast=True)
+            q_hp = x_r * inv_scale[:, None]
+        else:
+            largest_p2 = tl.floor(tl.log2(max_abs))
+            scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2
+            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
+            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
+
+            scale_biased_u8 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.uint8)
+            dequant_scale = tl.exp2(scale_unbiased).to(tl.float32)
+            q_hp = x_r / dequant_scale[:, None]
+
+        q_hp = tl.where(q_hp == q_hp, q_hp, 0.0)
+        q_hp = tl.maximum(q_hp, -F8E4M3_MAX)
+        q_hp = tl.minimum(q_hp, F8E4M3_MAX)
+
+        q_tile = tl.reshape(q_hp, (BLOCK_M, BLOCK_N)).to(tl.float8e4nv)
+        tl.store(q_ptr + q_offsets, q_tile, mask=q_mask)
+
+        row_vec = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        prev_group_end = 0
+        output_group_start = tl.zeros((BLOCK_M,), dtype=tl.int32)
+        running_output_group_start = 0
+        local_row = row_vec
+        row_is_active = tl.zeros((BLOCK_M,), dtype=tl.int1)
+        for group_idx in tl.static_range(0, NUM_GROUPS):
+            group_end = tl.load(offs + group_idx)
+            in_group = (row_vec >= prev_group_end) & (row_vec < group_end)
+            local_row = tl.where(in_group, row_vec - prev_group_end, local_row)
+            output_group_start = tl.where(in_group, running_output_group_start, output_group_start)
+            row_is_active = row_is_active | in_group
+            group_size = group_end - prev_group_end
+            running_output_group_start += ((group_size + 127) // 128) * 128
+            prev_group_end = group_end
+
+        scale_col_idx = pid_n * SCALE_BLOCKS_PER_TILE + tl.arange(0, SCALE_BLOCKS_PER_TILE)
+        scale_tile = tl.reshape(scale_biased_u8, (BLOCK_M, SCALE_BLOCKS_PER_TILE))
+        local_row_2d = local_row[:, None]
+        output_group_start_2d = output_group_start[:, None]
+        scale_col_2d = scale_col_idx[None, :]
+
+        macro_row_block = local_row_2d // 128
+        macro_col_block = scale_col_2d // 4
+        local_row_in_macro = local_row_2d % 128
+        local_col = scale_col_2d % 4
+        group_in_macro = local_row_in_macro // 32
+        sub_row = local_row_in_macro % 32
+
+        swizzled_offsets = (
+            (output_group_start_2d + macro_row_block * 128) * blocked_scale_stride_0
+            + macro_col_block * 512
+            + sub_row * 16
+            + group_in_macro * 4
+            + local_col
+        )
+        n_scale_cols = tl.cdiv(n_cols, BLOCK_SIZE)
+        scale_mask = (
+            (row_vec[:, None] < n_rows) & row_is_active[:, None] & (scale_col_2d < n_scale_cols)
+        )
+        tl.store(blocked_scale_ptr + swizzled_offsets, scale_tile, mask=scale_mask)
+
+    # NOTE: Deliberately no @triton.autotune here.
+    @triton.jit
+    def _triton_swiglu_quantize_dim0(
+        up_gate_ptr,
+        ug_stride_0,
+        ug_stride_1,
+        h_ptr,
+        h_stride_0,
+        h_stride_1,
+        q_ptr,
+        q_stride_0,
+        q_stride_1,
+        scale_ptr,
+        s_stride_0,
+        s_stride_1,
+        n_rows,
+        hidden,
+        BLOCK_SIZE: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        EVEN_M: tl.constexpr,
+        EVEN_N: tl.constexpr,
+    ):
+        # Computes h = up * silu(gate) and quantizes h to MXFP8 in one pass.
+        FP32_TINY: tl.constexpr = 1.1754943508222875e-38
+        F8E4M3_MAX: tl.constexpr = 448.0
+        E8M0_EXP_BIAS: tl.constexpr = 127.0
+        F8E4M3_LARGEST_POW2: tl.constexpr = 8.0
+        SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
+
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+
+        row_idx = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+        col_idx = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+        h_mask = (row_idx < n_rows) & (col_idx < hidden)
+
+        up_offsets = row_idx * ug_stride_0 + col_idx * ug_stride_1
+        gate_offsets = row_idx * ug_stride_0 + (col_idx + hidden) * ug_stride_1
+        if EVEN_M and EVEN_N:
+            up = tl.load(up_gate_ptr + up_offsets).to(tl.float32)
+            gate = tl.load(up_gate_ptr + gate_offsets).to(tl.float32)
+        else:
+            up = tl.load(up_gate_ptr + up_offsets, mask=h_mask, other=0.0).to(tl.float32)
+            gate = tl.load(up_gate_ptr + gate_offsets, mask=h_mask, other=0.0).to(tl.float32)
+        silu_gate = gate * tl.sigmoid(gate)
+        h = up * silu_gate
+
+        h_offsets = row_idx * h_stride_0 + col_idx * h_stride_1
+        if EVEN_M and EVEN_N:
+            tl.store(h_ptr + h_offsets, h)
+        else:
+            tl.store(h_ptr + h_offsets, h, mask=h_mask)
+
+        h_r = h.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE, BLOCK_SIZE)
+        max_abs = tl.max(tl.abs(h_r), axis=1)
+        max_abs = tl.where(max_abs == max_abs, max_abs, 0.0)  # NaN -> 0
+        max_abs = tl.maximum(max_abs, FP32_TINY)
+
+        largest_p2 = tl.floor(tl.log2(max_abs))
+        scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2
+        scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
+        scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
+        scale_biased_u8 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.uint8)
+
+        inv_dequant_scale = tl.exp2(-scale_unbiased).to(tl.float32)
+        q_hp = h_r * inv_dequant_scale[:, None]
+        q_hp = tl.where(q_hp == q_hp, q_hp, 0.0)
+        q_hp = tl.maximum(q_hp, -F8E4M3_MAX)
+        q_hp = tl.minimum(q_hp, F8E4M3_MAX)
+        q_tile = tl.reshape(q_hp, (BLOCK_M, BLOCK_N)).to(tl.float8e4nv)
+
+        q_offsets = row_idx * q_stride_0 + col_idx * q_stride_1
+        if EVEN_M and EVEN_N:
+            tl.store(q_ptr + q_offsets, q_tile)
+        else:
+            tl.store(q_ptr + q_offsets, q_tile, mask=h_mask)
+
+        n_scale_cols = hidden // BLOCK_SIZE
+        scale_col_idx = pid_n * SCALE_BLOCKS_PER_TILE + tl.arange(0, SCALE_BLOCKS_PER_TILE)[None, :]
+        scale_offsets = row_idx * s_stride_0 + scale_col_idx * s_stride_1
+        scale_mask = (row_idx < n_rows) & (scale_col_idx < n_scale_cols)
+        scale_tile = tl.reshape(scale_biased_u8, (BLOCK_M, SCALE_BLOCKS_PER_TILE))
+        if EVEN_M and EVEN_N:
+            tl.store(scale_ptr + scale_offsets, scale_tile)
+        else:
+            tl.store(scale_ptr + scale_offsets, scale_tile, mask=scale_mask)
+
+    # NOTE: Deliberately no @triton.autotune here.
+    @triton.jit
+    def _triton_swiglu_quantize_from_mxfp8_dim0(
+        up_gate_q_ptr,
+        uq_stride_0,
+        uq_stride_1,
+        up_gate_scales_u8_ptr,
+        us_stride_0,
+        us_stride_1,
+        h_ptr,
+        h_stride_0,
+        h_stride_1,
+        q_ptr,
+        q_stride_0,
+        q_stride_1,
+        scale_ptr,
+        s_stride_0,
+        s_stride_1,
+        n_rows,
+        hidden,
+        BLOCK_SIZE: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        # Computes h = up * silu(gate) from MXFP8 input and requantizes h to MXFP8.
+        FP32_TINY: tl.constexpr = 1.1754943508222875e-38
+        F8E4M3_MAX: tl.constexpr = 448.0
+        E8M0_EXP_BIAS: tl.constexpr = 127.0
+        F8E4M3_LARGEST_POW2: tl.constexpr = 8.0
+        SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
+
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+
+        row_idx = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+        col_idx = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+        h_mask = (row_idx < n_rows) & (col_idx < hidden)
+
+        up_offsets = row_idx * uq_stride_0 + col_idx * uq_stride_1
+        gate_offsets = row_idx * uq_stride_0 + (col_idx + hidden) * uq_stride_1
+        up_q = tl.load(up_gate_q_ptr + up_offsets, mask=h_mask, other=0.0).to(tl.float32)
+        gate_q = tl.load(up_gate_q_ptr + gate_offsets, mask=h_mask, other=0.0).to(tl.float32)
+
+        up_scale_cols = col_idx // BLOCK_SIZE
+        gate_scale_cols = (col_idx + hidden) // BLOCK_SIZE
+        up_scale_offsets = row_idx * us_stride_0 + up_scale_cols * us_stride_1
+        gate_scale_offsets = row_idx * us_stride_0 + gate_scale_cols * us_stride_1
+        up_scale_u8 = tl.load(
+            up_gate_scales_u8_ptr + up_scale_offsets,
+            mask=h_mask,
+            other=0,
+        ).to(tl.int32)
+        gate_scale_u8 = tl.load(
+            up_gate_scales_u8_ptr + gate_scale_offsets,
+            mask=h_mask,
+            other=0,
+        ).to(tl.int32)
+        up_scale = tl.exp2(up_scale_u8.to(tl.float32) - E8M0_EXP_BIAS)
+        gate_scale = tl.exp2(gate_scale_u8.to(tl.float32) - E8M0_EXP_BIAS)
+
+        up = up_q * up_scale
+        gate = gate_q * gate_scale
+        silu_gate = gate * tl.sigmoid(gate)
+        h = up * silu_gate
+
+        h_offsets = row_idx * h_stride_0 + col_idx * h_stride_1
+        tl.store(h_ptr + h_offsets, h, mask=h_mask)
+
+        h_r = h.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE, BLOCK_SIZE)
+        max_abs = tl.max(tl.abs(h_r), axis=1)
+        max_abs = tl.where(max_abs == max_abs, max_abs, 0.0)  # NaN -> 0
+        max_abs = tl.maximum(max_abs, FP32_TINY)
+
+        largest_p2 = tl.floor(tl.log2(max_abs))
+        scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2
+        scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
+        scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
+        scale_biased_u8 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.uint8)
+
+        inv_dequant_scale = tl.exp2(-scale_unbiased).to(tl.float32)
+        q_hp = h_r * inv_dequant_scale[:, None]
+        q_hp = tl.where(q_hp == q_hp, q_hp, 0.0)
+        q_hp = tl.maximum(q_hp, -F8E4M3_MAX)
+        q_hp = tl.minimum(q_hp, F8E4M3_MAX)
+        q_tile = tl.reshape(q_hp, (BLOCK_M, BLOCK_N)).to(tl.float8e4nv)
+
+        q_offsets = row_idx * q_stride_0 + col_idx * q_stride_1
+        tl.store(q_ptr + q_offsets, q_tile, mask=h_mask)
+
+        n_scale_cols = hidden // BLOCK_SIZE
+        scale_col_idx = pid_n * SCALE_BLOCKS_PER_TILE + tl.arange(0, SCALE_BLOCKS_PER_TILE)[None, :]
+        scale_offsets = row_idx * s_stride_0 + scale_col_idx * s_stride_1
+        scale_mask = (row_idx < n_rows) & (scale_col_idx < n_scale_cols)
+        scale_tile = tl.reshape(scale_biased_u8, (BLOCK_M, SCALE_BLOCKS_PER_TILE))
+        tl.store(scale_ptr + scale_offsets, scale_tile, mask=scale_mask)
+
+    # NOTE: Deliberately no @triton.autotune here.
+    @triton.jit
+    def _triton_mxfp8_reduce_gathered_dim1(
+        gathered_q_ptr,
+        gq_stride_0,
+        gq_stride_1,
+        gq_stride_2,
+        gathered_scales_u8_ptr,
+        gs_stride_0,
+        gs_stride_1,
+        gs_stride_2,
+        probs_ptr,
+        p_stride_0,
+        p_stride_1,
+        valid_mask_ptr,
+        v_stride_0,
+        v_stride_1,
+        out_acc_ptr,
+        o_stride_0,
+        o_stride_1,
+        n_rows,
+        top_k,
+        d_model,
+        BLOCK_SIZE: tl.constexpr,
+        HAS_PROBS: tl.constexpr,
+        HAS_VALID_MASK: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        # Reduces gathered [N, K, D] MXFP8 routes into [N, D] in fp32.
+        E8M0_EXP_BIAS: tl.constexpr = 127.0
+        SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
+
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+
+        row_ids = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        row_idx = row_ids[:, None]
+        col_idx = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+        out_mask = (row_idx < n_rows) & (col_idx < d_model)
+
+        n_scale_cols = d_model // BLOCK_SIZE
+        scale_col_idx = pid_n * SCALE_BLOCKS_PER_TILE + tl.arange(0, SCALE_BLOCKS_PER_TILE)[None, :]
+        scale_mask = (row_idx < n_rows) & (scale_col_idx < n_scale_cols)
+
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        k = 0
+        while k < top_k:
+            route_mask = out_mask
+            scale_route_mask = scale_mask
+            route_valid = tl.full((BLOCK_M,), 1, dtype=tl.int1)
+            if HAS_VALID_MASK:
+                route_valid = tl.load(
+                    valid_mask_ptr + row_ids * v_stride_0 + k * v_stride_1,
+                    mask=(row_ids < n_rows),
+                    other=0,
+                ).to(tl.int1)
+                route_mask = route_mask & route_valid[:, None]
+                scale_route_mask = scale_route_mask & route_valid[:, None]
+
+            q_offsets = row_idx * gq_stride_0 + k * gq_stride_1 + col_idx * gq_stride_2
+            q = tl.load(gathered_q_ptr + q_offsets, mask=route_mask, other=0.0).to(tl.float32)
+
+            s_offsets = row_idx * gs_stride_0 + k * gs_stride_1 + scale_col_idx * gs_stride_2
+            s_u8 = tl.load(gathered_scales_u8_ptr + s_offsets, mask=scale_route_mask, other=0).to(
+                tl.int32
+            )
+            scales = tl.exp2(s_u8.to(tl.float32) - E8M0_EXP_BIAS)
+
+            q_blocks = q.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE, BLOCK_SIZE)
+            scale_blocks = scales.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE)
+            route = tl.reshape(
+                q_blocks * scale_blocks[:, None],
+                (BLOCK_M, BLOCK_N),
+            )
+            if HAS_PROBS:
+                probs_row = tl.load(
+                    probs_ptr + row_ids * p_stride_0 + k * p_stride_1,
+                    mask=(row_ids < n_rows),
+                    other=0.0,
+                ).to(tl.float32)
+                if HAS_VALID_MASK:
+                    probs_row = tl.where(route_valid, probs_row, 0.0)
+                route = route * probs_row[:, None]
+
+            acc += route
+            k += 1
+
+        out_offsets = row_idx * o_stride_0 + col_idx * o_stride_1
+        tl.store(out_acc_ptr + out_offsets, acc, mask=out_mask)
+
+    @triton.autotune(
+        configs=_MXFP8_DQ_AUTOTUNE_CONFIGS,
+        key=["n_rows", "n_cols", "BLOCK_SIZE"],
+    )
+    @triton.jit
+    def _triton_mxfp8_dequantize_dim0(
+        q_ptr,
+        q_stride_0,
+        q_stride_1,
+        scales_u8_ptr,
+        s_stride_0,
+        s_stride_1,
+        out_ptr,
+        o_stride_0,
+        o_stride_1,
+        n_rows,
+        n_cols,
+        BLOCK_SIZE: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        E8M0_EXP_BIAS: tl.constexpr = 127.0
+        SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+
+        row_idx = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+        col_idx = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+        out_mask = (row_idx < n_rows) & (col_idx < n_cols)
+
+        q_offsets = row_idx * q_stride_0 + col_idx * q_stride_1
+        q = tl.load(q_ptr + q_offsets, mask=out_mask, other=0.0).to(tl.float32)
+
+        n_scale_cols = tl.cdiv(n_cols, BLOCK_SIZE)
+        scale_col_idx = pid_n * SCALE_BLOCKS_PER_TILE + tl.arange(0, SCALE_BLOCKS_PER_TILE)[None, :]
+        scale_mask = (row_idx < n_rows) & (scale_col_idx < n_scale_cols)
+        s_offsets = row_idx * s_stride_0 + scale_col_idx * s_stride_1
+        s_u8 = tl.load(scales_u8_ptr + s_offsets, mask=scale_mask, other=0).to(tl.int32)
+        scales = tl.exp2(s_u8.to(tl.float32) - E8M0_EXP_BIAS)
+
+        q_blocks = q.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE, BLOCK_SIZE)
+        scale_blocks = scales.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE)
+        out_val = tl.reshape(
+            q_blocks * scale_blocks[:, None],
+            (BLOCK_M, BLOCK_N),
+        )
+        out_offsets = row_idx * o_stride_0 + col_idx * o_stride_1
+        tl.store(out_ptr + out_offsets, out_val, mask=out_mask)
+
+    # NOTE: Deliberately no @triton.autotune here.
+    @triton.jit
+    def _triton_mxfp8_dot_gathered_with_grad(
+        gathered_q_ptr,
+        gq_stride_0,
+        gq_stride_1,
+        gq_stride_2,
+        gathered_scales_u8_ptr,
+        gs_stride_0,
+        gs_stride_1,
+        gs_stride_2,
+        grad_out_ptr,
+        go_stride_0,
+        go_stride_1,
+        valid_mask_ptr,
+        v_stride_0,
+        v_stride_1,
+        out_ptr,
+        o_stride_0,
+        o_stride_1,
+        n_rows,
+        top_k,
+        d_model,
+        BLOCK_SIZE: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        E8M0_EXP_BIAS: tl.constexpr = 127.0
+        SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
+
+        pid_m = tl.program_id(0)
+        pid_k = tl.program_id(1)
+
+        row_ids = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        rows_mask = row_ids < n_rows
+        route_valid = tl.load(
+            valid_mask_ptr + row_ids * v_stride_0 + pid_k * v_stride_1,
+            mask=rows_mask,
+            other=0,
+        ).to(tl.int1)
+        active_rows = rows_mask & route_valid
+
+        acc = tl.zeros((BLOCK_M,), dtype=tl.float32)
+        col_start = 0
+        while col_start < d_model:
+            col_idx = col_start + tl.arange(0, BLOCK_N)
+            q_mask = active_rows[:, None] & (col_idx[None, :] < d_model)
+
+            q_offsets = (
+                row_ids[:, None] * gq_stride_0
+                + pid_k * gq_stride_1
+                + col_idx[None, :] * gq_stride_2
+            )
+            q = tl.load(gathered_q_ptr + q_offsets, mask=q_mask, other=0.0).to(tl.float32)
+
+            scale_col_idx = (col_start // BLOCK_SIZE) + tl.arange(0, SCALE_BLOCKS_PER_TILE)
+            s_mask = active_rows[:, None] & (scale_col_idx[None, :] < (d_model // BLOCK_SIZE))
+            s_offsets = (
+                row_ids[:, None] * gs_stride_0
+                + pid_k * gs_stride_1
+                + scale_col_idx[None, :] * gs_stride_2
+            )
+            s_u8 = tl.load(gathered_scales_u8_ptr + s_offsets, mask=s_mask, other=0).to(tl.int32)
+            scales = tl.exp2(s_u8.to(tl.float32) - E8M0_EXP_BIAS)
+            q_blocks = q.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE, BLOCK_SIZE)
+            scale_blocks = scales.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE)
+            route = tl.reshape(
+                q_blocks * scale_blocks[:, None],
+                (BLOCK_M, BLOCK_N),
+            )
+
+            go_offsets = row_ids[:, None] * go_stride_0 + col_idx[None, :] * go_stride_1
+            grad = tl.load(grad_out_ptr + go_offsets, mask=q_mask, other=0.0).to(tl.float32)
+
+            acc += tl.sum(route * grad, axis=1)
+            col_start += BLOCK_N
+
+        out_offsets = row_ids * o_stride_0 + pid_k * o_stride_1
+        tl.store(out_ptr + out_offsets, acc, mask=rows_mask)
+
+
+def _to_blocked_m_groups_triton(
+    scales_tensor: torch.Tensor,
+    offs: torch.Tensor,
+    *,
+    zero_unwritten_tail: bool = True,
+) -> torch.Tensor:
+    if triton is None:
+        raise RuntimeError("Triton is required for CUDA no-sync grouped MXFP8 scale swizzle")
+
+    rows, cols = scales_tensor.shape
+    num_groups = int(offs.shape[0])
+    num_col_blocks = ceil_div(cols, 4)
+    padded_cols = num_col_blocks * 4
+
+    # Upper-bound static padding per group to avoid host-side offset inspection.
+    padded_rows = rows + num_groups * 128
+    if zero_unwritten_tail:
+        output = scales_tensor.new_zeros((padded_rows, padded_cols))
+    else:
+        # The Triton kernel writes every row/column that grouped-mm can read
+        # from the per-group 128-row padded layout. The extra upper-bound tail
+        # rows are unreachable through `offs`, so the hot path can skip memset.
+        output = scales_tensor.new_empty((padded_rows, padded_cols))
+
+    block_rows = 128
+    block_cols = 4
+    output_stride_per_block = block_rows * block_cols
+    output_stride_per_row_of_blocks = block_rows * block_cols * (padded_cols // block_cols)
+
+    grid = (num_groups, num_col_blocks)
+    _triton_scale_swizzle_m_groups[grid](
+        scales_tensor.view(torch.uint8),
+        scales_tensor.stride(0),
+        scales_tensor.stride(1),
+        cols,
+        offs,
+        output.view(torch.uint8),
+        output.stride(0),
+        output_stride_per_block,
+        output_stride_per_row_of_blocks,
+        num_groups=num_groups,
+        BLOCK_ROWS=block_rows,
+        BLOCK_COLS=block_cols,
+    )
+    return output
+
+
+def _to_blocked_m_groups_fallback(scales_tensor: torch.Tensor, offs: torch.Tensor) -> torch.Tensor:
+    """
+    Reference path (CPU/non-Triton). Not intended for CUDA no-sync training.
+    """
+    rows, cols = scales_tensor.shape
+    num_groups = int(offs.shape[0])
+    padded_rows = rows + num_groups * 128
+    output = scales_tensor.new_zeros((padded_rows, cols))
+
+    offs_cpu = offs.to(device="cpu", dtype=torch.int64)
+    in_start = 0
+    out_start = 0
+    for end in offs_cpu.tolist():
+        end_i = int(end)
+        group_rows = end_i - in_start
+        if group_rows <= 0:
+            in_start = end_i
+            continue
+
+        blocked = to_blocked(scales_tensor[in_start:end_i]).view(-1, cols)
+        out_end = out_start + blocked.shape[0]
+        output[out_start:out_end].copy_(blocked)
+        in_start = end_i
+        out_start = out_end
+
+    return output
+
+
+def _to_blocked_per_group_triton(scales: torch.Tensor) -> torch.Tensor:
+    if triton is None:
+        raise RuntimeError("Triton is required for CUDA per-group MXFP8 scale swizzle")
+
+    num_groups, rows, cols = scales.shape
+    num_row_blocks = ceil_div(rows, 128)
+    num_col_blocks = ceil_div(cols, 4)
+    padded_rows = num_row_blocks * 128
+    padded_cols = num_col_blocks * 4
+    output = scales.new_empty((num_groups, padded_rows * padded_cols))
+
+    block_rows = 128
+    block_cols = 4
+    output_block_stride = block_rows * block_cols * (padded_cols // block_cols)
+    grid = (num_groups, num_row_blocks, num_col_blocks)
+    _triton_scale_swizzle_per_group_3d[grid](
+        scales.view(torch.uint8),
+        scales.stride(0),
+        scales.stride(1),
+        scales.stride(2),
+        output.view(torch.uint8),
+        output.stride(0),
+        output_block_stride,
+        rows,
+        cols,
+        BLOCK_ROWS=block_rows,
+        BLOCK_COLS=block_cols,
+    )
+    return output
+
+
+def _to_blocked_per_group(scales: torch.Tensor) -> torch.Tensor:
+    """
+    Vectorized per-group blocked swizzle for scales shaped [G, R, C].
+    """
+    if scales.ndim != 3:
+        raise ValueError(f"Expected rank-3 scales [G, R, C], got {tuple(scales.shape)}")
+    if scales.is_cuda and triton is not None:
+        return _to_blocked_per_group_triton(scales)
+
+    g, rows, cols = scales.shape
+    n_row_blocks = ceil_div(rows, 128)
+    n_col_blocks = ceil_div(cols, 4)
+    padded_rows = n_row_blocks * 128
+    padded_cols = n_col_blocks * 4
+
+    padded = scales
+    if (rows, cols) != (padded_rows, padded_cols):
+        padded = torch.zeros(
+            (g, padded_rows, padded_cols),
+            device=scales.device,
+            dtype=scales.dtype,
+        )
+        padded[:, :rows, :cols] = scales
+
+    blocks = padded.view(g, n_row_blocks, 128, n_col_blocks, 4).permute(0, 1, 3, 2, 4)
+    rearranged = blocks.reshape(g, n_row_blocks * n_col_blocks, 4, 32, 4).transpose(2, 3)
+    return rearranged.reshape(g, -1).contiguous()
+
+
+def _quantize_to_mxfp8_torch(
+    x: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    orig_shape = x.shape
+    x_blocks = x.reshape(*orig_shape[:-1], orig_shape[-1] // block_size, block_size)
+
+    max_abs = torch.amax(torch.abs(x_blocks), dim=-1)
+    max_abs = torch.clamp(max_abs, min=torch.finfo(torch.float32).tiny)
+
+    largest_p2 = torch.floor(torch.log2(max_abs))
+    scale_unbiased = largest_p2 - _F8E4M3_LARGEST_POW2
+    scale_unbiased = torch.clamp(scale_unbiased, -_F8E8M0_EXP_BIAS, _F8E8M0_EXP_BIAS)
+    scale_biased = (scale_unbiased + _F8E8M0_EXP_BIAS).to(torch.uint8)
+    scales = scale_biased.view(torch.float8_e8m0fnu)
+
+    dequant_scale = scales.to(torch.float32).unsqueeze(-1)
+    qdata_hp = x_blocks.to(torch.float32) / dequant_scale
+    qdata_hp = torch.nan_to_num(
+        qdata_hp,
+        nan=0.0,
+        posinf=_F8E4M3_MAX,
+        neginf=-_F8E4M3_MAX,
+    )
+    qdata_hp = torch.clamp(qdata_hp, min=-_F8E4M3_MAX, max=_F8E4M3_MAX)
+    qdata = qdata_hp.to(torch.float8_e4m3fn)
+    qdata = qdata.reshape(orig_shape).contiguous()
+    scales = scales.reshape(orig_shape[0], -1).contiguous()
+    return qdata, scales
+
+
+def _quantize_to_mxfp8_triton(
+    x: torch.Tensor,
+    *,
+    block_size: int = 32,
+    out: Optional[torch.Tensor] = None,
+    scales_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if triton is None or tl is None:
+        raise RuntimeError("Triton is not available")
+    if not x.is_cuda:
+        raise RuntimeError("Triton MXFP8 quantization requires CUDA")
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(f"Unsupported dtype for Triton MXFP8 quantization: {x.dtype}")
+
+    rows, cols = x.shape
+    if out is not None:
+        qdata = out
+    else:
+        qdata = torch.empty((rows, cols), device=x.device, dtype=torch.float8_e4m3fn)
+    if scales_out is not None:
+        scales_u8 = scales_out.view(torch.uint8)
+    else:
+        scales_u8 = torch.empty((rows, cols // block_size), device=x.device, dtype=torch.uint8)
+
+    def grid(meta):
+        return (
+            triton.cdiv(rows, meta["BLOCK_M"]),
+            triton.cdiv(cols, meta["BLOCK_N"]),
+        )
+
+    _triton_mxfp8_quantize_dim0[grid](
+        x,
+        x.stride(0),
+        x.stride(1),
+        qdata,
+        qdata.stride(0),
+        qdata.stride(1),
+        scales_u8,
+        scales_u8.stride(0),
+        scales_u8.stride(1),
+        rows,
+        cols,
+        BLOCK_SIZE=block_size,
+        USE_BF16_EXP=x.dtype == torch.bfloat16,
+    )
+    if scales_out is not None:
+        return qdata, scales_out
+    return qdata, scales_u8.view(torch.float8_e8m0fnu)
+
+
+def _swiglu_quantize_rows_to_mxfp8_torch(
+    up_gate: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    hidden = up_gate.shape[1] // 2
+    up, gate = up_gate.split(hidden, dim=-1)
+    h = up * torch.nn.functional.silu(gate)
+    qdata, scales = quantize_to_mxfp8(h, block_size=block_size)
+    return h, qdata, scales
+
+
+def _swiglu_quantize_rows_to_mxfp8_triton(
+    up_gate: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if triton is None or tl is None:
+        raise RuntimeError("Triton is not available")
+    if not up_gate.is_cuda:
+        raise RuntimeError("Triton SwiGLU MXFP8 quantization requires CUDA")
+    if up_gate.ndim != 2:
+        raise ValueError(f"Expected rank-2 up_gate [M, 2H], got {tuple(up_gate.shape)}")
+    if up_gate.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(f"Unsupported dtype for Triton SwiGLU MXFP8 quantization: {up_gate.dtype}")
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+    if up_gate.shape[1] % 2 != 0:
+        raise ValueError(
+            f"up_gate last dim must be even for SwiGLU split, got {tuple(up_gate.shape)}"
+        )
+
+    up_gate_contig = up_gate if up_gate.is_contiguous() else up_gate.contiguous()
+    rows = up_gate_contig.shape[0]
+    hidden = up_gate_contig.shape[1] // 2
+    if hidden % block_size != 0:
+        raise ValueError(
+            f"SwiGLU hidden dim must be divisible by {block_size}, got hidden={hidden}"
+        )
+    if _MXFP8_SWIGLU_BLOCK_N % block_size != 0:
+        raise ValueError(
+            f"SWIGLU BLOCK_N must be divisible by {block_size}, got {_MXFP8_SWIGLU_BLOCK_N}"
+        )
+    h = torch.empty((rows, hidden), device=up_gate_contig.device, dtype=up_gate_contig.dtype)
+    qdata = torch.empty((rows, hidden), device=up_gate_contig.device, dtype=torch.float8_e4m3fn)
+    scales_u8 = torch.empty(
+        (rows, hidden // block_size), device=up_gate_contig.device, dtype=torch.uint8
+    )
+
+    grid = (
+        triton.cdiv(rows, _MXFP8_SWIGLU_BLOCK_M),
+        triton.cdiv(hidden, _MXFP8_SWIGLU_BLOCK_N),
+    )
+    _triton_swiglu_quantize_dim0[grid](
+        up_gate_contig,
+        up_gate_contig.stride(0),
+        up_gate_contig.stride(1),
+        h,
+        h.stride(0),
+        h.stride(1),
+        qdata,
+        qdata.stride(0),
+        qdata.stride(1),
+        scales_u8,
+        scales_u8.stride(0),
+        scales_u8.stride(1),
+        rows,
+        hidden,
+        BLOCK_SIZE=block_size,
+        BLOCK_M=_MXFP8_SWIGLU_BLOCK_M,
+        BLOCK_N=_MXFP8_SWIGLU_BLOCK_N,
+        EVEN_M=rows % _MXFP8_SWIGLU_BLOCK_M == 0,
+        EVEN_N=hidden % _MXFP8_SWIGLU_BLOCK_N == 0,
+        num_warps=_MXFP8_SWIGLU_NUM_WARPS,
+        num_stages=_MXFP8_SWIGLU_NUM_STAGES,
+    )
+    return h, qdata, scales_u8.view(torch.float8_e8m0fnu)
+
+
+def swiglu_quantize_rows_to_mxfp8(
+    up_gate: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Compute SwiGLU activation and quantize it to MXFP8 in one API.
+
+    Returns:
+      h: high-precision activation [M, H]
+      qdata: float8_e4m3fn [M, H]
+      scales: float8_e8m0fnu [M, H//block_size]
+    """
+    if up_gate.ndim != 2:
+        raise ValueError(f"Expected rank-2 up_gate [M, 2H], got {tuple(up_gate.shape)}")
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+    if up_gate.shape[1] % 2 != 0:
+        raise ValueError(f"up_gate last dim must be even, got {tuple(up_gate.shape)}")
+    hidden = up_gate.shape[1] // 2
+    if hidden % block_size != 0:
+        raise ValueError(
+            f"SwiGLU hidden dim must be divisible by {block_size}, got hidden={hidden}"
+        )
+
+    if up_gate.is_cuda:
+        if triton is None:
+            raise RuntimeError("Triton is required for CUDA SwiGLU MXFP8 quantization")
+        return _swiglu_quantize_rows_to_mxfp8_triton(up_gate, block_size=block_size)
+
+    return _swiglu_quantize_rows_to_mxfp8_torch(up_gate, block_size=block_size)
+
+
+def _swiglu_quantize_rows_from_mxfp8_torch(
+    up_gate_q: torch.Tensor,
+    up_gate_scales: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    up_gate = dequantize_from_mxfp8(
+        up_gate_q,
+        up_gate_scales,
+        block_size=block_size,
+        out_dtype=torch.bfloat16,
+    )
+    return _swiglu_quantize_rows_to_mxfp8_torch(up_gate, block_size=block_size)
+
+
+def _swiglu_quantize_rows_from_mxfp8_triton(
+    up_gate_q: torch.Tensor,
+    up_gate_scales: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if triton is None or tl is None:
+        raise RuntimeError("Triton is not available")
+    if not up_gate_q.is_cuda or not up_gate_scales.is_cuda:
+        raise RuntimeError("Triton FP8 SwiGLU requires CUDA tensors")
+    if up_gate_q.dtype != torch.float8_e4m3fn:
+        raise ValueError(f"up_gate_q must be float8_e4m3fn, got {up_gate_q.dtype}")
+    if up_gate_scales.dtype != torch.float8_e8m0fnu:
+        raise ValueError(f"up_gate_scales must be float8_e8m0fnu, got {up_gate_scales.dtype}")
+    if up_gate_q.ndim != 2 or up_gate_scales.ndim != 2:
+        raise ValueError(
+            "Expected rank-2 up_gate_q/up_gate_scales, "
+            f"got {tuple(up_gate_q.shape)} and {tuple(up_gate_scales.shape)}"
+        )
+    if up_gate_q.shape[0] != up_gate_scales.shape[0]:
+        raise ValueError(
+            f"Row mismatch: q={tuple(up_gate_q.shape)} scales={tuple(up_gate_scales.shape)}"
+        )
+    if up_gate_q.shape[1] % 2 != 0:
+        raise ValueError(
+            f"up_gate_q last dim must be even for SwiGLU split, got {tuple(up_gate_q.shape)}"
+        )
+    if up_gate_q.shape[1] % block_size != 0:
+        raise ValueError(
+            f"up_gate_q last dim must be divisible by {block_size}, got {tuple(up_gate_q.shape)}"
+        )
+    if up_gate_scales.shape[1] != up_gate_q.shape[1] // block_size:
+        raise ValueError(
+            "up_gate_scales shape mismatch: "
+            f"expected second dim {up_gate_q.shape[1] // block_size}, got {up_gate_scales.shape[1]}"
+        )
+
+    up_gate_q_contig = up_gate_q if up_gate_q.is_contiguous() else up_gate_q.contiguous()
+    up_gate_scales_contig = (
+        up_gate_scales if up_gate_scales.is_contiguous() else up_gate_scales.contiguous()
+    )
+    up_gate_scales_u8 = up_gate_scales_contig.view(torch.uint8)
+
+    rows = up_gate_q_contig.shape[0]
+    hidden = up_gate_q_contig.shape[1] // 2
+    h = torch.empty((rows, hidden), device=up_gate_q_contig.device, dtype=torch.bfloat16)
+    qdata = torch.empty((rows, hidden), device=up_gate_q_contig.device, dtype=torch.float8_e4m3fn)
+    scales_u8 = torch.empty(
+        (rows, hidden // block_size), device=up_gate_q_contig.device, dtype=torch.uint8
+    )
+
+    grid = (
+        triton.cdiv(rows, _MXFP8_SWIGLU_FROM_FP8_BLOCK_M),
+        triton.cdiv(hidden, _MXFP8_SWIGLU_FROM_FP8_BLOCK_N),
+    )
+    _triton_swiglu_quantize_from_mxfp8_dim0[grid](
+        up_gate_q_contig,
+        up_gate_q_contig.stride(0),
+        up_gate_q_contig.stride(1),
+        up_gate_scales_u8,
+        up_gate_scales_u8.stride(0),
+        up_gate_scales_u8.stride(1),
+        h,
+        h.stride(0),
+        h.stride(1),
+        qdata,
+        qdata.stride(0),
+        qdata.stride(1),
+        scales_u8,
+        scales_u8.stride(0),
+        scales_u8.stride(1),
+        rows,
+        hidden,
+        BLOCK_SIZE=block_size,
+        BLOCK_M=_MXFP8_SWIGLU_FROM_FP8_BLOCK_M,
+        BLOCK_N=_MXFP8_SWIGLU_FROM_FP8_BLOCK_N,
+        num_warps=_MXFP8_SWIGLU_FROM_FP8_NUM_WARPS,
+        num_stages=_MXFP8_SWIGLU_FROM_FP8_NUM_STAGES,
+    )
+    return h, qdata, scales_u8.view(torch.float8_e8m0fnu)
+
+
+def swiglu_quantize_rows_from_mxfp8(
+    up_gate_q: torch.Tensor,
+    up_gate_scales: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Compute SwiGLU from MXFP8 input and requantize output to MXFP8.
+
+    Inputs:
+      up_gate_q: float8_e4m3fn [M, 2H]
+      up_gate_scales: float8_e8m0fnu [M, 2H//block_size]
+
+    Returns:
+      h: bfloat16 [M, H]
+      qdata: float8_e4m3fn [M, H]
+      scales: float8_e8m0fnu [M, H//block_size]
+    """
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+    if up_gate_q.ndim != 2 or up_gate_scales.ndim != 2:
+        raise ValueError(
+            "Expected rank-2 up_gate_q/up_gate_scales, "
+            f"got {tuple(up_gate_q.shape)} and {tuple(up_gate_scales.shape)}"
+        )
+
+    if up_gate_q.is_cuda and up_gate_scales.is_cuda:
+        if triton is None:
+            raise RuntimeError("Triton is required for CUDA SwiGLU MXFP8 dequant+quant")
+        return _swiglu_quantize_rows_from_mxfp8_triton(
+            up_gate_q,
+            up_gate_scales,
+            block_size=block_size,
+        )
+
+    return _swiglu_quantize_rows_from_mxfp8_torch(
+        up_gate_q,
+        up_gate_scales,
+        block_size=block_size,
+    )
+
+
+def _quantize_to_mxfp8_te(
+    x: torch.Tensor,
+    *,
+    block_size: int,
+    out: Optional[torch.Tensor],
+    scales_out: Optional[torch.Tensor],
+) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+    if (
+        block_size != 32
+        or not x.is_cuda
+        or x.ndim != 2
+        or not x.is_contiguous()
+        or x.dtype not in {torch.bfloat16, torch.float16, torch.float32}
+    ):
+        return None
+
+    rows, cols = x.shape
+    if rows % 32 != 0 or cols % block_size != 0:
+        return None
+    if not _te_mxfp8_compact_scale_layout(rows, cols, block_size):
+        return None
+
+    state = _get_te_mxfp8_state()
+    if state is None:
+        return None
+    tex, MXFP8Tensor, quantizer = state
+
+    if out is None and scales_out is None:
+        te_tensor = quantizer(x)
+        qdata = te_tensor._rowwise_data.view(torch.float8_e4m3fn)
+        scales = te_tensor._rowwise_scale_inv.view(torch.float8_e8m0fnu)
+        return qdata, scales[:rows, : cols // block_size]
+
+    if out is None or scales_out is None:
+        return None
+    if not out.is_contiguous() or not scales_out.is_contiguous():
+        return None
+
+    te_tensor = MXFP8Tensor(
+        shape=tuple(x.shape),
+        dtype=x.dtype,
+        rowwise_data=out.view(torch.uint8),
+        rowwise_scale_inv=scales_out.view(torch.uint8),
+        columnwise_data=None,
+        columnwise_scale_inv=None,
+        fp8_dtype=tex.DType.kFloat8E4M3,
+        quantizer=quantizer,
+    )
+    quantizer.update_quantized(x, te_tensor)
+    return out, scales_out
+
+
+@nvtx.annotate("quantize_to_mxfp8", color="red")
+def quantize_to_mxfp8(
+    x: torch.Tensor,
+    *,
+    block_size: int = 32,
+    out: Optional[torch.Tensor] = None,
+    scales_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize a 2D high-precision tensor to MXFP8.
+
+    Returns:
+      qdata: float8_e4m3fn [M, K]
+      scales: float8_e8m0fnu [M, K//block_size]
+    """
+    if x.ndim != 2:
+        raise ValueError(f"Expected rank-2 tensor, got shape={tuple(x.shape)}")
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+    if x.shape[-1] % block_size != 0:
+        raise ValueError(
+            f"Last dim must be divisible by {block_size} for MXFP8 quantization, got {tuple(x.shape)}"
+        )
+    expected_scales_shape = (x.shape[0], x.shape[1] // block_size)
+    if out is not None:
+        if tuple(out.shape) != tuple(x.shape):
+            raise ValueError(
+                f"out shape mismatch: expected {tuple(x.shape)}, got {tuple(out.shape)}"
+            )
+        if out.dtype != torch.float8_e4m3fn:
+            raise ValueError(f"out dtype mismatch: expected {torch.float8_e4m3fn}, got {out.dtype}")
+        if out.device != x.device:
+            raise ValueError(f"out device mismatch: expected {x.device}, got {out.device}")
+    if scales_out is not None:
+        if tuple(scales_out.shape) != expected_scales_shape:
+            raise ValueError(
+                f"scales_out shape mismatch: expected {expected_scales_shape}, got {tuple(scales_out.shape)}"
+            )
+        if scales_out.dtype != torch.float8_e8m0fnu:
+            raise ValueError(
+                f"scales_out dtype mismatch: expected {torch.float8_e8m0fnu}, got {scales_out.dtype}"
+            )
+        if scales_out.device != x.device:
+            raise ValueError(
+                f"scales_out device mismatch: expected {x.device}, got {scales_out.device}"
+            )
+        if not scales_out.is_contiguous():
+            raise ValueError("scales_out must be contiguous")
+    if out is not None and not out.is_contiguous():
+        raise ValueError("out must be contiguous")
+
+    # CUDA fast path: fused Triton quantization avoids eager pointwise op chains.
+    if x.is_cuda:
+        if _mxfp8_backend_wants_te("Q"):
+            te_result = _quantize_to_mxfp8_te(
+                x,
+                block_size=block_size,
+                out=out,
+                scales_out=scales_out,
+            )
+            if te_result is not None:
+                return te_result
+        if triton is None:
+            raise RuntimeError("Triton is required for CUDA MXFP8 quantization")
+        return _quantize_to_mxfp8_triton(
+            x,
+            block_size=block_size,
+            out=out,
+            scales_out=scales_out,
+        )
+
+    qdata, scales = _quantize_to_mxfp8_torch(x, block_size=block_size)
+    if out is not None:
+        out.copy_(qdata)
+        qdata = out
+    if scales_out is not None:
+        scales_out.copy_(scales)
+        scales = scales_out
+    return qdata, scales
+
+
+def _dequantize_from_mxfp8_te(
+    qdata: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    block_size: int,
+    out_dtype: torch.dtype,
+    out: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    if (
+        out is not None
+        or block_size != 32
+        or not qdata.is_cuda
+        or not scales.is_cuda
+        or not qdata.is_contiguous()
+        or not scales.is_contiguous()
+        or qdata.dtype != torch.float8_e4m3fn
+        or scales.dtype != torch.float8_e8m0fnu
+        or out_dtype not in {torch.bfloat16, torch.float16, torch.float32}
+    ):
+        return None
+
+    rows, cols = qdata.shape
+    if rows % 32 != 0 or cols % block_size != 0:
+        return None
+    if not _te_mxfp8_compact_scale_layout(rows, cols, block_size):
+        return None
+
+    state = _get_te_mxfp8_state()
+    if state is None:
+        return None
+    tex, MXFP8Tensor, quantizer = state
+
+    te_tensor = MXFP8Tensor(
+        shape=tuple(qdata.shape),
+        dtype=out_dtype,
+        rowwise_data=qdata.view(torch.uint8),
+        rowwise_scale_inv=scales.view(torch.uint8),
+        columnwise_data=None,
+        columnwise_scale_inv=None,
+        fp8_dtype=tex.DType.kFloat8E4M3,
+        quantizer=quantizer,
+    )
+    return te_tensor.dequantize(dtype=out_dtype)
+
+
+@nvtx.annotate("dequantize_from_mxfp8", color="red")
+def dequantize_from_mxfp8(
+    qdata: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    block_size: int = 32,
+    out_dtype: torch.dtype = torch.bfloat16,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    Dequantize MXFP8 qdata/scales back to high precision.
+
+    qdata shape: [M, K]
+    scales shape: [M, K//block_size]
+    """
+    if qdata.ndim != 2 or scales.ndim != 2:
+        raise ValueError(
+            f"Expected rank-2 qdata/scales, got qdata={tuple(qdata.shape)} scales={tuple(scales.shape)}"
+        )
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+    if qdata.shape[0] != scales.shape[0]:
+        raise ValueError(
+            f"qdata/scales row mismatch: qdata={tuple(qdata.shape)} scales={tuple(scales.shape)}"
+        )
+    if qdata.shape[1] % block_size != 0:
+        raise ValueError(
+            f"qdata last dim must be divisible by {block_size}, got {tuple(qdata.shape)}"
+        )
+    if scales.shape[1] != qdata.shape[1] // block_size:
+        raise ValueError(
+            f"scales second dim must be K//{block_size}, got qdata={tuple(qdata.shape)} scales={tuple(scales.shape)}"
+        )
+
+    m, k = qdata.shape
+
+    if out is not None:
+        if tuple(out.shape) != (m, k):
+            raise ValueError(f"out shape mismatch: expected {(m, k)}, got {tuple(out.shape)}")
+        if out.dtype != out_dtype:
+            raise ValueError(f"out dtype mismatch: expected {out_dtype}, got {out.dtype}")
+        if out.device != qdata.device:
+            raise ValueError(f"out device mismatch: expected {qdata.device}, got {out.device}")
+        out_tensor = out
+    else:
+        if _mxfp8_backend_wants_te("DQ"):
+            te_out = _dequantize_from_mxfp8_te(
+                qdata,
+                scales,
+                block_size=block_size,
+                out_dtype=out_dtype,
+                out=out,
+            )
+            if te_out is not None:
+                return te_out
+        out_tensor = torch.empty((m, k), device=qdata.device, dtype=out_dtype)
+
+    use_triton = qdata.is_cuda and scales.is_cuda and triton is not None
+    if qdata.is_cuda and scales.is_cuda and triton is None:
+        raise RuntimeError("Triton is required for CUDA MXFP8 dequantization")
+    if use_triton:
+        q_contig = qdata if qdata.is_contiguous() else qdata.contiguous()
+        scales_contig = scales if scales.is_contiguous() else scales.contiguous()
+        scales_u8 = scales_contig.view(torch.uint8)
+        out_contig = out_tensor if out_tensor.is_contiguous() else out_tensor.contiguous()
+
+        def grid(meta):
+            return (
+                triton.cdiv(m, meta["BLOCK_M"]),
+                triton.cdiv(k, meta["BLOCK_N"]),
+            )
+
+        _triton_mxfp8_dequantize_dim0[grid](
+            q_contig,
+            q_contig.stride(0),
+            q_contig.stride(1),
+            scales_u8,
+            scales_u8.stride(0),
+            scales_u8.stride(1),
+            out_contig,
+            out_contig.stride(0),
+            out_contig.stride(1),
+            m,
+            k,
+            BLOCK_SIZE=block_size,
+        )
+        if out_contig is not out_tensor:
+            out_tensor.copy_(out_contig)
+        return out_tensor
+
+    q_blocks = qdata.reshape(m, k // block_size, block_size)
+    x = q_blocks.to(torch.float32) * scales.to(torch.float32).unsqueeze(-1)
+    x = x.reshape(m, k).to(out_dtype)
+    out_tensor.copy_(x)
+    return out_tensor
+
+
+def _reduce_gathered_rows_from_mxfp8_triton(
+    gathered_q: torch.Tensor,
+    gathered_scales: torch.Tensor,
+    *,
+    probs: Optional[torch.Tensor],
+    valid_mask: Optional[torch.Tensor],
+    block_size: int = 32,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if triton is None or tl is None:
+        raise RuntimeError("Triton is not available")
+    if not gathered_q.is_cuda or not gathered_scales.is_cuda:
+        raise RuntimeError("Triton reduce requires CUDA tensors")
+    if gathered_q.ndim != 3 or gathered_scales.ndim != 3:
+        raise ValueError(
+            "Expected gathered tensors rank-3 [N,K,D] and [N,K,D//32], "
+            f"got {tuple(gathered_q.shape)} and {tuple(gathered_scales.shape)}"
+        )
+
+    n, top_k, d_model = gathered_q.shape
+    if gathered_scales.shape != (n, top_k, d_model // block_size):
+        raise ValueError(
+            "gathered_scales shape mismatch for gathered_q: "
+            f"q={tuple(gathered_q.shape)} scales={tuple(gathered_scales.shape)}"
+        )
+
+    q_contig = gathered_q if gathered_q.is_contiguous() else gathered_q.contiguous()
+    scales_contig = (
+        gathered_scales if gathered_scales.is_contiguous() else gathered_scales.contiguous()
+    )
+    scales_u8 = scales_contig.view(torch.uint8)
+    probs_tensor = probs
+    if probs_tensor is None:
+        probs_tensor = torch.empty((1, 1), device=q_contig.device, dtype=torch.float32)
+    elif not probs_tensor.is_contiguous():
+        probs_tensor = probs_tensor.contiguous()
+    valid_mask_tensor = valid_mask
+    if valid_mask_tensor is None:
+        valid_mask_tensor = torch.empty((1, 1), device=q_contig.device, dtype=torch.bool)
+    elif not valid_mask_tensor.is_contiguous():
+        valid_mask_tensor = valid_mask_tensor.contiguous()
+
+    if out is None:
+        out_tensor = torch.empty((n, d_model), device=q_contig.device, dtype=torch.float32)
+    else:
+        if tuple(out.shape) != (n, d_model):
+            raise ValueError(f"out shape mismatch: expected {(n, d_model)}, got {tuple(out.shape)}")
+        if out.device != q_contig.device:
+            raise ValueError(f"out device mismatch: expected {q_contig.device}, got {out.device}")
+        if not out.dtype.is_floating_point:
+            raise ValueError(f"out must have floating dtype, got {out.dtype}")
+        out_tensor = out
+
+    block_m = _MXFP8_REDUCE_BLOCK_M
+    block_n = _MXFP8_REDUCE_BLOCK_N
+    grid = (
+        triton.cdiv(n, block_m),
+        triton.cdiv(d_model, block_n),
+    )
+    _triton_mxfp8_reduce_gathered_dim1[grid](
+        q_contig,
+        q_contig.stride(0),
+        q_contig.stride(1),
+        q_contig.stride(2),
+        scales_u8,
+        scales_u8.stride(0),
+        scales_u8.stride(1),
+        scales_u8.stride(2),
+        probs_tensor,
+        probs_tensor.stride(0),
+        probs_tensor.stride(1),
+        valid_mask_tensor,
+        valid_mask_tensor.stride(0),
+        valid_mask_tensor.stride(1),
+        out_tensor,
+        out_tensor.stride(0),
+        out_tensor.stride(1),
+        n,
+        top_k,
+        d_model,
+        BLOCK_SIZE=block_size,
+        HAS_PROBS=probs is not None,
+        HAS_VALID_MASK=valid_mask is not None,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=_MXFP8_REDUCE_NUM_WARPS,
+        num_stages=_MXFP8_REDUCE_NUM_STAGES,
+    )
+    return out_tensor
+
+
+@nvtx.annotate("reduce_gathered_rows_from_mxfp8")
+def reduce_gathered_rows_from_mxfp8(
+    gathered_q: torch.Tensor,
+    gathered_scales: torch.Tensor,
+    out: torch.Tensor,
+    *,
+    probs: Optional[torch.Tensor] = None,
+    valid_mask: Optional[torch.Tensor] = None,
+    block_size: int = 32,
+    gathered_out: Optional[torch.Tensor] = None,
+) -> None:
+    """
+    Reduce gathered MXFP8 routes [N, K, D] into out [N, D].
+
+    If `gathered_out` is provided, it receives dequantized [N, K, D] in `out` dtype.
+    """
+    if gathered_q.ndim != 3 or gathered_scales.ndim != 3:
+        raise ValueError(
+            "Expected gathered_q/gathered_scales rank-3 [N,K,D]/[N,K,D//32], "
+            f"got {tuple(gathered_q.shape)} and {tuple(gathered_scales.shape)}"
+        )
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+
+    n, top_k, d_model = gathered_q.shape
+    if out.shape != (n, d_model):
+        raise ValueError(f"out shape mismatch: expected {(n, d_model)}, got {tuple(out.shape)}")
+    if gathered_scales.shape != (n, top_k, d_model // block_size):
+        raise ValueError(
+            "gathered_scales shape mismatch for gathered_q: "
+            f"q={tuple(gathered_q.shape)} scales={tuple(gathered_scales.shape)}"
+        )
+    if probs is not None and probs.shape != (n, top_k):
+        raise ValueError(f"probs shape mismatch: expected {(n, top_k)}, got {tuple(probs.shape)}")
+    if valid_mask is not None and valid_mask.shape != (n, top_k):
+        raise ValueError(
+            f"valid_mask shape mismatch: expected {(n, top_k)}, got {tuple(valid_mask.shape)}"
+        )
+    if gathered_out is not None and gathered_out.shape != gathered_q.shape:
+        raise ValueError(
+            f"gathered_out shape mismatch: expected {tuple(gathered_q.shape)}, got {tuple(gathered_out.shape)}"
+        )
+
+    use_triton_reduce = (
+        gathered_out is None
+        and gathered_q.is_cuda
+        and gathered_scales.is_cuda
+        and out.is_cuda
+        and triton is not None
+    )
+    if gathered_out is None and gathered_q.is_cuda and gathered_scales.is_cuda and triton is None:
+        raise RuntimeError("Triton is required for CUDA MXFP8 gather-reduce")
+
+    if use_triton_reduce:
+        _reduce_gathered_rows_from_mxfp8_triton(
+            gathered_q,
+            gathered_scales,
+            probs=probs,
+            valid_mask=valid_mask,
+            block_size=block_size,
+            out=out,
+        )
+        return
+    else:
+        assert False, "Deprecated"
+
+    gathered_hp = dequantize_from_mxfp8(
+        gathered_q.reshape(n * top_k, d_model),
+        gathered_scales.reshape(n * top_k, d_model // block_size),
+        block_size=block_size,
+        out_dtype=torch.float32,
+    ).view(n, top_k, d_model)
+
+    if gathered_out is not None:
+        gathered_out.copy_(gathered_hp.to(gathered_out.dtype))
+
+    if valid_mask is not None:
+        gathered_hp = gathered_hp * valid_mask.to(torch.float32).unsqueeze(-1)
+
+    if probs is not None:
+        gathered_hp = gathered_hp * probs.to(torch.float32).unsqueeze(-1)
+
+    out.copy_(gathered_hp.sum(dim=1).to(out.dtype))
+
+
+def dot_gathered_rows_mxfp8_with_grad(
+    gathered_q: torch.Tensor,
+    gathered_scales: torch.Tensor,
+    grad_out: torch.Tensor,
+    *,
+    valid_mask: torch.Tensor,
+    block_size: int = 32,
+    out_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """
+    Compute per-route dot products for grad(probs):
+      out[n, k] = dot(dequant(gathered_q[n, k, :]), grad_out[n, :])
+    Invalid routes are masked out via `valid_mask`.
+    """
+    if gathered_q.ndim != 3 or gathered_scales.ndim != 3:
+        raise ValueError(
+            "Expected gathered_q/gathered_scales rank-3 [N,K,D]/[N,K,D//32], "
+            f"got {tuple(gathered_q.shape)} and {tuple(gathered_scales.shape)}"
+        )
+    if grad_out.ndim != 2:
+        raise ValueError(f"Expected grad_out rank-2 [N,D], got {tuple(grad_out.shape)}")
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+
+    n, top_k, d_model = gathered_q.shape
+    if gathered_scales.shape != (n, top_k, d_model // block_size):
+        raise ValueError(
+            "gathered_scales shape mismatch for gathered_q: "
+            f"q={tuple(gathered_q.shape)} scales={tuple(gathered_scales.shape)}"
+        )
+    if grad_out.shape != (n, d_model):
+        raise ValueError(
+            f"grad_out shape mismatch: expected {(n, d_model)}, got {tuple(grad_out.shape)}"
+        )
+    if valid_mask.shape != (n, top_k):
+        raise ValueError(
+            f"valid_mask shape mismatch: expected {(n, top_k)}, got {tuple(valid_mask.shape)}"
+        )
+
+    use_triton = (
+        gathered_q.is_cuda
+        and gathered_scales.is_cuda
+        and grad_out.is_cuda
+        and valid_mask.is_cuda
+        and triton is not None
+    )
+    if (
+        gathered_q.is_cuda
+        and gathered_scales.is_cuda
+        and grad_out.is_cuda
+        and valid_mask.is_cuda
+        and triton is None
+    ):
+        raise RuntimeError("Triton is required for CUDA MXFP8 gathered-dot")
+    if use_triton:
+        q_contig = gathered_q if gathered_q.is_contiguous() else gathered_q.contiguous()
+        scales_contig = (
+            gathered_scales if gathered_scales.is_contiguous() else gathered_scales.contiguous()
+        )
+        grad_contig = grad_out if grad_out.is_contiguous() else grad_out.contiguous()
+        valid_contig = valid_mask if valid_mask.is_contiguous() else valid_mask.contiguous()
+        scales_u8 = scales_contig.view(torch.uint8)
+        out = torch.empty((n, top_k), device=q_contig.device, dtype=torch.float32)
+        block_m = _MXFP8_DOT_BLOCK_M
+        block_n = _MXFP8_DOT_BLOCK_N
+        grid = (triton.cdiv(n, block_m), top_k)
+        _triton_mxfp8_dot_gathered_with_grad[grid](
+            q_contig,
+            q_contig.stride(0),
+            q_contig.stride(1),
+            q_contig.stride(2),
+            scales_u8,
+            scales_u8.stride(0),
+            scales_u8.stride(1),
+            scales_u8.stride(2),
+            grad_contig,
+            grad_contig.stride(0),
+            grad_contig.stride(1),
+            valid_contig,
+            valid_contig.stride(0),
+            valid_contig.stride(1),
+            out,
+            out.stride(0),
+            out.stride(1),
+            n,
+            top_k,
+            d_model,
+            BLOCK_SIZE=block_size,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            num_warps=_MXFP8_DOT_NUM_WARPS,
+            num_stages=_MXFP8_DOT_NUM_STAGES,
+        )
+        if out_dtype != torch.float32:
+            out = out.to(dtype=out_dtype)
+        return out
+
+    gathered_hp = dequantize_from_mxfp8(
+        gathered_q.reshape(n * top_k, d_model),
+        gathered_scales.reshape(n * top_k, d_model // block_size),
+        block_size=block_size,
+        out_dtype=torch.float32,
+    ).view(n, top_k, d_model)
+    gathered_hp = gathered_hp * valid_mask.to(torch.float32).unsqueeze(-1)
+    dot = (gathered_hp * grad_out.to(torch.float32).unsqueeze(1)).sum(dim=-1)
+    if out_dtype != torch.float32:
+        dot = dot.to(dtype=out_dtype)
+    return dot
+
+
+def quantize_grouped_2d_to_mxfp8_blocked(
+    x: torch.Tensor,
+    offs: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize grouped 2D input for scaled_grouped_mm (2D-3D).
+
+    Returns:
+      qdata: [M, K] float8_e4m3fn
+      scales_blocked: [>=M, K//block_size] float8_e8m0fnu in grouped blocked layout packing.
+    """
+    if x.ndim != 2:
+        raise ValueError(f"Expected x to be rank-2, got {tuple(x.shape)}")
+    if offs.ndim != 1:
+        raise ValueError(f"Expected offs to be rank-1, got {tuple(offs.shape)}")
+    if x.shape[1] % block_size != 0:
+        raise ValueError(f"x last dim must be divisible by {block_size}, got {tuple(x.shape)}")
+
+    k_blocks = x.shape[1] // block_size
+    if k_blocks % 4 != 0:
+        raise ValueError(
+            f"MXFP8 blocked scales require K//{block_size} divisible by 4, got {k_blocks}"
+        )
+
+    if x.is_cuda and offs.device.type != "cuda":
+        raise RuntimeError(
+            "quantize_grouped_2d_to_mxfp8_blocked requires CUDA offs when x is CUDA "
+            "(CPU offs would reintroduce host-sync behavior)."
+        )
+
+    if offs.dtype != torch.int32:
+        offs = offs.to(dtype=torch.int32)
+    if offs.device != x.device:
+        offs = offs.to(device=x.device)
+
+    # Keep capacity/static shape for mat_a and avoid active-row compaction.
+    qdata, scales = quantize_to_mxfp8(x, block_size=block_size)
+
+    if x.is_cuda:
+        scales_blocked = _to_blocked_m_groups_triton(scales, offs)
+    else:
+        scales_blocked = _to_blocked_m_groups_fallback(scales, offs)
+
+    return qdata, scales_blocked
+
+
+def _grouped_blocked_scale_shape(
+    rows: int,
+    cols: int,
+    num_groups: int,
+    *,
+    block_size: int,
+) -> tuple[int, int]:
+    scale_cols = cols // block_size
+    padded_scale_cols = ceil_div(scale_cols, 4) * 4
+    # Keep the same upper-bound shape as _to_blocked_m_groups_triton. The
+    # exact per-group padded row count depends on device-side offs; this avoids
+    # host inspection and leaves unused capacity rows zero.
+    return rows + num_groups * 128, padded_scale_cols
+
+
+def _quantize_grouped_2d_to_mxfp8_blocked_fused_triton(
+    x: torch.Tensor,
+    offs: torch.Tensor,
+    *,
+    block_size: int = 32,
+    out: Optional[torch.Tensor] = None,
+    blocked_scales_out: Optional[torch.Tensor] = None,
+    zero_unwritten_tail: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if triton is None or tl is None:
+        raise RuntimeError("Triton is required for fused grouped MXFP8 quantize+swizzle")
+    if not x.is_cuda:
+        raise RuntimeError("fused grouped MXFP8 quantize+swizzle requires CUDA")
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(f"Unsupported dtype for fused grouped MXFP8 quantization: {x.dtype}")
+
+    rows, cols = x.shape
+    num_groups = int(offs.shape[0])
+    blocked_shape = _grouped_blocked_scale_shape(
+        rows,
+        cols,
+        num_groups,
+        block_size=block_size,
+    )
+
+    qdata = out if out is not None else torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    if tuple(qdata.shape) != tuple(x.shape):
+        raise ValueError(f"out shape mismatch: expected {tuple(x.shape)}, got {tuple(qdata.shape)}")
+    if qdata.dtype != torch.float8_e4m3fn:
+        raise ValueError(f"out dtype mismatch: expected {torch.float8_e4m3fn}, got {qdata.dtype}")
+    if qdata.device != x.device:
+        raise ValueError(f"out device mismatch: expected {x.device}, got {qdata.device}")
+    if not qdata.is_contiguous():
+        raise ValueError("out must be contiguous")
+
+    if blocked_scales_out is None and zero_unwritten_tail:
+        blocked_scales = torch.zeros(blocked_shape, device=x.device, dtype=torch.float8_e8m0fnu)
+    elif blocked_scales_out is None:
+        blocked_scales = torch.empty(blocked_shape, device=x.device, dtype=torch.float8_e8m0fnu)
+    else:
+        blocked_scales = blocked_scales_out
+        if tuple(blocked_scales.shape) != blocked_shape:
+            raise ValueError(
+                f"blocked_scales_out shape mismatch: expected {blocked_shape}, got {tuple(blocked_scales.shape)}"
+            )
+        if blocked_scales.dtype != torch.float8_e8m0fnu:
+            raise ValueError(
+                f"blocked_scales_out dtype mismatch: expected {torch.float8_e8m0fnu}, got {blocked_scales.dtype}"
+            )
+        if blocked_scales.device != x.device:
+            raise ValueError(
+                f"blocked_scales_out device mismatch: expected {x.device}, got {blocked_scales.device}"
+            )
+        if not blocked_scales.is_contiguous():
+            raise ValueError("blocked_scales_out must be contiguous")
+        if zero_unwritten_tail:
+            blocked_scales.zero_()
+
+    if offs.dtype != torch.int32:
+        offs = offs.to(dtype=torch.int32)
+    if offs.device != x.device:
+        offs = offs.to(device=x.device)
+
+    grid = (
+        triton.cdiv(rows, _MXFP8_Q_BLOCK_M),
+        triton.cdiv(cols, _MXFP8_Q_BLOCK_N),
+    )
+    _triton_mxfp8_quantize_grouped_blocked_tiled_dim0[grid](
+        x,
+        x.stride(0),
+        x.stride(1),
+        qdata,
+        qdata.stride(0),
+        qdata.stride(1),
+        blocked_scales.view(torch.uint8),
+        blocked_scales.stride(0),
+        offs,
+        rows,
+        cols,
+        BLOCK_SIZE=block_size,
+        BLOCK_M=_MXFP8_Q_BLOCK_M,
+        BLOCK_N=_MXFP8_Q_BLOCK_N,
+        NUM_GROUPS=num_groups,
+        USE_BF16_EXP=x.dtype == torch.bfloat16,
+        num_warps=_MXFP8_Q_NUM_WARPS,
+        num_stages=_MXFP8_Q_NUM_STAGES,
+    )
+    return qdata, blocked_scales
+
+
+def quantize_grouped_2d_to_mxfp8_blocked_fused(
+    x: torch.Tensor,
+    offs: torch.Tensor,
+    *,
+    block_size: int = 32,
+    out: Optional[torch.Tensor] = None,
+    blocked_scales_out: Optional[torch.Tensor] = None,
+    zero_unwritten_tail: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize grouped 2D input and write scales directly in grouped blocked layout.
+
+    This is equivalent to quantize_rows_to_mxfp8(x) followed by
+    grouped_scales_to_mxfp8_blocked(scales, offs), but fuses the scale swizzle
+    into the quantization kernel for CUDA inputs.
+    """
+    if x.ndim != 2:
+        raise ValueError(f"Expected x to be rank-2, got {tuple(x.shape)}")
+    if offs.ndim != 1:
+        raise ValueError(f"Expected offs to be rank-1, got {tuple(offs.shape)}")
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+    if x.shape[1] % block_size != 0:
+        raise ValueError(f"x last dim must be divisible by {block_size}, got {tuple(x.shape)}")
+    k_blocks = x.shape[1] // block_size
+    if k_blocks % 4 != 0:
+        raise ValueError(
+            f"MXFP8 blocked scales require K//{block_size} divisible by 4, got {k_blocks}"
+        )
+
+    if x.is_cuda:
+        return _quantize_grouped_2d_to_mxfp8_blocked_fused_triton(
+            x,
+            offs,
+            block_size=block_size,
+            out=out,
+            blocked_scales_out=blocked_scales_out,
+            zero_unwritten_tail=zero_unwritten_tail,
+        )
+
+    qdata, scales_blocked = quantize_grouped_2d_to_mxfp8_blocked(
+        x,
+        offs,
+        block_size=block_size,
+    )
+    if out is not None:
+        out.copy_(qdata)
+        qdata = out
+    if blocked_scales_out is not None:
+        blocked_scales_out.copy_(scales_blocked)
+        scales_blocked = blocked_scales_out
+    return qdata, scales_blocked
+
+
+def grouped_scales_to_mxfp8_blocked(
+    scales: torch.Tensor,
+    offs: torch.Tensor,
+    *,
+    zero_unwritten_tail: bool = True,
+) -> torch.Tensor:
+    """
+    Convert grouped row-wise MXFP8 scales [M, K//32] into grouped blocked layout.
+    """
+    if scales.ndim != 2:
+        raise ValueError(f"Expected scales rank-2 [M, K//32], got {tuple(scales.shape)}")
+    if offs.ndim != 1:
+        raise ValueError(f"Expected offs rank-1, got {tuple(offs.shape)}")
+    if offs.dtype != torch.int32:
+        offs = offs.to(dtype=torch.int32)
+    if offs.device != scales.device:
+        offs = offs.to(device=scales.device)
+
+    if scales.is_cuda:
+        return _to_blocked_m_groups_triton(
+            scales,
+            offs,
+            zero_unwritten_tail=zero_unwritten_tail,
+        )
+    return _to_blocked_m_groups_fallback(scales, offs)
+
+
+def quantize_grouped_weight_3d_to_mxfp8_blocked(
+    mat_b: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize grouped 3D RHS operand [G, K, N] for scaled_grouped_mm.
+
+    Returns:
+      qdata: [G, K, N] float8_e4m3fn
+      scales_blocked: [G, blocked_scale_K * blocked_scale_N] float8_e8m0fnu
+    """
+    if mat_b.ndim != 3:
+        raise ValueError(f"Expected mat_b rank-3 [G, K, N], got {tuple(mat_b.shape)}")
+
+    g, k, n = mat_b.shape
+    if k % block_size != 0:
+        raise ValueError(
+            f"mat_b K dim must be divisible by {block_size}, got shape={tuple(mat_b.shape)}"
+        )
+
+    # Quantize non-transposed expert weights [N, K], then expose [K, N] as
+    # transposed views so trailing dims are already column-major (stride [1, K]).
+    mat_b_nk = mat_b.transpose(-2, -1)  # [G, N, K]
+    if mat_b_nk.is_contiguous():
+        q_nk, s_nk = quantize_to_mxfp8(mat_b_nk.reshape(g * n, k), block_size=block_size)
+        q_nk = q_nk.reshape(g, n, k)
+        s_nk = s_nk.reshape(g, n, k // block_size)
+    else:
+        q_parts = []
+        s_parts = []
+        for i in range(g):
+            q_i, s_i = quantize_to_mxfp8(mat_b_nk[i], block_size=block_size)
+            q_parts.append(q_i)
+            s_parts.append(s_i)
+        q_nk = torch.stack(q_parts, dim=0)
+        s_nk = torch.stack(s_parts, dim=0)
+
+    qdata = q_nk.transpose(-2, -1)  # [G, K, N], column-major trailing dims
+    scales_blocked = _to_blocked_per_group(s_nk)  # [G, ...]
+    return qdata, scales_blocked
+
+
+def quantize_grouped_weight_3d_to_mxfp8_unblocked(
+    mat_b: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize grouped 3D RHS operand [G, K, N] to:
+      qdata: [G, K, N] float8_e4m3fn (column-major trailing dims)
+      scales_nk: [G, N, K//block_size] float8_e8m0fnu (unblocked, non-swizzled)
+    """
+    if mat_b.ndim != 3:
+        raise ValueError(f"Expected mat_b rank-3 [G, K, N], got {tuple(mat_b.shape)}")
+
+    g, k, n = mat_b.shape
+    if k % block_size != 0:
+        raise ValueError(
+            f"mat_b K dim must be divisible by {block_size}, got shape={tuple(mat_b.shape)}"
+        )
+
+    # Quantize non-transposed expert weights [N, K], then expose [K, N] as
+    # transposed views so trailing dims are column-major (stride [1, K]).
+    mat_b_nk = mat_b.transpose(-2, -1)  # [G, N, K]
+    if mat_b_nk.is_contiguous():
+        q_nk, s_nk = quantize_to_mxfp8(mat_b_nk.reshape(g * n, k), block_size=block_size)
+        q_nk = q_nk.reshape(g, n, k)
+        s_nk = s_nk.reshape(g, n, k // block_size)
+    else:
+        q_parts = []
+        s_parts = []
+        for i in range(g):
+            q_i, s_i = quantize_to_mxfp8(mat_b_nk[i], block_size=block_size)
+            q_parts.append(q_i)
+            s_parts.append(s_i)
+        q_nk = torch.stack(q_parts, dim=0)
+        s_nk = torch.stack(s_parts, dim=0)
+
+    qdata = q_nk.transpose(-2, -1)  # [G, K, N]
+    return qdata, s_nk.contiguous()
+
+
+def quantize_rows_to_mxfp8(
+    x: torch.Tensor,
+    *,
+    block_size: int = 32,
+    out: Optional[torch.Tensor] = None,
+    scales_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Convenience alias used by rowwise comm paths."""
+    return quantize_to_mxfp8(
+        x,
+        block_size=block_size,
+        out=out,
+        scales_out=scales_out,
+    )
+
+
+@torch.compiler.disable
+def quantize_row_halves_to_mxfp8(
+    x: torch.Tensor,
+    *,
+    block_size: int = 32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize a row-major [M, 2H] tensor as two [M, H] halves.
+
+    This is equivalent to quantize_rows_to_mxfp8(x) when H is block-aligned,
+    since MXFP8 scales are independent 32-column blocks. Keep this helper out
+    of Dynamo/Inductor: tracing the non-contiguous FP8 half views can make
+    Inductor generate an fp8 masked-load fill constant that Triton cannot lower.
+    The useful work is still done by the two explicit Triton quantize kernels.
+    """
+    if x.ndim != 2:
+        raise ValueError(f"Expected rank-2 tensor, got shape={tuple(x.shape)}")
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+    if x.shape[1] % 2 != 0:
+        raise ValueError(f"Expected even last dim for split quantization, got {tuple(x.shape)}")
+
+    hidden = x.shape[1] // 2
+    if hidden % block_size != 0:
+        raise ValueError(f"Split dim must be divisible by {block_size}, got hidden={hidden}")
+    if not x.is_cuda or triton is None or _mxfp8_backend_wants_te("Q"):
+        return quantize_rows_to_mxfp8(x, block_size=block_size)
+
+    rows = x.shape[0]
+    qdata = torch.empty((rows, 2 * hidden), device=x.device, dtype=torch.float8_e4m3fn)
+    scales = torch.empty(
+        (rows, (2 * hidden) // block_size),
+        device=x.device,
+        dtype=torch.float8_e8m0fnu,
+    )
+    scale_hidden = hidden // block_size
+    _quantize_to_mxfp8_triton(
+        x[:, :hidden],
+        block_size=block_size,
+        out=qdata[:, :hidden],
+        scales_out=scales[:, :scale_hidden],
+    )
+    _quantize_to_mxfp8_triton(
+        x[:, hidden:],
+        block_size=block_size,
+        out=qdata[:, hidden:],
+        scales_out=scales[:, scale_hidden:],
+    )
+    return qdata, scales
+
+
+def dequantize_rows_from_mxfp8(
+    qdata: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    block_size: int = 32,
+    out_dtype: torch.dtype = torch.bfloat16,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Convenience alias used by rowwise comm paths."""
+    return dequantize_from_mxfp8(
+        qdata,
+        scales,
+        block_size=block_size,
+        out_dtype=out_dtype,
+        out=out,
+    )

--- a/src/olmo_core/kernels/scaled_grouped_mm.py
+++ b/src/olmo_core/kernels/scaled_grouped_mm.py
@@ -1,0 +1,725 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+try:
+    import nvtx
+except ImportError:
+    from olmo_core._nvtx import nvtx
+
+from .mxfp8_tensor import OlmoMXFP8Tensor
+from .mxfp8_utils import (
+    dequantize_rows_from_mxfp8,
+    grouped_scales_to_mxfp8_blocked,
+    quantize_grouped_weight_3d_to_mxfp8_blocked,
+    quantize_rows_to_mxfp8,
+)
+
+try:
+    _MXFP8_RECIPE_BLOCKWISE_1X32 = [int(F.ScalingType.BlockWise1x32)]
+    _MXFP8_SWIZZLE = (
+        [int(F.SwizzleType.NO_SWIZZLE)]
+        if torch.version.hip
+        else [int(F.SwizzleType.SWIZZLE_32_4_4)]
+    )
+except AttributeError:
+    # Fallback values for torch builds where enum symbols are not exposed.
+    _MXFP8_RECIPE_BLOCKWISE_1X32 = [3]
+    _MXFP8_SWIZZLE = [0] if torch.version.hip else [1]
+
+
+@dataclass(frozen=True)
+class ScaledGroupedMMPrequantizedLHS:
+    mat_a_q: Tensor
+    scale_a: Tensor
+    mat_a_shape: Tuple[int, ...]  # logically (M, K)
+    scales_are_blocked: bool = False
+
+
+@dataclass(frozen=True)
+class ScaledGroupedMMPrequantizedRHS:
+    mat_b_q: Tensor
+    scale_b: Tensor
+    mat_b_shape: Tuple[int, ...]  # logically (E, N, K)
+    mat_b_version: int = -1
+
+
+def _tensor_version(x: Tensor) -> int:
+    try:
+        return int(x._version)
+    except Exception:
+        return -1
+
+
+def _prequantized_lhs_tensors_for_backward(
+    prequantized_lhs: ScaledGroupedMMPrequantizedLHS,
+) -> tuple[Tensor, Tensor]:
+    return prequantized_lhs.mat_a_q, prequantized_lhs.scale_a
+
+
+def _to_col_major_last2(x: Tensor) -> Tensor:
+    # Keep shape while forcing column-major storage for the trailing 2 dims.
+    # _scaled_grouped_mm_v2 requires mat_b to be transposed (K,N with strides [1, K]).
+    if x.stride(-2) == 1 and x.stride(-1) == x.shape[-2]:
+        return x
+    return x.transpose(-2, -1).contiguous().transpose(-2, -1)
+
+
+@torch.no_grad()
+def prequantize_scaled_grouped_mm_rhs(
+    mat_b: Tensor,
+    *,
+    check_mat_b_version: bool = True,
+) -> ScaledGroupedMMPrequantizedRHS:
+    with nvtx.annotate("prequantize_scaled_grouped_mm_rhs", color="red"):
+        if mat_b.ndim != 3:
+            raise ValueError(
+                "prequantize_scaled_grouped_mm_rhs expects mat_b rank-3 [G,K,N], "
+                f"got {tuple(mat_b.shape)}"
+            )
+        mat_b_q, scale_b = quantize_grouped_weight_3d_to_mxfp8_blocked(mat_b)
+        mat_b_q = _to_col_major_last2(mat_b_q)
+        return ScaledGroupedMMPrequantizedRHS(
+            mat_b_q=mat_b_q,
+            scale_b=scale_b,
+            mat_b_shape=tuple(mat_b.shape),
+            mat_b_version=_tensor_version(mat_b) if check_mat_b_version else -1,
+        )
+
+
+@torch.compiler.disable
+def _scaled_grouped_mm_v2_cuda(
+    mat_a_q: Tensor,
+    mat_b_q: Tensor,
+    scale_a_blocked: Tensor,
+    scale_b_blocked: Tensor,
+    *,
+    offs: Tensor,
+    use_fast_accum: bool,
+) -> Tensor:
+    return torch.ops.aten._scaled_grouped_mm_v2.default(
+        mat_a_q,
+        mat_b_q,
+        [scale_a_blocked],
+        _MXFP8_RECIPE_BLOCKWISE_1X32,
+        _MXFP8_SWIZZLE,
+        [scale_b_blocked],
+        _MXFP8_RECIPE_BLOCKWISE_1X32,
+        _MXFP8_SWIZZLE,
+        offs,
+        None,
+        torch.bfloat16,
+        [],
+        use_fast_accum,
+    )
+
+
+def _forward_scaled_grouped_mm_mxfp8(
+    mat_a: Tensor,
+    mat_b: Tensor,
+    offs: Tensor,
+    *,
+    use_fast_accum: bool,
+    prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS] = None,
+    prequantized_rhs: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+) -> Tensor:
+    if mat_a.ndim != 2 or mat_b.ndim != 3:
+        raise ValueError(
+            "scaled_grouped_mm_q currently supports 2D-3D grouped mm only, "
+            f"got mat_a={tuple(mat_a.shape)} mat_b={tuple(mat_b.shape)}"
+        )
+
+    if offs.dtype != torch.int32:
+        offs = offs.to(dtype=torch.int32)
+
+    if not mat_a.is_cuda or not mat_b.is_cuda:
+        raise RuntimeError("scaled_grouped_mm_q requires CUDA tensors")
+
+    scale_a_blocked: Optional[Tensor] = None
+    scale_b_blocked: Optional[Tensor] = None
+
+    if prequantized_lhs is not None:
+        if tuple(prequantized_lhs.mat_a_shape) != tuple(mat_a.shape):
+            raise ValueError(
+                "prequantized_lhs shape mismatch: "
+                f"expected {tuple(mat_a.shape)}, got {tuple(prequantized_lhs.mat_a_shape)}"
+            )
+        if prequantized_lhs.mat_a_q.device != mat_a.device:
+            raise ValueError(
+                "prequantized_lhs device mismatch: "
+                f"q_device={prequantized_lhs.mat_a_q.device} mat_a_device={mat_a.device}"
+            )
+        mat_a_q = prequantized_lhs.mat_a_q
+        if prequantized_lhs.scales_are_blocked:
+            scale_a_blocked = prequantized_lhs.scale_a
+        else:
+            scale_a_blocked = grouped_scales_to_mxfp8_blocked(
+                prequantized_lhs.scale_a,
+                offs,
+                zero_unwritten_tail=False,
+            )
+    else:
+        mat_a_q, scale_a_unblocked = quantize_rows_to_mxfp8(mat_a, block_size=32)
+        scale_a_blocked = grouped_scales_to_mxfp8_blocked(
+            scale_a_unblocked,
+            offs,
+            zero_unwritten_tail=False,
+        )
+
+    use_cached_rhs = (
+        prequantized_rhs is not None
+        and tuple(prequantized_rhs.mat_b_shape) == tuple(mat_b.shape)
+        and prequantized_rhs.mat_b_q.device == mat_b.device
+        and (
+            prequantized_rhs.mat_b_version < 0
+            or prequantized_rhs.mat_b_version == _tensor_version(mat_b)
+        )
+    )
+    if use_cached_rhs:
+        assert prequantized_rhs is not None
+        mat_b_q = prequantized_rhs.mat_b_q
+        scale_b_blocked = prequantized_rhs.scale_b
+        mat_b_q = _to_col_major_last2(mat_b_q)
+    else:
+        with nvtx.annotate("scaled_grouped_mm_q_rhs_cache_miss_quantize", color="red"):
+            mat_b_q, scale_b_blocked = quantize_grouped_weight_3d_to_mxfp8_blocked(mat_b)
+            mat_b_q = _to_col_major_last2(mat_b_q)
+
+    if scale_a_blocked is None:
+        raise RuntimeError("aten::_scaled_grouped_mm_v2 path requires blocked lhs scales")
+    if scale_b_blocked is None:
+        raise RuntimeError("aten::_scaled_grouped_mm_v2 path requires blocked rhs scales")
+
+    return _scaled_grouped_mm_v2_cuda(
+        mat_a_q,
+        mat_b_q,
+        scale_a_blocked,
+        scale_b_blocked,
+        offs=offs,
+        use_fast_accum=use_fast_accum,
+    )
+
+
+def _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
+    mat_a: Tensor,
+    prequantized_rhs: ScaledGroupedMMPrequantizedRHS,
+    offs: Tensor,
+    *,
+    use_fast_accum: bool,
+    prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS] = None,
+) -> Tensor:
+    if mat_a.ndim != 2:
+        raise ValueError(
+            "scaled_grouped_mm_q_fp8_weight currently supports rank-2 LHS only, "
+            f"got mat_a={tuple(mat_a.shape)}"
+        )
+
+    mat_b_shape = tuple(prequantized_rhs.mat_b_shape)
+    if len(mat_b_shape) != 3:
+        raise ValueError(
+            "prequantized_rhs must describe rank-3 [G,K,N] RHS, " f"got mat_b_shape={mat_b_shape}"
+        )
+
+    if offs.dtype != torch.int32:
+        offs = offs.to(dtype=torch.int32)
+
+    if not mat_a.is_cuda or not prequantized_rhs.mat_b_q.is_cuda:
+        raise RuntimeError("scaled_grouped_mm_q_fp8_weight requires CUDA tensors")
+    if prequantized_rhs.mat_b_q.device != mat_a.device:
+        raise RuntimeError(
+            "prequantized_rhs device mismatch: "
+            f"rhs_device={prequantized_rhs.mat_b_q.device} mat_a_device={mat_a.device}"
+        )
+
+    scale_a_blocked: Optional[Tensor] = None
+    if prequantized_lhs is not None:
+        if tuple(prequantized_lhs.mat_a_shape) != tuple(mat_a.shape):
+            raise ValueError(
+                "prequantized_lhs shape mismatch: "
+                f"expected {tuple(mat_a.shape)}, got {tuple(prequantized_lhs.mat_a_shape)}"
+            )
+        if prequantized_lhs.mat_a_q.device != mat_a.device:
+            raise ValueError(
+                "prequantized_lhs device mismatch: "
+                f"q_device={prequantized_lhs.mat_a_q.device} mat_a_device={mat_a.device}"
+            )
+        mat_a_q = prequantized_lhs.mat_a_q
+        if prequantized_lhs.scales_are_blocked:
+            scale_a_blocked = prequantized_lhs.scale_a
+        else:
+            scale_a_blocked = grouped_scales_to_mxfp8_blocked(
+                prequantized_lhs.scale_a,
+                offs,
+                zero_unwritten_tail=False,
+            )
+    else:
+        mat_a_q, scale_a_unblocked = quantize_rows_to_mxfp8(mat_a, block_size=32)
+        scale_a_blocked = grouped_scales_to_mxfp8_blocked(
+            scale_a_unblocked,
+            offs,
+            zero_unwritten_tail=False,
+        )
+
+    mat_b_q = _to_col_major_last2(prequantized_rhs.mat_b_q)
+    scale_b_blocked = prequantized_rhs.scale_b
+
+    if scale_a_blocked is None:
+        raise RuntimeError("aten::_scaled_grouped_mm_v2 path requires blocked lhs scales")
+
+    return _scaled_grouped_mm_v2_cuda(
+        mat_a_q,
+        mat_b_q,
+        scale_a_blocked,
+        scale_b_blocked,
+        offs=offs,
+        use_fast_accum=use_fast_accum,
+    )
+
+
+class _ScaledGroupedMMQFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        mat_a: Tensor,
+        mat_b: Tensor,
+        offs: Optional[Tensor],
+        input_grad_out: Optional[Tensor],
+        use_fast_accum: bool,
+        prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS],
+        prequantized_rhs: Optional[ScaledGroupedMMPrequantizedRHS],
+        prequantized_rhs_for_dgrad: Optional[ScaledGroupedMMPrequantizedRHS],
+    ) -> Tensor:
+        if offs is None:
+            raise ValueError("offs is required for scaled_grouped_mm_q")
+
+        if input_grad_out is not None:
+            if input_grad_out.shape != mat_a.shape:
+                raise ValueError(
+                    f"input_grad_out shape mismatch: expected {tuple(mat_a.shape)}, got {tuple(input_grad_out.shape)}"
+                )
+            if input_grad_out.dtype != mat_a.dtype:
+                raise ValueError(
+                    f"input_grad_out dtype mismatch: expected {mat_a.dtype}, got {input_grad_out.dtype}"
+                )
+        if prequantized_rhs_for_dgrad is not None:
+            mat_b_t_shape = tuple(mat_b.transpose(-2, -1).shape)
+            if tuple(prequantized_rhs_for_dgrad.mat_b_shape) != mat_b_t_shape:
+                raise ValueError(
+                    "prequantized_rhs_for_dgrad shape mismatch: "
+                    f"expected {mat_b_t_shape}, got {tuple(prequantized_rhs_for_dgrad.mat_b_shape)}"
+                )
+            if prequantized_rhs_for_dgrad.mat_b_q.device != mat_b.device:
+                raise ValueError(
+                    "prequantized_rhs_for_dgrad device mismatch: "
+                    f"expected {mat_b.device}, got {prequantized_rhs_for_dgrad.mat_b_q.device}"
+                )
+
+        if mat_a.numel() == 0:
+            result = torch.empty(
+                (mat_a.shape[0], mat_b.shape[-1]),
+                device=mat_a.device,
+                dtype=torch.bfloat16,
+            )
+            ctx.save_for_backward(mat_a, mat_b, offs)
+            ctx._saved_mat_a_from_prequantized_lhs = False
+            ctx._mat_a_empty = True
+            ctx.input_grad_out = input_grad_out
+            ctx.prequantized_rhs_for_dgrad = prequantized_rhs_for_dgrad
+            return result
+
+        result = _forward_scaled_grouped_mm_mxfp8(
+            mat_a,
+            mat_b,
+            offs,
+            use_fast_accum=use_fast_accum,
+            prequantized_lhs=prequantized_lhs,
+            prequantized_rhs=prequantized_rhs,
+        )
+
+        # In rowwise FP8 paths we can skip saving bf16 mat_a and reconstruct it
+        # from saved prequantized (q, scale) during backward to avoid dispatch DQ.
+        use_saved_prequantized_lhs = (
+            prequantized_lhs is not None and not prequantized_lhs.scales_are_blocked
+        )
+        if use_saved_prequantized_lhs:
+            assert prequantized_lhs is not None
+            mat_a_q, scale_a = _prequantized_lhs_tensors_for_backward(prequantized_lhs)
+            ctx.save_for_backward(
+                mat_b,
+                offs,
+                mat_a_q,
+                scale_a,
+            )
+            ctx._saved_mat_a_from_prequantized_lhs = True
+        else:
+            ctx.save_for_backward(mat_a, mat_b, offs)
+            ctx._saved_mat_a_from_prequantized_lhs = False
+        ctx.input_grad_out = input_grad_out
+        ctx.prequantized_rhs_for_dgrad = prequantized_rhs_for_dgrad
+        ctx._mat_a_empty = False
+        return result
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):  # type: ignore[override]
+        mat_a: Optional[Tensor] = None
+        saved_mat_a_q: Optional[Tensor] = None
+        saved_mat_a_scale: Optional[Tensor] = None
+        grad_out_compute = grad_out
+        grad_out_mxfp8 = grad_out if isinstance(grad_out, OlmoMXFP8Tensor) else None
+        if grad_out_mxfp8 is not None:
+            grad_out_prequantized_lhs = grad_out_mxfp8.as_scaled_grouped_mm_prequantized_lhs()
+        else:
+            grad_out_prequantized_lhs = None
+        if grad_out_compute.dtype == torch.float8_e4m3fn:
+            grad_out_compute = grad_out_compute.to(dtype=torch.bfloat16)
+        if bool(getattr(ctx, "_saved_mat_a_from_prequantized_lhs", False)):
+            mat_b, offs, mat_a_q, mat_a_scale = ctx.saved_tensors
+            saved_mat_a_q = mat_a_q
+            saved_mat_a_scale = mat_a_scale
+        else:
+            mat_a, mat_b, offs = ctx.saved_tensors
+
+        grad_a = None
+        grad_b = None
+
+        if bool(getattr(ctx, "_mat_a_empty", False)):
+            if ctx.needs_input_grad[0]:
+                assert mat_a is not None
+                grad_a = torch.empty_like(mat_a)
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+            if ctx.needs_input_grad[1]:
+                grad_b = torch.zeros_like(mat_b)
+            return grad_a, grad_b, None, None, None, None, None, None
+
+        if ctx.needs_input_grad[0]:
+            if grad_out_compute.is_cuda and mat_b.is_cuda:
+                grad_a = _forward_scaled_grouped_mm_mxfp8(
+                    grad_out_compute,
+                    mat_b.transpose(-2, -1),
+                    offs,
+                    use_fast_accum=True,
+                    prequantized_lhs=grad_out_prequantized_lhs,
+                    prequantized_rhs=ctx.prequantized_rhs_for_dgrad,
+                )
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+            else:
+                grad_a = F.grouped_mm(grad_out_compute, mat_b.transpose(-2, -1), offs=offs)
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+
+        if ctx.needs_input_grad[1]:
+            if grad_b is None:
+                if mat_a is None:
+                    if saved_mat_a_q is None or saved_mat_a_scale is None:
+                        raise RuntimeError(
+                            "scaled_grouped_mm_q backward expected mat_a when grad_b is required"
+                        )
+                    mat_a = dequantize_rows_from_mxfp8(
+                        saved_mat_a_q,
+                        saved_mat_a_scale,
+                        block_size=32,
+                        out_dtype=grad_out_compute.dtype,
+                    )
+                if grad_out_mxfp8 is not None:
+                    grad_out_compute = grad_out_mxfp8.dequantize(out_dtype=mat_a.dtype)
+                grad_b = F.grouped_mm(
+                    grad_out_compute.transpose(-2, -1),
+                    mat_a,
+                    offs=offs,
+                ).transpose(-2, -1)
+
+        return grad_a, grad_b, None, None, None, None, None, None
+
+
+class _ScaledGroupedMMQFP8WeightFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        mat_a: Tensor,
+        grad_anchor: Tensor,
+        offs: Optional[Tensor],
+        input_grad_out: Optional[Tensor],
+        use_fast_accum: bool,
+        prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS],
+        prequantized_rhs: ScaledGroupedMMPrequantizedRHS,
+        prequantized_rhs_for_dgrad: ScaledGroupedMMPrequantizedRHS,
+        wgrad_sink: Optional[Any],
+        wgrad_sink_transpose_last2: bool,
+        wgrad_sink_squeeze_first_dim: bool,
+    ) -> Tensor:
+        if offs is None:
+            raise ValueError("offs is required for scaled_grouped_mm_q_fp8_weight")
+        if grad_anchor.ndim != 3:
+            raise ValueError(
+                "scaled_grouped_mm_q_fp8_weight expects a rank-3 gradient anchor, "
+                f"got {tuple(grad_anchor.shape)}"
+            )
+        if tuple(prequantized_rhs.mat_b_shape) != tuple(grad_anchor.shape):
+            raise ValueError(
+                "prequantized_rhs shape mismatch: "
+                f"expected {tuple(grad_anchor.shape)}, got {tuple(prequantized_rhs.mat_b_shape)}"
+            )
+        grad_anchor_t_shape = tuple(grad_anchor.transpose(-2, -1).shape)
+        if tuple(prequantized_rhs_for_dgrad.mat_b_shape) != grad_anchor_t_shape:
+            raise ValueError(
+                "prequantized_rhs_for_dgrad shape mismatch: "
+                f"expected {grad_anchor_t_shape}, got {tuple(prequantized_rhs_for_dgrad.mat_b_shape)}"
+            )
+
+        if input_grad_out is not None:
+            if input_grad_out.shape != mat_a.shape:
+                raise ValueError(
+                    f"input_grad_out shape mismatch: expected {tuple(mat_a.shape)}, got {tuple(input_grad_out.shape)}"
+                )
+            if input_grad_out.dtype != mat_a.dtype:
+                raise ValueError(
+                    f"input_grad_out dtype mismatch: expected {mat_a.dtype}, got {input_grad_out.dtype}"
+                )
+
+        ctx.grad_anchor_shape = tuple(grad_anchor.shape)
+        ctx.grad_anchor_dtype = grad_anchor.dtype
+        ctx.grad_anchor_device = grad_anchor.device
+        ctx.input_grad_out = input_grad_out
+        ctx.prequantized_rhs_for_dgrad = prequantized_rhs_for_dgrad
+        ctx.wgrad_sink = wgrad_sink
+        ctx.wgrad_sink_transpose_last2 = bool(wgrad_sink_transpose_last2)
+        ctx.wgrad_sink_squeeze_first_dim = bool(wgrad_sink_squeeze_first_dim)
+
+        if mat_a.numel() == 0:
+            result = torch.empty(
+                (mat_a.shape[0], grad_anchor.shape[-1]),
+                device=mat_a.device,
+                dtype=torch.bfloat16,
+            )
+            ctx.save_for_backward(mat_a, offs)
+            ctx._saved_mat_a_from_prequantized_lhs = False
+            ctx._mat_a_empty = True
+            return result
+
+        result = _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
+            mat_a,
+            prequantized_rhs,
+            offs,
+            use_fast_accum=use_fast_accum,
+            prequantized_lhs=prequantized_lhs,
+        )
+
+        use_saved_prequantized_lhs = (
+            prequantized_lhs is not None and not prequantized_lhs.scales_are_blocked
+        )
+        if use_saved_prequantized_lhs:
+            assert prequantized_lhs is not None
+            mat_a_q, scale_a = _prequantized_lhs_tensors_for_backward(prequantized_lhs)
+            ctx.save_for_backward(
+                offs,
+                mat_a_q,
+                scale_a,
+            )
+            ctx._saved_mat_a_from_prequantized_lhs = True
+        else:
+            ctx.save_for_backward(mat_a, offs)
+            ctx._saved_mat_a_from_prequantized_lhs = False
+        ctx._mat_a_empty = False
+        return result
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):  # type: ignore[override]
+        mat_a: Optional[Tensor] = None
+        saved_mat_a_q: Optional[Tensor] = None
+        saved_mat_a_scale: Optional[Tensor] = None
+        grad_out_compute = grad_out
+        grad_out_mxfp8 = grad_out if isinstance(grad_out, OlmoMXFP8Tensor) else None
+        if grad_out_mxfp8 is not None:
+            grad_out_prequantized_lhs = grad_out_mxfp8.as_scaled_grouped_mm_prequantized_lhs()
+        else:
+            grad_out_prequantized_lhs = None
+        if grad_out_compute.dtype == torch.float8_e4m3fn:
+            grad_out_compute = grad_out_compute.to(dtype=torch.bfloat16)
+
+        if bool(getattr(ctx, "_saved_mat_a_from_prequantized_lhs", False)):
+            offs, mat_a_q, mat_a_scale = ctx.saved_tensors
+            saved_mat_a_q = mat_a_q
+            saved_mat_a_scale = mat_a_scale
+        else:
+            mat_a, offs = ctx.saved_tensors
+
+        grad_a = None
+        grad_anchor = None
+
+        if bool(getattr(ctx, "_mat_a_empty", False)):
+            if ctx.needs_input_grad[0]:
+                assert mat_a is not None
+                grad_a = torch.empty_like(mat_a)
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+            if ctx.needs_input_grad[1] or ctx.wgrad_sink is not None:
+                grad_anchor = torch.zeros(
+                    ctx.grad_anchor_shape,
+                    device=ctx.grad_anchor_device,
+                    dtype=ctx.grad_anchor_dtype,
+                )
+                if ctx.wgrad_sink is not None:
+                    sink_grad = (
+                        grad_anchor.transpose(-2, -1).contiguous()
+                        if ctx.wgrad_sink_transpose_last2
+                        else grad_anchor
+                    )
+                    if ctx.wgrad_sink_squeeze_first_dim:
+                        if sink_grad.shape[0] != 1:
+                            raise RuntimeError(
+                                "wgrad_sink_squeeze_first_dim expects first dim size 1, "
+                                f"got {tuple(sink_grad.shape)}"
+                            )
+                        sink_grad = sink_grad.squeeze(0).contiguous()
+                    ctx.wgrad_sink.accumulate_wgrad(sink_grad)
+            if not ctx.needs_input_grad[1]:
+                grad_anchor = None
+            return grad_a, grad_anchor, None, None, None, None, None, None, None, None, None
+
+        if ctx.needs_input_grad[0]:
+            if grad_out_compute.is_cuda and ctx.prequantized_rhs_for_dgrad.mat_b_q.is_cuda:
+                grad_a = _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
+                    grad_out_compute,
+                    ctx.prequantized_rhs_for_dgrad,
+                    offs,
+                    use_fast_accum=True,
+                    prequantized_lhs=grad_out_prequantized_lhs,
+                )
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+            else:
+                raise RuntimeError("scaled_grouped_mm_q_fp8_weight dgrad requires CUDA cached RHS")
+
+        need_wgrad = ctx.needs_input_grad[1] or ctx.wgrad_sink is not None
+        if need_wgrad:
+            if mat_a is None:
+                if saved_mat_a_q is None or saved_mat_a_scale is None:
+                    raise RuntimeError(
+                        "scaled_grouped_mm_q_fp8_weight backward expected mat_a when wgrad is required"
+                    )
+                mat_a = dequantize_rows_from_mxfp8(
+                    saved_mat_a_q,
+                    saved_mat_a_scale,
+                    block_size=32,
+                    out_dtype=grad_out_compute.dtype,
+                )
+            if grad_out_mxfp8 is not None:
+                grad_out_compute = grad_out_mxfp8.dequantize(out_dtype=mat_a.dtype)
+            grad_anchor = F.grouped_mm(
+                grad_out_compute.transpose(-2, -1),
+                mat_a,
+                offs=offs,
+            ).transpose(-2, -1)
+            if ctx.wgrad_sink is not None:
+                sink_grad = (
+                    grad_anchor.transpose(-2, -1).contiguous()
+                    if ctx.wgrad_sink_transpose_last2
+                    else grad_anchor
+                )
+                if ctx.wgrad_sink_squeeze_first_dim:
+                    if sink_grad.shape[0] != 1:
+                        raise RuntimeError(
+                            "wgrad_sink_squeeze_first_dim expects first dim size 1, "
+                            f"got {tuple(sink_grad.shape)}"
+                        )
+                    sink_grad = sink_grad.squeeze(0).contiguous()
+                ctx.wgrad_sink.accumulate_wgrad(sink_grad)
+            if not ctx.needs_input_grad[1]:
+                grad_anchor = None
+
+        return grad_a, grad_anchor, None, None, None, None, None, None, None, None, None
+
+
+def scaled_grouped_mm_q(
+    mat_a: Tensor,
+    mat_b: Tensor,
+    *,
+    offs: Tensor,
+    input_grad_out: Optional[Tensor] = None,
+    use_fast_accum: bool = True,
+    prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS] = None,
+    prequantized_rhs: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+    prequantized_rhs_for_dgrad: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+) -> Tensor:
+    """
+    MXFP8 grouped mm wrapper used by MoE routed experts.
+
+    Forward uses aten::_scaled_grouped_mm_v2 and returns bf16 output.
+    Backward uses the same bf16 grouped MXFP8 path for dgrad on CUDA and grouped_mm for wgrad.
+
+    Supports 2D-3D grouped mm with `offs` and optional explicit buffers:
+    - input_grad_out: grad(mat_a) destination in backward
+    - prequantized_lhs: optional pre-quantized LHS q/scales to bypass LHS quantization
+    - prequantized_rhs: optional pre-quantized RHS q/scales to bypass RHS quantization
+    - prequantized_rhs_for_dgrad: optional pre-quantized transposed RHS used by backward dgrad
+    """
+    return _ScaledGroupedMMQFunction.apply(
+        mat_a,
+        mat_b,
+        offs,
+        input_grad_out,
+        use_fast_accum,
+        prequantized_lhs,
+        prequantized_rhs,
+        prequantized_rhs_for_dgrad,
+    )
+
+
+def scaled_grouped_mm_q_fp8_weight(
+    mat_a: Tensor,
+    grad_anchor: Tensor,
+    *,
+    offs: Tensor,
+    input_grad_out: Optional[Tensor] = None,
+    use_fast_accum: bool = True,
+    prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS] = None,
+    prequantized_rhs: ScaledGroupedMMPrequantizedRHS,
+    prequantized_rhs_for_dgrad: ScaledGroupedMMPrequantizedRHS,
+    wgrad_sink: Optional[Any] = None,
+    wgrad_sink_transpose_last2: bool = False,
+    wgrad_sink_squeeze_first_dim: bool = False,
+) -> Tensor:
+    """
+    MXFP8 grouped mm for a prequantized expert weight.
+
+    This transitional API uses only the cached MXFP8 RHS tensors for forward
+    and dgrad, while `grad_anchor` receives the normal high-precision wgrad.
+    If `wgrad_sink` is provided, the same wgrad is also accumulated there as a
+    side channel for the staged FP8-only-params refactor. That keeps today's
+    DDP/optimizer behavior intact while decoupling kernel execution from the
+    bf16 model weight storage.
+    """
+    return _ScaledGroupedMMQFP8WeightFunction.apply(
+        mat_a,
+        grad_anchor,
+        offs,
+        input_grad_out,
+        use_fast_accum,
+        prequantized_lhs,
+        prequantized_rhs,
+        prequantized_rhs_for_dgrad,
+        wgrad_sink,
+        bool(wgrad_sink_transpose_last2),
+        bool(wgrad_sink_squeeze_first_dim),
+    )
+
+
+__all__ = [
+    "scaled_grouped_mm_q",
+    "scaled_grouped_mm_q_fp8_weight",
+    "prequantize_scaled_grouped_mm_rhs",
+    "ScaledGroupedMMPrequantizedLHS",
+    "ScaledGroupedMMPrequantizedRHS",
+]

--- a/src/olmo_core/kernels/scaled_grouped_mm.py
+++ b/src/olmo_core/kernels/scaled_grouped_mm.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     from olmo_core._nvtx import nvtx
 
+from ..doc_utils import beta_feature
 from .mxfp8_tensor import OlmoMXFP8Tensor
 from .mxfp8_utils import (
     dequantize_rows_from_mxfp8,
@@ -642,6 +643,7 @@ class _ScaledGroupedMMQFP8WeightFunction(torch.autograd.Function):
         return grad_a, grad_anchor, None, None, None, None, None, None, None, None, None
 
 
+@beta_feature
 def scaled_grouped_mm_q(
     mat_a: Tensor,
     mat_b: Tensor,
@@ -677,6 +679,7 @@ def scaled_grouped_mm_q(
     )
 
 
+@beta_feature
 def scaled_grouped_mm_q_fp8_weight(
     mat_a: Tensor,
     grad_anchor: Tensor,

--- a/src/olmo_core/nn/fp8_weight.py
+++ b/src/olmo_core/nn/fp8_weight.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping, Optional, Sequence
+
+import torch
+
+from olmo_core.kernels import (
+    ScaledGroupedMMPrequantizedRHS,
+    prequantize_scaled_grouped_mm_rhs,
+)
+
+
+@dataclass(frozen=True)
+class FP8WeightCacheSpec:
+    """
+    Describes one cached FP8 RHS layout derived from a logical weight.
+
+    The transform is intentionally explicit. MoE routed experts, shared
+    experts, and future attention projections can each provide the layouts
+    their kernels need without the store guessing from parameter names.
+    """
+
+    name: str
+    transform: Callable[[torch.Tensor], torch.Tensor]
+
+
+class FP8WeightStore:
+    """
+    Generic logical weight store for fp32-main -> FP8-model training.
+
+    This object presents just enough tensor-like surface for the fused optimizer
+    while physically storing named FP8 RHS caches plus BF16 logical gradients.
+    A normal parameter can remain attached as a shape/device anchor until the
+    optimizer has initialized fp32 main params, after which its backing storage
+    may be released.
+    """
+
+    def __init__(
+        self,
+        *,
+        logical_name: str,
+        logical_shape: tuple[int, ...],
+        cache_specs: Sequence[FP8WeightCacheSpec] = (),
+        anchor_param: Optional[torch.nn.Parameter] = None,
+        optimizer_enabled: bool = False,
+        prequantized_rhs: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+        prequantized_rhs_for_dgrad: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+    ) -> None:
+        self.logical_name = logical_name
+        self.logical_shape = logical_shape
+        self.cache_specs = tuple(cache_specs)
+        self.anchor_param = anchor_param
+        self.optimizer_enabled = optimizer_enabled
+        self.cache_values: dict[str, ScaledGroupedMMPrequantizedRHS] = {}
+        if prequantized_rhs is not None:
+            self.cache_values["rhs"] = prequantized_rhs
+        if prequantized_rhs_for_dgrad is not None:
+            self.cache_values["rhs_for_dgrad"] = prequantized_rhs_for_dgrad
+        self.weight_versions: Optional[tuple[int, ...]] = None
+        self.grad_bf16: Optional[torch.Tensor] = None
+        self.main_grad_fp32: Optional[torch.Tensor] = None
+        self.accumulate_wgrad_in_fp32 = False
+        self.anchor_storage_released = False
+
+    @property
+    def requires_grad(self) -> bool:
+        return True
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self.logical_shape
+
+    @property
+    def ndim(self) -> int:
+        return len(self.logical_shape)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        if self.anchor_param is not None:
+            return self.anchor_param.dtype
+        if self.grad_bf16 is not None:
+            return self.grad_bf16.dtype
+        return torch.bfloat16
+
+    @property
+    def device(self) -> torch.device:
+        if self.anchor_param is not None:
+            return self.anchor_param.device
+        if self.grad_bf16 is not None:
+            return self.grad_bf16.device
+        for cache in self.cache_values.values():
+            return cache.mat_b_q.device
+        return torch.device("cpu")
+
+    @property
+    def data(self) -> torch.Tensor:
+        if self.anchor_param is None:
+            raise RuntimeError(
+                f"FP8 weight store '{self.logical_name}' has no anchor tensor to expose as data"
+            )
+        return self.anchor_param.data
+
+    @property
+    def grad(self) -> Optional[torch.Tensor]:
+        return self.grad_bf16
+
+    @property
+    def _main_grad_fp32(self) -> Optional[torch.Tensor]:
+        return self.main_grad_fp32
+
+    @_main_grad_fp32.setter
+    def _main_grad_fp32(self, value: Optional[torch.Tensor]) -> None:
+        self.main_grad_fp32 = value
+
+    @property
+    def prequantized_rhs(self) -> Optional[ScaledGroupedMMPrequantizedRHS]:
+        return self.cache_values.get("rhs")
+
+    @prequantized_rhs.setter
+    def prequantized_rhs(self, value: Optional[ScaledGroupedMMPrequantizedRHS]) -> None:
+        self._set_cache("rhs", value)
+
+    @property
+    def prequantized_rhs_for_dgrad(self) -> Optional[ScaledGroupedMMPrequantizedRHS]:
+        return self.cache_values.get("rhs_for_dgrad")
+
+    @prequantized_rhs_for_dgrad.setter
+    def prequantized_rhs_for_dgrad(self, value: Optional[ScaledGroupedMMPrequantizedRHS]) -> None:
+        self._set_cache("rhs_for_dgrad", value)
+
+    def _set_cache(self, name: str, value: Optional[ScaledGroupedMMPrequantizedRHS]) -> None:
+        if value is None:
+            self.cache_values.pop(name, None)
+            return
+        self.cache_values[name] = value
+
+    def numel(self) -> int:
+        out = 1
+        for dim in self.logical_shape:
+            out *= dim
+        return out
+
+    def element_size(self) -> int:
+        return torch.tensor([], dtype=self.dtype).element_size()
+
+    def type(self) -> str:
+        device_prefix = "torch.cuda" if self.device.type == "cuda" else "torch"
+        if self.dtype == torch.bfloat16:
+            return f"{device_prefix}.BFloat16Tensor"
+        if self.dtype == torch.float16:
+            return f"{device_prefix}.HalfTensor"
+        if self.dtype == torch.float32:
+            return f"{device_prefix}.FloatTensor"
+        return str(self.dtype)
+
+    def invalidate(self) -> None:
+        self.cache_values.clear()
+        self.weight_versions = None
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        if set_to_none:
+            self.grad_bf16 = None
+            self.main_grad_fp32 = None
+            return
+        if self.grad_bf16 is not None:
+            self.grad_bf16.zero_()
+        if self.main_grad_fp32 is not None:
+            self.main_grad_fp32.zero_()
+
+    def set_main_grad_to_none(self) -> None:
+        self.main_grad_fp32 = None
+
+    def replace_wgrad(self, grad: torch.Tensor) -> None:
+        if self.accumulate_wgrad_in_fp32:
+            self.main_grad_fp32 = grad.detach().to(torch.float32).contiguous()
+            self.grad_bf16 = None
+        else:
+            self.grad_bf16 = grad.detach().to(torch.bfloat16).contiguous()
+            self.main_grad_fp32 = None
+
+    @torch.no_grad()
+    def release_anchor_storage(self) -> None:
+        if self.anchor_param is None or self.anchor_storage_released:
+            return
+        missing = [spec.name for spec in self.cache_specs if spec.name not in self.cache_values]
+        if missing:
+            raise RuntimeError(
+                f"Cannot release bf16 anchor storage for FP8 weight store '{self.logical_name}' "
+                f"before its FP8 caches are initialized: missing {missing}"
+            )
+        base = torch.empty(
+            (1,),
+            dtype=self.anchor_param.dtype,
+            device=self.anchor_param.device,
+        )
+        placeholder = torch.as_strided(
+            base,
+            size=self.logical_shape,
+            stride=(0,) * len(self.logical_shape),
+        )
+        self.anchor_param.requires_grad_(False)
+        self.anchor_param.grad = None
+        if hasattr(self.anchor_param, "_main_grad_fp32"):
+            self.anchor_param._main_grad_fp32 = None  # type: ignore[attr-defined]
+        self.anchor_param.data = placeholder
+        self.anchor_storage_released = True
+
+    @torch.no_grad()
+    def refresh_from_logical_weight(
+        self,
+        logical_weight: torch.Tensor,
+        *,
+        version_tensors: Sequence[torch.Tensor] = (),
+        update_anchor: bool = False,
+    ) -> None:
+        if tuple(logical_weight.shape) != self.logical_shape:
+            raise ValueError(
+                f"FP8 weight store '{self.logical_name}' expected logical shape "
+                f"{self.logical_shape}, got {tuple(logical_weight.shape)}"
+            )
+        if update_anchor and self.anchor_param is not None and not self.anchor_storage_released:
+            self.anchor_param.data.copy_(logical_weight.to(dtype=self.anchor_param.dtype))
+        if not self.cache_specs:
+            raise RuntimeError(f"FP8 weight store '{self.logical_name}' has no cache specs")
+        self.refresh_from_tensors(
+            cache_tensors={spec.name: spec.transform(logical_weight) for spec in self.cache_specs},
+            version_tensors=version_tensors,
+        )
+
+    @torch.no_grad()
+    def refresh_from_tensors(
+        self,
+        *,
+        cache_tensors: Optional[Mapping[str, torch.Tensor]] = None,
+        rhs: Optional[torch.Tensor] = None,
+        rhs_for_dgrad: Optional[torch.Tensor] = None,
+        version_tensors: Sequence[torch.Tensor] = (),
+    ) -> None:
+        tensors: dict[str, torch.Tensor] = {}
+        if cache_tensors is not None:
+            tensors.update(cache_tensors)
+        if rhs is not None:
+            tensors["rhs"] = rhs
+        if rhs_for_dgrad is not None:
+            tensors["rhs_for_dgrad"] = rhs_for_dgrad
+        if not tensors:
+            raise ValueError("refresh_from_tensors requires at least one cache tensor")
+        for name, tensor in tensors.items():
+            self.cache_values[name] = prequantize_scaled_grouped_mm_rhs(
+                tensor,
+                check_mat_b_version=False,
+            )
+        self.weight_versions = tuple(int(t._version) for t in version_tensors)
+
+    def require_cache(self, name: str) -> ScaledGroupedMMPrequantizedRHS:
+        cache = self.cache_values.get(name)
+        if cache is None:
+            raise RuntimeError(
+                f"FP8 weight store '{self.logical_name}' cache '{name}' is not initialized"
+            )
+        return cache
+
+    def require_prequantized_rhs(self) -> ScaledGroupedMMPrequantizedRHS:
+        return self.require_cache("rhs")
+
+    def require_prequantized_rhs_for_dgrad(self) -> ScaledGroupedMMPrequantizedRHS:
+        return self.require_cache("rhs_for_dgrad")
+
+    def iter_prequantized_caches(self):
+        return self.cache_values.values()
+
+    def accumulate_wgrad(self, grad: torch.Tensor) -> None:
+        if self.accumulate_wgrad_in_fp32:
+            grad_fp32 = grad.detach().to(torch.float32)
+            if self.main_grad_fp32 is None:
+                self.main_grad_fp32 = grad_fp32.contiguous()
+            else:
+                self.main_grad_fp32.add_(grad_fp32)
+            self.grad_bf16 = None
+        else:
+            grad_bf16 = grad.detach().to(torch.bfloat16)
+            if self.grad_bf16 is None:
+                self.grad_bf16 = grad_bf16.contiguous()
+            else:
+                self.grad_bf16.add_(grad_bf16)
+            self.main_grad_fp32 = None
+
+
+__all__ = ["FP8WeightCacheSpec", "FP8WeightStore"]

--- a/src/olmo_core/nn/fp8_weight.py
+++ b/src/olmo_core/nn/fp8_weight.py
@@ -5,6 +5,7 @@ from typing import Callable, Mapping, Optional, Sequence
 
 import torch
 
+from olmo_core.doc_utils import beta_feature
 from olmo_core.kernels import (
     ScaledGroupedMMPrequantizedRHS,
     prequantize_scaled_grouped_mm_rhs,
@@ -25,6 +26,7 @@ class FP8WeightCacheSpec:
     transform: Callable[[torch.Tensor], torch.Tensor]
 
 
+@beta_feature
 class FP8WeightStore:
     """
     Generic logical weight store for fp32-main -> FP8-model training.

--- a/src/test/kernels/mxfp8_tensor_subclass_test.py
+++ b/src/test/kernels/mxfp8_tensor_subclass_test.py
@@ -1,0 +1,143 @@
+import pytest
+import torch
+
+from olmo_core.kernels import OlmoMXFP8Tensor
+
+
+def test_olmo_mxfp8_tensor_roundtrip_and_fallback_dispatch():
+    torch.manual_seed(123)
+    x = torch.randn(8, 64, dtype=torch.float32)
+
+    mx = OlmoMXFP8Tensor.from_hp(x)
+
+    assert isinstance(mx, OlmoMXFP8Tensor)
+    assert mx.shape == x.shape
+    assert mx.dtype == x.dtype
+    assert mx.qdata.dtype == torch.float8_e4m3fn
+    assert mx.scales.dtype == torch.float8_e8m0fnu
+    assert mx.scales.shape == (x.shape[0], x.shape[1] // 32)
+    preq = mx.as_scaled_grouped_mm_prequantized_lhs()
+    assert preq.mat_a_q is mx.qdata
+    assert preq.scale_a is mx.scales
+    assert preq.mat_a_shape == tuple(mx.shape)
+
+    x_hat = mx.dequantize(out_dtype=torch.float32)
+    assert x_hat.shape == x.shape
+    assert torch.isfinite(torch.nan_to_num(x_hat)).all()
+
+    # Generic torch ops fall back to dequantized high-precision tensors.
+    y = mx + 1.0
+    assert not isinstance(y, OlmoMXFP8Tensor)
+    torch.testing.assert_close(y, x_hat + 1.0)
+
+
+def test_olmo_mxfp8_tensor_can_be_backward_gradient_object():
+    seen: dict = {}
+
+    class Upstream(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x):  # type: ignore[override]
+            del ctx
+            return x * 2.0
+
+        @staticmethod
+        def backward(ctx, grad_out):  # type: ignore[override]
+            del ctx
+            seen["grad_type"] = type(grad_out).__name__
+            seen["is_mxfp8"] = isinstance(grad_out, OlmoMXFP8Tensor)
+            if isinstance(grad_out, OlmoMXFP8Tensor):
+                return grad_out.dequantize()
+            return torch.zeros_like(grad_out)
+
+    class Downstream(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, y):  # type: ignore[override]
+            ctx.shape = tuple(y.shape)
+            ctx.dtype = y.dtype
+            ctx.device = y.device
+            return y.sum()
+
+        @staticmethod
+        def backward(ctx, grad_out):  # type: ignore[override]
+            hp_grad = torch.ones(ctx.shape, dtype=ctx.dtype, device=ctx.device) * grad_out.to(
+                ctx.dtype
+            )
+            return OlmoMXFP8Tensor.from_hp(hp_grad, prefer_triton=False)
+
+    x = torch.randn(4, 64, dtype=torch.bfloat16, requires_grad=True)
+    loss = Downstream.apply(Upstream.apply(x))
+    loss.backward()
+
+    assert seen == {"grad_type": "OlmoMXFP8Tensor", "is_mxfp8": True}
+    assert x.grad is not None
+    torch.testing.assert_close(x.grad, torch.ones_like(x))
+
+
+class _QuantizeMX(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):  # type: ignore[override]
+        del ctx
+        return OlmoMXFP8Tensor.from_hp(x, prefer_triton=False)
+
+    @staticmethod
+    def backward(ctx, grad_out):  # type: ignore[override]
+        del ctx
+        if isinstance(grad_out, OlmoMXFP8Tensor):
+            return grad_out.dequantize()
+        return torch.zeros_like(grad_out)
+
+
+class _ConsumeMX(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, mx):  # type: ignore[override]
+        if not isinstance(mx, OlmoMXFP8Tensor):
+            raise RuntimeError(f"expected OlmoMXFP8Tensor, got {type(mx)!r}")
+        ctx.shape = tuple(mx.shape)
+        ctx.dtype = mx.dtype
+        ctx.device = mx.device
+        return mx.dequantize().sum()
+
+    @staticmethod
+    def backward(ctx, grad_out):  # type: ignore[override]
+        hp_grad = torch.ones(ctx.shape, dtype=ctx.dtype, device=ctx.device) * grad_out.to(ctx.dtype)
+        return OlmoMXFP8Tensor.from_hp(hp_grad, prefer_triton=False)
+
+
+def _mx_loss(x: torch.Tensor) -> torch.Tensor:
+    return _ConsumeMX.apply(_QuantizeMX.apply(x))
+
+
+def test_olmo_mxfp8_tensor_forward_backward_edge():
+    x = torch.randn(4, 64, dtype=torch.bfloat16, requires_grad=True)
+    loss = _mx_loss(x)
+    loss.backward()
+
+    assert x.grad is not None
+    torch.testing.assert_close(x.grad, torch.ones_like(x))
+
+
+def test_olmo_mxfp8_tensor_torch_compile_eager_backend():
+    x = torch.randn(4, 64, dtype=torch.bfloat16, requires_grad=True)
+    compiled = torch.compile(_mx_loss, fullgraph=True, backend="eager")
+
+    loss = compiled(x)
+    loss.backward()
+
+    assert x.grad is not None
+    torch.testing.assert_close(x.grad, torch.ones_like(x))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA inductor smoke test requires CUDA")
+def test_olmo_mxfp8_tensor_torch_compile_inductor_cuda_smoke():
+    x = torch.randn(4, 64, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    # The custom Functions below use prefer_triton=False so Dynamo/Inductor can
+    # trace the prototype through torch ops. The production Triton quant/DQ
+    # kernels still need opaque custom-op/fake impl wrapping for fullgraph
+    # inductor capture.
+    compiled = torch.compile(_mx_loss, fullgraph=True, backend="inductor")
+
+    loss = compiled(x)
+    loss.backward()
+
+    assert x.grad is not None
+    torch.testing.assert_close(x.grad, torch.ones_like(x))

--- a/src/test/kernels/scaled_grouped_mm_q_test.py
+++ b/src/test/kernels/scaled_grouped_mm_q_test.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 import torch.nn.functional as F
 
@@ -14,6 +15,14 @@ from olmo_core.kernels.scaled_grouped_mm import (
     prequantize_scaled_grouped_mm_rhs,
     scaled_grouped_mm_q,
     scaled_grouped_mm_q_fp8_weight,
+)
+from olmo_core.testing import has_torch_grouped_mm
+
+# The whole FP8 scaled-grouped-mm path requires torch >= 2.10 (F.grouped_mm reference +
+# F.ScalingType/F.SwizzleType). Skip the file wholesale on older torch.
+pytestmark = pytest.mark.skipif(
+    not has_torch_grouped_mm,
+    reason="Requires torch.nn.functional.grouped_mm (torch>=2.10)",
 )
 
 

--- a/src/test/kernels/scaled_grouped_mm_q_test.py
+++ b/src/test/kernels/scaled_grouped_mm_q_test.py
@@ -1,0 +1,711 @@
+import torch
+import torch.nn.functional as F
+
+import olmo_core.kernels.scaled_grouped_mm as scaled_grouped_mm_module
+from olmo_core.kernels.mxfp8_utils import (
+    dequantize_rows_from_mxfp8,
+    quantize_grouped_2d_to_mxfp8_blocked,
+    quantize_grouped_2d_to_mxfp8_blocked_fused,
+    quantize_grouped_weight_3d_to_mxfp8_blocked,
+    quantize_rows_to_mxfp8,
+)
+from olmo_core.kernels.scaled_grouped_mm import (
+    ScaledGroupedMMPrequantizedRHS,
+    prequantize_scaled_grouped_mm_rhs,
+    scaled_grouped_mm_q,
+    scaled_grouped_mm_q_fp8_weight,
+)
+
+
+def _build_inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(123)
+    group_sizes = torch.tensor([3, 2, 4], dtype=torch.int32)
+    offs = torch.cumsum(group_sizes, dim=0, dtype=torch.int32)
+    a = torch.randn(int(offs[-1].item()), 512, dtype=torch.float32)
+    b = torch.randn(group_sizes.numel(), 512, 512, dtype=torch.float32)
+    return a, b, offs
+
+
+def _stub_forward(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    offs: torch.Tensor,
+    *,
+    use_fast_accum: bool,
+    prequantized_lhs=None,
+    prequantized_rhs=None,
+) -> torch.Tensor:
+    del use_fast_accum, prequantized_lhs, prequantized_rhs
+    return F.grouped_mm(mat_a, mat_b, offs=offs)
+
+
+def _stub_forward_prequantized_rhs(
+    mat_a: torch.Tensor,
+    prequantized_rhs: ScaledGroupedMMPrequantizedRHS,
+    offs: torch.Tensor,
+    *,
+    use_fast_accum: bool,
+    prequantized_lhs=None,
+) -> torch.Tensor:
+    del offs, use_fast_accum, prequantized_lhs
+    return torch.zeros(
+        (mat_a.shape[0], prequantized_rhs.mat_b_shape[-1]),
+        dtype=mat_a.dtype,
+        device=mat_a.device,
+    )
+
+
+def _fake_prequantized_rhs(
+    shape: tuple[int, ...],
+    *,
+    device: torch.device | str = "cpu",
+) -> ScaledGroupedMMPrequantizedRHS:
+    return ScaledGroupedMMPrequantizedRHS(
+        mat_b_q=torch.empty(shape, dtype=torch.float8_e4m3fn, device=device),
+        scale_b=torch.empty((1,), dtype=torch.float8_e8m0fnu, device=device),
+        mat_b_shape=shape,
+        mat_b_version=-1,
+    )
+
+
+class _WgradSink:
+    def __init__(self):
+        self.grad_bf16 = None
+
+    def accumulate_wgrad(self, grad: torch.Tensor) -> None:
+        grad_bf16 = grad.detach().to(torch.bfloat16)
+        if self.grad_bf16 is None:
+            self.grad_bf16 = grad_bf16.clone()
+        else:
+            self.grad_bf16.add_(grad_bf16)
+
+
+def test_mxfp8_row_quant_dequant_roundtrip():
+    x = torch.randn(16, 512, dtype=torch.float32)
+    qdata, scales = quantize_rows_to_mxfp8(x, block_size=32)
+    assert qdata.dtype == torch.float8_e4m3fn
+    assert scales.dtype == torch.float8_e8m0fnu
+
+    x_hat = dequantize_rows_from_mxfp8(qdata, scales, block_size=32, out_dtype=torch.float32)
+    assert x_hat.shape == x.shape
+    finite = torch.isfinite(x_hat)
+    # e4m3fn quantization can produce a small number of non-finite values on CPU.
+    assert float(finite.float().mean().item()) > 0.98
+    # Float8 round-trip error can be large; keep this as a coarse sanity bound.
+    x_hat_safe = torch.nan_to_num(x_hat, nan=0.0, posinf=0.0, neginf=0.0)
+    rel_err = (x - x_hat_safe).norm() / x.norm().clamp_min(1e-6)
+    assert float(rel_err.item()) < 0.6
+
+
+def test_mxfp8_row_quant_no_nan_on_cuda():
+    if not torch.cuda.is_available():
+        return
+    x = torch.randn(256, 512, device="cuda", dtype=torch.bfloat16)
+    qdata, scales = quantize_rows_to_mxfp8(x, block_size=32)
+    assert bool(torch.isfinite(qdata.float()).all())
+    assert bool(torch.isfinite(scales.float()).all())
+
+
+def test_quantize_rows_to_mxfp8_supports_output_buffers():
+    x = torch.randn(16, 512, dtype=torch.float32)
+    out_q = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    out_scales = torch.empty((x.shape[0], x.shape[1] // 32), dtype=torch.float8_e8m0fnu)
+
+    qdata, scales = quantize_rows_to_mxfp8(
+        x,
+        block_size=32,
+        out=out_q,
+        scales_out=out_scales,
+    )
+    assert qdata.untyped_storage().data_ptr() == out_q.untyped_storage().data_ptr()
+    assert scales.untyped_storage().data_ptr() == out_scales.untyped_storage().data_ptr()
+    assert qdata.shape == x.shape
+    assert scales.shape == (x.shape[0], x.shape[1] // 32)
+
+
+def test_scaled_grouped_mm_q_forward_matches_grouped_mm_reference(monkeypatch):
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+    a, b, offs = _build_inputs()
+
+    out = scaled_grouped_mm_q(a, b, offs=offs)
+    ref = F.grouped_mm(a, b, offs=offs)
+    torch.testing.assert_close(out, ref)
+
+
+def test_scaled_grouped_mm_q_backward_matches_grouped_mm_reference(monkeypatch):
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+
+    a, b, offs = _build_inputs()
+    a = a.detach().requires_grad_(True)
+    b = b.detach().requires_grad_(True)
+
+    out = scaled_grouped_mm_q(a, b, offs=offs)
+    loss = (out * out).mean()
+    grad_a, grad_b = torch.autograd.grad(loss, (a, b))
+
+    a_ref = a.detach().clone().requires_grad_(True)
+    b_ref = b.detach().clone().requires_grad_(True)
+    out_ref = F.grouped_mm(a_ref, b_ref, offs=offs)
+    loss_ref = (out_ref * out_ref).mean()
+    grad_a_ref, grad_b_ref = torch.autograd.grad(loss_ref, (a_ref, b_ref))
+
+    torch.testing.assert_close(grad_a, grad_a_ref)
+    torch.testing.assert_close(grad_b, grad_b_ref)
+
+
+def test_scaled_grouped_mm_q_fp8_weight_returns_grad_to_anchor(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    a, b, offs = _build_inputs()
+    a = a.detach()
+    b = b.detach().requires_grad_(True)
+    rhs = _fake_prequantized_rhs(tuple(b.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(b.transpose(-2, -1).shape))
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        b,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_b,) = torch.autograd.grad(out, (b,), grad_outputs=grad_out)
+
+    grad_b_ref = F.grouped_mm(grad_out.transpose(-2, -1), a, offs=offs).transpose(-2, -1)
+    torch.testing.assert_close(grad_b, grad_b_ref)
+
+
+def test_scaled_grouped_mm_q_fp8_weight_accumulates_wgrad_sink(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    a, b, offs = _build_inputs()
+    a = a.detach()
+    b = b.detach().requires_grad_(True)
+    rhs = _fake_prequantized_rhs(tuple(b.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(b.transpose(-2, -1).shape))
+    sink = _WgradSink()
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        b,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_b,) = torch.autograd.grad(out, (b,), grad_outputs=grad_out)
+
+    assert sink.grad_bf16 is not None
+    torch.testing.assert_close(sink.grad_bf16, grad_b.to(torch.bfloat16))
+
+
+def test_scaled_grouped_mm_q_fp8_weight_uses_prequantized_lhs_for_wgrad(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    torch.manual_seed(123)
+    offs = torch.tensor([3, 5, 9], dtype=torch.int32)
+    mat_a_real = torch.randn(int(offs[-1].item()), 512, dtype=torch.float32)
+    mat_a_placeholder = torch.zeros_like(mat_a_real)
+    anchor = torch.randn(offs.numel(), 512, 512, dtype=torch.float32, requires_grad=True)
+    mat_a_q, mat_a_s = quantize_rows_to_mxfp8(mat_a_real, block_size=32)
+    preq_lhs = scaled_grouped_mm_module.ScaledGroupedMMPrequantizedLHS(
+        mat_a_q=mat_a_q,
+        scale_a=mat_a_s,
+        mat_a_shape=tuple(mat_a_placeholder.shape),
+        scales_are_blocked=False,
+    )
+    rhs = _fake_prequantized_rhs(tuple(anchor.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(anchor.transpose(-2, -1).shape))
+    sink = _WgradSink()
+
+    captured = {}
+
+    def _fake_grouped_mm(mat_a: torch.Tensor, mat_b: torch.Tensor, *, offs: torch.Tensor):
+        if mat_b.ndim == 2 and tuple(mat_b.shape) == tuple(mat_a_placeholder.shape):
+            captured["lhs_for_wgrad"] = mat_b.clone()
+            return torch.zeros((offs.numel(), mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+        return torch.zeros((mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+
+    monkeypatch.setattr(F, "grouped_mm", _fake_grouped_mm)
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        mat_a_placeholder,
+        anchor,
+        offs=offs,
+        prequantized_lhs=preq_lhs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+    )
+    (grad_anchor,) = torch.autograd.grad(out.sum(), (anchor,))
+
+    assert grad_anchor is not None
+    assert "lhs_for_wgrad" in captured
+    mat_a_expected = dequantize_rows_from_mxfp8(
+        mat_a_q,
+        mat_a_s,
+        block_size=32,
+        out_dtype=out.dtype,
+    )
+    torch.testing.assert_close(captured["lhs_for_wgrad"], mat_a_expected)
+
+
+def test_scaled_grouped_mm_q_fp8_weight_accumulates_sink_for_detached_anchor(monkeypatch):
+    if not torch.cuda.is_available():
+        return
+
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    a, b, offs = _build_inputs()
+    a = a.cuda().detach().requires_grad_(True)
+    anchor = b.cuda().detach()
+    offs = offs.cuda()
+    rhs = _fake_prequantized_rhs(tuple(anchor.shape), device=anchor.device)
+    rhs_t = _fake_prequantized_rhs(tuple(anchor.transpose(-2, -1).shape), device=anchor.device)
+    sink = _WgradSink()
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        anchor,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_a,) = torch.autograd.grad(out, (a,), grad_outputs=grad_out)
+
+    assert grad_a is not None
+    assert sink.grad_bf16 is not None
+    grad_anchor_ref = F.grouped_mm(grad_out.transpose(-2, -1), a, offs=offs).transpose(-2, -1)
+    torch.testing.assert_close(sink.grad_bf16, grad_anchor_ref.to(torch.bfloat16))
+
+
+def test_scaled_grouped_mm_q_fp8_weight_transposes_wgrad_sink(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    a, b, offs = _build_inputs()
+    a = a.detach()
+    anchor = b.detach().transpose(-2, -1).contiguous().requires_grad_(True)
+    rhs = _fake_prequantized_rhs(tuple(anchor.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(anchor.transpose(-2, -1).shape))
+    sink = _WgradSink()
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        anchor,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+        wgrad_sink_transpose_last2=True,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_anchor,) = torch.autograd.grad(out, (anchor,), grad_outputs=grad_out)
+
+    assert sink.grad_bf16 is not None
+    torch.testing.assert_close(
+        sink.grad_bf16,
+        grad_anchor.transpose(-2, -1).contiguous().to(torch.bfloat16),
+    )
+
+
+def test_scaled_grouped_mm_q_fp8_weight_squeezes_wgrad_sink(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    torch.manual_seed(123)
+    offs = torch.tensor([4], dtype=torch.int32)
+    a = torch.randn(4, 512, dtype=torch.float32)
+    anchor = torch.randn(1, 512, 512, dtype=torch.float32, requires_grad=True)
+    rhs = _fake_prequantized_rhs(tuple(anchor.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(anchor.transpose(-2, -1).shape))
+    sink = _WgradSink()
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        anchor,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+        wgrad_sink_squeeze_first_dim=True,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_anchor,) = torch.autograd.grad(out, (anchor,), grad_outputs=grad_out)
+
+    assert sink.grad_bf16 is not None
+    torch.testing.assert_close(
+        sink.grad_bf16,
+        grad_anchor.squeeze(0).contiguous().to(torch.bfloat16),
+    )
+
+
+def test_scaled_grouped_mm_q_input_grad_out_alias(monkeypatch):
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+
+    a, b, offs = _build_inputs()
+    a = a.detach().requires_grad_(True)
+    b = b.detach().requires_grad_(True)
+
+    input_grad_out = torch.empty_like(a)
+
+    out = scaled_grouped_mm_q(
+        a,
+        b,
+        offs=offs,
+        input_grad_out=input_grad_out,
+    )
+
+    grad_a, _grad_b = torch.autograd.grad(
+        out,
+        (a, b),
+        grad_outputs=torch.ones_like(out).contiguous(),
+    )
+    assert grad_a.untyped_storage().data_ptr() == input_grad_out.untyped_storage().data_ptr()
+
+
+def test_scaled_grouped_mm_q_empty_input_backward_returns_zero_grads():
+    mat_a = torch.empty((0, 512), dtype=torch.float32, requires_grad=True)
+    mat_b = torch.randn(3, 512, 512, dtype=torch.float32, requires_grad=True)
+    offs = torch.zeros((3,), dtype=torch.int32)
+
+    out = scaled_grouped_mm_q(mat_a, mat_b, offs=offs)
+    assert out.shape == (0, 512)
+    assert out.dtype == torch.bfloat16
+
+    out.sum().backward()
+
+    assert mat_a.grad is not None
+    assert mat_a.grad.shape == mat_a.shape
+    assert mat_b.grad is not None
+    torch.testing.assert_close(mat_b.grad, torch.zeros_like(mat_b))
+
+
+def test_scaled_grouped_mm_q_empty_input_backward_uses_input_grad_out():
+    mat_a = torch.empty((0, 512), dtype=torch.float32, requires_grad=True)
+    mat_b = torch.randn(3, 512, 512, dtype=torch.float32, requires_grad=True)
+    offs = torch.zeros((3,), dtype=torch.int32)
+    input_grad_out = torch.empty_like(mat_a)
+
+    out = scaled_grouped_mm_q(
+        mat_a,
+        mat_b,
+        offs=offs,
+        input_grad_out=input_grad_out,
+    )
+    (grad_a, _grad_b) = torch.autograd.grad(out.sum(), (mat_a, mat_b))
+
+    assert grad_a.untyped_storage().data_ptr() == input_grad_out.untyped_storage().data_ptr()
+
+
+def test_quantize_grouped_2d_to_mxfp8_blocked_keeps_capacity_shape():
+    x = torch.randn(16, 512, dtype=torch.float32)
+    # Active rows are 9, but input has capacity 16.
+    offs = torch.tensor([4, 7, 9], dtype=torch.int32)
+
+    qdata, scales_blocked = quantize_grouped_2d_to_mxfp8_blocked(x, offs)
+    assert qdata.shape == x.shape
+    assert qdata.dtype == torch.float8_e4m3fn
+
+    assert scales_blocked.dtype == torch.float8_e8m0fnu
+    assert scales_blocked.shape[1] == x.shape[1] // 32
+    assert scales_blocked.shape[0] >= x.shape[0]
+
+
+def test_quantize_grouped_2d_to_mxfp8_blocked_fused_matches_two_stage_cuda():
+    if not torch.cuda.is_available():
+        return
+    x = torch.randn(64, 512, device="cuda", dtype=torch.bfloat16)
+    # Active rows are 41, but input has capacity 64.
+    offs = torch.tensor([11, 17, 41], device="cuda", dtype=torch.int32)
+
+    q_ref, scales_ref = quantize_grouped_2d_to_mxfp8_blocked(x, offs)
+    q_fused, scales_fused = quantize_grouped_2d_to_mxfp8_blocked_fused(x, offs)
+
+    assert q_fused.shape == q_ref.shape
+    assert scales_fused.shape == scales_ref.shape
+    assert torch.equal(q_fused.view(torch.uint8), q_ref.view(torch.uint8))
+    assert torch.equal(scales_fused.view(torch.uint8), scales_ref.view(torch.uint8))
+
+
+def test_quantize_grouped_weight_3d_to_mxfp8_blocked_returns_col_major_layout():
+    b = torch.randn(3, 512, 512, dtype=torch.float32)
+    qdata, scales_blocked = quantize_grouped_weight_3d_to_mxfp8_blocked(b)
+
+    assert qdata.shape == b.shape
+    assert qdata.dtype == torch.float8_e4m3fn
+    # scaled_grouped_mm expects transposed RHS memory layout on trailing dims.
+    assert qdata.stride(-2) == 1
+    assert qdata.stride(-1) == b.shape[-2]
+    assert scales_blocked.shape[0] == b.shape[0]
+    assert scales_blocked.dtype == torch.float8_e8m0fnu
+
+
+def test_scaled_grouped_mm_q_forces_mat2_col_major_layout(monkeypatch):
+    if not torch.cuda.is_available():
+        return
+    a, b, offs = _build_inputs()
+    a = a.to(device="cuda")
+    b = b.to(device="cuda")
+    offs = offs.to(device="cuda")
+
+    def _fake_quant_a(mat_a: torch.Tensor, *, block_size: int = 32):
+        del block_size
+        return mat_a.to(torch.float8_e4m3fn), torch.ones(
+            (mat_a.shape[0], mat_a.shape[1] // 32),
+            dtype=torch.float8_e8m0fnu,
+            device=mat_a.device,
+        )
+
+    def _fake_quant_b(mat_b: torch.Tensor, *, block_size: int = 32):
+        del block_size
+        # Return row-major data intentionally; wrapper should convert it.
+        q = mat_b.to(torch.float8_e4m3fn).contiguous()
+        s = torch.ones(
+            (mat_b.shape[0], mat_b.shape[2], mat_b.shape[1] // 32),
+            dtype=torch.float8_e8m0fnu,
+            device=mat_b.device,
+        )
+        return q, s
+
+    seen = {}
+
+    def _fake_scaled_grouped_mm_v2_cuda(
+        mat_a_q: torch.Tensor,
+        mat_b_q: torch.Tensor,
+        scale_a_unblocked: torch.Tensor,
+        scale_b_unblocked: torch.Tensor,
+        *,
+        offs: torch.Tensor,
+        use_fast_accum: bool,
+    ):
+        del mat_a_q, scale_a_unblocked, scale_b_unblocked, offs, use_fast_accum
+        seen["shape"] = tuple(mat_b_q.shape)
+        seen["stride"] = tuple(mat_b_q.stride())
+        return torch.zeros(
+            (a.shape[0], b.shape[-1]),
+            device=mat_b_q.device,
+            dtype=torch.bfloat16,
+        )
+
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "quantize_rows_to_mxfp8",
+        _fake_quant_a,
+    )
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "quantize_grouped_weight_3d_to_mxfp8_blocked",
+        _fake_quant_b,
+    )
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_scaled_grouped_mm_v2_cuda",
+        _fake_scaled_grouped_mm_v2_cuda,
+    )
+
+    _ = scaled_grouped_mm_module._forward_scaled_grouped_mm_mxfp8(
+        a,
+        b,
+        offs,
+        use_fast_accum=True,
+    )
+
+    assert seen["shape"] == tuple(b.shape)
+    # trailing 2D strides must be column-major: (.., 1, K)
+    assert seen["stride"][-2] == 1
+    assert seen["stride"][-1] == b.shape[-2]
+
+
+def test_scaled_grouped_mm_q_uses_prequantized_rhs(monkeypatch):
+    if not torch.cuda.is_available():
+        return
+    torch.manual_seed(123)
+    offs = torch.tensor([3, 5, 9], dtype=torch.int32, device="cuda")
+    a = torch.randn(int(offs[-1].item()), 512, dtype=torch.float32, device="cuda")
+    b = torch.randn(offs.numel(), 512, 512, dtype=torch.float32, device="cuda")
+    preq = prequantize_scaled_grouped_mm_rhs(b)
+    assert isinstance(preq, ScaledGroupedMMPrequantizedRHS)
+
+    called = {"rhs_quant": 0}
+
+    def _forbidden_rhs_quant(_mat_b, *, block_size: int = 32):
+        del block_size
+        called["rhs_quant"] += 1
+        raise AssertionError(
+            "RHS quantization should be bypassed when prequantized_rhs is provided"
+        )
+
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "quantize_grouped_weight_3d_to_mxfp8_blocked",
+        _forbidden_rhs_quant,
+    )
+
+    def _fake_scaled_grouped_mm_v2_cuda(
+        mat_a_q: torch.Tensor,
+        mat_b_q: torch.Tensor,
+        scale_a_unblocked: torch.Tensor,
+        scale_b_unblocked: torch.Tensor,
+        *,
+        offs: torch.Tensor,
+        use_fast_accum: bool,
+    ):
+        del mat_a_q, scale_a_unblocked, scale_b_unblocked, offs, use_fast_accum
+        # Ensure the prequantized RHS object is the one actually consumed.
+        assert mat_b_q.untyped_storage().data_ptr() == preq.mat_b_q.untyped_storage().data_ptr()
+        return torch.zeros((a.shape[0], b.shape[-1]), dtype=torch.bfloat16, device=a.device)
+
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_scaled_grouped_mm_v2_cuda",
+        _fake_scaled_grouped_mm_v2_cuda,
+    )
+    out = scaled_grouped_mm_q(
+        a,
+        b,
+        offs=offs,
+        prequantized_rhs=preq,
+    )
+    assert out.shape == (a.shape[0], b.shape[-1])
+    assert called["rhs_quant"] == 0
+
+
+def test_scaled_grouped_mm_q_backward_uses_prequantized_lhs_when_mat_a_not_saved(monkeypatch):
+    torch.manual_seed(123)
+    offs = torch.tensor([3, 5, 9], dtype=torch.int32)
+    mat_a_real = torch.randn(int(offs[-1].item()), 512, dtype=torch.float32)
+    mat_a_bad = torch.zeros_like(mat_a_real)
+    mat_b = torch.randn(offs.numel(), 512, 512, dtype=torch.float32, requires_grad=True)
+    mat_a_q, mat_a_s = quantize_rows_to_mxfp8(mat_a_real, block_size=32)
+    preq_lhs = scaled_grouped_mm_module.ScaledGroupedMMPrequantizedLHS(
+        mat_a_q=mat_a_q,
+        scale_a=mat_a_s,
+        mat_a_shape=tuple(mat_a_bad.shape),
+        scales_are_blocked=False,
+    )
+
+    def _stub_forward(
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        offs: torch.Tensor,
+        *,
+        use_fast_accum: bool,
+        prequantized_lhs=None,
+        prequantized_rhs=None,
+    ) -> torch.Tensor:
+        del use_fast_accum, prequantized_lhs, prequantized_rhs
+        return F.grouped_mm(mat_a, mat_b, offs=offs)
+
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+
+    captured = {}
+
+    def _fake_grouped_mm(mat_a: torch.Tensor, mat_b: torch.Tensor, *, offs: torch.Tensor):
+        # Backward grad_b path: mat_b is reconstructed lhs (rank-2 [M, K]).
+        if mat_b.ndim == 2 and tuple(mat_b.shape) == tuple(mat_a_bad.shape):
+            captured["lhs_for_grad_b"] = mat_b.clone()
+            return torch.zeros((offs.numel(), mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+        return torch.zeros((mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+
+    monkeypatch.setattr(F, "grouped_mm", _fake_grouped_mm)
+
+    out = scaled_grouped_mm_q(
+        mat_a_bad,
+        mat_b,
+        offs=offs,
+        prequantized_lhs=preq_lhs,
+    )
+    loss = out.sum()
+    (grad_b,) = torch.autograd.grad(loss, (mat_b,))
+    assert grad_b is not None
+
+    assert "lhs_for_grad_b" in captured
+    mat_a_expected = dequantize_rows_from_mxfp8(
+        mat_a_q, mat_a_s, block_size=32, out_dtype=out.dtype
+    )
+    torch.testing.assert_close(captured["lhs_for_grad_b"], mat_a_expected)
+
+
+def test_scaled_grouped_mm_q_backward_reconstructs_full_prequantized_lhs_capacity(monkeypatch):
+    torch.manual_seed(123)
+    offs = torch.tensor([3, 5, 9], dtype=torch.int32)
+    capacity_rows = 12
+    mat_a_real = torch.randn(capacity_rows, 512, dtype=torch.float32)
+    mat_a_bad = torch.zeros_like(mat_a_real)
+    mat_b = torch.randn(offs.numel(), 512, 512, dtype=torch.float32, requires_grad=True)
+    mat_a_q, mat_a_s = quantize_rows_to_mxfp8(mat_a_real, block_size=32)
+    preq_lhs = scaled_grouped_mm_module.ScaledGroupedMMPrequantizedLHS(
+        mat_a_q=mat_a_q,
+        scale_a=mat_a_s,
+        mat_a_shape=tuple(mat_a_bad.shape),
+        scales_are_blocked=False,
+    )
+
+    def _stub_forward(
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        offs: torch.Tensor,
+        *,
+        use_fast_accum: bool,
+        prequantized_lhs=None,
+        prequantized_rhs=None,
+    ) -> torch.Tensor:
+        del use_fast_accum, prequantized_lhs, prequantized_rhs
+        return F.grouped_mm(mat_a, mat_b, offs=offs)
+
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+
+    captured = {}
+
+    def _fake_grouped_mm(mat_a: torch.Tensor, mat_b: torch.Tensor, *, offs: torch.Tensor):
+        # Backward grad_b path: mat_b is reconstructed lhs (rank-2 [capacity, K]).
+        if mat_b.ndim == 2 and tuple(mat_b.shape) == tuple(mat_a_bad.shape):
+            captured["lhs_for_grad_b"] = mat_b.clone()
+            return torch.zeros((offs.numel(), mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+        return torch.zeros((mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+
+    monkeypatch.setattr(F, "grouped_mm", _fake_grouped_mm)
+
+    out = scaled_grouped_mm_q(
+        mat_a_bad,
+        mat_b,
+        offs=offs,
+        prequantized_lhs=preq_lhs,
+    )
+    loss = out.sum()
+    (grad_b,) = torch.autograd.grad(loss, (mat_b,))
+    assert grad_b is not None
+
+    assert "lhs_for_grad_b" in captured
+    assert captured["lhs_for_grad_b"].shape[0] == capacity_rows
+    mat_a_expected = dequantize_rows_from_mxfp8(
+        mat_a_q, mat_a_s, block_size=32, out_dtype=out.dtype
+    )
+    torch.testing.assert_close(captured["lhs_for_grad_b"], mat_a_expected)


### PR DESCRIPTION
## What this adds

The FP8 expert-compute path:

- **MXFP8 (OCP microscaling FP8) kernels** (`olmo_core.kernels.mxfp8_utils`) and the `OlmoMXFP8Tensor` subclass — quantize/dequantize to block-scaled FP8.
- **`scaled_grouped_mm_q` / `scaled_grouped_mm_q_fp8_weight`** — MXFP8-quantized grouped matmul built on `torch.nn.functional.scaled_grouped_mm`, with prequantized-weight caching (`prequantize_scaled_grouped_mm_rhs`, `ScaledGroupedMMPrequantized{LHS,RHS}`) to reuse a quantized operand across calls.
- **`FP8WeightStore` / `FP8WeightCacheSpec`** (`olmo_core.nn.fp8_weight`) — prequantizes a weight to its MXFP8 RHS form (and the dgrad transpose) and caches it.

All public FP8 entry points (`OlmoMXFP8Tensor`, `scaled_grouped_mm_q`, `scaled_grouped_mm_q_fp8_weight`, `FP8WeightStore`) are marked `@beta_feature`.

## Import-safety

Triton and nvtx imports are guarded, and the CUDA extension builds lazily, so the modules import on CPU without a GPU. Kernel correctness is covered by GPU tests on hardware.
