### PR TITLE
Add scaled_grouped_mm FP8 kernels and FP8 weight cache

### DIFF
--- a/src/olmo_core/kernels/__init__.py
+++ b/src/olmo_core/kernels/__init__.py
@@ -8,8 +8,20 @@ not require a GPU or a compiler.
 
 from .grouped_mm import grouped_mm
 from .mxfp8_tensor import OlmoMXFP8Tensor
+from .scaled_grouped_mm import (
+    ScaledGroupedMMPrequantizedLHS,
+    ScaledGroupedMMPrequantizedRHS,
+    prequantize_scaled_grouped_mm_rhs,
+    scaled_grouped_mm_q,
+    scaled_grouped_mm_q_fp8_weight,
+)
 
 __all__ = [
     "grouped_mm",
     "OlmoMXFP8Tensor",
+    "ScaledGroupedMMPrequantizedLHS",
+    "ScaledGroupedMMPrequantizedRHS",
+    "prequantize_scaled_grouped_mm_rhs",
+    "scaled_grouped_mm_q",
+    "scaled_grouped_mm_q_fp8_weight",
 ]

--- a/src/olmo_core/kernels/cuda/scaled_grouped_mm_out.cpp
+++ b/src/olmo_core/kernels/cuda/scaled_grouped_mm_out.cpp
@@ -1,0 +1,110 @@
+#include <torch/extension.h>
+
+#include <ATen/core/Tensor.h>
+
+#include <optional>
+
+namespace py = pybind11;
+
+// Exported by libtorch_cuda when PyTorch is built with USE_FBGEMM_GENAI.
+// We intentionally call this backend directly so we can write into `out`
+// without creating a temporary tensor and copying.
+namespace fbgemm_gpu {
+at::Tensor mx8mx8bf16_grouped_mm(
+    at::Tensor mat_a,
+    at::Tensor mat_b,
+    at::Tensor scale_a,
+    at::Tensor scale_b,
+    at::Tensor offs,
+    std::optional<at::Tensor> out);
+}  // namespace fbgemm_gpu
+
+namespace {
+
+std::optional<at::Tensor> normalize_optional_tensor(
+    const c10::optional<at::Tensor>& tensor) {
+  if (tensor.has_value() && tensor->defined()) {
+    return std::optional<at::Tensor>(tensor.value());
+  }
+  return std::nullopt;
+}
+
+bool is_transposed_last2(const at::Tensor& t) {
+  if (t.dim() < 2) {
+    return false;
+  }
+  return t.stride(-2) == 1 && t.stride(-1) == t.size(-2);
+}
+
+}  // namespace
+
+at::Tensor scaled_grouped_mm_v2_out_cuda(
+    const at::Tensor& mat_a_q,
+    const at::Tensor& mat_b_q,
+    const at::Tensor& scale_a,
+    const at::Tensor& scale_b,
+    at::Tensor out,
+    const c10::optional<at::Tensor>& offs_opt,
+    bool use_fast_accum) {
+  TORCH_CHECK(mat_a_q.is_cuda(), "mat_a_q must be CUDA");
+  TORCH_CHECK(mat_b_q.is_cuda(), "mat_b_q must be CUDA");
+  TORCH_CHECK(scale_a.is_cuda(), "scale_a must be CUDA");
+  TORCH_CHECK(scale_b.is_cuda(), "scale_b must be CUDA");
+  TORCH_CHECK(out.is_cuda(), "out must be CUDA");
+  TORCH_CHECK(mat_a_q.scalar_type() == at::kFloat8_e4m3fn, "mat_a_q must be float8_e4m3fn");
+  TORCH_CHECK(mat_b_q.scalar_type() == at::kFloat8_e4m3fn, "mat_b_q must be float8_e4m3fn");
+  TORCH_CHECK(scale_a.scalar_type() == at::kFloat8_e8m0fnu, "scale_a must be float8_e8m0fnu");
+  TORCH_CHECK(scale_b.scalar_type() == at::kFloat8_e8m0fnu, "scale_b must be float8_e8m0fnu");
+  TORCH_CHECK(out.scalar_type() == at::kBFloat16, "out must be bfloat16");
+  TORCH_CHECK(mat_a_q.dim() == 2, "mat_a_q must be rank-2 [M, K]");
+  TORCH_CHECK(mat_b_q.dim() == 3, "mat_b_q must be rank-3 [G, K, N]");
+  TORCH_CHECK(is_transposed_last2(mat_b_q), "Expected mat_b_q to be transposed in trailing dims");
+  TORCH_CHECK(
+      mat_a_q.size(1) == mat_b_q.size(1),
+      "mat_a_q K dimension must match mat_b_q K dimension, got ",
+      mat_a_q.size(1),
+      " vs ",
+      mat_b_q.size(1));
+  TORCH_CHECK(
+      out.dim() == 2 && out.size(0) == mat_a_q.size(0) && out.size(1) == mat_b_q.size(2),
+      "out shape must be [M, N] = [",
+      mat_a_q.size(0),
+      ", ",
+      mat_b_q.size(2),
+      "], got ",
+      out.sizes());
+  (void)use_fast_accum;
+
+  auto offs = normalize_optional_tensor(offs_opt);
+  TORCH_CHECK(offs.has_value(), "offs is required for MXFP8 grouped mm");
+  TORCH_CHECK(offs->is_cuda(), "offs must be CUDA");
+  TORCH_CHECK(offs->scalar_type() == at::kInt, "offs must be int32");
+  TORCH_CHECK(offs->dim() == 1, "offs must be rank-1");
+
+  auto result = fbgemm_gpu::mx8mx8bf16_grouped_mm(
+      mat_a_q,
+      mat_b_q,
+      scale_a,
+      scale_b,
+      offs.value(),
+      std::optional<at::Tensor>(out));
+  TORCH_CHECK(result.defined(), "mx8mx8bf16_grouped_mm returned undefined tensor");
+  TORCH_CHECK(
+      result.data_ptr() == out.data_ptr(),
+      "mx8mx8bf16_grouped_mm did not write into provided out buffer");
+  return out;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+      "scaled_grouped_mm_v2_out_cuda",
+      &scaled_grouped_mm_v2_out_cuda,
+      "Scaled grouped_mm_v2 with explicit output tensor",
+      py::arg("mat_a_q"),
+      py::arg("mat_b_q"),
+      py::arg("scale_a"),
+      py::arg("scale_b"),
+      py::arg("out"),
+      py::arg("offs") = py::none(),
+      py::arg("use_fast_accum") = true);
+}

--- a/src/olmo_core/kernels/scaled_grouped_mm.py
+++ b/src/olmo_core/kernels/scaled_grouped_mm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 import torch
 import torch.nn.functional as F
@@ -36,25 +36,52 @@ except AttributeError:
 
 @dataclass(frozen=True)
 class ScaledGroupedMMPrequantizedLHS:
+    """
+    A pre-quantized left-hand side (activations) for the scaled grouped matmul.
+
+    Holds the MXFP8 quantized data and scales so the forward can skip
+    re-quantizing the activations.
+
+    :param mat_a_q: The MXFP8-quantized activations.
+    :param scale_a: The MXFP8 scales for ``mat_a_q``.
+    :param mat_a_shape: The logical (M, K) shape of the original activations.
+    :param scales_are_blocked: Whether ``scale_a`` is already in the blocked
+        (swizzled) layout the kernel expects.
+    """
+
     mat_a_q: Tensor
     scale_a: Tensor
-    mat_a_shape: Tuple[int, ...]  # logically (M, K)
+    mat_a_shape: tuple[int, ...]  # logically (M, K)
     scales_are_blocked: bool = False
 
 
 @dataclass(frozen=True)
 class ScaledGroupedMMPrequantizedRHS:
+    """
+    A pre-quantized right-hand side (expert weights) for the scaled grouped matmul.
+
+    Holds the MXFP8 quantized weights in the column-major layout the grouped
+    GEMM requires, so the weights can be quantized once per optimizer step and
+    reused across microbatches.
+
+    :param mat_b_q: The MXFP8-quantized weights (column-major in the last two dims).
+    :param scale_b: The MXFP8 scales for ``mat_b_q``.
+    :param mat_b_shape: The logical (E, N, K) shape of the original weights.
+    :param mat_b_version: The ``_version`` of the source weight when quantized,
+        or ``-1`` if not tracked; used to detect a stale cache.
+    """
+
     mat_b_q: Tensor
     scale_b: Tensor
-    mat_b_shape: Tuple[int, ...]  # logically (E, N, K)
+    mat_b_shape: tuple[int, ...]  # logically (E, N, K)
     mat_b_version: int = -1
 
 
 def _tensor_version(x: Tensor) -> int:
-    try:
-        return int(x._version)
-    except Exception:
-        return -1
+    # `_version` is present on real tensors; fall back to -1 for anything that
+    # doesn't expose it rather than swallowing unrelated errors.
+    version = getattr(x, "_version", None)
+    return -1 if version is None else int(version)
 
 
 def _prequantized_lhs_tensors_for_backward(

--- a/src/olmo_core/kernels/scaled_grouped_mm.py
+++ b/src/olmo_core/kernels/scaled_grouped_mm.py
@@ -1,0 +1,725 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+try:
+    import nvtx
+except ImportError:
+    from olmo_core._nvtx import nvtx
+
+from .mxfp8_tensor import OlmoMXFP8Tensor
+from .mxfp8_utils import (
+    dequantize_rows_from_mxfp8,
+    grouped_scales_to_mxfp8_blocked,
+    quantize_grouped_weight_3d_to_mxfp8_blocked,
+    quantize_rows_to_mxfp8,
+)
+
+try:
+    _MXFP8_RECIPE_BLOCKWISE_1X32 = [int(F.ScalingType.BlockWise1x32)]
+    _MXFP8_SWIZZLE = (
+        [int(F.SwizzleType.NO_SWIZZLE)]
+        if torch.version.hip
+        else [int(F.SwizzleType.SWIZZLE_32_4_4)]
+    )
+except AttributeError:
+    # Fallback values for torch builds where enum symbols are not exposed.
+    _MXFP8_RECIPE_BLOCKWISE_1X32 = [3]
+    _MXFP8_SWIZZLE = [0] if torch.version.hip else [1]
+
+
+@dataclass(frozen=True)
+class ScaledGroupedMMPrequantizedLHS:
+    mat_a_q: Tensor
+    scale_a: Tensor
+    mat_a_shape: Tuple[int, ...]  # logically (M, K)
+    scales_are_blocked: bool = False
+
+
+@dataclass(frozen=True)
+class ScaledGroupedMMPrequantizedRHS:
+    mat_b_q: Tensor
+    scale_b: Tensor
+    mat_b_shape: Tuple[int, ...]  # logically (E, N, K)
+    mat_b_version: int = -1
+
+
+def _tensor_version(x: Tensor) -> int:
+    try:
+        return int(x._version)
+    except Exception:
+        return -1
+
+
+def _prequantized_lhs_tensors_for_backward(
+    prequantized_lhs: ScaledGroupedMMPrequantizedLHS,
+) -> tuple[Tensor, Tensor]:
+    return prequantized_lhs.mat_a_q, prequantized_lhs.scale_a
+
+
+def _to_col_major_last2(x: Tensor) -> Tensor:
+    # Keep shape while forcing column-major storage for the trailing 2 dims.
+    # _scaled_grouped_mm_v2 requires mat_b to be transposed (K,N with strides [1, K]).
+    if x.stride(-2) == 1 and x.stride(-1) == x.shape[-2]:
+        return x
+    return x.transpose(-2, -1).contiguous().transpose(-2, -1)
+
+
+@torch.no_grad()
+def prequantize_scaled_grouped_mm_rhs(
+    mat_b: Tensor,
+    *,
+    check_mat_b_version: bool = True,
+) -> ScaledGroupedMMPrequantizedRHS:
+    with nvtx.annotate("prequantize_scaled_grouped_mm_rhs", color="red"):
+        if mat_b.ndim != 3:
+            raise ValueError(
+                "prequantize_scaled_grouped_mm_rhs expects mat_b rank-3 [G,K,N], "
+                f"got {tuple(mat_b.shape)}"
+            )
+        mat_b_q, scale_b = quantize_grouped_weight_3d_to_mxfp8_blocked(mat_b)
+        mat_b_q = _to_col_major_last2(mat_b_q)
+        return ScaledGroupedMMPrequantizedRHS(
+            mat_b_q=mat_b_q,
+            scale_b=scale_b,
+            mat_b_shape=tuple(mat_b.shape),
+            mat_b_version=_tensor_version(mat_b) if check_mat_b_version else -1,
+        )
+
+
+@torch.compiler.disable
+def _scaled_grouped_mm_v2_cuda(
+    mat_a_q: Tensor,
+    mat_b_q: Tensor,
+    scale_a_blocked: Tensor,
+    scale_b_blocked: Tensor,
+    *,
+    offs: Tensor,
+    use_fast_accum: bool,
+) -> Tensor:
+    return torch.ops.aten._scaled_grouped_mm_v2.default(
+        mat_a_q,
+        mat_b_q,
+        [scale_a_blocked],
+        _MXFP8_RECIPE_BLOCKWISE_1X32,
+        _MXFP8_SWIZZLE,
+        [scale_b_blocked],
+        _MXFP8_RECIPE_BLOCKWISE_1X32,
+        _MXFP8_SWIZZLE,
+        offs,
+        None,
+        torch.bfloat16,
+        [],
+        use_fast_accum,
+    )
+
+
+def _forward_scaled_grouped_mm_mxfp8(
+    mat_a: Tensor,
+    mat_b: Tensor,
+    offs: Tensor,
+    *,
+    use_fast_accum: bool,
+    prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS] = None,
+    prequantized_rhs: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+) -> Tensor:
+    if mat_a.ndim != 2 or mat_b.ndim != 3:
+        raise ValueError(
+            "scaled_grouped_mm_q currently supports 2D-3D grouped mm only, "
+            f"got mat_a={tuple(mat_a.shape)} mat_b={tuple(mat_b.shape)}"
+        )
+
+    if offs.dtype != torch.int32:
+        offs = offs.to(dtype=torch.int32)
+
+    if not mat_a.is_cuda or not mat_b.is_cuda:
+        raise RuntimeError("scaled_grouped_mm_q requires CUDA tensors")
+
+    scale_a_blocked: Optional[Tensor] = None
+    scale_b_blocked: Optional[Tensor] = None
+
+    if prequantized_lhs is not None:
+        if tuple(prequantized_lhs.mat_a_shape) != tuple(mat_a.shape):
+            raise ValueError(
+                "prequantized_lhs shape mismatch: "
+                f"expected {tuple(mat_a.shape)}, got {tuple(prequantized_lhs.mat_a_shape)}"
+            )
+        if prequantized_lhs.mat_a_q.device != mat_a.device:
+            raise ValueError(
+                "prequantized_lhs device mismatch: "
+                f"q_device={prequantized_lhs.mat_a_q.device} mat_a_device={mat_a.device}"
+            )
+        mat_a_q = prequantized_lhs.mat_a_q
+        if prequantized_lhs.scales_are_blocked:
+            scale_a_blocked = prequantized_lhs.scale_a
+        else:
+            scale_a_blocked = grouped_scales_to_mxfp8_blocked(
+                prequantized_lhs.scale_a,
+                offs,
+                zero_unwritten_tail=False,
+            )
+    else:
+        mat_a_q, scale_a_unblocked = quantize_rows_to_mxfp8(mat_a, block_size=32)
+        scale_a_blocked = grouped_scales_to_mxfp8_blocked(
+            scale_a_unblocked,
+            offs,
+            zero_unwritten_tail=False,
+        )
+
+    use_cached_rhs = (
+        prequantized_rhs is not None
+        and tuple(prequantized_rhs.mat_b_shape) == tuple(mat_b.shape)
+        and prequantized_rhs.mat_b_q.device == mat_b.device
+        and (
+            prequantized_rhs.mat_b_version < 0
+            or prequantized_rhs.mat_b_version == _tensor_version(mat_b)
+        )
+    )
+    if use_cached_rhs:
+        assert prequantized_rhs is not None
+        mat_b_q = prequantized_rhs.mat_b_q
+        scale_b_blocked = prequantized_rhs.scale_b
+        mat_b_q = _to_col_major_last2(mat_b_q)
+    else:
+        with nvtx.annotate("scaled_grouped_mm_q_rhs_cache_miss_quantize", color="red"):
+            mat_b_q, scale_b_blocked = quantize_grouped_weight_3d_to_mxfp8_blocked(mat_b)
+            mat_b_q = _to_col_major_last2(mat_b_q)
+
+    if scale_a_blocked is None:
+        raise RuntimeError("aten::_scaled_grouped_mm_v2 path requires blocked lhs scales")
+    if scale_b_blocked is None:
+        raise RuntimeError("aten::_scaled_grouped_mm_v2 path requires blocked rhs scales")
+
+    return _scaled_grouped_mm_v2_cuda(
+        mat_a_q,
+        mat_b_q,
+        scale_a_blocked,
+        scale_b_blocked,
+        offs=offs,
+        use_fast_accum=use_fast_accum,
+    )
+
+
+def _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
+    mat_a: Tensor,
+    prequantized_rhs: ScaledGroupedMMPrequantizedRHS,
+    offs: Tensor,
+    *,
+    use_fast_accum: bool,
+    prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS] = None,
+) -> Tensor:
+    if mat_a.ndim != 2:
+        raise ValueError(
+            "scaled_grouped_mm_q_fp8_weight currently supports rank-2 LHS only, "
+            f"got mat_a={tuple(mat_a.shape)}"
+        )
+
+    mat_b_shape = tuple(prequantized_rhs.mat_b_shape)
+    if len(mat_b_shape) != 3:
+        raise ValueError(
+            "prequantized_rhs must describe rank-3 [G,K,N] RHS, " f"got mat_b_shape={mat_b_shape}"
+        )
+
+    if offs.dtype != torch.int32:
+        offs = offs.to(dtype=torch.int32)
+
+    if not mat_a.is_cuda or not prequantized_rhs.mat_b_q.is_cuda:
+        raise RuntimeError("scaled_grouped_mm_q_fp8_weight requires CUDA tensors")
+    if prequantized_rhs.mat_b_q.device != mat_a.device:
+        raise RuntimeError(
+            "prequantized_rhs device mismatch: "
+            f"rhs_device={prequantized_rhs.mat_b_q.device} mat_a_device={mat_a.device}"
+        )
+
+    scale_a_blocked: Optional[Tensor] = None
+    if prequantized_lhs is not None:
+        if tuple(prequantized_lhs.mat_a_shape) != tuple(mat_a.shape):
+            raise ValueError(
+                "prequantized_lhs shape mismatch: "
+                f"expected {tuple(mat_a.shape)}, got {tuple(prequantized_lhs.mat_a_shape)}"
+            )
+        if prequantized_lhs.mat_a_q.device != mat_a.device:
+            raise ValueError(
+                "prequantized_lhs device mismatch: "
+                f"q_device={prequantized_lhs.mat_a_q.device} mat_a_device={mat_a.device}"
+            )
+        mat_a_q = prequantized_lhs.mat_a_q
+        if prequantized_lhs.scales_are_blocked:
+            scale_a_blocked = prequantized_lhs.scale_a
+        else:
+            scale_a_blocked = grouped_scales_to_mxfp8_blocked(
+                prequantized_lhs.scale_a,
+                offs,
+                zero_unwritten_tail=False,
+            )
+    else:
+        mat_a_q, scale_a_unblocked = quantize_rows_to_mxfp8(mat_a, block_size=32)
+        scale_a_blocked = grouped_scales_to_mxfp8_blocked(
+            scale_a_unblocked,
+            offs,
+            zero_unwritten_tail=False,
+        )
+
+    mat_b_q = _to_col_major_last2(prequantized_rhs.mat_b_q)
+    scale_b_blocked = prequantized_rhs.scale_b
+
+    if scale_a_blocked is None:
+        raise RuntimeError("aten::_scaled_grouped_mm_v2 path requires blocked lhs scales")
+
+    return _scaled_grouped_mm_v2_cuda(
+        mat_a_q,
+        mat_b_q,
+        scale_a_blocked,
+        scale_b_blocked,
+        offs=offs,
+        use_fast_accum=use_fast_accum,
+    )
+
+
+class _ScaledGroupedMMQFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        mat_a: Tensor,
+        mat_b: Tensor,
+        offs: Optional[Tensor],
+        input_grad_out: Optional[Tensor],
+        use_fast_accum: bool,
+        prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS],
+        prequantized_rhs: Optional[ScaledGroupedMMPrequantizedRHS],
+        prequantized_rhs_for_dgrad: Optional[ScaledGroupedMMPrequantizedRHS],
+    ) -> Tensor:
+        if offs is None:
+            raise ValueError("offs is required for scaled_grouped_mm_q")
+
+        if input_grad_out is not None:
+            if input_grad_out.shape != mat_a.shape:
+                raise ValueError(
+                    f"input_grad_out shape mismatch: expected {tuple(mat_a.shape)}, got {tuple(input_grad_out.shape)}"
+                )
+            if input_grad_out.dtype != mat_a.dtype:
+                raise ValueError(
+                    f"input_grad_out dtype mismatch: expected {mat_a.dtype}, got {input_grad_out.dtype}"
+                )
+        if prequantized_rhs_for_dgrad is not None:
+            mat_b_t_shape = tuple(mat_b.transpose(-2, -1).shape)
+            if tuple(prequantized_rhs_for_dgrad.mat_b_shape) != mat_b_t_shape:
+                raise ValueError(
+                    "prequantized_rhs_for_dgrad shape mismatch: "
+                    f"expected {mat_b_t_shape}, got {tuple(prequantized_rhs_for_dgrad.mat_b_shape)}"
+                )
+            if prequantized_rhs_for_dgrad.mat_b_q.device != mat_b.device:
+                raise ValueError(
+                    "prequantized_rhs_for_dgrad device mismatch: "
+                    f"expected {mat_b.device}, got {prequantized_rhs_for_dgrad.mat_b_q.device}"
+                )
+
+        if mat_a.numel() == 0:
+            result = torch.empty(
+                (mat_a.shape[0], mat_b.shape[-1]),
+                device=mat_a.device,
+                dtype=torch.bfloat16,
+            )
+            ctx.save_for_backward(mat_a, mat_b, offs)
+            ctx._saved_mat_a_from_prequantized_lhs = False
+            ctx._mat_a_empty = True
+            ctx.input_grad_out = input_grad_out
+            ctx.prequantized_rhs_for_dgrad = prequantized_rhs_for_dgrad
+            return result
+
+        result = _forward_scaled_grouped_mm_mxfp8(
+            mat_a,
+            mat_b,
+            offs,
+            use_fast_accum=use_fast_accum,
+            prequantized_lhs=prequantized_lhs,
+            prequantized_rhs=prequantized_rhs,
+        )
+
+        # In rowwise FP8 paths we can skip saving bf16 mat_a and reconstruct it
+        # from saved prequantized (q, scale) during backward to avoid dispatch DQ.
+        use_saved_prequantized_lhs = (
+            prequantized_lhs is not None and not prequantized_lhs.scales_are_blocked
+        )
+        if use_saved_prequantized_lhs:
+            assert prequantized_lhs is not None
+            mat_a_q, scale_a = _prequantized_lhs_tensors_for_backward(prequantized_lhs)
+            ctx.save_for_backward(
+                mat_b,
+                offs,
+                mat_a_q,
+                scale_a,
+            )
+            ctx._saved_mat_a_from_prequantized_lhs = True
+        else:
+            ctx.save_for_backward(mat_a, mat_b, offs)
+            ctx._saved_mat_a_from_prequantized_lhs = False
+        ctx.input_grad_out = input_grad_out
+        ctx.prequantized_rhs_for_dgrad = prequantized_rhs_for_dgrad
+        ctx._mat_a_empty = False
+        return result
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):  # type: ignore[override]
+        mat_a: Optional[Tensor] = None
+        saved_mat_a_q: Optional[Tensor] = None
+        saved_mat_a_scale: Optional[Tensor] = None
+        grad_out_compute = grad_out
+        grad_out_mxfp8 = grad_out if isinstance(grad_out, OlmoMXFP8Tensor) else None
+        if grad_out_mxfp8 is not None:
+            grad_out_prequantized_lhs = grad_out_mxfp8.as_scaled_grouped_mm_prequantized_lhs()
+        else:
+            grad_out_prequantized_lhs = None
+        if grad_out_compute.dtype == torch.float8_e4m3fn:
+            grad_out_compute = grad_out_compute.to(dtype=torch.bfloat16)
+        if bool(getattr(ctx, "_saved_mat_a_from_prequantized_lhs", False)):
+            mat_b, offs, mat_a_q, mat_a_scale = ctx.saved_tensors
+            saved_mat_a_q = mat_a_q
+            saved_mat_a_scale = mat_a_scale
+        else:
+            mat_a, mat_b, offs = ctx.saved_tensors
+
+        grad_a = None
+        grad_b = None
+
+        if bool(getattr(ctx, "_mat_a_empty", False)):
+            if ctx.needs_input_grad[0]:
+                assert mat_a is not None
+                grad_a = torch.empty_like(mat_a)
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+            if ctx.needs_input_grad[1]:
+                grad_b = torch.zeros_like(mat_b)
+            return grad_a, grad_b, None, None, None, None, None, None
+
+        if ctx.needs_input_grad[0]:
+            if grad_out_compute.is_cuda and mat_b.is_cuda:
+                grad_a = _forward_scaled_grouped_mm_mxfp8(
+                    grad_out_compute,
+                    mat_b.transpose(-2, -1),
+                    offs,
+                    use_fast_accum=True,
+                    prequantized_lhs=grad_out_prequantized_lhs,
+                    prequantized_rhs=ctx.prequantized_rhs_for_dgrad,
+                )
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+            else:
+                grad_a = F.grouped_mm(grad_out_compute, mat_b.transpose(-2, -1), offs=offs)
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+
+        if ctx.needs_input_grad[1]:
+            if grad_b is None:
+                if mat_a is None:
+                    if saved_mat_a_q is None or saved_mat_a_scale is None:
+                        raise RuntimeError(
+                            "scaled_grouped_mm_q backward expected mat_a when grad_b is required"
+                        )
+                    mat_a = dequantize_rows_from_mxfp8(
+                        saved_mat_a_q,
+                        saved_mat_a_scale,
+                        block_size=32,
+                        out_dtype=grad_out_compute.dtype,
+                    )
+                if grad_out_mxfp8 is not None:
+                    grad_out_compute = grad_out_mxfp8.dequantize(out_dtype=mat_a.dtype)
+                grad_b = F.grouped_mm(
+                    grad_out_compute.transpose(-2, -1),
+                    mat_a,
+                    offs=offs,
+                ).transpose(-2, -1)
+
+        return grad_a, grad_b, None, None, None, None, None, None
+
+
+class _ScaledGroupedMMQFP8WeightFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        mat_a: Tensor,
+        grad_anchor: Tensor,
+        offs: Optional[Tensor],
+        input_grad_out: Optional[Tensor],
+        use_fast_accum: bool,
+        prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS],
+        prequantized_rhs: ScaledGroupedMMPrequantizedRHS,
+        prequantized_rhs_for_dgrad: ScaledGroupedMMPrequantizedRHS,
+        wgrad_sink: Optional[Any],
+        wgrad_sink_transpose_last2: bool,
+        wgrad_sink_squeeze_first_dim: bool,
+    ) -> Tensor:
+        if offs is None:
+            raise ValueError("offs is required for scaled_grouped_mm_q_fp8_weight")
+        if grad_anchor.ndim != 3:
+            raise ValueError(
+                "scaled_grouped_mm_q_fp8_weight expects a rank-3 gradient anchor, "
+                f"got {tuple(grad_anchor.shape)}"
+            )
+        if tuple(prequantized_rhs.mat_b_shape) != tuple(grad_anchor.shape):
+            raise ValueError(
+                "prequantized_rhs shape mismatch: "
+                f"expected {tuple(grad_anchor.shape)}, got {tuple(prequantized_rhs.mat_b_shape)}"
+            )
+        grad_anchor_t_shape = tuple(grad_anchor.transpose(-2, -1).shape)
+        if tuple(prequantized_rhs_for_dgrad.mat_b_shape) != grad_anchor_t_shape:
+            raise ValueError(
+                "prequantized_rhs_for_dgrad shape mismatch: "
+                f"expected {grad_anchor_t_shape}, got {tuple(prequantized_rhs_for_dgrad.mat_b_shape)}"
+            )
+
+        if input_grad_out is not None:
+            if input_grad_out.shape != mat_a.shape:
+                raise ValueError(
+                    f"input_grad_out shape mismatch: expected {tuple(mat_a.shape)}, got {tuple(input_grad_out.shape)}"
+                )
+            if input_grad_out.dtype != mat_a.dtype:
+                raise ValueError(
+                    f"input_grad_out dtype mismatch: expected {mat_a.dtype}, got {input_grad_out.dtype}"
+                )
+
+        ctx.grad_anchor_shape = tuple(grad_anchor.shape)
+        ctx.grad_anchor_dtype = grad_anchor.dtype
+        ctx.grad_anchor_device = grad_anchor.device
+        ctx.input_grad_out = input_grad_out
+        ctx.prequantized_rhs_for_dgrad = prequantized_rhs_for_dgrad
+        ctx.wgrad_sink = wgrad_sink
+        ctx.wgrad_sink_transpose_last2 = bool(wgrad_sink_transpose_last2)
+        ctx.wgrad_sink_squeeze_first_dim = bool(wgrad_sink_squeeze_first_dim)
+
+        if mat_a.numel() == 0:
+            result = torch.empty(
+                (mat_a.shape[0], grad_anchor.shape[-1]),
+                device=mat_a.device,
+                dtype=torch.bfloat16,
+            )
+            ctx.save_for_backward(mat_a, offs)
+            ctx._saved_mat_a_from_prequantized_lhs = False
+            ctx._mat_a_empty = True
+            return result
+
+        result = _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
+            mat_a,
+            prequantized_rhs,
+            offs,
+            use_fast_accum=use_fast_accum,
+            prequantized_lhs=prequantized_lhs,
+        )
+
+        use_saved_prequantized_lhs = (
+            prequantized_lhs is not None and not prequantized_lhs.scales_are_blocked
+        )
+        if use_saved_prequantized_lhs:
+            assert prequantized_lhs is not None
+            mat_a_q, scale_a = _prequantized_lhs_tensors_for_backward(prequantized_lhs)
+            ctx.save_for_backward(
+                offs,
+                mat_a_q,
+                scale_a,
+            )
+            ctx._saved_mat_a_from_prequantized_lhs = True
+        else:
+            ctx.save_for_backward(mat_a, offs)
+            ctx._saved_mat_a_from_prequantized_lhs = False
+        ctx._mat_a_empty = False
+        return result
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):  # type: ignore[override]
+        mat_a: Optional[Tensor] = None
+        saved_mat_a_q: Optional[Tensor] = None
+        saved_mat_a_scale: Optional[Tensor] = None
+        grad_out_compute = grad_out
+        grad_out_mxfp8 = grad_out if isinstance(grad_out, OlmoMXFP8Tensor) else None
+        if grad_out_mxfp8 is not None:
+            grad_out_prequantized_lhs = grad_out_mxfp8.as_scaled_grouped_mm_prequantized_lhs()
+        else:
+            grad_out_prequantized_lhs = None
+        if grad_out_compute.dtype == torch.float8_e4m3fn:
+            grad_out_compute = grad_out_compute.to(dtype=torch.bfloat16)
+
+        if bool(getattr(ctx, "_saved_mat_a_from_prequantized_lhs", False)):
+            offs, mat_a_q, mat_a_scale = ctx.saved_tensors
+            saved_mat_a_q = mat_a_q
+            saved_mat_a_scale = mat_a_scale
+        else:
+            mat_a, offs = ctx.saved_tensors
+
+        grad_a = None
+        grad_anchor = None
+
+        if bool(getattr(ctx, "_mat_a_empty", False)):
+            if ctx.needs_input_grad[0]:
+                assert mat_a is not None
+                grad_a = torch.empty_like(mat_a)
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+            if ctx.needs_input_grad[1] or ctx.wgrad_sink is not None:
+                grad_anchor = torch.zeros(
+                    ctx.grad_anchor_shape,
+                    device=ctx.grad_anchor_device,
+                    dtype=ctx.grad_anchor_dtype,
+                )
+                if ctx.wgrad_sink is not None:
+                    sink_grad = (
+                        grad_anchor.transpose(-2, -1).contiguous()
+                        if ctx.wgrad_sink_transpose_last2
+                        else grad_anchor
+                    )
+                    if ctx.wgrad_sink_squeeze_first_dim:
+                        if sink_grad.shape[0] != 1:
+                            raise RuntimeError(
+                                "wgrad_sink_squeeze_first_dim expects first dim size 1, "
+                                f"got {tuple(sink_grad.shape)}"
+                            )
+                        sink_grad = sink_grad.squeeze(0).contiguous()
+                    ctx.wgrad_sink.accumulate_wgrad(sink_grad)
+            if not ctx.needs_input_grad[1]:
+                grad_anchor = None
+            return grad_a, grad_anchor, None, None, None, None, None, None, None, None, None
+
+        if ctx.needs_input_grad[0]:
+            if grad_out_compute.is_cuda and ctx.prequantized_rhs_for_dgrad.mat_b_q.is_cuda:
+                grad_a = _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
+                    grad_out_compute,
+                    ctx.prequantized_rhs_for_dgrad,
+                    offs,
+                    use_fast_accum=True,
+                    prequantized_lhs=grad_out_prequantized_lhs,
+                )
+                if ctx.input_grad_out is not None:
+                    ctx.input_grad_out.copy_(grad_a)
+                    grad_a = ctx.input_grad_out
+            else:
+                raise RuntimeError("scaled_grouped_mm_q_fp8_weight dgrad requires CUDA cached RHS")
+
+        need_wgrad = ctx.needs_input_grad[1] or ctx.wgrad_sink is not None
+        if need_wgrad:
+            if mat_a is None:
+                if saved_mat_a_q is None or saved_mat_a_scale is None:
+                    raise RuntimeError(
+                        "scaled_grouped_mm_q_fp8_weight backward expected mat_a when wgrad is required"
+                    )
+                mat_a = dequantize_rows_from_mxfp8(
+                    saved_mat_a_q,
+                    saved_mat_a_scale,
+                    block_size=32,
+                    out_dtype=grad_out_compute.dtype,
+                )
+            if grad_out_mxfp8 is not None:
+                grad_out_compute = grad_out_mxfp8.dequantize(out_dtype=mat_a.dtype)
+            grad_anchor = F.grouped_mm(
+                grad_out_compute.transpose(-2, -1),
+                mat_a,
+                offs=offs,
+            ).transpose(-2, -1)
+            if ctx.wgrad_sink is not None:
+                sink_grad = (
+                    grad_anchor.transpose(-2, -1).contiguous()
+                    if ctx.wgrad_sink_transpose_last2
+                    else grad_anchor
+                )
+                if ctx.wgrad_sink_squeeze_first_dim:
+                    if sink_grad.shape[0] != 1:
+                        raise RuntimeError(
+                            "wgrad_sink_squeeze_first_dim expects first dim size 1, "
+                            f"got {tuple(sink_grad.shape)}"
+                        )
+                    sink_grad = sink_grad.squeeze(0).contiguous()
+                ctx.wgrad_sink.accumulate_wgrad(sink_grad)
+            if not ctx.needs_input_grad[1]:
+                grad_anchor = None
+
+        return grad_a, grad_anchor, None, None, None, None, None, None, None, None, None
+
+
+def scaled_grouped_mm_q(
+    mat_a: Tensor,
+    mat_b: Tensor,
+    *,
+    offs: Tensor,
+    input_grad_out: Optional[Tensor] = None,
+    use_fast_accum: bool = True,
+    prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS] = None,
+    prequantized_rhs: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+    prequantized_rhs_for_dgrad: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+) -> Tensor:
+    """
+    MXFP8 grouped mm wrapper used by MoE routed experts.
+
+    Forward uses aten::_scaled_grouped_mm_v2 and returns bf16 output.
+    Backward uses the same bf16 grouped MXFP8 path for dgrad on CUDA and grouped_mm for wgrad.
+
+    Supports 2D-3D grouped mm with `offs` and optional explicit buffers:
+    - input_grad_out: grad(mat_a) destination in backward
+    - prequantized_lhs: optional pre-quantized LHS q/scales to bypass LHS quantization
+    - prequantized_rhs: optional pre-quantized RHS q/scales to bypass RHS quantization
+    - prequantized_rhs_for_dgrad: optional pre-quantized transposed RHS used by backward dgrad
+    """
+    return _ScaledGroupedMMQFunction.apply(
+        mat_a,
+        mat_b,
+        offs,
+        input_grad_out,
+        use_fast_accum,
+        prequantized_lhs,
+        prequantized_rhs,
+        prequantized_rhs_for_dgrad,
+    )
+
+
+def scaled_grouped_mm_q_fp8_weight(
+    mat_a: Tensor,
+    grad_anchor: Tensor,
+    *,
+    offs: Tensor,
+    input_grad_out: Optional[Tensor] = None,
+    use_fast_accum: bool = True,
+    prequantized_lhs: Optional[ScaledGroupedMMPrequantizedLHS] = None,
+    prequantized_rhs: ScaledGroupedMMPrequantizedRHS,
+    prequantized_rhs_for_dgrad: ScaledGroupedMMPrequantizedRHS,
+    wgrad_sink: Optional[Any] = None,
+    wgrad_sink_transpose_last2: bool = False,
+    wgrad_sink_squeeze_first_dim: bool = False,
+) -> Tensor:
+    """
+    MXFP8 grouped mm for a prequantized expert weight.
+
+    This transitional API uses only the cached MXFP8 RHS tensors for forward
+    and dgrad, while `grad_anchor` receives the normal high-precision wgrad.
+    If `wgrad_sink` is provided, the same wgrad is also accumulated there as a
+    side channel for the staged FP8-only-params refactor. That keeps today's
+    DDP/optimizer behavior intact while decoupling kernel execution from the
+    bf16 model weight storage.
+    """
+    return _ScaledGroupedMMQFP8WeightFunction.apply(
+        mat_a,
+        grad_anchor,
+        offs,
+        input_grad_out,
+        use_fast_accum,
+        prequantized_lhs,
+        prequantized_rhs,
+        prequantized_rhs_for_dgrad,
+        wgrad_sink,
+        bool(wgrad_sink_transpose_last2),
+        bool(wgrad_sink_squeeze_first_dim),
+    )
+
+
+__all__ = [
+    "scaled_grouped_mm_q",
+    "scaled_grouped_mm_q_fp8_weight",
+    "prequantize_scaled_grouped_mm_rhs",
+    "ScaledGroupedMMPrequantizedLHS",
+    "ScaledGroupedMMPrequantizedRHS",
+]

--- a/src/olmo_core/kernels/scaled_grouped_mm.py
+++ b/src/olmo_core/kernels/scaled_grouped_mm.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     from olmo_core._nvtx import nvtx
 
+from ..doc_utils import beta_feature
 from .mxfp8_tensor import OlmoMXFP8Tensor
 from .mxfp8_utils import (
     dequantize_rows_from_mxfp8,
@@ -642,6 +643,7 @@ class _ScaledGroupedMMQFP8WeightFunction(torch.autograd.Function):
         return grad_a, grad_anchor, None, None, None, None, None, None, None, None, None
 
 
+@beta_feature
 def scaled_grouped_mm_q(
     mat_a: Tensor,
     mat_b: Tensor,
@@ -677,6 +679,7 @@ def scaled_grouped_mm_q(
     )
 
 
+@beta_feature
 def scaled_grouped_mm_q_fp8_weight(
     mat_a: Tensor,
     grad_anchor: Tensor,

--- a/src/olmo_core/nn/fp8_weight.py
+++ b/src/olmo_core/nn/fp8_weight.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping, Optional, Sequence
+
+import torch
+
+from olmo_core.kernels import (
+    ScaledGroupedMMPrequantizedRHS,
+    prequantize_scaled_grouped_mm_rhs,
+)
+
+
+@dataclass(frozen=True)
+class FP8WeightCacheSpec:
+    """
+    Describes one cached FP8 RHS layout derived from a logical weight.
+
+    The transform is intentionally explicit. MoE routed experts, shared
+    experts, and future attention projections can each provide the layouts
+    their kernels need without the store guessing from parameter names.
+    """
+
+    name: str
+    transform: Callable[[torch.Tensor], torch.Tensor]
+
+
+class FP8WeightStore:
+    """
+    Generic logical weight store for fp32-main -> FP8-model training.
+
+    This object presents just enough tensor-like surface for the fused optimizer
+    while physically storing named FP8 RHS caches plus BF16 logical gradients.
+    A normal parameter can remain attached as a shape/device anchor until the
+    optimizer has initialized fp32 main params, after which its backing storage
+    may be released.
+    """
+
+    def __init__(
+        self,
+        *,
+        logical_name: str,
+        logical_shape: tuple[int, ...],
+        cache_specs: Sequence[FP8WeightCacheSpec] = (),
+        anchor_param: Optional[torch.nn.Parameter] = None,
+        optimizer_enabled: bool = False,
+        prequantized_rhs: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+        prequantized_rhs_for_dgrad: Optional[ScaledGroupedMMPrequantizedRHS] = None,
+    ) -> None:
+        self.logical_name = logical_name
+        self.logical_shape = logical_shape
+        self.cache_specs = tuple(cache_specs)
+        self.anchor_param = anchor_param
+        self.optimizer_enabled = optimizer_enabled
+        self.cache_values: dict[str, ScaledGroupedMMPrequantizedRHS] = {}
+        if prequantized_rhs is not None:
+            self.cache_values["rhs"] = prequantized_rhs
+        if prequantized_rhs_for_dgrad is not None:
+            self.cache_values["rhs_for_dgrad"] = prequantized_rhs_for_dgrad
+        self.weight_versions: Optional[tuple[int, ...]] = None
+        self.grad_bf16: Optional[torch.Tensor] = None
+        self.main_grad_fp32: Optional[torch.Tensor] = None
+        self.accumulate_wgrad_in_fp32 = False
+        self.anchor_storage_released = False
+
+    @property
+    def requires_grad(self) -> bool:
+        return True
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self.logical_shape
+
+    @property
+    def ndim(self) -> int:
+        return len(self.logical_shape)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        if self.anchor_param is not None:
+            return self.anchor_param.dtype
+        if self.grad_bf16 is not None:
+            return self.grad_bf16.dtype
+        return torch.bfloat16
+
+    @property
+    def device(self) -> torch.device:
+        if self.anchor_param is not None:
+            return self.anchor_param.device
+        if self.grad_bf16 is not None:
+            return self.grad_bf16.device
+        for cache in self.cache_values.values():
+            return cache.mat_b_q.device
+        return torch.device("cpu")
+
+    @property
+    def data(self) -> torch.Tensor:
+        if self.anchor_param is None:
+            raise RuntimeError(
+                f"FP8 weight store '{self.logical_name}' has no anchor tensor to expose as data"
+            )
+        return self.anchor_param.data
+
+    @property
+    def grad(self) -> Optional[torch.Tensor]:
+        return self.grad_bf16
+
+    @property
+    def _main_grad_fp32(self) -> Optional[torch.Tensor]:
+        return self.main_grad_fp32
+
+    @_main_grad_fp32.setter
+    def _main_grad_fp32(self, value: Optional[torch.Tensor]) -> None:
+        self.main_grad_fp32 = value
+
+    @property
+    def prequantized_rhs(self) -> Optional[ScaledGroupedMMPrequantizedRHS]:
+        return self.cache_values.get("rhs")
+
+    @prequantized_rhs.setter
+    def prequantized_rhs(self, value: Optional[ScaledGroupedMMPrequantizedRHS]) -> None:
+        self._set_cache("rhs", value)
+
+    @property
+    def prequantized_rhs_for_dgrad(self) -> Optional[ScaledGroupedMMPrequantizedRHS]:
+        return self.cache_values.get("rhs_for_dgrad")
+
+    @prequantized_rhs_for_dgrad.setter
+    def prequantized_rhs_for_dgrad(self, value: Optional[ScaledGroupedMMPrequantizedRHS]) -> None:
+        self._set_cache("rhs_for_dgrad", value)
+
+    def _set_cache(self, name: str, value: Optional[ScaledGroupedMMPrequantizedRHS]) -> None:
+        if value is None:
+            self.cache_values.pop(name, None)
+            return
+        self.cache_values[name] = value
+
+    def numel(self) -> int:
+        out = 1
+        for dim in self.logical_shape:
+            out *= dim
+        return out
+
+    def element_size(self) -> int:
+        return torch.tensor([], dtype=self.dtype).element_size()
+
+    def type(self) -> str:
+        device_prefix = "torch.cuda" if self.device.type == "cuda" else "torch"
+        if self.dtype == torch.bfloat16:
+            return f"{device_prefix}.BFloat16Tensor"
+        if self.dtype == torch.float16:
+            return f"{device_prefix}.HalfTensor"
+        if self.dtype == torch.float32:
+            return f"{device_prefix}.FloatTensor"
+        return str(self.dtype)
+
+    def invalidate(self) -> None:
+        self.cache_values.clear()
+        self.weight_versions = None
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        if set_to_none:
+            self.grad_bf16 = None
+            self.main_grad_fp32 = None
+            return
+        if self.grad_bf16 is not None:
+            self.grad_bf16.zero_()
+        if self.main_grad_fp32 is not None:
+            self.main_grad_fp32.zero_()
+
+    def set_main_grad_to_none(self) -> None:
+        self.main_grad_fp32 = None
+
+    def replace_wgrad(self, grad: torch.Tensor) -> None:
+        if self.accumulate_wgrad_in_fp32:
+            self.main_grad_fp32 = grad.detach().to(torch.float32).contiguous()
+            self.grad_bf16 = None
+        else:
+            self.grad_bf16 = grad.detach().to(torch.bfloat16).contiguous()
+            self.main_grad_fp32 = None
+
+    @torch.no_grad()
+    def release_anchor_storage(self) -> None:
+        if self.anchor_param is None or self.anchor_storage_released:
+            return
+        missing = [spec.name for spec in self.cache_specs if spec.name not in self.cache_values]
+        if missing:
+            raise RuntimeError(
+                f"Cannot release bf16 anchor storage for FP8 weight store '{self.logical_name}' "
+                f"before its FP8 caches are initialized: missing {missing}"
+            )
+        base = torch.empty(
+            (1,),
+            dtype=self.anchor_param.dtype,
+            device=self.anchor_param.device,
+        )
+        placeholder = torch.as_strided(
+            base,
+            size=self.logical_shape,
+            stride=(0,) * len(self.logical_shape),
+        )
+        self.anchor_param.requires_grad_(False)
+        self.anchor_param.grad = None
+        if hasattr(self.anchor_param, "_main_grad_fp32"):
+            self.anchor_param._main_grad_fp32 = None  # type: ignore[attr-defined]
+        self.anchor_param.data = placeholder
+        self.anchor_storage_released = True
+
+    @torch.no_grad()
+    def refresh_from_logical_weight(
+        self,
+        logical_weight: torch.Tensor,
+        *,
+        version_tensors: Sequence[torch.Tensor] = (),
+        update_anchor: bool = False,
+    ) -> None:
+        if tuple(logical_weight.shape) != self.logical_shape:
+            raise ValueError(
+                f"FP8 weight store '{self.logical_name}' expected logical shape "
+                f"{self.logical_shape}, got {tuple(logical_weight.shape)}"
+            )
+        if update_anchor and self.anchor_param is not None and not self.anchor_storage_released:
+            self.anchor_param.data.copy_(logical_weight.to(dtype=self.anchor_param.dtype))
+        if not self.cache_specs:
+            raise RuntimeError(f"FP8 weight store '{self.logical_name}' has no cache specs")
+        self.refresh_from_tensors(
+            cache_tensors={spec.name: spec.transform(logical_weight) for spec in self.cache_specs},
+            version_tensors=version_tensors,
+        )
+
+    @torch.no_grad()
+    def refresh_from_tensors(
+        self,
+        *,
+        cache_tensors: Optional[Mapping[str, torch.Tensor]] = None,
+        rhs: Optional[torch.Tensor] = None,
+        rhs_for_dgrad: Optional[torch.Tensor] = None,
+        version_tensors: Sequence[torch.Tensor] = (),
+    ) -> None:
+        tensors: dict[str, torch.Tensor] = {}
+        if cache_tensors is not None:
+            tensors.update(cache_tensors)
+        if rhs is not None:
+            tensors["rhs"] = rhs
+        if rhs_for_dgrad is not None:
+            tensors["rhs_for_dgrad"] = rhs_for_dgrad
+        if not tensors:
+            raise ValueError("refresh_from_tensors requires at least one cache tensor")
+        for name, tensor in tensors.items():
+            self.cache_values[name] = prequantize_scaled_grouped_mm_rhs(
+                tensor,
+                check_mat_b_version=False,
+            )
+        self.weight_versions = tuple(int(t._version) for t in version_tensors)
+
+    def require_cache(self, name: str) -> ScaledGroupedMMPrequantizedRHS:
+        cache = self.cache_values.get(name)
+        if cache is None:
+            raise RuntimeError(
+                f"FP8 weight store '{self.logical_name}' cache '{name}' is not initialized"
+            )
+        return cache
+
+    def require_prequantized_rhs(self) -> ScaledGroupedMMPrequantizedRHS:
+        return self.require_cache("rhs")
+
+    def require_prequantized_rhs_for_dgrad(self) -> ScaledGroupedMMPrequantizedRHS:
+        return self.require_cache("rhs_for_dgrad")
+
+    def iter_prequantized_caches(self):
+        return self.cache_values.values()
+
+    def accumulate_wgrad(self, grad: torch.Tensor) -> None:
+        if self.accumulate_wgrad_in_fp32:
+            grad_fp32 = grad.detach().to(torch.float32)
+            if self.main_grad_fp32 is None:
+                self.main_grad_fp32 = grad_fp32.contiguous()
+            else:
+                self.main_grad_fp32.add_(grad_fp32)
+            self.grad_bf16 = None
+        else:
+            grad_bf16 = grad.detach().to(torch.bfloat16)
+            if self.grad_bf16 is None:
+                self.grad_bf16 = grad_bf16.contiguous()
+            else:
+                self.grad_bf16.add_(grad_bf16)
+            self.main_grad_fp32 = None
+
+
+__all__ = ["FP8WeightCacheSpec", "FP8WeightStore"]

--- a/src/olmo_core/nn/fp8_weight.py
+++ b/src/olmo_core/nn/fp8_weight.py
@@ -5,6 +5,7 @@ from typing import Callable, Mapping, Optional, Sequence
 
 import torch
 
+from olmo_core.doc_utils import beta_feature
 from olmo_core.kernels import (
     ScaledGroupedMMPrequantizedRHS,
     prequantize_scaled_grouped_mm_rhs,
@@ -25,6 +26,7 @@ class FP8WeightCacheSpec:
     transform: Callable[[torch.Tensor], torch.Tensor]
 
 
+@beta_feature
 class FP8WeightStore:
     """
     Generic logical weight store for fp32-main -> FP8-model training.

--- a/src/test/kernels/scaled_grouped_mm_q_test.py
+++ b/src/test/kernels/scaled_grouped_mm_q_test.py
@@ -17,7 +17,8 @@ from olmo_core.kernels.scaled_grouped_mm import (
     scaled_grouped_mm_q,
     scaled_grouped_mm_q_fp8_weight,
 )
-from olmo_core.testing import has_torch_grouped_mm
+from olmo_core.testing import has_torch_grouped_mm, requires_gpu
+from olmo_core.testing.utils import requires_compute_capability
 
 # The FP8 scaled-grouped-mm path requires torch >= 2.10 (F.grouped_mm reference +
 # F.ScalingType/F.SwizzleType). Skip the file wholesale on older torch.
@@ -118,9 +119,9 @@ def test_mxfp8_row_quant_dequant_roundtrip():
     assert float(rel_err.item()) < 0.6
 
 
+@requires_gpu
+@requires_compute_capability(min_cc=9)
 def test_mxfp8_row_quant_no_nan_on_cuda():
-    if not torch.cuda.is_available():
-        return
     x = torch.randn(256, 512, device="cuda", dtype=torch.bfloat16)
     qdata, scales = quantize_rows_to_mxfp8(x, block_size=32)
     assert bool(torch.isfinite(qdata.float()).all())
@@ -285,10 +286,8 @@ def test_scaled_grouped_mm_q_fp8_weight_uses_prequantized_lhs_for_wgrad(monkeypa
     torch.testing.assert_close(captured["lhs_for_wgrad"], mat_a_expected)
 
 
+@requires_gpu
 def test_scaled_grouped_mm_q_fp8_weight_accumulates_sink_for_detached_anchor(monkeypatch):
-    if not torch.cuda.is_available():
-        return
-
     monkeypatch.setattr(
         scaled_grouped_mm_module,
         "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
@@ -459,9 +458,9 @@ def test_quantize_grouped_2d_to_mxfp8_blocked_keeps_capacity_shape():
     assert scales_blocked.shape[0] >= x.shape[0]
 
 
+@requires_gpu
+@requires_compute_capability(min_cc=9)
 def test_quantize_grouped_2d_to_mxfp8_blocked_fused_matches_two_stage_cuda():
-    if not torch.cuda.is_available():
-        return
     x = torch.randn(64, 512, device="cuda", dtype=torch.bfloat16)
     # Active rows are 41, but input has capacity 64.
     offs = torch.tensor([11, 17, 41], device="cuda", dtype=torch.int32)
@@ -488,9 +487,8 @@ def test_quantize_grouped_weight_3d_to_mxfp8_blocked_returns_col_major_layout():
     assert scales_blocked.dtype == torch.float8_e8m0fnu
 
 
+@requires_gpu
 def test_scaled_grouped_mm_q_forces_mat2_col_major_layout(monkeypatch):
-    if not torch.cuda.is_available():
-        return
     a, b, offs = _build_inputs()
     a = a.to(device="cuda")
     b = b.to(device="cuda")
@@ -564,9 +562,9 @@ def test_scaled_grouped_mm_q_forces_mat2_col_major_layout(monkeypatch):
     assert seen["stride"][-1] == b.shape[-2]
 
 
+@requires_gpu
+@requires_compute_capability(min_cc=9)
 def test_scaled_grouped_mm_q_uses_prequantized_rhs(monkeypatch):
-    if not torch.cuda.is_available():
-        return
     torch.manual_seed(123)
     offs = torch.tensor([3, 5, 9], dtype=torch.int32, device="cuda")
     a = torch.randn(int(offs[-1].item()), 512, dtype=torch.float32, device="cuda")

--- a/src/test/kernels/scaled_grouped_mm_q_test.py
+++ b/src/test/kernels/scaled_grouped_mm_q_test.py
@@ -1,0 +1,732 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+import olmo_core.kernels.scaled_grouped_mm as scaled_grouped_mm_module
+from olmo_core.kernels import OlmoMXFP8Tensor
+from olmo_core.kernels.mxfp8_utils import (
+    dequantize_rows_from_mxfp8,
+    quantize_grouped_2d_to_mxfp8_blocked,
+    quantize_grouped_2d_to_mxfp8_blocked_fused,
+    quantize_grouped_weight_3d_to_mxfp8_blocked,
+    quantize_rows_to_mxfp8,
+)
+from olmo_core.kernels.scaled_grouped_mm import (
+    ScaledGroupedMMPrequantizedRHS,
+    prequantize_scaled_grouped_mm_rhs,
+    scaled_grouped_mm_q,
+    scaled_grouped_mm_q_fp8_weight,
+)
+from olmo_core.testing import has_torch_grouped_mm
+
+# The FP8 scaled-grouped-mm path requires torch >= 2.10 (F.grouped_mm reference +
+# F.ScalingType/F.SwizzleType). Skip the file wholesale on older torch.
+pytestmark = pytest.mark.skipif(
+    not has_torch_grouped_mm,
+    reason="Requires torch.nn.functional.grouped_mm (torch>=2.10)",
+)
+
+
+def test_olmo_mxfp8_tensor_as_scaled_grouped_mm_prequantized_lhs():
+    # OlmoMXFP8Tensor -> ScaledGroupedMMPrequantizedLHS bridge.
+    torch.manual_seed(123)
+    x = torch.randn(8, 64, dtype=torch.float32)
+    mx = OlmoMXFP8Tensor.from_hp(x)
+    preq = mx.as_scaled_grouped_mm_prequantized_lhs()
+    assert preq.mat_a_q is mx.qdata
+    assert preq.scale_a is mx.scales
+    assert preq.mat_a_shape == tuple(mx.shape)
+
+
+def _build_inputs() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(123)
+    group_sizes = torch.tensor([3, 2, 4], dtype=torch.int32)
+    offs = torch.cumsum(group_sizes, dim=0, dtype=torch.int32)
+    a = torch.randn(int(offs[-1].item()), 512, dtype=torch.float32)
+    b = torch.randn(group_sizes.numel(), 512, 512, dtype=torch.float32)
+    return a, b, offs
+
+
+def _stub_forward(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    offs: torch.Tensor,
+    *,
+    use_fast_accum: bool,
+    prequantized_lhs=None,
+    prequantized_rhs=None,
+) -> torch.Tensor:
+    del use_fast_accum, prequantized_lhs, prequantized_rhs
+    return F.grouped_mm(mat_a, mat_b, offs=offs)
+
+
+def _stub_forward_prequantized_rhs(
+    mat_a: torch.Tensor,
+    prequantized_rhs: ScaledGroupedMMPrequantizedRHS,
+    offs: torch.Tensor,
+    *,
+    use_fast_accum: bool,
+    prequantized_lhs=None,
+) -> torch.Tensor:
+    del offs, use_fast_accum, prequantized_lhs
+    return torch.zeros(
+        (mat_a.shape[0], prequantized_rhs.mat_b_shape[-1]),
+        dtype=mat_a.dtype,
+        device=mat_a.device,
+    )
+
+
+def _fake_prequantized_rhs(
+    shape: tuple[int, ...],
+    *,
+    device: torch.device | str = "cpu",
+) -> ScaledGroupedMMPrequantizedRHS:
+    return ScaledGroupedMMPrequantizedRHS(
+        mat_b_q=torch.empty(shape, dtype=torch.float8_e4m3fn, device=device),
+        scale_b=torch.empty((1,), dtype=torch.float8_e8m0fnu, device=device),
+        mat_b_shape=shape,
+        mat_b_version=-1,
+    )
+
+
+class _WgradSink:
+    def __init__(self):
+        self.grad_bf16 = None
+
+    def accumulate_wgrad(self, grad: torch.Tensor) -> None:
+        grad_bf16 = grad.detach().to(torch.bfloat16)
+        if self.grad_bf16 is None:
+            self.grad_bf16 = grad_bf16.clone()
+        else:
+            self.grad_bf16.add_(grad_bf16)
+
+
+def test_mxfp8_row_quant_dequant_roundtrip():
+    x = torch.randn(16, 512, dtype=torch.float32)
+    qdata, scales = quantize_rows_to_mxfp8(x, block_size=32)
+    assert qdata.dtype == torch.float8_e4m3fn
+    assert scales.dtype == torch.float8_e8m0fnu
+
+    x_hat = dequantize_rows_from_mxfp8(qdata, scales, block_size=32, out_dtype=torch.float32)
+    assert x_hat.shape == x.shape
+    finite = torch.isfinite(x_hat)
+    # e4m3fn quantization can produce a small number of non-finite values on CPU.
+    assert float(finite.float().mean().item()) > 0.98
+    # Float8 round-trip error can be large; keep this as a coarse sanity bound.
+    x_hat_safe = torch.nan_to_num(x_hat, nan=0.0, posinf=0.0, neginf=0.0)
+    rel_err = (x - x_hat_safe).norm() / x.norm().clamp_min(1e-6)
+    assert float(rel_err.item()) < 0.6
+
+
+def test_mxfp8_row_quant_no_nan_on_cuda():
+    if not torch.cuda.is_available():
+        return
+    x = torch.randn(256, 512, device="cuda", dtype=torch.bfloat16)
+    qdata, scales = quantize_rows_to_mxfp8(x, block_size=32)
+    assert bool(torch.isfinite(qdata.float()).all())
+    assert bool(torch.isfinite(scales.float()).all())
+
+
+def test_quantize_rows_to_mxfp8_supports_output_buffers():
+    x = torch.randn(16, 512, dtype=torch.float32)
+    out_q = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    out_scales = torch.empty((x.shape[0], x.shape[1] // 32), dtype=torch.float8_e8m0fnu)
+
+    qdata, scales = quantize_rows_to_mxfp8(
+        x,
+        block_size=32,
+        out=out_q,
+        scales_out=out_scales,
+    )
+    assert qdata.untyped_storage().data_ptr() == out_q.untyped_storage().data_ptr()
+    assert scales.untyped_storage().data_ptr() == out_scales.untyped_storage().data_ptr()
+    assert qdata.shape == x.shape
+    assert scales.shape == (x.shape[0], x.shape[1] // 32)
+
+
+def test_scaled_grouped_mm_q_forward_matches_grouped_mm_reference(monkeypatch):
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+    a, b, offs = _build_inputs()
+
+    out = scaled_grouped_mm_q(a, b, offs=offs)
+    ref = F.grouped_mm(a, b, offs=offs)
+    torch.testing.assert_close(out, ref)
+
+
+def test_scaled_grouped_mm_q_backward_matches_grouped_mm_reference(monkeypatch):
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+
+    a, b, offs = _build_inputs()
+    a = a.detach().requires_grad_(True)
+    b = b.detach().requires_grad_(True)
+
+    out = scaled_grouped_mm_q(a, b, offs=offs)
+    loss = (out * out).mean()
+    grad_a, grad_b = torch.autograd.grad(loss, (a, b))
+
+    a_ref = a.detach().clone().requires_grad_(True)
+    b_ref = b.detach().clone().requires_grad_(True)
+    out_ref = F.grouped_mm(a_ref, b_ref, offs=offs)
+    loss_ref = (out_ref * out_ref).mean()
+    grad_a_ref, grad_b_ref = torch.autograd.grad(loss_ref, (a_ref, b_ref))
+
+    torch.testing.assert_close(grad_a, grad_a_ref)
+    torch.testing.assert_close(grad_b, grad_b_ref)
+
+
+def test_scaled_grouped_mm_q_fp8_weight_returns_grad_to_anchor(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    a, b, offs = _build_inputs()
+    a = a.detach()
+    b = b.detach().requires_grad_(True)
+    rhs = _fake_prequantized_rhs(tuple(b.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(b.transpose(-2, -1).shape))
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        b,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_b,) = torch.autograd.grad(out, (b,), grad_outputs=grad_out)
+
+    grad_b_ref = F.grouped_mm(grad_out.transpose(-2, -1), a, offs=offs).transpose(-2, -1)
+    torch.testing.assert_close(grad_b, grad_b_ref)
+
+
+def test_scaled_grouped_mm_q_fp8_weight_accumulates_wgrad_sink(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    a, b, offs = _build_inputs()
+    a = a.detach()
+    b = b.detach().requires_grad_(True)
+    rhs = _fake_prequantized_rhs(tuple(b.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(b.transpose(-2, -1).shape))
+    sink = _WgradSink()
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        b,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_b,) = torch.autograd.grad(out, (b,), grad_outputs=grad_out)
+
+    assert sink.grad_bf16 is not None
+    torch.testing.assert_close(sink.grad_bf16, grad_b.to(torch.bfloat16))
+
+
+def test_scaled_grouped_mm_q_fp8_weight_uses_prequantized_lhs_for_wgrad(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    torch.manual_seed(123)
+    offs = torch.tensor([3, 5, 9], dtype=torch.int32)
+    mat_a_real = torch.randn(int(offs[-1].item()), 512, dtype=torch.float32)
+    mat_a_placeholder = torch.zeros_like(mat_a_real)
+    anchor = torch.randn(offs.numel(), 512, 512, dtype=torch.float32, requires_grad=True)
+    mat_a_q, mat_a_s = quantize_rows_to_mxfp8(mat_a_real, block_size=32)
+    preq_lhs = scaled_grouped_mm_module.ScaledGroupedMMPrequantizedLHS(
+        mat_a_q=mat_a_q,
+        scale_a=mat_a_s,
+        mat_a_shape=tuple(mat_a_placeholder.shape),
+        scales_are_blocked=False,
+    )
+    rhs = _fake_prequantized_rhs(tuple(anchor.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(anchor.transpose(-2, -1).shape))
+    sink = _WgradSink()
+
+    captured = {}
+
+    def _fake_grouped_mm(mat_a: torch.Tensor, mat_b: torch.Tensor, *, offs: torch.Tensor):
+        if mat_b.ndim == 2 and tuple(mat_b.shape) == tuple(mat_a_placeholder.shape):
+            captured["lhs_for_wgrad"] = mat_b.clone()
+            return torch.zeros((offs.numel(), mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+        return torch.zeros((mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+
+    monkeypatch.setattr(F, "grouped_mm", _fake_grouped_mm)
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        mat_a_placeholder,
+        anchor,
+        offs=offs,
+        prequantized_lhs=preq_lhs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+    )
+    (grad_anchor,) = torch.autograd.grad(out.sum(), (anchor,))
+
+    assert grad_anchor is not None
+    assert "lhs_for_wgrad" in captured
+    mat_a_expected = dequantize_rows_from_mxfp8(
+        mat_a_q,
+        mat_a_s,
+        block_size=32,
+        out_dtype=out.dtype,
+    )
+    torch.testing.assert_close(captured["lhs_for_wgrad"], mat_a_expected)
+
+
+def test_scaled_grouped_mm_q_fp8_weight_accumulates_sink_for_detached_anchor(monkeypatch):
+    if not torch.cuda.is_available():
+        return
+
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    a, b, offs = _build_inputs()
+    a = a.cuda().detach().requires_grad_(True)
+    anchor = b.cuda().detach()
+    offs = offs.cuda()
+    rhs = _fake_prequantized_rhs(tuple(anchor.shape), device=anchor.device)
+    rhs_t = _fake_prequantized_rhs(tuple(anchor.transpose(-2, -1).shape), device=anchor.device)
+    sink = _WgradSink()
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        anchor,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_a,) = torch.autograd.grad(out, (a,), grad_outputs=grad_out)
+
+    assert grad_a is not None
+    assert sink.grad_bf16 is not None
+    grad_anchor_ref = F.grouped_mm(grad_out.transpose(-2, -1), a, offs=offs).transpose(-2, -1)
+    torch.testing.assert_close(sink.grad_bf16, grad_anchor_ref.to(torch.bfloat16))
+
+
+def test_scaled_grouped_mm_q_fp8_weight_transposes_wgrad_sink(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    a, b, offs = _build_inputs()
+    a = a.detach()
+    anchor = b.detach().transpose(-2, -1).contiguous().requires_grad_(True)
+    rhs = _fake_prequantized_rhs(tuple(anchor.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(anchor.transpose(-2, -1).shape))
+    sink = _WgradSink()
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        anchor,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+        wgrad_sink_transpose_last2=True,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_anchor,) = torch.autograd.grad(out, (anchor,), grad_outputs=grad_out)
+
+    assert sink.grad_bf16 is not None
+    torch.testing.assert_close(
+        sink.grad_bf16,
+        grad_anchor.transpose(-2, -1).contiguous().to(torch.bfloat16),
+    )
+
+
+def test_scaled_grouped_mm_q_fp8_weight_squeezes_wgrad_sink(monkeypatch):
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_forward_scaled_grouped_mm_mxfp8_prequantized_rhs",
+        _stub_forward_prequantized_rhs,
+    )
+
+    torch.manual_seed(123)
+    offs = torch.tensor([4], dtype=torch.int32)
+    a = torch.randn(4, 512, dtype=torch.float32)
+    anchor = torch.randn(1, 512, 512, dtype=torch.float32, requires_grad=True)
+    rhs = _fake_prequantized_rhs(tuple(anchor.shape))
+    rhs_t = _fake_prequantized_rhs(tuple(anchor.transpose(-2, -1).shape))
+    sink = _WgradSink()
+
+    out = scaled_grouped_mm_q_fp8_weight(
+        a,
+        anchor,
+        offs=offs,
+        prequantized_rhs=rhs,
+        prequantized_rhs_for_dgrad=rhs_t,
+        wgrad_sink=sink,
+        wgrad_sink_squeeze_first_dim=True,
+    )
+    grad_out = torch.ones_like(out)
+    (grad_anchor,) = torch.autograd.grad(out, (anchor,), grad_outputs=grad_out)
+
+    assert sink.grad_bf16 is not None
+    torch.testing.assert_close(
+        sink.grad_bf16,
+        grad_anchor.squeeze(0).contiguous().to(torch.bfloat16),
+    )
+
+
+def test_scaled_grouped_mm_q_input_grad_out_alias(monkeypatch):
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+
+    a, b, offs = _build_inputs()
+    a = a.detach().requires_grad_(True)
+    b = b.detach().requires_grad_(True)
+
+    input_grad_out = torch.empty_like(a)
+
+    out = scaled_grouped_mm_q(
+        a,
+        b,
+        offs=offs,
+        input_grad_out=input_grad_out,
+    )
+
+    grad_a, _grad_b = torch.autograd.grad(
+        out,
+        (a, b),
+        grad_outputs=torch.ones_like(out).contiguous(),
+    )
+    assert grad_a.untyped_storage().data_ptr() == input_grad_out.untyped_storage().data_ptr()
+
+
+def test_scaled_grouped_mm_q_empty_input_backward_returns_zero_grads():
+    mat_a = torch.empty((0, 512), dtype=torch.float32, requires_grad=True)
+    mat_b = torch.randn(3, 512, 512, dtype=torch.float32, requires_grad=True)
+    offs = torch.zeros((3,), dtype=torch.int32)
+
+    out = scaled_grouped_mm_q(mat_a, mat_b, offs=offs)
+    assert out.shape == (0, 512)
+    assert out.dtype == torch.bfloat16
+
+    out.sum().backward()
+
+    assert mat_a.grad is not None
+    assert mat_a.grad.shape == mat_a.shape
+    assert mat_b.grad is not None
+    torch.testing.assert_close(mat_b.grad, torch.zeros_like(mat_b))
+
+
+def test_scaled_grouped_mm_q_empty_input_backward_uses_input_grad_out():
+    mat_a = torch.empty((0, 512), dtype=torch.float32, requires_grad=True)
+    mat_b = torch.randn(3, 512, 512, dtype=torch.float32, requires_grad=True)
+    offs = torch.zeros((3,), dtype=torch.int32)
+    input_grad_out = torch.empty_like(mat_a)
+
+    out = scaled_grouped_mm_q(
+        mat_a,
+        mat_b,
+        offs=offs,
+        input_grad_out=input_grad_out,
+    )
+    (grad_a, _grad_b) = torch.autograd.grad(out.sum(), (mat_a, mat_b))
+
+    assert grad_a.untyped_storage().data_ptr() == input_grad_out.untyped_storage().data_ptr()
+
+
+def test_quantize_grouped_2d_to_mxfp8_blocked_keeps_capacity_shape():
+    x = torch.randn(16, 512, dtype=torch.float32)
+    # Active rows are 9, but input has capacity 16.
+    offs = torch.tensor([4, 7, 9], dtype=torch.int32)
+
+    qdata, scales_blocked = quantize_grouped_2d_to_mxfp8_blocked(x, offs)
+    assert qdata.shape == x.shape
+    assert qdata.dtype == torch.float8_e4m3fn
+
+    assert scales_blocked.dtype == torch.float8_e8m0fnu
+    assert scales_blocked.shape[1] == x.shape[1] // 32
+    assert scales_blocked.shape[0] >= x.shape[0]
+
+
+def test_quantize_grouped_2d_to_mxfp8_blocked_fused_matches_two_stage_cuda():
+    if not torch.cuda.is_available():
+        return
+    x = torch.randn(64, 512, device="cuda", dtype=torch.bfloat16)
+    # Active rows are 41, but input has capacity 64.
+    offs = torch.tensor([11, 17, 41], device="cuda", dtype=torch.int32)
+
+    q_ref, scales_ref = quantize_grouped_2d_to_mxfp8_blocked(x, offs)
+    q_fused, scales_fused = quantize_grouped_2d_to_mxfp8_blocked_fused(x, offs)
+
+    assert q_fused.shape == q_ref.shape
+    assert scales_fused.shape == scales_ref.shape
+    assert torch.equal(q_fused.view(torch.uint8), q_ref.view(torch.uint8))
+    assert torch.equal(scales_fused.view(torch.uint8), scales_ref.view(torch.uint8))
+
+
+def test_quantize_grouped_weight_3d_to_mxfp8_blocked_returns_col_major_layout():
+    b = torch.randn(3, 512, 512, dtype=torch.float32)
+    qdata, scales_blocked = quantize_grouped_weight_3d_to_mxfp8_blocked(b)
+
+    assert qdata.shape == b.shape
+    assert qdata.dtype == torch.float8_e4m3fn
+    # scaled_grouped_mm expects transposed RHS memory layout on trailing dims.
+    assert qdata.stride(-2) == 1
+    assert qdata.stride(-1) == b.shape[-2]
+    assert scales_blocked.shape[0] == b.shape[0]
+    assert scales_blocked.dtype == torch.float8_e8m0fnu
+
+
+def test_scaled_grouped_mm_q_forces_mat2_col_major_layout(monkeypatch):
+    if not torch.cuda.is_available():
+        return
+    a, b, offs = _build_inputs()
+    a = a.to(device="cuda")
+    b = b.to(device="cuda")
+    offs = offs.to(device="cuda")
+
+    def _fake_quant_a(mat_a: torch.Tensor, *, block_size: int = 32):
+        del block_size
+        return mat_a.to(torch.float8_e4m3fn), torch.ones(
+            (mat_a.shape[0], mat_a.shape[1] // 32),
+            dtype=torch.float8_e8m0fnu,
+            device=mat_a.device,
+        )
+
+    def _fake_quant_b(mat_b: torch.Tensor, *, block_size: int = 32):
+        del block_size
+        # Return row-major data intentionally; wrapper should convert it.
+        q = mat_b.to(torch.float8_e4m3fn).contiguous()
+        s = torch.ones(
+            (mat_b.shape[0], mat_b.shape[2], mat_b.shape[1] // 32),
+            dtype=torch.float8_e8m0fnu,
+            device=mat_b.device,
+        )
+        return q, s
+
+    seen = {}
+
+    def _fake_scaled_grouped_mm_v2_cuda(
+        mat_a_q: torch.Tensor,
+        mat_b_q: torch.Tensor,
+        scale_a_unblocked: torch.Tensor,
+        scale_b_unblocked: torch.Tensor,
+        *,
+        offs: torch.Tensor,
+        use_fast_accum: bool,
+    ):
+        del mat_a_q, scale_a_unblocked, scale_b_unblocked, offs, use_fast_accum
+        seen["shape"] = tuple(mat_b_q.shape)
+        seen["stride"] = tuple(mat_b_q.stride())
+        return torch.zeros(
+            (a.shape[0], b.shape[-1]),
+            device=mat_b_q.device,
+            dtype=torch.bfloat16,
+        )
+
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "quantize_rows_to_mxfp8",
+        _fake_quant_a,
+    )
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "quantize_grouped_weight_3d_to_mxfp8_blocked",
+        _fake_quant_b,
+    )
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_scaled_grouped_mm_v2_cuda",
+        _fake_scaled_grouped_mm_v2_cuda,
+    )
+
+    _ = scaled_grouped_mm_module._forward_scaled_grouped_mm_mxfp8(
+        a,
+        b,
+        offs,
+        use_fast_accum=True,
+    )
+
+    assert seen["shape"] == tuple(b.shape)
+    # trailing 2D strides must be column-major: (.., 1, K)
+    assert seen["stride"][-2] == 1
+    assert seen["stride"][-1] == b.shape[-2]
+
+
+def test_scaled_grouped_mm_q_uses_prequantized_rhs(monkeypatch):
+    if not torch.cuda.is_available():
+        return
+    torch.manual_seed(123)
+    offs = torch.tensor([3, 5, 9], dtype=torch.int32, device="cuda")
+    a = torch.randn(int(offs[-1].item()), 512, dtype=torch.float32, device="cuda")
+    b = torch.randn(offs.numel(), 512, 512, dtype=torch.float32, device="cuda")
+    preq = prequantize_scaled_grouped_mm_rhs(b)
+    assert isinstance(preq, ScaledGroupedMMPrequantizedRHS)
+
+    called = {"rhs_quant": 0}
+
+    def _forbidden_rhs_quant(_mat_b, *, block_size: int = 32):
+        del block_size
+        called["rhs_quant"] += 1
+        raise AssertionError(
+            "RHS quantization should be bypassed when prequantized_rhs is provided"
+        )
+
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "quantize_grouped_weight_3d_to_mxfp8_blocked",
+        _forbidden_rhs_quant,
+    )
+
+    def _fake_scaled_grouped_mm_v2_cuda(
+        mat_a_q: torch.Tensor,
+        mat_b_q: torch.Tensor,
+        scale_a_unblocked: torch.Tensor,
+        scale_b_unblocked: torch.Tensor,
+        *,
+        offs: torch.Tensor,
+        use_fast_accum: bool,
+    ):
+        del mat_a_q, scale_a_unblocked, scale_b_unblocked, offs, use_fast_accum
+        # Ensure the prequantized RHS object is the one actually consumed.
+        assert mat_b_q.untyped_storage().data_ptr() == preq.mat_b_q.untyped_storage().data_ptr()
+        return torch.zeros((a.shape[0], b.shape[-1]), dtype=torch.bfloat16, device=a.device)
+
+    monkeypatch.setattr(
+        scaled_grouped_mm_module,
+        "_scaled_grouped_mm_v2_cuda",
+        _fake_scaled_grouped_mm_v2_cuda,
+    )
+    out = scaled_grouped_mm_q(
+        a,
+        b,
+        offs=offs,
+        prequantized_rhs=preq,
+    )
+    assert out.shape == (a.shape[0], b.shape[-1])
+    assert called["rhs_quant"] == 0
+
+
+def test_scaled_grouped_mm_q_backward_uses_prequantized_lhs_when_mat_a_not_saved(monkeypatch):
+    torch.manual_seed(123)
+    offs = torch.tensor([3, 5, 9], dtype=torch.int32)
+    mat_a_real = torch.randn(int(offs[-1].item()), 512, dtype=torch.float32)
+    mat_a_bad = torch.zeros_like(mat_a_real)
+    mat_b = torch.randn(offs.numel(), 512, 512, dtype=torch.float32, requires_grad=True)
+    mat_a_q, mat_a_s = quantize_rows_to_mxfp8(mat_a_real, block_size=32)
+    preq_lhs = scaled_grouped_mm_module.ScaledGroupedMMPrequantizedLHS(
+        mat_a_q=mat_a_q,
+        scale_a=mat_a_s,
+        mat_a_shape=tuple(mat_a_bad.shape),
+        scales_are_blocked=False,
+    )
+
+    def _stub_forward(
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        offs: torch.Tensor,
+        *,
+        use_fast_accum: bool,
+        prequantized_lhs=None,
+        prequantized_rhs=None,
+    ) -> torch.Tensor:
+        del use_fast_accum, prequantized_lhs, prequantized_rhs
+        return F.grouped_mm(mat_a, mat_b, offs=offs)
+
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+
+    captured = {}
+
+    def _fake_grouped_mm(mat_a: torch.Tensor, mat_b: torch.Tensor, *, offs: torch.Tensor):
+        # Backward grad_b path: mat_b is reconstructed lhs (rank-2 [M, K]).
+        if mat_b.ndim == 2 and tuple(mat_b.shape) == tuple(mat_a_bad.shape):
+            captured["lhs_for_grad_b"] = mat_b.clone()
+            return torch.zeros((offs.numel(), mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+        return torch.zeros((mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+
+    monkeypatch.setattr(F, "grouped_mm", _fake_grouped_mm)
+
+    out = scaled_grouped_mm_q(
+        mat_a_bad,
+        mat_b,
+        offs=offs,
+        prequantized_lhs=preq_lhs,
+    )
+    loss = out.sum()
+    (grad_b,) = torch.autograd.grad(loss, (mat_b,))
+    assert grad_b is not None
+
+    assert "lhs_for_grad_b" in captured
+    mat_a_expected = dequantize_rows_from_mxfp8(
+        mat_a_q, mat_a_s, block_size=32, out_dtype=out.dtype
+    )
+    torch.testing.assert_close(captured["lhs_for_grad_b"], mat_a_expected)
+
+
+def test_scaled_grouped_mm_q_backward_reconstructs_full_prequantized_lhs_capacity(monkeypatch):
+    torch.manual_seed(123)
+    offs = torch.tensor([3, 5, 9], dtype=torch.int32)
+    capacity_rows = 12
+    mat_a_real = torch.randn(capacity_rows, 512, dtype=torch.float32)
+    mat_a_bad = torch.zeros_like(mat_a_real)
+    mat_b = torch.randn(offs.numel(), 512, 512, dtype=torch.float32, requires_grad=True)
+    mat_a_q, mat_a_s = quantize_rows_to_mxfp8(mat_a_real, block_size=32)
+    preq_lhs = scaled_grouped_mm_module.ScaledGroupedMMPrequantizedLHS(
+        mat_a_q=mat_a_q,
+        scale_a=mat_a_s,
+        mat_a_shape=tuple(mat_a_bad.shape),
+        scales_are_blocked=False,
+    )
+
+    def _stub_forward(
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        offs: torch.Tensor,
+        *,
+        use_fast_accum: bool,
+        prequantized_lhs=None,
+        prequantized_rhs=None,
+    ) -> torch.Tensor:
+        del use_fast_accum, prequantized_lhs, prequantized_rhs
+        return F.grouped_mm(mat_a, mat_b, offs=offs)
+
+    monkeypatch.setattr(scaled_grouped_mm_module, "_forward_scaled_grouped_mm_mxfp8", _stub_forward)
+
+    captured = {}
+
+    def _fake_grouped_mm(mat_a: torch.Tensor, mat_b: torch.Tensor, *, offs: torch.Tensor):
+        # Backward grad_b path: mat_b is reconstructed lhs (rank-2 [capacity, K]).
+        if mat_b.ndim == 2 and tuple(mat_b.shape) == tuple(mat_a_bad.shape):
+            captured["lhs_for_grad_b"] = mat_b.clone()
+            return torch.zeros((offs.numel(), mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+        return torch.zeros((mat_a.shape[0], mat_b.shape[-1]), dtype=mat_a.dtype)
+
+    monkeypatch.setattr(F, "grouped_mm", _fake_grouped_mm)
+
+    out = scaled_grouped_mm_q(
+        mat_a_bad,
+        mat_b,
+        offs=offs,
+        prequantized_lhs=preq_lhs,
+    )
+    loss = out.sum()
+    (grad_b,) = torch.autograd.grad(loss, (mat_b,))
+    assert grad_b is not None
+
+    assert "lhs_for_grad_b" in captured
+    assert captured["lhs_for_grad_b"].shape[0] == capacity_rows
+    mat_a_expected = dequantize_rows_from_mxfp8(
+        mat_a_q, mat_a_s, block_size=32, out_dtype=out.dtype
+    )
+    torch.testing.assert_close(captured["lhs_for_grad_b"], mat_a_expected)


### PR DESCRIPTION
## What this adds

The FP8 grouped-matmul compute path, built on MXFP8:

- **`scaled_grouped_mm_q` / `scaled_grouped_mm_q_fp8_weight`** (`olmo_core.kernels.scaled_grouped_mm`) — MXFP8-quantized grouped matmul on `torch.nn.functional.scaled_grouped_mm`, with prequantized-weight caching (`prequantize_scaled_grouped_mm_rhs`, `ScaledGroupedMMPrequantized{LHS,RHS}`).
- **`FP8WeightStore` / `FP8WeightCacheSpec`** (`olmo_core.nn.fp8_weight`) — prequantizes a weight to its MXFP8 RHS form (and the dgrad transpose) and caches it.

All public entry points are marked `@beta_feature`.

## torch version

This path uses `torch.nn.functional.grouped_mm` (backward) and `F.ScalingType`/`F.SwizzleType` — torch 2.10 APIs. The module imports safely on older torch (the enum constants fall back via `try/except`), and the tests are version-gated (`has_torch_grouped_mm`) so they skip on torch < 2.10 rather than erroring; CI exercises them on a torch 2.10 GPU image. The autograd-plumbing tests stub the CUDA forward and run on CPU.
