### PR TITLE
Add MoE token permute/reorder kernels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,18 +214,10 @@ jobs:
                 src/integration_tests/
 
           # The MoE kernels require torch >= 2.10 (torch.nn.functional.grouped_mm,
-          # F.ScalingType/F.SwizzleType); their tests are version-gated and skip on the
-          # torch 2.9 image above, so run them on a torch 2.10 image here.
+          # F.ScalingType/F.SwizzleType) and JIT-build .cu extensions, so they need an
+          # image with both torch 2.10 and the CUDA toolkit (nvcc). Their tests are
+          # version-gated and skip on the torch 2.9 image above.
           - name: Test MoE kernels (GPU, torch 2.10)
-            image: petew/olmo-core-tch2100cu128-2026-01-23
-            gpus: 2
-            run: |
-              pytest -v --color=yes --durations=3 -m gpu \
-                src/test/kernels/
-
-          # Trial run of the MoE kernel tests on an image that ships the CUDA
-          # toolkit (nvcc), which is needed to JIT-build the .cu kernel extensions.
-          - name: Test MoE kernels (GPU, torch 2.10, CUDA toolkit)
             image: tianhuat/olmo-core-torch210-2404-cu128
             gpus: 2
             run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,6 +168,7 @@ jobs:
                 --ignore-glob='src/test/nn/attention*' \
                 --ignore-glob='src/test/nn/moe*' \
                 --ignore-glob='src/test/optim*' \
+                --ignore-glob='src/test/kernels*' \
                 src/test/
 
           - name: Test checkpoint (GPU)
@@ -217,6 +218,15 @@ jobs:
           # torch 2.9 image above, so run them on a torch 2.10 image here.
           - name: Test MoE kernels (GPU, torch 2.10)
             image: petew/olmo-core-tch2100cu128-2026-01-23
+            gpus: 2
+            run: |
+              pytest -v --color=yes --durations=3 -m gpu \
+                src/test/kernels/
+
+          # Trial run of the MoE kernel tests on an image that ships the CUDA
+          # toolkit (nvcc), which is needed to JIT-build the .cu kernel extensions.
+          - name: Test MoE kernels (GPU, torch 2.10, CUDA toolkit)
+            image: tianhuat/olmo-core-torch210-2404-cu128
             gpus: 2
             run: |
               pytest -v --color=yes --durations=3 -m gpu \

--- a/src/olmo_core/kernels/cuda/moe_chunk_reorder.cpp
+++ b/src/olmo_core/kernels/cuda/moe_chunk_reorder.cpp
@@ -1,0 +1,95 @@
+#include <torch/extension.h>
+
+namespace py = pybind11;
+
+std::tuple<torch::Tensor, torch::Tensor> chunk_permute_fwd_cuda_launcher(
+    const torch::Tensor& input,
+    const torch::Tensor& routing_map,
+    int64_t num_out_tokens,
+    const c10::optional<torch::Tensor>& out);
+
+torch::Tensor chunk_permute_by_row_id_map_cuda_launcher(
+    const torch::Tensor& input,
+    const torch::Tensor& row_id_map,
+    int64_t num_out_tokens,
+    const c10::optional<torch::Tensor>& out);
+
+torch::Tensor chunk_unpermute_fwd_cuda_launcher(
+    const torch::Tensor& input,
+    const torch::Tensor& row_id_map,
+    int64_t num_tokens,
+    const c10::optional<torch::Tensor>& out);
+
+std::tuple<torch::Tensor, torch::Tensor> chunk_permute_fwd_cuda(
+    const torch::Tensor& input,
+    const torch::Tensor& routing_map,
+    int64_t num_out_tokens,
+    const c10::optional<torch::Tensor>& out) {
+  TORCH_CHECK(input.is_cuda(), "input must be CUDA");
+  TORCH_CHECK(routing_map.is_cuda(), "routing_map must be CUDA");
+  TORCH_CHECK(input.dim() == 2, "input must be rank-2");
+  TORCH_CHECK(routing_map.dim() == 2, "routing_map must be rank-2 [num_tokens, topK]");
+  TORCH_CHECK(routing_map.size(0) == input.size(0), "routing_map/input rows must match");
+  TORCH_CHECK(routing_map.size(1) == 1, "only topK=1 is supported");
+  TORCH_CHECK(routing_map.scalar_type() == torch::kInt32, "routing_map must be int32");
+
+  return chunk_permute_fwd_cuda_launcher(input, routing_map, num_out_tokens, out);
+}
+
+torch::Tensor chunk_permute_by_row_id_map_cuda(
+    const torch::Tensor& input,
+    const torch::Tensor& row_id_map,
+    int64_t num_out_tokens,
+    const c10::optional<torch::Tensor>& out) {
+  TORCH_CHECK(input.is_cuda(), "input must be CUDA");
+  TORCH_CHECK(row_id_map.is_cuda(), "row_id_map must be CUDA");
+  TORCH_CHECK(input.dim() == 2, "input must be rank-2");
+  TORCH_CHECK(row_id_map.dim() == 1, "row_id_map must be rank-1");
+  TORCH_CHECK(row_id_map.size(0) == input.size(0), "row_id_map/input rows must match");
+  TORCH_CHECK(row_id_map.scalar_type() == torch::kInt32, "row_id_map must be int32");
+
+  return chunk_permute_by_row_id_map_cuda_launcher(input, row_id_map, num_out_tokens, out);
+}
+
+torch::Tensor chunk_unpermute_fwd_cuda(
+    const torch::Tensor& input,
+    const torch::Tensor& row_id_map,
+    int64_t num_tokens,
+    const c10::optional<torch::Tensor>& out) {
+  TORCH_CHECK(input.is_cuda(), "input must be CUDA");
+  TORCH_CHECK(row_id_map.is_cuda(), "row_id_map must be CUDA");
+  TORCH_CHECK(input.dim() == 2, "input must be rank-2");
+  TORCH_CHECK(row_id_map.dim() == 1, "row_id_map must be rank-1");
+  TORCH_CHECK(row_id_map.scalar_type() == torch::kInt32, "row_id_map must be int32");
+
+  return chunk_unpermute_fwd_cuda_launcher(input, row_id_map, num_tokens, out);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+      "chunk_permute_fwd_cuda",
+      &chunk_permute_fwd_cuda,
+      "Chunk permute forward (CUDA)",
+      py::arg("input"),
+      py::arg("routing_map"),
+      py::arg("num_out_tokens"),
+      py::arg("out") = py::none());
+
+  m.def(
+      "chunk_permute_by_row_id_map_cuda",
+      &chunk_permute_by_row_id_map_cuda,
+      "Chunk permute by row_id_map (CUDA)",
+      py::arg("input"),
+      py::arg("row_id_map"),
+      py::arg("num_out_tokens"),
+      py::arg("out") = py::none());
+
+  m.def(
+      "chunk_unpermute_fwd_cuda",
+      &chunk_unpermute_fwd_cuda,
+      "Chunk unpermute forward (CUDA)",
+      py::arg("input"),
+      py::arg("row_id_map"),
+      py::arg("num_tokens"),
+      py::arg("out") = py::none());
+}

--- a/src/olmo_core/kernels/cuda/moe_chunk_reorder_kernel.cu
+++ b/src/olmo_core/kernels/cuda/moe_chunk_reorder_kernel.cu
@@ -1,0 +1,450 @@
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/extension.h>
+
+#include <cub/cub.cuh>
+
+#include <algorithm>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+__global__ void moe_permute_row_map_kernel(
+    const int* __restrict__ sorted_row_id,
+    int* __restrict__ row_id_map,
+    int num_rows,
+    int topk,
+    int num_out_tokens) {
+  const int idx = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= num_rows * topk) {
+    return;
+  }
+
+  const int source_row = sorted_row_id[idx];
+  const int source_token_id = source_row / topk;
+  const int source_topk_id = source_row % topk;
+
+  if (idx >= num_out_tokens) {
+    row_id_map[source_topk_id * num_rows + source_token_id] = -1;
+  } else {
+    row_id_map[source_topk_id * num_rows + source_token_id] = idx;
+  }
+}
+
+template <typename scalar_t, int kElementsPerAccess>
+__global__ void permute_by_row_id_map_vec_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    const int* __restrict__ row_id_map,
+    int num_rows,
+    int num_cols,
+    int num_out_tokens) {
+  const int source_token = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  if (source_token >= num_rows) {
+    return;
+  }
+
+  const int dest_row = row_id_map[source_token];
+  if (dest_row < 0 || dest_row >= num_out_tokens) {
+    return;
+  }
+
+  const scalar_t* source_row_ptr = input + static_cast<int64_t>(source_token) * num_cols;
+  scalar_t* dest_row_ptr = output + static_cast<int64_t>(dest_row) * num_cols;
+
+  for (int col = tid * kElementsPerAccess; col < num_cols;
+       col += static_cast<int>(blockDim.x) * kElementsPerAccess) {
+    float4 frag = reinterpret_cast<const float4*>(source_row_ptr + col)[0];
+    reinterpret_cast<float4*>(dest_row_ptr + col)[0] = frag;
+  }
+}
+
+template <typename scalar_t>
+__global__ void permute_by_row_id_map_scalar_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    const int* __restrict__ row_id_map,
+    int num_rows,
+    int num_cols,
+    int num_out_tokens) {
+  const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t total = static_cast<int64_t>(num_rows) * num_cols;
+  if (idx >= total) {
+    return;
+  }
+
+  const int source_token = static_cast<int>(idx / num_cols);
+  const int col = static_cast<int>(idx % num_cols);
+  const int dest_row = row_id_map[source_token];
+  if (dest_row < 0 || dest_row >= num_out_tokens) {
+    return;
+  }
+
+  output[static_cast<int64_t>(dest_row) * num_cols + col] = input[idx];
+}
+
+template <typename scalar_t, int kElementsPerAccess>
+__global__ void unpermute_vec_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    const int* __restrict__ row_id_map,
+    int input_rows,
+    int num_tokens,
+    int num_cols) {
+  const int token = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  if (token >= num_tokens) {
+    return;
+  }
+
+  const int source_row = row_id_map[token];
+  scalar_t* dest_row_ptr = output + static_cast<int64_t>(token) * num_cols;
+
+  if (source_row < 0 || source_row >= input_rows) {
+    float4 zero_frag;
+    scalar_t* zero_ptr = reinterpret_cast<scalar_t*>(&zero_frag);
+#pragma unroll
+    for (int i = 0; i < kElementsPerAccess; ++i) {
+      zero_ptr[i] = scalar_t(0);
+    }
+    for (int col = tid * kElementsPerAccess; col < num_cols;
+         col += static_cast<int>(blockDim.x) * kElementsPerAccess) {
+      reinterpret_cast<float4*>(dest_row_ptr + col)[0] = zero_frag;
+    }
+    return;
+  }
+
+  const scalar_t* source_row_ptr = input + static_cast<int64_t>(source_row) * num_cols;
+  for (int col = tid * kElementsPerAccess; col < num_cols;
+       col += static_cast<int>(blockDim.x) * kElementsPerAccess) {
+    float4 frag = reinterpret_cast<const float4*>(source_row_ptr + col)[0];
+    reinterpret_cast<float4*>(dest_row_ptr + col)[0] = frag;
+  }
+}
+
+template <typename scalar_t>
+__global__ void unpermute_scalar_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    const int* __restrict__ row_id_map,
+    int input_rows,
+    int num_tokens,
+    int num_cols) {
+  const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t total = static_cast<int64_t>(num_tokens) * num_cols;
+  if (idx >= total) {
+    return;
+  }
+
+  const int token = static_cast<int>(idx / num_cols);
+  const int col = static_cast<int>(idx % num_cols);
+  const int source_row = row_id_map[token];
+  if (source_row < 0 || source_row >= input_rows) {
+    output[idx] = scalar_t(0);
+    return;
+  }
+
+  output[idx] = input[static_cast<int64_t>(source_row) * num_cols + col];
+}
+
+template <typename scalar_t>
+void launch_permute_by_row_id_map(
+    const torch::Tensor& input,
+    const torch::Tensor& row_id_map,
+    const torch::Tensor& output,
+    cudaStream_t stream) {
+  constexpr int kElementsPerAccess = 16 / sizeof(scalar_t);
+  const int num_rows = static_cast<int>(input.size(0));
+  const int num_cols = static_cast<int>(input.size(1));
+  const int num_out_tokens = static_cast<int>(output.size(0));
+
+  if (num_rows == 0 || num_cols == 0 || num_out_tokens == 0) {
+    return;
+  }
+
+  if (num_cols % kElementsPerAccess == 0) {
+    const int threads = std::max(1, std::min(num_cols / kElementsPerAccess, 1024));
+    const int blocks = num_rows;
+    permute_by_row_id_map_vec_kernel<scalar_t, kElementsPerAccess><<<blocks, threads, 0, stream>>>(
+        input.data_ptr<scalar_t>(),
+        output.data_ptr<scalar_t>(),
+        row_id_map.data_ptr<int>(),
+        num_rows,
+        num_cols,
+        num_out_tokens);
+  } else {
+    constexpr int threads = 256;
+    const int64_t total = static_cast<int64_t>(num_rows) * num_cols;
+    const int blocks = static_cast<int>((total + threads - 1) / threads);
+    permute_by_row_id_map_scalar_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        input.data_ptr<scalar_t>(),
+        output.data_ptr<scalar_t>(),
+        row_id_map.data_ptr<int>(),
+        num_rows,
+        num_cols,
+        num_out_tokens);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename scalar_t>
+void launch_unpermute(
+    const torch::Tensor& input,
+    const torch::Tensor& row_id_map,
+    const torch::Tensor& output,
+    cudaStream_t stream) {
+  constexpr int kElementsPerAccess = 16 / sizeof(scalar_t);
+  const int input_rows = static_cast<int>(input.size(0));
+  const int num_tokens = static_cast<int>(output.size(0));
+  const int num_cols = static_cast<int>(input.size(1));
+
+  if (num_tokens == 0 || num_cols == 0) {
+    return;
+  }
+
+  if (num_cols % kElementsPerAccess == 0) {
+    const int threads = std::max(1, std::min(num_cols / kElementsPerAccess, 1024));
+    const int blocks = num_tokens;
+    unpermute_vec_kernel<scalar_t, kElementsPerAccess><<<blocks, threads, 0, stream>>>(
+        input.data_ptr<scalar_t>(),
+        output.data_ptr<scalar_t>(),
+        row_id_map.data_ptr<int>(),
+        input_rows,
+        num_tokens,
+        num_cols);
+  } else {
+    constexpr int threads = 256;
+    const int64_t total = static_cast<int64_t>(num_tokens) * num_cols;
+    const int blocks = static_cast<int>((total + threads - 1) / threads);
+    unpermute_scalar_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        input.data_ptr<scalar_t>(),
+        output.data_ptr<scalar_t>(),
+        row_id_map.data_ptr<int>(),
+        input_rows,
+        num_tokens,
+        num_cols);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+torch::Tensor get_or_create_output(
+    const torch::Tensor& input,
+    int64_t out_rows,
+    const c10::optional<torch::Tensor>& out,
+    const char* op_name) {
+  if (out.has_value()) {
+    const auto& out_tensor = out.value();
+    TORCH_CHECK(out_tensor.is_cuda(), op_name, ": out must be CUDA");
+    TORCH_CHECK(out_tensor.dim() == 2, op_name, ": out must be rank-2");
+    TORCH_CHECK(
+        out_tensor.size(0) == out_rows && out_tensor.size(1) == input.size(1),
+        op_name,
+        ": out shape mismatch, expected [",
+        out_rows,
+        ", ",
+        input.size(1),
+        "] got ",
+        out_tensor.sizes());
+    TORCH_CHECK(
+        out_tensor.scalar_type() == input.scalar_type(),
+        op_name,
+        ": out dtype mismatch");
+    TORCH_CHECK(out_tensor.device() == input.device(), op_name, ": out device mismatch");
+    TORCH_CHECK(out_tensor.is_contiguous(), op_name, ": out must be contiguous");
+    return out_tensor;
+  }
+
+  return torch::empty(
+      {out_rows, input.size(1)},
+      torch::TensorOptions()
+          .dtype(input.scalar_type())
+          .device(input.device())
+          .requires_grad(false));
+}
+
+std::tuple<torch::Tensor, torch::Tensor> chunk_permute_fwd_cuda_launcher(
+    const torch::Tensor& input,
+    const torch::Tensor& routing_map,
+    int64_t num_out_tokens,
+    const c10::optional<torch::Tensor>& out) {
+  c10::cuda::CUDAGuard device_guard(input.device());
+  auto cuda_stream = at::cuda::getCurrentCUDAStream(input.device().index());
+  cudaStream_t stream = cuda_stream.stream();
+
+  TORCH_CHECK(input.is_contiguous(), "chunk_permute_fwd_cuda: input must be contiguous");
+  TORCH_CHECK(
+      routing_map.is_contiguous(),
+      "chunk_permute_fwd_cuda: routing_map must be contiguous");
+
+  const int64_t num_tokens = input.size(0);
+  if (num_out_tokens <= 0) {
+    num_out_tokens = num_tokens;
+  }
+  TORCH_CHECK(
+      num_out_tokens <= num_tokens,
+      "chunk_permute_fwd_cuda: num_out_tokens must be <= num_tokens, got ",
+      num_out_tokens,
+      " > ",
+      num_tokens);
+
+  auto output = get_or_create_output(input, num_out_tokens, out, "chunk_permute_fwd_cuda");
+  auto row_id_map = torch::empty(
+      {num_tokens},
+      torch::TensorOptions()
+          .dtype(torch::kInt32)
+          .device(input.device())
+          .requires_grad(false));
+
+  if (num_tokens == 0 || input.size(1) == 0 || num_out_tokens == 0) {
+    return std::make_tuple(output, row_id_map);
+  }
+
+  auto routing_flat = routing_map.reshape({num_tokens}).contiguous();
+  auto sorted_indices = torch::empty_like(routing_flat);
+  auto row_id = torch::arange(
+      num_tokens,
+      torch::TensorOptions()
+          .dtype(torch::kInt32)
+          .device(input.device())
+          .requires_grad(false));
+  auto sorted_row_id = torch::empty_like(row_id);
+
+  size_t temp_storage_bytes = 0;
+  cub::DeviceRadixSort::SortPairs(
+      nullptr,
+      temp_storage_bytes,
+      routing_flat.data_ptr<int>(),
+      sorted_indices.data_ptr<int>(),
+      row_id.data_ptr<int>(),
+      sorted_row_id.data_ptr<int>(),
+      static_cast<int>(num_tokens),
+      0,
+      static_cast<int>(sizeof(int) * 8),
+      stream);
+
+  auto temp_storage = torch::empty(
+      {static_cast<int64_t>(temp_storage_bytes)},
+      torch::TensorOptions()
+          .dtype(torch::kUInt8)
+          .device(input.device())
+          .requires_grad(false));
+
+  cub::DeviceRadixSort::SortPairs(
+      temp_storage.data_ptr<uint8_t>(),
+      temp_storage_bytes,
+      routing_flat.data_ptr<int>(),
+      sorted_indices.data_ptr<int>(),
+      row_id.data_ptr<int>(),
+      sorted_row_id.data_ptr<int>(),
+      static_cast<int>(num_tokens),
+      0,
+      static_cast<int>(sizeof(int) * 8),
+      stream);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  constexpr int kMapThreads = 64;
+  const int map_blocks = static_cast<int>((num_tokens + kMapThreads - 1) / kMapThreads);
+  moe_permute_row_map_kernel<<<map_blocks, kMapThreads, 0, stream>>>(
+      sorted_row_id.data_ptr<int>(),
+      row_id_map.data_ptr<int>(),
+      static_cast<int>(num_tokens),
+      1,
+      static_cast<int>(num_out_tokens));
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::kHalf,
+      at::kBFloat16,
+      input.scalar_type(),
+      "chunk_permute_fwd_cuda",
+      [&] {
+        launch_permute_by_row_id_map<scalar_t>(input, row_id_map, output, stream);
+      });
+
+  return std::make_tuple(output, row_id_map);
+}
+
+torch::Tensor chunk_permute_by_row_id_map_cuda_launcher(
+    const torch::Tensor& input,
+    const torch::Tensor& row_id_map,
+    int64_t num_out_tokens,
+    const c10::optional<torch::Tensor>& out) {
+  c10::cuda::CUDAGuard device_guard(input.device());
+  auto cuda_stream = at::cuda::getCurrentCUDAStream(input.device().index());
+  cudaStream_t stream = cuda_stream.stream();
+
+  TORCH_CHECK(
+      input.is_contiguous(),
+      "chunk_permute_by_row_id_map_cuda: input must be contiguous");
+  TORCH_CHECK(
+      row_id_map.is_contiguous(),
+      "chunk_permute_by_row_id_map_cuda: row_id_map must be contiguous");
+  TORCH_CHECK(
+      row_id_map.size(0) == input.size(0),
+      "chunk_permute_by_row_id_map_cuda: row_id_map/input rows must match");
+
+  if (num_out_tokens <= 0) {
+    num_out_tokens = input.size(0);
+  }
+
+  auto output = get_or_create_output(
+      input,
+      num_out_tokens,
+      out,
+      "chunk_permute_by_row_id_map_cuda");
+
+  if (input.size(0) == 0 || input.size(1) == 0 || num_out_tokens == 0) {
+    return output;
+  }
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::kHalf,
+      at::kBFloat16,
+      input.scalar_type(),
+      "chunk_permute_by_row_id_map_cuda",
+      [&] {
+        launch_permute_by_row_id_map<scalar_t>(input, row_id_map, output, stream);
+      });
+
+  return output;
+}
+
+torch::Tensor chunk_unpermute_fwd_cuda_launcher(
+    const torch::Tensor& input,
+    const torch::Tensor& row_id_map,
+    int64_t num_tokens,
+    const c10::optional<torch::Tensor>& out) {
+  c10::cuda::CUDAGuard device_guard(input.device());
+  auto cuda_stream = at::cuda::getCurrentCUDAStream(input.device().index());
+  cudaStream_t stream = cuda_stream.stream();
+
+  TORCH_CHECK(input.is_contiguous(), "chunk_unpermute_fwd_cuda: input must be contiguous");
+  TORCH_CHECK(
+      row_id_map.is_contiguous(),
+      "chunk_unpermute_fwd_cuda: row_id_map must be contiguous");
+
+  if (num_tokens <= 0) {
+    num_tokens = row_id_map.size(0);
+  }
+  TORCH_CHECK(
+      row_id_map.size(0) == num_tokens,
+      "chunk_unpermute_fwd_cuda: row_id_map length must equal num_tokens");
+
+  auto output = get_or_create_output(input, num_tokens, out, "chunk_unpermute_fwd_cuda");
+
+  if (num_tokens == 0 || input.size(1) == 0) {
+    return output;
+  }
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::kHalf,
+      at::kBFloat16,
+      input.scalar_type(),
+      "chunk_unpermute_fwd_cuda",
+      [&] { launch_unpermute<scalar_t>(input, row_id_map, output, stream); });
+
+  return output;
+}

--- a/src/olmo_core/kernels/cuda/moe_permute_drop.cpp
+++ b/src/olmo_core/kernels/cuda/moe_permute_drop.cpp
@@ -1,0 +1,116 @@
+#include <torch/extension.h>
+
+namespace py = pybind11;
+
+std::tuple<torch::Tensor, torch::Tensor> moe_permute_drop_fwd_cuda_launcher(
+    const torch::Tensor& input,
+    const torch::Tensor& routing_map,
+    const torch::Tensor& requested_offsets,
+    const torch::Tensor& keep_offsets,
+    const torch::Tensor& keep_splits,
+    int64_t num_out_tokens,
+    const torch::Tensor& sorted_indices_workspace,
+    const torch::Tensor& row_id_workspace,
+    const torch::Tensor& sorted_row_id_workspace,
+    const torch::Tensor& temp_storage_workspace,
+    const c10::optional<torch::Tensor>& out);
+
+int64_t moe_permute_drop_temp_storage_bytes_cuda(int64_t num_items);
+
+std::tuple<torch::Tensor, torch::Tensor> moe_permute_drop_fwd_cuda(
+    const torch::Tensor& input,
+    const torch::Tensor& routing_map,
+    const torch::Tensor& requested_offsets,
+    const torch::Tensor& keep_offsets,
+    const torch::Tensor& keep_splits,
+    int64_t num_out_tokens,
+    const torch::Tensor& sorted_indices_workspace,
+    const torch::Tensor& row_id_workspace,
+    const torch::Tensor& sorted_row_id_workspace,
+    const torch::Tensor& temp_storage_workspace,
+    const c10::optional<torch::Tensor>& out) {
+  TORCH_CHECK(input.is_cuda(), "input must be CUDA");
+  TORCH_CHECK(routing_map.is_cuda(), "routing_map must be CUDA");
+  TORCH_CHECK(requested_offsets.is_cuda(), "requested_offsets must be CUDA");
+  TORCH_CHECK(keep_offsets.is_cuda(), "keep_offsets must be CUDA");
+  TORCH_CHECK(keep_splits.is_cuda(), "keep_splits must be CUDA");
+  TORCH_CHECK(sorted_indices_workspace.is_cuda(), "sorted_indices_workspace must be CUDA");
+  TORCH_CHECK(row_id_workspace.is_cuda(), "row_id_workspace must be CUDA");
+  TORCH_CHECK(sorted_row_id_workspace.is_cuda(), "sorted_row_id_workspace must be CUDA");
+  TORCH_CHECK(temp_storage_workspace.is_cuda(), "temp_storage_workspace must be CUDA");
+
+  TORCH_CHECK(input.dim() == 2, "input must be rank-2");
+  TORCH_CHECK(routing_map.dim() == 2, "routing_map must be rank-2 [num_tokens, topK]");
+  TORCH_CHECK(routing_map.size(0) == input.size(0), "routing_map/input rows must match");
+  TORCH_CHECK(routing_map.scalar_type() == torch::kInt32, "routing_map must be int32");
+
+  TORCH_CHECK(requested_offsets.dim() == 1, "requested_offsets must be rank-1");
+  TORCH_CHECK(keep_offsets.dim() == 1, "keep_offsets must be rank-1");
+  TORCH_CHECK(keep_splits.dim() == 1, "keep_splits must be rank-1");
+  TORCH_CHECK(
+      requested_offsets.scalar_type() == torch::kInt64,
+      "requested_offsets must be int64");
+  TORCH_CHECK(keep_offsets.scalar_type() == torch::kInt64, "keep_offsets must be int64");
+  TORCH_CHECK(keep_splits.scalar_type() == torch::kInt64, "keep_splits must be int64");
+  TORCH_CHECK(
+      requested_offsets.size(0) == keep_offsets.size(0) &&
+          requested_offsets.size(0) == keep_splits.size(0),
+      "requested_offsets/keep_offsets/keep_splits sizes must match");
+
+  TORCH_CHECK(sorted_indices_workspace.dim() == 1, "sorted_indices_workspace must be rank-1");
+  TORCH_CHECK(row_id_workspace.dim() == 1, "row_id_workspace must be rank-1");
+  TORCH_CHECK(sorted_row_id_workspace.dim() == 1, "sorted_row_id_workspace must be rank-1");
+  TORCH_CHECK(temp_storage_workspace.dim() == 1, "temp_storage_workspace must be rank-1");
+  TORCH_CHECK(
+      sorted_indices_workspace.scalar_type() == torch::kInt32,
+      "sorted_indices_workspace must be int32");
+  TORCH_CHECK(row_id_workspace.scalar_type() == torch::kInt32, "row_id_workspace must be int32");
+  TORCH_CHECK(
+      sorted_row_id_workspace.scalar_type() == torch::kInt32,
+      "sorted_row_id_workspace must be int32");
+  TORCH_CHECK(
+      temp_storage_workspace.scalar_type() == torch::kUInt8,
+      "temp_storage_workspace must be uint8");
+
+  return moe_permute_drop_fwd_cuda_launcher(
+      input,
+      routing_map,
+      requested_offsets,
+      keep_offsets,
+      keep_splits,
+      num_out_tokens,
+      sorted_indices_workspace,
+      row_id_workspace,
+      sorted_row_id_workspace,
+      temp_storage_workspace,
+      out);
+}
+
+int64_t moe_permute_drop_temp_storage_bytes(int64_t num_items) {
+  TORCH_CHECK(num_items >= 0, "num_items must be non-negative");
+  return moe_permute_drop_temp_storage_bytes_cuda(num_items);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+      "moe_permute_drop_fwd_cuda",
+      &moe_permute_drop_fwd_cuda,
+      "MoE one-shot permute+drop forward (CUDA)",
+      py::arg("input"),
+      py::arg("routing_map"),
+      py::arg("requested_offsets"),
+      py::arg("keep_offsets"),
+      py::arg("keep_splits"),
+      py::arg("num_out_tokens"),
+      py::arg("sorted_indices_workspace"),
+      py::arg("row_id_workspace"),
+      py::arg("sorted_row_id_workspace"),
+      py::arg("temp_storage_workspace"),
+      py::arg("out") = py::none());
+
+  m.def(
+      "moe_permute_drop_temp_storage_bytes",
+      &moe_permute_drop_temp_storage_bytes,
+      "Temporary storage bytes required by MoE one-shot permute+drop radix sort");
+}
+

--- a/src/olmo_core/kernels/cuda/moe_permute_drop_kernel.cu
+++ b/src/olmo_core/kernels/cuda/moe_permute_drop_kernel.cu
@@ -1,0 +1,378 @@
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/extension.h>
+
+#include <cub/cub.cuh>
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+template <typename scalar_t, int kElementsPerAccess>
+__global__ void moe_permute_drop_vec_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    const int* __restrict__ sorted_indices,
+    const int* __restrict__ sorted_row_id,
+    const int64_t* __restrict__ requested_offsets,
+    const int64_t* __restrict__ keep_offsets,
+    const int64_t* __restrict__ keep_splits,
+    int* __restrict__ row_id_map,
+    int num_tokens,
+    int topk,
+    int num_cols,
+    int num_experts,
+    int num_out_tokens,
+    int expanded_rows) {
+  const int sorted_pos = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  if (sorted_pos >= expanded_rows) {
+    return;
+  }
+
+  const int expert = sorted_indices[sorted_pos];
+  int dest_row = -1;
+  int source_token = 0;
+  int source_topk = 0;
+
+  if (expert >= 0 && expert < num_experts) {
+    const int64_t exp_offset = requested_offsets[expert];
+    const int64_t keep_offset = keep_offsets[expert];
+    const int64_t keep_count = keep_splits[expert];
+    const int64_t rank_in_expert = static_cast<int64_t>(sorted_pos) - exp_offset;
+
+    if (rank_in_expert >= 0 && rank_in_expert < keep_count) {
+      const int64_t dst64 = keep_offset + rank_in_expert;
+      if (dst64 >= 0 && dst64 < static_cast<int64_t>(num_out_tokens)) {
+        dest_row = static_cast<int>(dst64);
+      }
+    }
+  }
+
+  const int source_row = sorted_row_id[sorted_pos];
+  source_token = source_row / topk;
+  source_topk = source_row - source_token * topk;
+
+  if (tid == 0) {
+    const int map_idx = source_topk * num_tokens + source_token;
+    row_id_map[map_idx] = dest_row;
+  }
+
+  if (dest_row < 0) {
+    return;
+  }
+
+  const scalar_t* source_ptr = input + static_cast<int64_t>(source_token) * num_cols;
+  scalar_t* dest_ptr = output + static_cast<int64_t>(dest_row) * num_cols;
+
+  for (int col = tid * kElementsPerAccess; col < num_cols;
+       col += static_cast<int>(blockDim.x) * kElementsPerAccess) {
+    float4 frag = reinterpret_cast<const float4*>(source_ptr + col)[0];
+    reinterpret_cast<float4*>(dest_ptr + col)[0] = frag;
+  }
+}
+
+template <typename scalar_t>
+__global__ void moe_permute_drop_scalar_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    const int* __restrict__ sorted_indices,
+    const int* __restrict__ sorted_row_id,
+    const int64_t* __restrict__ requested_offsets,
+    const int64_t* __restrict__ keep_offsets,
+    const int64_t* __restrict__ keep_splits,
+    int* __restrict__ row_id_map,
+    int num_tokens,
+    int topk,
+    int num_cols,
+    int num_experts,
+    int num_out_tokens,
+    int expanded_rows) {
+  const int sorted_pos = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  if (sorted_pos >= expanded_rows) {
+    return;
+  }
+
+  const int expert = sorted_indices[sorted_pos];
+  int dest_row = -1;
+  int source_token = 0;
+  int source_topk = 0;
+
+  if (expert >= 0 && expert < num_experts) {
+    const int64_t exp_offset = requested_offsets[expert];
+    const int64_t keep_offset = keep_offsets[expert];
+    const int64_t keep_count = keep_splits[expert];
+    const int64_t rank_in_expert = static_cast<int64_t>(sorted_pos) - exp_offset;
+
+    if (rank_in_expert >= 0 && rank_in_expert < keep_count) {
+      const int64_t dst64 = keep_offset + rank_in_expert;
+      if (dst64 >= 0 && dst64 < static_cast<int64_t>(num_out_tokens)) {
+        dest_row = static_cast<int>(dst64);
+      }
+    }
+  }
+
+  const int source_row = sorted_row_id[sorted_pos];
+  source_token = source_row / topk;
+  source_topk = source_row - source_token * topk;
+
+  if (tid == 0) {
+    const int map_idx = source_topk * num_tokens + source_token;
+    row_id_map[map_idx] = dest_row;
+  }
+
+  if (dest_row < 0) {
+    return;
+  }
+
+  const scalar_t* source_ptr = input + static_cast<int64_t>(source_token) * num_cols;
+  scalar_t* dest_ptr = output + static_cast<int64_t>(dest_row) * num_cols;
+  for (int col = tid; col < num_cols; col += static_cast<int>(blockDim.x)) {
+    dest_ptr[col] = source_ptr[col];
+  }
+}
+
+torch::Tensor get_or_create_output(
+    const torch::Tensor& input,
+    int64_t out_rows,
+    const c10::optional<torch::Tensor>& out) {
+  if (out.has_value()) {
+    const auto& out_tensor = out.value();
+    TORCH_CHECK(out_tensor.is_cuda(), "moe_permute_drop_fwd_cuda: out must be CUDA");
+    TORCH_CHECK(out_tensor.dim() == 2, "moe_permute_drop_fwd_cuda: out must be rank-2");
+    TORCH_CHECK(
+        out_tensor.size(0) == out_rows && out_tensor.size(1) == input.size(1),
+        "moe_permute_drop_fwd_cuda: out shape mismatch, expected [",
+        out_rows,
+        ", ",
+        input.size(1),
+        "] got ",
+        out_tensor.sizes());
+    TORCH_CHECK(
+        out_tensor.scalar_type() == input.scalar_type(),
+        "moe_permute_drop_fwd_cuda: out dtype mismatch");
+    TORCH_CHECK(
+        out_tensor.device() == input.device(),
+        "moe_permute_drop_fwd_cuda: out device mismatch");
+    TORCH_CHECK(out_tensor.is_contiguous(), "moe_permute_drop_fwd_cuda: out must be contiguous");
+    return out_tensor;
+  }
+
+  return torch::empty(
+      {out_rows, input.size(1)},
+      torch::TensorOptions()
+          .dtype(input.scalar_type())
+          .device(input.device())
+          .requires_grad(false));
+}
+
+template <typename scalar_t>
+void launch_moe_permute_drop_scatter(
+    const torch::Tensor& input,
+    const torch::Tensor& output,
+    const torch::Tensor& sorted_indices,
+    const torch::Tensor& sorted_row_id,
+    const torch::Tensor& requested_offsets,
+    const torch::Tensor& keep_offsets,
+    const torch::Tensor& keep_splits,
+    const torch::Tensor& row_id_map,
+    int num_tokens,
+    int topk,
+    int num_experts,
+    int num_out_tokens,
+    int expanded_rows,
+    cudaStream_t stream) {
+  const int num_cols = static_cast<int>(input.size(1));
+  if (expanded_rows == 0 || num_cols == 0) {
+    return;
+  }
+
+  constexpr int kElementsPerAccess = 16 / sizeof(scalar_t);
+  if (num_cols % kElementsPerAccess == 0) {
+    const int threads = std::max(1, std::min(num_cols / kElementsPerAccess, 256));
+    const int blocks = expanded_rows;
+    moe_permute_drop_vec_kernel<scalar_t, kElementsPerAccess><<<blocks, threads, 0, stream>>>(
+        input.data_ptr<scalar_t>(),
+        output.data_ptr<scalar_t>(),
+        sorted_indices.data_ptr<int>(),
+        sorted_row_id.data_ptr<int>(),
+        requested_offsets.data_ptr<int64_t>(),
+        keep_offsets.data_ptr<int64_t>(),
+        keep_splits.data_ptr<int64_t>(),
+        row_id_map.data_ptr<int>(),
+        num_tokens,
+        topk,
+        num_cols,
+        num_experts,
+        num_out_tokens,
+        expanded_rows);
+  } else {
+    const int threads = std::max(1, std::min(num_cols, 256));
+    const int blocks = expanded_rows;
+    moe_permute_drop_scalar_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        input.data_ptr<scalar_t>(),
+        output.data_ptr<scalar_t>(),
+        sorted_indices.data_ptr<int>(),
+        sorted_row_id.data_ptr<int>(),
+        requested_offsets.data_ptr<int64_t>(),
+        keep_offsets.data_ptr<int64_t>(),
+        keep_splits.data_ptr<int64_t>(),
+        row_id_map.data_ptr<int>(),
+        num_tokens,
+        topk,
+        num_cols,
+        num_experts,
+        num_out_tokens,
+        expanded_rows);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+int64_t moe_permute_drop_temp_storage_bytes_cuda(int64_t num_items) {
+  size_t temp_storage_bytes = 0;
+  cub::DeviceRadixSort::SortPairs(
+      nullptr,
+      temp_storage_bytes,
+      static_cast<int*>(nullptr),
+      static_cast<int*>(nullptr),
+      static_cast<int*>(nullptr),
+      static_cast<int*>(nullptr),
+      static_cast<int>(num_items));
+  TORCH_CHECK(
+      temp_storage_bytes <= static_cast<size_t>(std::numeric_limits<int64_t>::max()),
+      "moe_permute_drop_temp_storage_bytes_cuda overflow");
+  return static_cast<int64_t>(temp_storage_bytes);
+}
+
+std::tuple<torch::Tensor, torch::Tensor> moe_permute_drop_fwd_cuda_launcher(
+    const torch::Tensor& input,
+    const torch::Tensor& routing_map,
+    const torch::Tensor& requested_offsets,
+    const torch::Tensor& keep_offsets,
+    const torch::Tensor& keep_splits,
+    int64_t num_out_tokens,
+    const torch::Tensor& sorted_indices_workspace,
+    const torch::Tensor& row_id_workspace,
+    const torch::Tensor& sorted_row_id_workspace,
+    const torch::Tensor& temp_storage_workspace,
+    const c10::optional<torch::Tensor>& out) {
+  c10::cuda::CUDAGuard device_guard(input.device());
+  auto cuda_stream = at::cuda::getCurrentCUDAStream(input.device().index());
+  cudaStream_t stream = cuda_stream.stream();
+
+  TORCH_CHECK(input.is_contiguous(), "moe_permute_drop_fwd_cuda: input must be contiguous");
+  TORCH_CHECK(
+      routing_map.is_contiguous(), "moe_permute_drop_fwd_cuda: routing_map must be contiguous");
+  TORCH_CHECK(
+      requested_offsets.is_contiguous(),
+      "moe_permute_drop_fwd_cuda: requested_offsets must be contiguous");
+  TORCH_CHECK(
+      keep_offsets.is_contiguous(), "moe_permute_drop_fwd_cuda: keep_offsets must be contiguous");
+  TORCH_CHECK(
+      keep_splits.is_contiguous(), "moe_permute_drop_fwd_cuda: keep_splits must be contiguous");
+
+  const int64_t num_tokens = input.size(0);
+  const int64_t topk = routing_map.size(1);
+  const int64_t expanded_rows = num_tokens * topk;
+  const int64_t num_experts = keep_splits.numel();
+
+  TORCH_CHECK(topk > 0, "moe_permute_drop_fwd_cuda: topK must be > 0");
+  TORCH_CHECK(
+      requested_offsets.numel() == num_experts && keep_offsets.numel() == num_experts,
+      "moe_permute_drop_fwd_cuda: offsets/splits size mismatch");
+  TORCH_CHECK(
+      sorted_indices_workspace.numel() >= expanded_rows,
+      "moe_permute_drop_fwd_cuda: sorted_indices_workspace too small");
+  TORCH_CHECK(
+      row_id_workspace.numel() >= expanded_rows,
+      "moe_permute_drop_fwd_cuda: row_id_workspace too small");
+  TORCH_CHECK(
+      sorted_row_id_workspace.numel() >= expanded_rows,
+      "moe_permute_drop_fwd_cuda: sorted_row_id_workspace too small");
+
+  if (num_out_tokens <= 0) {
+    num_out_tokens = expanded_rows;
+  }
+  TORCH_CHECK(num_out_tokens >= 0, "moe_permute_drop_fwd_cuda: num_out_tokens must be >= 0");
+  TORCH_CHECK(
+      num_out_tokens <= expanded_rows,
+      "moe_permute_drop_fwd_cuda: num_out_tokens must be <= expanded rows");
+
+  auto output = get_or_create_output(input, num_out_tokens, out);
+  auto row_id_map = torch::empty(
+      {expanded_rows},
+      torch::TensorOptions()
+          .dtype(torch::kInt32)
+          .device(input.device())
+          .requires_grad(false));
+
+  if (expanded_rows == 0 || input.size(1) == 0 || num_out_tokens == 0) {
+    return std::make_tuple(output, row_id_map);
+  }
+
+  auto routing_flat = routing_map.reshape({expanded_rows}).contiguous();
+  auto sorted_indices = sorted_indices_workspace.narrow(0, 0, expanded_rows);
+  auto row_id = row_id_workspace.narrow(0, 0, expanded_rows);
+  auto sorted_row_id = sorted_row_id_workspace.narrow(0, 0, expanded_rows);
+
+  size_t temp_storage_bytes = 0;
+  cub::DeviceRadixSort::SortPairs(
+      nullptr,
+      temp_storage_bytes,
+      routing_flat.data_ptr<int>(),
+      sorted_indices.data_ptr<int>(),
+      row_id.data_ptr<int>(),
+      sorted_row_id.data_ptr<int>(),
+      static_cast<int>(expanded_rows),
+      0,
+      static_cast<int>(sizeof(int) * 8),
+      stream);
+  TORCH_CHECK(
+      temp_storage_workspace.numel() >= static_cast<int64_t>(temp_storage_bytes),
+      "moe_permute_drop_fwd_cuda: temp_storage_workspace too small");
+
+  cub::DeviceRadixSort::SortPairs(
+      temp_storage_workspace.data_ptr<uint8_t>(),
+      temp_storage_bytes,
+      routing_flat.data_ptr<int>(),
+      sorted_indices.data_ptr<int>(),
+      row_id.data_ptr<int>(),
+      sorted_row_id.data_ptr<int>(),
+      static_cast<int>(expanded_rows),
+      0,
+      static_cast<int>(sizeof(int) * 8),
+      stream);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::kHalf,
+      at::kBFloat16,
+      input.scalar_type(),
+      "moe_permute_drop_fwd_cuda",
+      [&] {
+        launch_moe_permute_drop_scatter<scalar_t>(
+            input,
+            output,
+            sorted_indices,
+            sorted_row_id,
+            requested_offsets,
+            keep_offsets,
+            keep_splits,
+            row_id_map,
+            static_cast<int>(num_tokens),
+            static_cast<int>(topk),
+            static_cast<int>(num_experts),
+            static_cast<int>(num_out_tokens),
+            static_cast<int>(expanded_rows),
+            stream);
+      });
+
+  return std::make_tuple(output, row_id_map);
+}

--- a/src/olmo_core/kernels/cuda/moe_unpermute_bwd.cpp
+++ b/src/olmo_core/kernels/cuda/moe_unpermute_bwd.cpp
@@ -1,0 +1,65 @@
+#include <torch/extension.h>
+
+namespace py = pybind11;
+
+std::tuple<torch::Tensor, torch::Tensor> moe_unpermute_bwd_cuda_launcher(
+    const torch::Tensor& grad_output,
+    const torch::Tensor& input_fwd,
+    const torch::Tensor& row_id_map,
+    const torch::Tensor& probs,
+    const c10::optional<torch::Tensor>& keep_mask,
+    const c10::optional<torch::Tensor>& out);
+
+std::tuple<torch::Tensor, torch::Tensor> moe_unpermute_bwd_cuda(
+    const torch::Tensor& grad_output,
+    const torch::Tensor& input_fwd,
+    const torch::Tensor& row_id_map,
+    const torch::Tensor& probs,
+    const c10::optional<torch::Tensor>& keep_mask,
+    const c10::optional<torch::Tensor>& out) {
+  TORCH_CHECK(grad_output.is_cuda(), "grad_output must be CUDA");
+  TORCH_CHECK(input_fwd.is_cuda(), "input_fwd must be CUDA");
+  TORCH_CHECK(row_id_map.is_cuda(), "row_id_map must be CUDA");
+  TORCH_CHECK(probs.is_cuda(), "probs must be CUDA");
+
+  TORCH_CHECK(grad_output.dim() == 2, "grad_output must be rank-2 [num_tokens, hidden]");
+  TORCH_CHECK(input_fwd.dim() == 2, "input_fwd must be rank-2 [input_rows, hidden]");
+  TORCH_CHECK(row_id_map.dim() == 1, "row_id_map must be rank-1 [topK * num_tokens]");
+  TORCH_CHECK(probs.dim() == 2, "probs must be rank-2 [num_tokens, topK]");
+
+  TORCH_CHECK(grad_output.scalar_type() == input_fwd.scalar_type(), "dtype mismatch between grad_output and input_fwd");
+  TORCH_CHECK(row_id_map.scalar_type() == torch::kInt32, "row_id_map must be int32");
+  TORCH_CHECK(probs.scalar_type() == torch::kFloat32, "probs must be float32");
+
+  TORCH_CHECK(grad_output.size(1) == input_fwd.size(1), "hidden-size mismatch between grad_output and input_fwd");
+  TORCH_CHECK(grad_output.size(0) == probs.size(0), "num_tokens mismatch between grad_output and probs");
+
+  const int64_t num_tokens = probs.size(0);
+  const int64_t topk = probs.size(1);
+  TORCH_CHECK(row_id_map.numel() == num_tokens * topk, "row_id_map size must equal num_tokens * topK");
+  if (keep_mask.has_value()) {
+    const auto& keep_mask_tensor = keep_mask.value();
+    TORCH_CHECK(keep_mask_tensor.is_cuda(), "keep_mask must be CUDA");
+    TORCH_CHECK(keep_mask_tensor.dim() == 1, "keep_mask must be rank-1 [input_rows]");
+    TORCH_CHECK(keep_mask_tensor.scalar_type() == torch::kBool, "keep_mask must be bool");
+    TORCH_CHECK(
+        keep_mask_tensor.size(0) == input_fwd.size(0),
+        "keep_mask length must equal input_fwd rows");
+  }
+
+  return moe_unpermute_bwd_cuda_launcher(
+      grad_output, input_fwd, row_id_map, probs, keep_mask, out);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+      "moe_unpermute_bwd_cuda",
+      &moe_unpermute_bwd_cuda,
+      "MoE unpermute backward (CUDA)",
+      py::arg("grad_output"),
+      py::arg("input_fwd"),
+      py::arg("row_id_map"),
+      py::arg("probs"),
+      py::arg("keep_mask") = py::none(),
+      py::arg("out") = py::none());
+}

--- a/src/olmo_core/kernels/cuda/moe_unpermute_bwd_kernel.cu
+++ b/src/olmo_core/kernels/cuda/moe_unpermute_bwd_kernel.cu
@@ -1,0 +1,434 @@
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/extension.h>
+
+#include <cub/cub.cuh>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <type_traits>
+
+namespace {
+
+torch::Tensor get_or_create_output(
+    const torch::Tensor& input_fwd,
+    const c10::optional<torch::Tensor>& out) {
+  if (out.has_value()) {
+    auto out_tensor = out.value();
+    TORCH_CHECK(out_tensor.is_cuda(), "moe_unpermute_bwd_cuda: out must be CUDA");
+    TORCH_CHECK(out_tensor.dim() == 2, "moe_unpermute_bwd_cuda: out must be rank-2");
+    TORCH_CHECK(
+        out_tensor.size(0) == input_fwd.size(0) && out_tensor.size(1) == input_fwd.size(1),
+        "moe_unpermute_bwd_cuda: out shape mismatch, expected [",
+        input_fwd.size(0),
+        ", ",
+        input_fwd.size(1),
+        "] got ",
+        out_tensor.sizes());
+    TORCH_CHECK(
+        out_tensor.scalar_type() == input_fwd.scalar_type(),
+        "moe_unpermute_bwd_cuda: out dtype mismatch");
+    TORCH_CHECK(
+        out_tensor.device() == input_fwd.device(),
+        "moe_unpermute_bwd_cuda: out device mismatch");
+    TORCH_CHECK(out_tensor.is_contiguous(), "moe_unpermute_bwd_cuda: out must be contiguous");
+
+    return out_tensor;
+  }
+
+  return torch::empty(
+      {input_fwd.size(0), input_fwd.size(1)},
+      torch::TensorOptions()
+          .dtype(input_fwd.scalar_type())
+          .device(input_fwd.device())
+          .requires_grad(false));
+}
+
+template <typename scalar_t, int kThreads>
+__global__ void zero_rows_by_keep_mask_scalar_kernel(
+    scalar_t* __restrict__ output,
+    const bool* __restrict__ keep_mask,
+    int num_rows,
+    int num_cols) {
+  const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t total = static_cast<int64_t>(num_rows) * num_cols;
+  if (idx >= total) {
+    return;
+  }
+  const int row = static_cast<int>(idx / num_cols);
+  if (!keep_mask[row]) {
+    output[idx] = scalar_t(0);
+  }
+}
+
+template <typename scalar_t, int kElementsPerAccess>
+__global__ void zero_rows_by_keep_mask_vec_kernel(
+    scalar_t* __restrict__ output,
+    const bool* __restrict__ keep_mask,
+    int num_rows,
+    int num_cols) {
+  const int row = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  if (row >= num_rows || keep_mask[row]) {
+    return;
+  }
+
+  float4 zero_frag;
+  scalar_t* zero_ptr = reinterpret_cast<scalar_t*>(&zero_frag);
+#pragma unroll
+  for (int i = 0; i < kElementsPerAccess; ++i) {
+    zero_ptr[i] = scalar_t(0);
+  }
+
+  scalar_t* row_ptr = output + static_cast<int64_t>(row) * num_cols;
+  for (int col = tid * kElementsPerAccess; col < num_cols;
+       col += static_cast<int>(blockDim.x) * kElementsPerAccess) {
+    *reinterpret_cast<float4*>(row_ptr + col) = zero_frag;
+  }
+}
+
+template <typename scalar_t>
+void launch_zero_rows_by_keep_mask(
+    const torch::Tensor& output,
+    const torch::Tensor& keep_mask,
+    cudaStream_t stream) {
+  const int num_rows = static_cast<int>(output.size(0));
+  const int num_cols = static_cast<int>(output.size(1));
+  if (num_rows == 0 || num_cols == 0) {
+    return;
+  }
+
+  static constexpr int kElementsPerAccess = 16 / sizeof(scalar_t);
+  if (num_cols % kElementsPerAccess == 0) {
+    const int threads = std::max(1, std::min(num_cols / kElementsPerAccess, 1024));
+    const int blocks = num_rows;
+    zero_rows_by_keep_mask_vec_kernel<scalar_t, kElementsPerAccess><<<blocks, threads, 0, stream>>>(
+        output.data_ptr<scalar_t>(),
+        keep_mask.data_ptr<bool>(),
+        num_rows,
+        num_cols);
+  } else {
+    constexpr int kThreads = 256;
+    const int64_t total = static_cast<int64_t>(num_rows) * num_cols;
+    const int blocks = static_cast<int>((total + kThreads - 1) / kThreads);
+    zero_rows_by_keep_mask_scalar_kernel<scalar_t, kThreads><<<blocks, kThreads, 0, stream>>>(
+        output.data_ptr<scalar_t>(),
+        keep_mask.data_ptr<bool>(),
+        num_rows,
+        num_cols);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename scalar_t, typename compute_t, int topk_tile, bool has_prob>
+__global__ void moe_unpermute_bwd_vec_kernel(
+    const scalar_t* __restrict__ grad_output,
+    const scalar_t* __restrict__ input_fwd,
+    scalar_t* __restrict__ act_grad,
+    const int* __restrict__ row_id_map,
+    const float* __restrict__ probs,
+    float* __restrict__ prob_grad,
+    int num_tokens,
+    int topk,
+    int num_cols,
+    int input_rows) {
+  extern __shared__ int8_t shared_mem[];
+  compute_t* shared_probs = reinterpret_cast<compute_t*>(shared_mem);
+
+  const int token = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  if (token >= num_tokens) {
+    return;
+  }
+
+  if (has_prob) {
+    for (int i = tid; i < topk; i += blockDim.x) {
+      shared_probs[i] = static_cast<compute_t>(probs[token * topk + i]);
+    }
+    __syncthreads();
+  }
+
+  float accum[topk_tile] = {0.0f};
+  float4 frag_load_store;
+  scalar_t* frag_load_store_ptr = reinterpret_cast<scalar_t*>(&frag_load_store);
+  static constexpr int kElementsPerAccess = 16 / sizeof(scalar_t);
+
+  const scalar_t* grad_row_ptr = grad_output + static_cast<int64_t>(token) * num_cols;
+  for (int col = tid * kElementsPerAccess; col < num_cols;
+       col += static_cast<int>(blockDim.x) * kElementsPerAccess) {
+    compute_t grad_frag[kElementsPerAccess];
+    frag_load_store = __ldlu(reinterpret_cast<const float4*>(grad_row_ptr + col));
+    for (int e = 0; e < kElementsPerAccess; ++e) {
+      grad_frag[e] = static_cast<compute_t>(frag_load_store_ptr[e]);
+    }
+
+    int index = token;
+    for (int k = 0; k < topk_tile; ++k) {
+      if (k == topk) {
+        break;
+      }
+      const int dest_row = row_id_map[index];
+      index += num_tokens;
+
+      if (dest_row < 0 || dest_row >= input_rows) {
+        continue;
+      }
+
+      if (has_prob) {
+        const compute_t p = shared_probs[k];
+        for (int e = 0; e < kElementsPerAccess; ++e) {
+          frag_load_store_ptr[e] = static_cast<scalar_t>(grad_frag[e] * p);
+        }
+      } else {
+        for (int e = 0; e < kElementsPerAccess; ++e) {
+          frag_load_store_ptr[e] = static_cast<scalar_t>(grad_frag[e]);
+        }
+      }
+
+      scalar_t* out_row_ptr = act_grad + static_cast<int64_t>(dest_row) * num_cols;
+      *reinterpret_cast<float4*>(out_row_ptr + col) = frag_load_store;
+
+      if (has_prob) {
+        const scalar_t* input_fwd_ptr = input_fwd + static_cast<int64_t>(dest_row) * num_cols;
+        frag_load_store = __ldlu(reinterpret_cast<const float4*>(input_fwd_ptr + col));
+        for (int e = 0; e < kElementsPerAccess; ++e) {
+          const compute_t input_val = static_cast<compute_t>(frag_load_store_ptr[e]);
+          accum[k] += static_cast<float>(grad_frag[e] * input_val);
+        }
+      }
+    }
+  }
+
+  if (has_prob) {
+#pragma unroll
+    for (int k = 0; k < topk_tile; ++k) {
+      if (k == topk) {
+        break;
+      }
+      for (int mask = 16; mask > 0; mask /= 2) {
+        accum[k] += __shfl_xor_sync(0xffffffff, accum[k], mask, 32);
+      }
+    }
+
+    if (tid == 0) {
+      for (int k = 0; k < topk_tile; ++k) {
+        if (k == topk) {
+          break;
+        }
+        prob_grad[token * topk + k] = accum[k];
+      }
+    }
+  }
+}
+
+template <typename scalar_t, int kThreads>
+__global__ void moe_unpermute_bwd_scalar_kernel(
+    const scalar_t* __restrict__ grad_output,
+    const scalar_t* __restrict__ input_fwd,
+    scalar_t* __restrict__ act_grad,
+    const int* __restrict__ row_id_map,
+    const float* __restrict__ probs,
+    float* __restrict__ prob_grad,
+    int num_tokens,
+    int topk,
+    int num_cols,
+    int input_rows) {
+  const int token = static_cast<int>(blockIdx.x);
+  const int k = static_cast<int>(blockIdx.y);
+  const int tid = static_cast<int>(threadIdx.x);
+  if (token >= num_tokens || k >= topk) {
+    return;
+  }
+
+  const int dest_row = row_id_map[k * num_tokens + token];
+  float local_prob_grad = 0.0f;
+  if (dest_row >= 0 && dest_row < input_rows) {
+    const float p = probs[token * topk + k];
+    const scalar_t* grad_row_ptr = grad_output + static_cast<int64_t>(token) * num_cols;
+    const scalar_t* input_row_ptr = input_fwd + static_cast<int64_t>(dest_row) * num_cols;
+    scalar_t* out_row_ptr = act_grad + static_cast<int64_t>(dest_row) * num_cols;
+    for (int col = tid; col < num_cols; col += kThreads) {
+      const float grad_val = static_cast<float>(grad_row_ptr[col]);
+      out_row_ptr[col] = static_cast<scalar_t>(grad_val * p);
+      local_prob_grad += grad_val * static_cast<float>(input_row_ptr[col]);
+    }
+  }
+
+  using BlockReduce = cub::BlockReduce<float, kThreads>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  const float sum = BlockReduce(temp_storage).Sum(local_prob_grad);
+  if (tid == 0) {
+    prob_grad[token * topk + k] = (dest_row >= 0 && dest_row < input_rows) ? sum : 0.0f;
+  }
+}
+
+template <typename scalar_t>
+void launch_moe_unpermute_bwd(
+    const torch::Tensor& grad_output,
+    const torch::Tensor& input_fwd,
+    const torch::Tensor& row_id_map,
+    const torch::Tensor& probs,
+    const torch::Tensor& act_grad,
+    const torch::Tensor& prob_grad,
+    cudaStream_t stream) {
+  const int num_tokens = static_cast<int>(grad_output.size(0));
+  const int topk = static_cast<int>(probs.size(1));
+  const int num_cols = static_cast<int>(grad_output.size(1));
+  const int input_rows = static_cast<int>(input_fwd.size(0));
+
+  if (num_tokens == 0 || topk == 0 || num_cols == 0) {
+    return;
+  }
+
+  using compute_t = scalar_t;
+  static constexpr int kElementsPerAccess = 16 / sizeof(scalar_t);
+
+  if (num_cols % kElementsPerAccess == 0) {
+    const int threads = 32;
+    const int blocks = num_tokens;
+    const size_t smem_bytes = static_cast<size_t>(topk) * sizeof(compute_t);
+    if (topk <= 8) {
+      moe_unpermute_bwd_vec_kernel<scalar_t, compute_t, 8, true><<<blocks, threads, smem_bytes, stream>>>(
+          grad_output.data_ptr<scalar_t>(),
+          input_fwd.data_ptr<scalar_t>(),
+          act_grad.data_ptr<scalar_t>(),
+          row_id_map.data_ptr<int>(),
+          probs.data_ptr<float>(),
+          prob_grad.data_ptr<float>(),
+          num_tokens,
+          topk,
+          num_cols,
+          input_rows);
+    } else if (topk <= 16) {
+      moe_unpermute_bwd_vec_kernel<scalar_t, compute_t, 16, true><<<blocks, threads, smem_bytes, stream>>>(
+          grad_output.data_ptr<scalar_t>(),
+          input_fwd.data_ptr<scalar_t>(),
+          act_grad.data_ptr<scalar_t>(),
+          row_id_map.data_ptr<int>(),
+          probs.data_ptr<float>(),
+          prob_grad.data_ptr<float>(),
+          num_tokens,
+          topk,
+          num_cols,
+          input_rows);
+    } else if (topk <= 32) {
+      moe_unpermute_bwd_vec_kernel<scalar_t, compute_t, 32, true><<<blocks, threads, smem_bytes, stream>>>(
+          grad_output.data_ptr<scalar_t>(),
+          input_fwd.data_ptr<scalar_t>(),
+          act_grad.data_ptr<scalar_t>(),
+          row_id_map.data_ptr<int>(),
+          probs.data_ptr<float>(),
+          prob_grad.data_ptr<float>(),
+          num_tokens,
+          topk,
+          num_cols,
+          input_rows);
+    } else if (topk <= 64) {
+      moe_unpermute_bwd_vec_kernel<scalar_t, compute_t, 64, true><<<blocks, threads, smem_bytes, stream>>>(
+          grad_output.data_ptr<scalar_t>(),
+          input_fwd.data_ptr<scalar_t>(),
+          act_grad.data_ptr<scalar_t>(),
+          row_id_map.data_ptr<int>(),
+          probs.data_ptr<float>(),
+          prob_grad.data_ptr<float>(),
+          num_tokens,
+          topk,
+          num_cols,
+          input_rows);
+    } else {
+      moe_unpermute_bwd_vec_kernel<scalar_t, compute_t, 128, true><<<blocks, threads, smem_bytes, stream>>>(
+          grad_output.data_ptr<scalar_t>(),
+          input_fwd.data_ptr<scalar_t>(),
+          act_grad.data_ptr<scalar_t>(),
+          row_id_map.data_ptr<int>(),
+          probs.data_ptr<float>(),
+          prob_grad.data_ptr<float>(),
+          num_tokens,
+          topk,
+          num_cols,
+          input_rows);
+    }
+  } else {
+    constexpr int kThreads = 256;
+    const dim3 grid(num_tokens, topk);
+    moe_unpermute_bwd_scalar_kernel<scalar_t, kThreads><<<grid, kThreads, 0, stream>>>(
+        grad_output.data_ptr<scalar_t>(),
+        input_fwd.data_ptr<scalar_t>(),
+        act_grad.data_ptr<scalar_t>(),
+        row_id_map.data_ptr<int>(),
+        probs.data_ptr<float>(),
+        prob_grad.data_ptr<float>(),
+        num_tokens,
+        topk,
+        num_cols,
+        input_rows);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+}  // namespace
+
+std::tuple<torch::Tensor, torch::Tensor> moe_unpermute_bwd_cuda_launcher(
+    const torch::Tensor& grad_output,
+    const torch::Tensor& input_fwd,
+    const torch::Tensor& row_id_map,
+    const torch::Tensor& probs,
+    const c10::optional<torch::Tensor>& keep_mask,
+    const c10::optional<torch::Tensor>& out) {
+  c10::cuda::CUDAGuard device_guard(grad_output.device());
+  auto cuda_stream = at::cuda::getCurrentCUDAStream(grad_output.device().index());
+  cudaStream_t stream = cuda_stream.stream();
+
+  TORCH_CHECK(grad_output.is_contiguous(), "moe_unpermute_bwd_cuda: grad_output must be contiguous");
+  TORCH_CHECK(input_fwd.is_contiguous(), "moe_unpermute_bwd_cuda: input_fwd must be contiguous");
+  TORCH_CHECK(row_id_map.is_contiguous(), "moe_unpermute_bwd_cuda: row_id_map must be contiguous");
+  TORCH_CHECK(probs.is_contiguous(), "moe_unpermute_bwd_cuda: probs must be contiguous");
+
+  const int64_t num_tokens = grad_output.size(0);
+  const int64_t topk = probs.size(1);
+
+  auto act_grad = get_or_create_output(input_fwd, out);
+  TORCH_CHECK(topk > 0, "moe_unpermute_bwd_cuda: topk must be > 0");
+  TORCH_CHECK(topk <= 128, "moe_unpermute_bwd_cuda: topk must be <= 128");
+  if (keep_mask.has_value()) {
+    const auto& keep_mask_tensor = keep_mask.value();
+    TORCH_CHECK(
+        keep_mask_tensor.is_contiguous(),
+        "moe_unpermute_bwd_cuda: keep_mask must be contiguous");
+  } else {
+    act_grad.zero_();
+  }
+
+  auto prob_grad = torch::empty(
+      {num_tokens, topk},
+      torch::TensorOptions().dtype(torch::kFloat32).device(grad_output.device()).requires_grad(false));
+
+  if (num_tokens == 0 || topk == 0 || grad_output.size(1) == 0) {
+    return std::make_tuple(act_grad, prob_grad);
+  }
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::kHalf,
+      at::kBFloat16,
+      grad_output.scalar_type(),
+      "moe_unpermute_bwd_cuda",
+      [&] {
+        if (keep_mask.has_value()) {
+          launch_zero_rows_by_keep_mask<scalar_t>(act_grad, keep_mask.value(), stream);
+        }
+        launch_moe_unpermute_bwd<scalar_t>(
+            grad_output,
+            input_fwd,
+            row_id_map,
+            probs,
+            act_grad,
+            prob_grad,
+            stream);
+      });
+
+  return std::make_tuple(act_grad, prob_grad);
+}

--- a/src/olmo_core/kernels/cuda_extension_utils.py
+++ b/src/olmo_core/kernels/cuda_extension_utils.py
@@ -21,7 +21,7 @@ import torch
 
 log = logging.getLogger(__name__)
 
-__all__ = ["load_cuda_extension"]
+__all__ = ["load_cuda_extension", "LazyCudaExtension"]
 
 PathLikeStr = Union[str, os.PathLike[str]]
 
@@ -265,3 +265,81 @@ def load_cuda_extension(
                 time.sleep(retry_sleep_s * (attempt + 1))
 
     raise RuntimeError("Failed to load CUDA extension after retries")
+
+
+class LazyCudaExtension:
+    """
+    Lazily JIT-build and cache a single CUDA/C++ extension.
+
+    Wraps :func:`load_cuda_extension` with memoization and clear error reporting:
+    the extension is built on the first :meth:`load` call and cached; if that build
+    fails, the original error is cached and re-raised (chained) on every later call
+    so the build isn't retried in a loop. Source file names are resolved relative to
+    the ``cuda/`` directory of this package.
+
+    :param name: Human-readable extension name used in error messages.
+    :param base_name: Base name passed to :func:`load_cuda_extension`.
+    :param sources: Source file names, relative to this package's ``cuda/`` directory.
+    :param extra_cflags: Extra host-compiler flags.
+    :param extra_cuda_cflags: Extra ``nvcc`` flags; omit for C++-only extensions.
+    :param verbose_env_names: See :func:`load_cuda_extension`.
+    :param force_rebuild_env_names: See :func:`load_cuda_extension`.
+    :param stale_lock_timeout_env_names: See :func:`load_cuda_extension`.
+    :param with_arch_suffix: See :func:`load_cuda_extension`.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        base_name: str,
+        sources: Sequence[str],
+        extra_cflags: Optional[Sequence[str]] = None,
+        extra_cuda_cflags: Optional[Sequence[str]] = None,
+        verbose_env_names: Sequence[str] = (),
+        force_rebuild_env_names: Sequence[str] = (),
+        stale_lock_timeout_env_names: Sequence[str] = ("OLMO_MOE_EXT_STALE_LOCK_TIMEOUT_SEC",),
+        with_arch_suffix: bool = True,
+    ) -> None:
+        self.name = name
+        self.base_name = base_name
+        self.sources = tuple(sources)
+        self.extra_cflags = list(extra_cflags) if extra_cflags is not None else None
+        self.extra_cuda_cflags = list(extra_cuda_cflags) if extra_cuda_cflags is not None else None
+        self.verbose_env_names = tuple(verbose_env_names)
+        self.force_rebuild_env_names = tuple(force_rebuild_env_names)
+        self.stale_lock_timeout_env_names = tuple(stale_lock_timeout_env_names)
+        self.with_arch_suffix = with_arch_suffix
+        self._extension: Any = None
+        self._attempted = False
+        self._error: Optional[Exception] = None
+
+    def load(self) -> Any:
+        """
+        Return the loaded extension module, building it on first call.
+
+        :raises RuntimeError: If the extension cannot be built or loaded.
+        """
+        if self._extension is not None:
+            return self._extension
+        if self._attempted:
+            raise RuntimeError(f"CUDA {self.name} extension is unavailable") from self._error
+
+        self._attempted = True
+        cuda_dir = Path(__file__).resolve().parent / "cuda"
+        try:
+            self._extension = load_cuda_extension(
+                base_name=self.base_name,
+                sources=[cuda_dir / src for src in self.sources],
+                extra_cflags=self.extra_cflags,
+                extra_cuda_cflags=self.extra_cuda_cflags,
+                verbose_env_names=self.verbose_env_names,
+                force_rebuild_env_names=self.force_rebuild_env_names,
+                stale_lock_timeout_env_names=self.stale_lock_timeout_env_names,
+                with_arch_suffix=self.with_arch_suffix,
+            )
+        except Exception as e:
+            self._error = e
+            raise RuntimeError(f"Failed to build/load CUDA {self.name} extension: {e}") from e
+
+        return self._extension

--- a/src/olmo_core/kernels/grouped_mm.py
+++ b/src/olmo_core/kernels/grouped_mm.py
@@ -1,48 +1,27 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Optional
 
 import torch
 import torch.nn.functional as F
 
-from .cuda_extension_utils import load_cuda_extension
+from .cuda_extension_utils import LazyCudaExtension
 
-_CUDA_EXTENSION = None
-_CUDA_EXTENSION_ATTEMPTED = False
-_CUDA_EXTENSION_ERROR: Optional[Exception] = None
+_EXTENSION = LazyCudaExtension(
+    name="grouped_mm",
+    base_name="olmo_grouped_mm_out_ext",
+    sources=("grouped_mm_out.cpp",),
+    extra_cflags=["-O3"],
+    verbose_env_names=("OLMO_GROUPED_MM_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
+    force_rebuild_env_names=(
+        "OLMO_GROUPED_MM_FORCE_REBUILD",
+        "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
+    ),
+)
 
 
 def _load_cuda_extension():
-    global _CUDA_EXTENSION
-    global _CUDA_EXTENSION_ATTEMPTED
-    global _CUDA_EXTENSION_ERROR
-    if _CUDA_EXTENSION is not None:
-        return _CUDA_EXTENSION
-    if _CUDA_EXTENSION_ATTEMPTED and _CUDA_EXTENSION is None:
-        raise RuntimeError("CUDA grouped_mm extension is unavailable") from _CUDA_EXTENSION_ERROR
-
-    _CUDA_EXTENSION_ATTEMPTED = True
-    try:
-        this_dir = Path(__file__).resolve().parent
-        cpp_src = this_dir / "cuda" / "grouped_mm_out.cpp"
-        _CUDA_EXTENSION = load_cuda_extension(
-            base_name="olmo_grouped_mm_out_ext",
-            sources=[cpp_src],
-            extra_cflags=["-O3"],
-            verbose_env_names=("OLMO_GROUPED_MM_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
-            force_rebuild_env_names=(
-                "OLMO_GROUPED_MM_FORCE_REBUILD",
-                "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
-            ),
-            stale_lock_timeout_env_names=("OLMO_MOE_EXT_STALE_LOCK_TIMEOUT_SEC",),
-            with_arch_suffix=True,
-        )
-    except Exception as e:
-        _CUDA_EXTENSION_ERROR = e
-        raise RuntimeError(f"Failed to build/load CUDA grouped_mm extension: {e}") from e
-
-    return _CUDA_EXTENSION
+    return _EXTENSION.load()
 
 
 @torch.compiler.disable

--- a/src/olmo_core/kernels/moe_chunk_reorder.py
+++ b/src/olmo_core/kernels/moe_chunk_reorder.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, Optional, Tuple
+
+import torch
+
+from .cuda_extension_utils import load_cuda_extension
+
+_CUDA_EXTENSION = None
+_CUDA_EXTENSION_ATTEMPTED = False
+_CUDA_EXTENSION_ERROR: Optional[Exception] = None
+
+
+def _load_cuda_extension():
+    global _CUDA_EXTENSION
+    global _CUDA_EXTENSION_ATTEMPTED
+    global _CUDA_EXTENSION_ERROR
+    if _CUDA_EXTENSION is not None:
+        return _CUDA_EXTENSION
+    if _CUDA_EXTENSION_ATTEMPTED and _CUDA_EXTENSION is None:
+        raise RuntimeError("CUDA chunk reorder extension is unavailable") from _CUDA_EXTENSION_ERROR
+
+    _CUDA_EXTENSION_ATTEMPTED = True
+    try:
+        this_dir = Path(__file__).resolve().parent
+        cpp_src = this_dir / "cuda" / "moe_chunk_reorder.cpp"
+        cu_src = this_dir / "cuda" / "moe_chunk_reorder_kernel.cu"
+        _CUDA_EXTENSION = load_cuda_extension(
+            base_name="olmo_moe_chunk_reorder_ext",
+            sources=[cpp_src, cu_src],
+            extra_cflags=["-O3"],
+            extra_cuda_cflags=["-O3"],
+            verbose_env_names=("OLMO_MOE_CHUNK_REORDER_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
+            force_rebuild_env_names=(
+                "OLMO_MOE_CHUNK_REORDER_FORCE_REBUILD",
+                "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
+            ),
+            stale_lock_timeout_env_names=("OLMO_MOE_EXT_STALE_LOCK_TIMEOUT_SEC",),
+            with_arch_suffix=True,
+        )
+    except Exception as e:
+        _CUDA_EXTENSION_ERROR = e
+        raise RuntimeError(f"Failed to build/load CUDA chunk reorder extension: {e}") from e
+
+    return _CUDA_EXTENSION
+
+
+def _check_perm_inputs(
+    inp: torch.Tensor,
+    routing_map: torch.Tensor,
+    num_out_tokens: int,
+    out: Optional[torch.Tensor],
+) -> None:
+    if inp.ndim != 2:
+        raise ValueError(f"permute expects rank-2 input, got shape={tuple(inp.shape)}")
+    if not inp.is_cuda:
+        raise ValueError("permute expects CUDA input")
+    if routing_map.ndim != 2:
+        raise ValueError(
+            f"routing_map must be rank-2 [num_tokens, topK], got shape={tuple(routing_map.shape)}"
+        )
+    if routing_map.shape[0] != inp.shape[0]:
+        raise ValueError(
+            f"routing_map/input rows mismatch: routing_map={routing_map.shape[0]} input={inp.shape[0]}"
+        )
+    if routing_map.shape[1] != 1:
+        raise ValueError(
+            f"only topK=1 is supported, got routing_map shape={tuple(routing_map.shape)}"
+        )
+    if routing_map.device != inp.device:
+        raise ValueError(
+            f"routing_map/input device mismatch: routing_map={routing_map.device} input={inp.device}"
+        )
+    if num_out_tokens < 0:
+        raise ValueError(f"num_out_tokens must be non-negative, got {num_out_tokens}")
+    if out is not None:
+        expected_shape = (num_out_tokens, inp.shape[1])
+        if tuple(out.shape) != expected_shape:
+            raise ValueError(
+                f"out shape mismatch: expected={expected_shape} got={tuple(out.shape)}"
+            )
+        if out.dtype != inp.dtype:
+            raise ValueError(f"out dtype mismatch: out={out.dtype} inp={inp.dtype}")
+        if out.device != inp.device:
+            raise ValueError(f"out device mismatch: out={out.device} inp={inp.device}")
+
+
+def _check_unperm_inputs(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    num_tokens: int,
+    out: Optional[torch.Tensor],
+) -> None:
+    if inp.ndim != 2:
+        raise ValueError(f"unpermute expects rank-2 input, got shape={tuple(inp.shape)}")
+    if not inp.is_cuda:
+        raise ValueError("unpermute expects CUDA input")
+    if row_id_map.ndim != 1:
+        raise ValueError(f"row_id_map must be rank-1, got shape={tuple(row_id_map.shape)}")
+    if row_id_map.device != inp.device:
+        raise ValueError(
+            f"row_id_map/input device mismatch: row_id_map={row_id_map.device} input={inp.device}"
+        )
+    if num_tokens < 0:
+        raise ValueError(f"num_tokens must be non-negative, got {num_tokens}")
+    if out is not None:
+        expected_shape = (num_tokens, inp.shape[1])
+        if tuple(out.shape) != expected_shape:
+            raise ValueError(
+                f"out shape mismatch: expected={expected_shape} got={tuple(out.shape)}"
+            )
+        if out.dtype != inp.dtype:
+            raise ValueError(f"out dtype mismatch: out={out.dtype} inp={inp.dtype}")
+        if out.device != inp.device:
+            raise ValueError(f"out device mismatch: out={out.device} inp={inp.device}")
+
+
+def _chunk_permute_torch(
+    inp: torch.Tensor,
+    routing_map: torch.Tensor,
+    *,
+    num_out_tokens: int,
+    out: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    routing_flat = routing_map.reshape(-1).to(dtype=torch.int64)
+    sorted_row_id = torch.argsort(routing_flat, stable=True)
+    keep_row_id = sorted_row_id[:num_out_tokens]
+
+    row_id_map = torch.full((inp.shape[0],), -1, dtype=torch.int32, device=inp.device)
+    if keep_row_id.numel() > 0:
+        row_id_map.index_copy_(
+            0,
+            keep_row_id,
+            torch.arange(keep_row_id.numel(), device=inp.device, dtype=torch.int32),
+        )
+
+    output = inp.index_select(0, keep_row_id)
+    if out is not None:
+        out.copy_(output)
+        output = out
+    return output, row_id_map
+
+
+def _chunk_unpermute_torch(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    *,
+    num_tokens: int,
+    out: Optional[torch.Tensor],
+) -> torch.Tensor:
+    if num_tokens == 0:
+        output = inp.new_empty((0, inp.shape[1]))
+        if out is not None:
+            out.copy_(output)
+            return out
+        return output
+
+    row_id_map_int64 = row_id_map.to(dtype=torch.int64)
+    valid = (row_id_map_int64 >= 0) & (row_id_map_int64 < inp.shape[0])
+    safe_row_id = torch.where(valid, row_id_map_int64, torch.zeros_like(row_id_map_int64))
+    gathered = inp.index_select(0, safe_row_id)
+    gathered = torch.where(valid.unsqueeze(-1), gathered, torch.zeros_like(gathered))
+
+    if out is not None:
+        out.copy_(gathered)
+        return out
+    return gathered
+
+
+def _chunk_permute_by_row_id_map_torch(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    *,
+    num_out_tokens: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    output = inp.new_zeros((num_out_tokens, inp.shape[1]))
+    if row_id_map.numel() == 0 or num_out_tokens == 0:
+        if out is not None:
+            out.copy_(output)
+            return out
+        return output
+
+    row_id_map_int64 = row_id_map.to(dtype=torch.int64)
+    valid = (row_id_map_int64 >= 0) & (row_id_map_int64 < num_out_tokens)
+    safe_dst_idx = torch.where(valid, row_id_map_int64, torch.zeros_like(row_id_map_int64))
+    src_rows = inp * valid.unsqueeze(-1).to(dtype=inp.dtype)
+    output.index_add_(0, safe_dst_idx, src_rows)
+    if out is not None:
+        out.copy_(output)
+        return out
+    return output
+
+
+@torch.compiler.disable
+def _chunk_permute_cuda(
+    inp: torch.Tensor,
+    routing_map: torch.Tensor,
+    *,
+    num_out_tokens: int,
+    out: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    ext = _load_cuda_extension()
+    return ext.chunk_permute_fwd_cuda(inp, routing_map, num_out_tokens, out)
+
+
+@torch.compiler.disable
+def _chunk_unpermute_cuda(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    *,
+    num_tokens: int,
+    out: Optional[torch.Tensor],
+) -> torch.Tensor:
+    ext = _load_cuda_extension()
+    return ext.chunk_unpermute_fwd_cuda(inp, row_id_map, num_tokens, out)
+
+
+@torch.compiler.disable
+def _chunk_permute_by_row_id_map_cuda(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    *,
+    num_out_tokens: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    ext = _load_cuda_extension()
+    return ext.chunk_permute_by_row_id_map_cuda(inp, row_id_map, num_out_tokens, out)
+
+
+@torch.compiler.disable
+def _dispatch_permute(
+    inp: torch.Tensor,
+    routing_map: torch.Tensor,
+    *,
+    num_out_tokens: int,
+    out: Optional[torch.Tensor],
+    backend: Literal["cuda", "triton"],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if backend == "cuda":
+        return _chunk_permute_cuda(inp, routing_map, num_out_tokens=num_out_tokens, out=out)
+    if backend == "triton":
+        return _chunk_permute_torch(inp, routing_map, num_out_tokens=num_out_tokens, out=out)
+    raise ValueError(f"Invalid backend: {backend}")
+
+
+def _dispatch_unpermute(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    *,
+    num_tokens: int,
+    out: Optional[torch.Tensor],
+    backend: Literal["cuda", "triton"],
+) -> torch.Tensor:
+    if backend == "cuda":
+        return _chunk_unpermute_cuda(inp, row_id_map, num_tokens=num_tokens, out=out)
+    if backend == "triton":
+        return _chunk_unpermute_torch(inp, row_id_map, num_tokens=num_tokens, out=out)
+    raise ValueError(f"Invalid backend: {backend}")
+
+
+def _dispatch_permute_by_row_id_map(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    *,
+    num_out_tokens: int,
+    backend: Literal["cuda", "triton"],
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if backend == "cuda":
+        return _chunk_permute_by_row_id_map_cuda(
+            inp, row_id_map, num_out_tokens=num_out_tokens, out=out
+        )
+    if backend == "triton":
+        return _chunk_permute_by_row_id_map_torch(
+            inp,
+            row_id_map,
+            num_out_tokens=num_out_tokens,
+            out=out,
+        )
+    raise ValueError(f"Invalid backend: {backend}")
+
+
+class _ChunkPermuteFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        inp: torch.Tensor,
+        routing_map: torch.Tensor,
+        num_out_tokens: int,
+        backend: str,
+        out: Optional[torch.Tensor],
+        backward_grad_input_buffer: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        output, row_id_map = _dispatch_permute(
+            inp,
+            routing_map,
+            num_out_tokens=num_out_tokens,
+            out=out,
+            backend=backend,  # type: ignore[arg-type]
+        )
+        if out is not None and output is out:
+            ctx.mark_dirty(output)
+
+        # Keep metadata as direct references to avoid saved_tensors lifetime
+        # issues under compiled autograd.
+        ctx.row_id_map = row_id_map
+        ctx.num_tokens = inp.shape[0]
+        ctx.backend = backend
+        ctx.backward_grad_input_buffer = backward_grad_input_buffer  # this should point to a symm buffer that can be used in backward to avoid one extra copy
+        ctx.mark_non_differentiable(row_id_map)
+        return output, row_id_map
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor, grad_row_id_map: torch.Tensor):  # type: ignore[override]
+        del grad_row_id_map
+
+        grad_inp = None
+
+        if ctx.needs_input_grad[0]:
+            grad_inp = _dispatch_unpermute(
+                grad_output,
+                ctx.row_id_map,
+                num_tokens=ctx.num_tokens,
+                out=ctx.backward_grad_input_buffer,  # try to write directly into the provided buffer to save memory and copy if possible
+                backend=ctx.backend,  # type: ignore[arg-type]
+            )
+            if ctx.backward_grad_input_buffer is not None:
+                assert (
+                    grad_inp is ctx.backward_grad_input_buffer
+                ), "Expected the output to be written to the provided backward_grad_input_buffer"
+
+        return grad_inp, None, None, None, None, None
+
+
+class _ChunkUnpermuteFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        inp: torch.Tensor,
+        row_id_map: torch.Tensor,
+        num_tokens: int,
+        backend: str,
+        out: Optional[torch.Tensor],
+        backward_grad_input_buffer: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        output = _dispatch_unpermute(
+            inp,
+            row_id_map,
+            num_tokens=num_tokens,
+            out=out,
+            backend=backend,  # type: ignore[arg-type]
+        )
+        if out is not None and output is out:
+            ctx.mark_dirty(output)
+
+        ctx.row_id_map = row_id_map
+        ctx.input_rows = inp.shape[0]
+        ctx.backend = backend
+        ctx.backward_grad_input_buffer = backward_grad_input_buffer  # this should point to a symm buffer that can be used in backward to avoid one extra copy
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):  # type: ignore[override]
+        grad_inp = None
+        if ctx.needs_input_grad[0]:
+            grad_inp = _dispatch_permute_by_row_id_map(
+                grad_output,
+                ctx.row_id_map,
+                num_out_tokens=ctx.input_rows,
+                backend=ctx.backend,  # type: ignore[arg-type]
+                out=ctx.backward_grad_input_buffer,
+            )
+            if ctx.backward_grad_input_buffer is not None:
+                assert (
+                    grad_inp is ctx.backward_grad_input_buffer
+                ), "Expected the output to be written to the provided backward_grad_input_buffer"
+
+        return grad_inp, None, None, None, None, None
+
+
+def moe_chunk_permute(
+    inp: torch.Tensor,
+    routing_map: torch.Tensor,
+    *,
+    num_out_tokens: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+    backend: Literal["auto", "cuda", "triton"] = "auto",
+    backward_grad_input_buffer=None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if not inp.is_cuda:
+        raise ValueError("moe_chunk_permute expects CUDA input")
+    if backend not in ("auto", "cuda", "triton"):
+        raise ValueError(f"Invalid backend: {backend}")
+
+    if num_out_tokens is None:
+        num_out_tokens = int(inp.shape[0])
+    _check_perm_inputs(inp, routing_map, num_out_tokens, out)
+
+    routing_map_i32 = routing_map
+    if routing_map_i32.dtype != torch.int32:
+        routing_map_i32 = routing_map_i32.to(dtype=torch.int32)
+
+    if backend == "auto":
+        backend = "cuda"
+
+    return _ChunkPermuteFunction.apply(
+        inp,
+        routing_map_i32,
+        num_out_tokens,
+        backend,
+        out,
+        backward_grad_input_buffer,
+    )
+
+
+def moe_chunk_unpermute(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    *,
+    num_tokens: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+    backend: Literal["auto", "cuda", "triton"] = "auto",
+    backward_grad_input_buffer=None,
+) -> torch.Tensor:
+    if not inp.is_cuda:
+        raise ValueError("moe_chunk_unpermute expects CUDA input")
+    if backend not in ("auto", "cuda", "triton"):
+        raise ValueError(f"Invalid backend: {backend}")
+
+    if num_tokens is None:
+        num_tokens = int(row_id_map.numel())
+    _check_unperm_inputs(inp, row_id_map, num_tokens, out)
+
+    row_id_map_i32 = row_id_map
+    if row_id_map_i32.dtype != torch.int32:
+        row_id_map_i32 = row_id_map_i32.to(dtype=torch.int32)
+
+    if backend == "auto":
+        errors = []
+        for candidate in ("cuda", "triton"):
+            try:
+                return _ChunkUnpermuteFunction.apply(
+                    inp, row_id_map_i32, num_tokens, candidate, out, backward_grad_input_buffer
+                )
+            except Exception as e:
+                errors.append((candidate, str(e)))
+        errors_str = "; ".join([f"{name}: {msg}" for name, msg in errors])
+        raise RuntimeError(f"All chunk unpermute backends failed ({errors_str})")
+
+    return _ChunkUnpermuteFunction.apply(
+        inp, row_id_map_i32, num_tokens, backend, out, backward_grad_input_buffer
+    )

--- a/src/olmo_core/kernels/moe_chunk_reorder.py
+++ b/src/olmo_core/kernels/moe_chunk_reorder.py
@@ -1,49 +1,27 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Literal, Optional, Tuple
 
 import torch
 
-from .cuda_extension_utils import load_cuda_extension
+from .cuda_extension_utils import LazyCudaExtension
 
-_CUDA_EXTENSION = None
-_CUDA_EXTENSION_ATTEMPTED = False
-_CUDA_EXTENSION_ERROR: Optional[Exception] = None
+_EXTENSION = LazyCudaExtension(
+    name="chunk reorder",
+    base_name="olmo_moe_chunk_reorder_ext",
+    sources=("moe_chunk_reorder.cpp", "moe_chunk_reorder_kernel.cu"),
+    extra_cflags=["-O3"],
+    extra_cuda_cflags=["-O3"],
+    verbose_env_names=("OLMO_MOE_CHUNK_REORDER_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
+    force_rebuild_env_names=(
+        "OLMO_MOE_CHUNK_REORDER_FORCE_REBUILD",
+        "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
+    ),
+)
 
 
 def _load_cuda_extension():
-    global _CUDA_EXTENSION
-    global _CUDA_EXTENSION_ATTEMPTED
-    global _CUDA_EXTENSION_ERROR
-    if _CUDA_EXTENSION is not None:
-        return _CUDA_EXTENSION
-    if _CUDA_EXTENSION_ATTEMPTED and _CUDA_EXTENSION is None:
-        raise RuntimeError("CUDA chunk reorder extension is unavailable") from _CUDA_EXTENSION_ERROR
-
-    _CUDA_EXTENSION_ATTEMPTED = True
-    try:
-        this_dir = Path(__file__).resolve().parent
-        cpp_src = this_dir / "cuda" / "moe_chunk_reorder.cpp"
-        cu_src = this_dir / "cuda" / "moe_chunk_reorder_kernel.cu"
-        _CUDA_EXTENSION = load_cuda_extension(
-            base_name="olmo_moe_chunk_reorder_ext",
-            sources=[cpp_src, cu_src],
-            extra_cflags=["-O3"],
-            extra_cuda_cflags=["-O3"],
-            verbose_env_names=("OLMO_MOE_CHUNK_REORDER_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
-            force_rebuild_env_names=(
-                "OLMO_MOE_CHUNK_REORDER_FORCE_REBUILD",
-                "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
-            ),
-            stale_lock_timeout_env_names=("OLMO_MOE_EXT_STALE_LOCK_TIMEOUT_SEC",),
-            with_arch_suffix=True,
-        )
-    except Exception as e:
-        _CUDA_EXTENSION_ERROR = e
-        raise RuntimeError(f"Failed to build/load CUDA chunk reorder extension: {e}") from e
-
-    return _CUDA_EXTENSION
+    return _EXTENSION.load()
 
 
 def _check_perm_inputs(

--- a/src/olmo_core/kernels/moe_chunk_reorder.py
+++ b/src/olmo_core/kernels/moe_chunk_reorder.py
@@ -389,6 +389,24 @@ def moe_chunk_permute(
     backend: Literal["auto", "cuda", "triton"] = "auto",
     backward_grad_input_buffer=None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Permute token rows so that tokens routed to the same expert are contiguous.
+
+    Gathers rows of ``inp`` according to ``routing_map`` into the expert-grouped
+    layout a grouped matmul expects. Differentiable: the backward scatters the
+    gradient back to the original row order.
+
+    :param inp: The activations to permute, shape ``(num_tokens, d_model)``. Must be on CUDA.
+    :param routing_map: The per-row expert assignment used to build the permutation.
+    :param num_out_tokens: The number of output rows; defaults to ``inp.shape[0]``.
+    :param out: Optional pre-allocated buffer to write the permuted rows into.
+    :param backend: Which kernel to use (``"cuda"``, ``"triton"``, or ``"auto"``).
+    :param backward_grad_input_buffer: Optional buffer for the backward pass to write
+        the input gradient into, so a communication buffer can be reused.
+
+    :returns: A tuple ``(permuted, row_id_map)`` of the permuted activations and the
+        row-id map describing the permutation (reused by :func:`moe_chunk_unpermute`).
+    """
     if not inp.is_cuda:
         raise ValueError("moe_chunk_permute expects CUDA input")
     if backend not in ("auto", "cuda", "triton"):
@@ -424,6 +442,22 @@ def moe_chunk_unpermute(
     backend: Literal["auto", "cuda", "triton"] = "auto",
     backward_grad_input_buffer=None,
 ) -> torch.Tensor:
+    """
+    Invert :func:`moe_chunk_permute`, restoring the original token order.
+
+    Scatters the expert-grouped rows of ``inp`` back to their original positions
+    using ``row_id_map``; rows whose map entry is ``-1`` are zero-filled.
+
+    :param inp: The expert-grouped activations to unpermute. Must be on CUDA.
+    :param row_id_map: The row-id map produced by :func:`moe_chunk_permute`.
+    :param num_tokens: The number of output tokens; defaults to ``row_id_map.numel()``.
+    :param out: Optional pre-allocated buffer to write the result into.
+    :param backend: Which kernel to use (``"cuda"``, ``"triton"``, or ``"auto"``).
+    :param backward_grad_input_buffer: Optional buffer for the backward pass to write
+        its gradient into, so a communication buffer can be reused.
+
+    :returns: The unpermuted activations in the original token order.
+    """
     if not inp.is_cuda:
         raise ValueError("moe_chunk_unpermute expects CUDA input")
     if backend not in ("auto", "cuda", "triton"):
@@ -452,3 +486,6 @@ def moe_chunk_unpermute(
     return _ChunkUnpermuteFunction.apply(
         inp, row_id_map_i32, num_tokens, backend, out, backward_grad_input_buffer
     )
+
+
+__all__ = ["moe_chunk_permute", "moe_chunk_unpermute"]

--- a/src/olmo_core/kernels/moe_permute_drop.py
+++ b/src/olmo_core/kernels/moe_permute_drop.py
@@ -103,6 +103,24 @@ def moe_permute_drop_fwd(
     num_out_tokens: int,
     out: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Permute tokens into expert-grouped order while dropping over-capacity tokens.
+
+    Fuses the routing permutation with token dropping: tokens beyond an expert's
+    capacity (the gap between ``requested_offsets`` and ``keep_offsets``) are
+    dropped as part of the permute rather than in a separate pass.
+
+    :param inp: The activations to permute, shape ``(num_tokens, d_model)``. Must be on CUDA.
+    :param routing_map: The per-row expert assignment.
+    :param requested_offsets: Per-expert cumulative counts of requested tokens.
+    :param keep_offsets: Per-expert cumulative counts after capacity dropping.
+    :param keep_splits: Per-expert kept-token counts.
+    :param num_out_tokens: The number of output rows in the permuted buffer.
+    :param out: Optional pre-allocated buffer to write the permuted rows into.
+
+    :returns: A tuple ``(permuted, row_id_map)`` of the permuted-and-dropped
+        activations and the row-id map describing the mapping.
+    """
     if inp.ndim != 2:
         raise ValueError(f"Expected rank-2 input, got shape={tuple(inp.shape)}")
     if routing_map.ndim != 2:
@@ -148,3 +166,6 @@ def moe_permute_drop_fwd(
         ws.temp_storage,
         out,
     )
+
+
+__all__ = ["moe_permute_drop_fwd"]

--- a/src/olmo_core/kernels/moe_permute_drop.py
+++ b/src/olmo_core/kernels/moe_permute_drop.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Optional, Tuple
 
 import torch
 
-from .cuda_extension_utils import load_cuda_extension
-
-_CUDA_EXTENSION = None
-_CUDA_EXTENSION_ATTEMPTED = False
-_CUDA_EXTENSION_ERROR: Optional[Exception] = None
+from .cuda_extension_utils import LazyCudaExtension
 
 
 @dataclass
@@ -25,40 +20,22 @@ class _PermuteDropWorkspace:
 _WORKSPACE_BY_DEVICE: dict[Tuple[str, int], _PermuteDropWorkspace] = {}
 
 
+_EXTENSION = LazyCudaExtension(
+    name="moe_permute_drop",
+    base_name="olmo_moe_permute_drop_ext",
+    sources=("moe_permute_drop.cpp", "moe_permute_drop_kernel.cu"),
+    extra_cflags=["-O3"],
+    extra_cuda_cflags=["-O3"],
+    verbose_env_names=("OLMO_MOE_PERMUTE_DROP_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
+    force_rebuild_env_names=(
+        "OLMO_MOE_PERMUTE_DROP_FORCE_REBUILD",
+        "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
+    ),
+)
+
+
 def _load_cuda_extension():
-    global _CUDA_EXTENSION
-    global _CUDA_EXTENSION_ATTEMPTED
-    global _CUDA_EXTENSION_ERROR
-    if _CUDA_EXTENSION is not None:
-        return _CUDA_EXTENSION
-    if _CUDA_EXTENSION_ATTEMPTED and _CUDA_EXTENSION is None:
-        raise RuntimeError(
-            "CUDA moe_permute_drop extension is unavailable"
-        ) from _CUDA_EXTENSION_ERROR
-
-    _CUDA_EXTENSION_ATTEMPTED = True
-    try:
-        this_dir = Path(__file__).resolve().parent
-        cpp_src = this_dir / "cuda" / "moe_permute_drop.cpp"
-        cu_src = this_dir / "cuda" / "moe_permute_drop_kernel.cu"
-        _CUDA_EXTENSION = load_cuda_extension(
-            base_name="olmo_moe_permute_drop_ext",
-            sources=[cpp_src, cu_src],
-            extra_cflags=["-O3"],
-            extra_cuda_cflags=["-O3"],
-            verbose_env_names=("OLMO_MOE_PERMUTE_DROP_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
-            force_rebuild_env_names=(
-                "OLMO_MOE_PERMUTE_DROP_FORCE_REBUILD",
-                "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
-            ),
-            stale_lock_timeout_env_names=("OLMO_MOE_EXT_STALE_LOCK_TIMEOUT_SEC",),
-            with_arch_suffix=True,
-        )
-    except Exception as e:
-        _CUDA_EXTENSION_ERROR = e
-        raise RuntimeError(f"Failed to build/load CUDA moe_permute_drop extension: {e}") from e
-
-    return _CUDA_EXTENSION
+    return _EXTENSION.load()
 
 
 def _workspace_key(device: torch.device) -> Tuple[str, int]:

--- a/src/olmo_core/kernels/moe_permute_drop.py
+++ b/src/olmo_core/kernels/moe_permute_drop.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+import torch
+
+from .cuda_extension_utils import load_cuda_extension
+
+_CUDA_EXTENSION = None
+_CUDA_EXTENSION_ATTEMPTED = False
+_CUDA_EXTENSION_ERROR: Optional[Exception] = None
+
+
+@dataclass
+class _PermuteDropWorkspace:
+    sorted_indices: torch.Tensor
+    row_id: torch.Tensor
+    sorted_row_id: torch.Tensor
+    temp_storage: torch.Tensor
+    max_expanded_rows: int
+
+
+_WORKSPACE_BY_DEVICE: dict[Tuple[str, int], _PermuteDropWorkspace] = {}
+
+
+def _load_cuda_extension():
+    global _CUDA_EXTENSION
+    global _CUDA_EXTENSION_ATTEMPTED
+    global _CUDA_EXTENSION_ERROR
+    if _CUDA_EXTENSION is not None:
+        return _CUDA_EXTENSION
+    if _CUDA_EXTENSION_ATTEMPTED and _CUDA_EXTENSION is None:
+        raise RuntimeError(
+            "CUDA moe_permute_drop extension is unavailable"
+        ) from _CUDA_EXTENSION_ERROR
+
+    _CUDA_EXTENSION_ATTEMPTED = True
+    try:
+        this_dir = Path(__file__).resolve().parent
+        cpp_src = this_dir / "cuda" / "moe_permute_drop.cpp"
+        cu_src = this_dir / "cuda" / "moe_permute_drop_kernel.cu"
+        _CUDA_EXTENSION = load_cuda_extension(
+            base_name="olmo_moe_permute_drop_ext",
+            sources=[cpp_src, cu_src],
+            extra_cflags=["-O3"],
+            extra_cuda_cflags=["-O3"],
+            verbose_env_names=("OLMO_MOE_PERMUTE_DROP_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
+            force_rebuild_env_names=(
+                "OLMO_MOE_PERMUTE_DROP_FORCE_REBUILD",
+                "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
+            ),
+            stale_lock_timeout_env_names=("OLMO_MOE_EXT_STALE_LOCK_TIMEOUT_SEC",),
+            with_arch_suffix=True,
+        )
+    except Exception as e:
+        _CUDA_EXTENSION_ERROR = e
+        raise RuntimeError(f"Failed to build/load CUDA moe_permute_drop extension: {e}") from e
+
+    return _CUDA_EXTENSION
+
+
+def _workspace_key(device: torch.device) -> Tuple[str, int]:
+    idx = device.index if device.index is not None else torch.cuda.current_device()
+    return (device.type, idx)
+
+
+def _ensure_workspace(
+    *,
+    device: torch.device,
+    expanded_rows: int,
+) -> _PermuteDropWorkspace:
+    ext = _load_cuda_extension()
+    key = _workspace_key(device)
+    ws = _WORKSPACE_BY_DEVICE.get(key)
+    if ws is not None and ws.max_expanded_rows >= expanded_rows:
+        return ws
+
+    temp_storage_bytes = int(ext.moe_permute_drop_temp_storage_bytes(expanded_rows))
+    sorted_indices = torch.empty((expanded_rows,), device=device, dtype=torch.int32)
+    row_id = torch.arange(expanded_rows, device=device, dtype=torch.int32)
+    sorted_row_id = torch.empty((expanded_rows,), device=device, dtype=torch.int32)
+    temp_storage = torch.empty((temp_storage_bytes,), device=device, dtype=torch.uint8)
+    ws = _PermuteDropWorkspace(
+        sorted_indices=sorted_indices,
+        row_id=row_id,
+        sorted_row_id=sorted_row_id,
+        temp_storage=temp_storage,
+        max_expanded_rows=expanded_rows,
+    )
+    _WORKSPACE_BY_DEVICE[key] = ws
+    return ws
+
+
+def moe_permute_drop_fwd(
+    *,
+    inp: torch.Tensor,
+    routing_map: torch.Tensor,
+    requested_offsets: torch.Tensor,
+    keep_offsets: torch.Tensor,
+    keep_splits: torch.Tensor,
+    num_out_tokens: int,
+    out: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if inp.ndim != 2:
+        raise ValueError(f"Expected rank-2 input, got shape={tuple(inp.shape)}")
+    if routing_map.ndim != 2:
+        raise ValueError(f"Expected rank-2 routing_map, got shape={tuple(routing_map.shape)}")
+    if routing_map.shape[0] != inp.shape[0]:
+        raise ValueError(
+            f"routing_map/input rows mismatch: routing_map={routing_map.shape[0]} input={inp.shape[0]}"
+        )
+    if requested_offsets.ndim != 1:
+        raise ValueError(
+            f"Expected rank-1 requested_offsets, got shape={tuple(requested_offsets.shape)}"
+        )
+    if keep_offsets.ndim != 1:
+        raise ValueError(f"Expected rank-1 keep_offsets, got shape={tuple(keep_offsets.shape)}")
+    if keep_splits.ndim != 1:
+        raise ValueError(f"Expected rank-1 keep_splits, got shape={tuple(keep_splits.shape)}")
+    if (
+        requested_offsets.numel() != keep_offsets.numel()
+        or requested_offsets.numel() != keep_splits.numel()
+    ):
+        raise ValueError(
+            "requested_offsets/keep_offsets/keep_splits size mismatch: "
+            f"{requested_offsets.numel()} vs {keep_offsets.numel()} vs {keep_splits.numel()}"
+        )
+    if not inp.is_cuda:
+        raise ValueError("moe_permute_drop_fwd expects CUDA input")
+
+    expanded_rows = int(routing_map.numel())
+    ws = _ensure_workspace(device=inp.device, expanded_rows=expanded_rows)
+    ext = _load_cuda_extension()
+    return ext.moe_permute_drop_fwd_cuda(
+        inp,
+        routing_map if routing_map.dtype == torch.int32 else routing_map.to(dtype=torch.int32),
+        requested_offsets
+        if requested_offsets.dtype == torch.long
+        else requested_offsets.to(dtype=torch.long),
+        keep_offsets if keep_offsets.dtype == torch.long else keep_offsets.to(dtype=torch.long),
+        keep_splits if keep_splits.dtype == torch.long else keep_splits.to(dtype=torch.long),
+        int(num_out_tokens),
+        ws.sorted_indices,
+        ws.row_id,
+        ws.sorted_row_id,
+        ws.temp_storage,
+        out,
+    )

--- a/src/olmo_core/kernels/moe_unpermute_bwd.py
+++ b/src/olmo_core/kernels/moe_unpermute_bwd.py
@@ -1,51 +1,27 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Optional, Tuple
 
 import torch
 
-from .cuda_extension_utils import load_cuda_extension
+from .cuda_extension_utils import LazyCudaExtension
 
-_CUDA_EXTENSION = None
-_CUDA_EXTENSION_ATTEMPTED = False
-_CUDA_EXTENSION_ERROR: Optional[Exception] = None
+_EXTENSION = LazyCudaExtension(
+    name="moe_unpermute_bwd",
+    base_name="olmo_moe_unpermute_bwd_ext",
+    sources=("moe_unpermute_bwd.cpp", "moe_unpermute_bwd_kernel.cu"),
+    extra_cflags=["-O3"],
+    extra_cuda_cflags=["-O3"],
+    verbose_env_names=("OLMO_MOE_UNPERMUTE_BWD_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
+    force_rebuild_env_names=(
+        "OLMO_MOE_UNPERMUTE_BWD_FORCE_REBUILD",
+        "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
+    ),
+)
 
 
 def _load_cuda_extension():
-    global _CUDA_EXTENSION
-    global _CUDA_EXTENSION_ATTEMPTED
-    global _CUDA_EXTENSION_ERROR
-    if _CUDA_EXTENSION is not None:
-        return _CUDA_EXTENSION
-    if _CUDA_EXTENSION_ATTEMPTED and _CUDA_EXTENSION is None:
-        raise RuntimeError(
-            "CUDA moe_unpermute_bwd extension is unavailable"
-        ) from _CUDA_EXTENSION_ERROR
-
-    _CUDA_EXTENSION_ATTEMPTED = True
-    try:
-        this_dir = Path(__file__).resolve().parent
-        cpp_src = this_dir / "cuda" / "moe_unpermute_bwd.cpp"
-        cu_src = this_dir / "cuda" / "moe_unpermute_bwd_kernel.cu"
-        _CUDA_EXTENSION = load_cuda_extension(
-            base_name="olmo_moe_unpermute_bwd_ext",
-            sources=[cpp_src, cu_src],
-            extra_cflags=["-O3"],
-            extra_cuda_cflags=["-O3"],
-            verbose_env_names=("OLMO_MOE_UNPERMUTE_BWD_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
-            force_rebuild_env_names=(
-                "OLMO_MOE_UNPERMUTE_BWD_FORCE_REBUILD",
-                "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
-            ),
-            stale_lock_timeout_env_names=("OLMO_MOE_EXT_STALE_LOCK_TIMEOUT_SEC",),
-            with_arch_suffix=True,
-        )
-    except Exception as e:
-        _CUDA_EXTENSION_ERROR = e
-        raise RuntimeError(f"Failed to build/load CUDA moe_unpermute_bwd extension: {e}") from e
-
-    return _CUDA_EXTENSION
+    return _EXTENSION.load()
 
 
 def _check_inputs(

--- a/src/olmo_core/kernels/moe_unpermute_bwd.py
+++ b/src/olmo_core/kernels/moe_unpermute_bwd.py
@@ -137,6 +137,25 @@ def moe_unpermute_bwd(
     keep_mask: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Backward of the MoE unpermute-and-combine.
+
+    The unpermute forward combines a token's top-k expert outputs weighted by the
+    router probabilities (``out[token] = sum_k input_fwd[row] * probs[token, k]``).
+    This computes the gradients of that operation.
+
+    :param grad_output: The gradient w.r.t. the combined output, shape
+        ``(num_tokens, hidden)``.
+    :param input_fwd: The permuted expert outputs from the forward pass.
+    :param row_id_map: The row-id map describing the permutation; entries of ``-1``
+        mark dropped rows and are skipped.
+    :param probs: The router probabilities, shape ``(num_tokens, top_k)``, float32.
+    :param keep_mask: Optional mask of which rows were kept (not dropped).
+    :param out: Optional pre-allocated buffer for the ``input_fwd`` gradient.
+
+    :returns: A tuple ``(grad_input_fwd, grad_probs)`` of the gradients w.r.t. the
+        permuted expert outputs and the router probabilities.
+    """
     _check_inputs(grad_output, input_fwd, row_id_map, probs, keep_mask, out)
 
     grad_output_in = grad_output if grad_output.is_contiguous() else grad_output.contiguous()
@@ -166,3 +185,6 @@ def moe_unpermute_bwd(
         keep_mask_bool,
         out,
     )
+
+
+__all__ = ["moe_unpermute_bwd"]

--- a/src/olmo_core/kernels/moe_unpermute_bwd.py
+++ b/src/olmo_core/kernels/moe_unpermute_bwd.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+import torch
+
+from .cuda_extension_utils import load_cuda_extension
+
+_CUDA_EXTENSION = None
+_CUDA_EXTENSION_ATTEMPTED = False
+_CUDA_EXTENSION_ERROR: Optional[Exception] = None
+
+
+def _load_cuda_extension():
+    global _CUDA_EXTENSION
+    global _CUDA_EXTENSION_ATTEMPTED
+    global _CUDA_EXTENSION_ERROR
+    if _CUDA_EXTENSION is not None:
+        return _CUDA_EXTENSION
+    if _CUDA_EXTENSION_ATTEMPTED and _CUDA_EXTENSION is None:
+        raise RuntimeError(
+            "CUDA moe_unpermute_bwd extension is unavailable"
+        ) from _CUDA_EXTENSION_ERROR
+
+    _CUDA_EXTENSION_ATTEMPTED = True
+    try:
+        this_dir = Path(__file__).resolve().parent
+        cpp_src = this_dir / "cuda" / "moe_unpermute_bwd.cpp"
+        cu_src = this_dir / "cuda" / "moe_unpermute_bwd_kernel.cu"
+        _CUDA_EXTENSION = load_cuda_extension(
+            base_name="olmo_moe_unpermute_bwd_ext",
+            sources=[cpp_src, cu_src],
+            extra_cflags=["-O3"],
+            extra_cuda_cflags=["-O3"],
+            verbose_env_names=("OLMO_MOE_UNPERMUTE_BWD_VERBOSE", "OLMO_MOE_CUDA_EXT_VERBOSE"),
+            force_rebuild_env_names=(
+                "OLMO_MOE_UNPERMUTE_BWD_FORCE_REBUILD",
+                "OLMO_MOE_CUDA_EXT_FORCE_REBUILD",
+            ),
+            stale_lock_timeout_env_names=("OLMO_MOE_EXT_STALE_LOCK_TIMEOUT_SEC",),
+            with_arch_suffix=True,
+        )
+    except Exception as e:
+        _CUDA_EXTENSION_ERROR = e
+        raise RuntimeError(f"Failed to build/load CUDA moe_unpermute_bwd extension: {e}") from e
+
+    return _CUDA_EXTENSION
+
+
+def _check_inputs(
+    grad_output: torch.Tensor,
+    input_fwd: torch.Tensor,
+    row_id_map: torch.Tensor,
+    probs: torch.Tensor,
+    keep_mask: Optional[torch.Tensor],
+    out: Optional[torch.Tensor],
+) -> None:
+    if grad_output.ndim != 2:
+        raise ValueError(f"Expected rank-2 grad_output, got shape={tuple(grad_output.shape)}")
+    if input_fwd.ndim != 2:
+        raise ValueError(f"Expected rank-2 input_fwd, got shape={tuple(input_fwd.shape)}")
+    if row_id_map.ndim != 1:
+        raise ValueError(f"Expected rank-1 row_id_map, got shape={tuple(row_id_map.shape)}")
+    if probs.ndim != 2:
+        raise ValueError(f"Expected rank-2 probs, got shape={tuple(probs.shape)}")
+    if not grad_output.is_cuda:
+        raise ValueError("moe_unpermute_bwd expects CUDA grad_output")
+    if not input_fwd.is_cuda or not row_id_map.is_cuda or not probs.is_cuda:
+        raise ValueError("All moe_unpermute_bwd inputs must be CUDA tensors")
+    if grad_output.device != input_fwd.device:
+        raise ValueError(
+            f"grad_output/input_fwd device mismatch: grad_output={grad_output.device} input_fwd={input_fwd.device}"
+        )
+    if row_id_map.device != grad_output.device:
+        raise ValueError(
+            f"row_id_map/grad_output device mismatch: row_id_map={row_id_map.device} grad_output={grad_output.device}"
+        )
+    if probs.device != grad_output.device:
+        raise ValueError(
+            f"probs/grad_output device mismatch: probs={probs.device} grad_output={grad_output.device}"
+        )
+    if grad_output.dtype != input_fwd.dtype:
+        raise ValueError(
+            f"grad_output/input_fwd dtype mismatch: grad_output={grad_output.dtype} input_fwd={input_fwd.dtype}"
+        )
+    if grad_output.shape[1] != input_fwd.shape[1]:
+        raise ValueError(
+            "grad_output/input_fwd hidden size mismatch: "
+            f"grad_output={grad_output.shape[1]} input_fwd={input_fwd.shape[1]}"
+        )
+
+    num_tokens = probs.shape[0]
+    topk = probs.shape[1]
+    if grad_output.shape[0] != num_tokens:
+        raise ValueError(
+            f"grad_output/probs rows mismatch: grad_output={grad_output.shape[0]} probs={num_tokens}"
+        )
+    if row_id_map.numel() != num_tokens * topk:
+        raise ValueError(
+            "row_id_map/probs size mismatch: "
+            f"row_id_map={row_id_map.numel()} probs={num_tokens}x{topk}"
+        )
+    if keep_mask is not None:
+        if keep_mask.ndim != 1:
+            raise ValueError(f"Expected rank-1 keep_mask, got shape={tuple(keep_mask.shape)}")
+        if keep_mask.numel() != input_fwd.shape[0]:
+            raise ValueError(
+                f"keep_mask/input_fwd rows mismatch: keep_mask={keep_mask.numel()} input_fwd={input_fwd.shape[0]}"
+            )
+        if keep_mask.device != input_fwd.device:
+            raise ValueError(
+                f"keep_mask/input_fwd device mismatch: keep_mask={keep_mask.device} input_fwd={input_fwd.device}"
+            )
+
+    if out is not None:
+        expected_shape = input_fwd.shape
+        if tuple(out.shape) != tuple(expected_shape):
+            raise ValueError(
+                f"out shape mismatch: expected={tuple(expected_shape)} got={tuple(out.shape)}"
+            )
+        if out.dtype != input_fwd.dtype:
+            raise ValueError(f"out dtype mismatch: out={out.dtype} input_fwd={input_fwd.dtype}")
+        if out.device != input_fwd.device:
+            raise ValueError(f"out device mismatch: out={out.device} input_fwd={input_fwd.device}")
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous")
+
+
+@torch.compiler.disable
+def moe_unpermute_bwd(
+    *,
+    grad_output: torch.Tensor,
+    input_fwd: torch.Tensor,
+    row_id_map: torch.Tensor,
+    probs: torch.Tensor,
+    keep_mask: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    _check_inputs(grad_output, input_fwd, row_id_map, probs, keep_mask, out)
+
+    grad_output_in = grad_output if grad_output.is_contiguous() else grad_output.contiguous()
+    input_fwd_in = input_fwd if input_fwd.is_contiguous() else input_fwd.contiguous()
+    row_id_map_i32 = (
+        row_id_map if row_id_map.dtype == torch.int32 else row_id_map.to(dtype=torch.int32)
+    )
+    probs_f32 = probs if probs.dtype == torch.float32 else probs.to(dtype=torch.float32)
+    keep_mask_bool = None
+    if keep_mask is not None:
+        keep_mask_bool = (
+            keep_mask if keep_mask.dtype == torch.bool else keep_mask.to(dtype=torch.bool)
+        )
+    row_id_map_i32 = (
+        row_id_map_i32 if row_id_map_i32.is_contiguous() else row_id_map_i32.contiguous()
+    )
+    probs_f32 = probs_f32 if probs_f32.is_contiguous() else probs_f32.contiguous()
+    if keep_mask_bool is not None and not keep_mask_bool.is_contiguous():
+        keep_mask_bool = keep_mask_bool.contiguous()
+
+    ext = _load_cuda_extension()
+    return ext.moe_unpermute_bwd_cuda(
+        grad_output_in,
+        input_fwd_in,
+        row_id_map_i32,
+        probs_f32,
+        keep_mask_bool,
+        out,
+    )

--- a/src/test/kernels/moe_chunk_reorder_test.py
+++ b/src/test/kernels/moe_chunk_reorder_test.py
@@ -1,0 +1,38 @@
+import torch
+
+from olmo_core.kernels.moe_chunk_reorder import (
+    _chunk_unpermute_torch,
+    _dispatch_permute_by_row_id_map,
+)
+
+
+def test_chunk_unpermute_torch_zeros_out_of_range_rows():
+    inp = torch.arange(3 * 512, dtype=torch.float32).view(3, 512)
+    row_id_map = torch.tensor([0, 3, -1, 2], dtype=torch.int32)
+
+    out = _chunk_unpermute_torch(inp, row_id_map, num_tokens=4, out=None)
+
+    expected = torch.zeros(4, 512)
+    expected[0].copy_(inp[0])
+    expected[3].copy_(inp[2])
+    torch.testing.assert_close(out, expected)
+
+
+def test_chunk_permute_by_row_id_map_torch_honors_out_buffer():
+    inp = torch.arange(3 * 512, dtype=torch.float32).view(3, 512)
+    row_id_map = torch.tensor([2, -1, 0], dtype=torch.int32)
+    out_buffer = torch.empty((3, 512), dtype=inp.dtype)
+
+    out = _dispatch_permute_by_row_id_map(
+        inp,
+        row_id_map,
+        num_out_tokens=3,
+        backend="triton",
+        out=out_buffer,
+    )
+
+    assert out.data_ptr() == out_buffer.data_ptr()
+    expected = torch.zeros(3, 512)
+    expected[0].copy_(inp[2])
+    expected[2].copy_(inp[0])
+    torch.testing.assert_close(out, expected)

--- a/src/test/kernels/moe_unpermute_bwd_test.py
+++ b/src/test/kernels/moe_unpermute_bwd_test.py
@@ -1,0 +1,70 @@
+import torch
+
+from olmo_core.kernels.moe_unpermute_bwd import moe_unpermute_bwd
+from olmo_core.testing import requires_gpu
+
+
+def _reference_unpermute(
+    *,
+    input_fwd: torch.Tensor,
+    row_id_map: torch.Tensor,
+    probs: torch.Tensor,
+) -> torch.Tensor:
+    num_tokens, top_k = probs.shape
+    out = input_fwd.new_zeros((num_tokens, input_fwd.shape[-1]))
+    for token_idx in range(num_tokens):
+        for topk_idx in range(top_k):
+            row_idx = int(row_id_map[topk_idx * num_tokens + token_idx].item())
+            if row_idx >= 0:
+                out[token_idx] = out[token_idx] + input_fwd[row_idx] * probs[
+                    token_idx, topk_idx
+                ].to(dtype=input_fwd.dtype)
+    return out
+
+
+@requires_gpu
+def test_moe_unpermute_bwd_matches_autograd_reference_with_out_buffer():
+    torch.manual_seed(43)
+    device = torch.device("cuda")
+    num_tokens = 8
+    top_k = 2
+    d_model = 512
+    num_rows = num_tokens * top_k
+
+    route_rows = (
+        torch.arange(num_rows, device=device, dtype=torch.int32).reshape(top_k, num_tokens).T
+    )
+    route_rows[3, 1] = -1
+    dropped_row = 11
+    row_id_map = route_rows.T.contiguous().reshape(-1)
+    keep_mask = torch.ones(num_rows, device=device, dtype=torch.bool)
+    keep_mask[dropped_row] = False
+
+    input_fwd = torch.randn(num_rows, d_model, device=device, dtype=torch.float32)
+    probs = torch.rand(num_tokens, top_k, device=device, dtype=torch.float32)
+    grad_output = torch.randn(num_tokens, d_model, device=device, dtype=torch.float32)
+
+    input_ref = input_fwd.detach().clone().requires_grad_(True)
+    probs_ref = probs.detach().clone().requires_grad_(True)
+    out_ref = _reference_unpermute(
+        input_fwd=input_ref,
+        row_id_map=row_id_map,
+        probs=probs_ref,
+    )
+    grad_input_ref, grad_probs_ref = torch.autograd.grad(
+        out_ref, (input_ref, probs_ref), grad_outputs=grad_output
+    )
+
+    out_buffer = torch.empty_like(input_fwd)
+    grad_input, grad_probs = moe_unpermute_bwd(
+        grad_output=grad_output,
+        input_fwd=input_fwd,
+        row_id_map=row_id_map,
+        probs=probs,
+        keep_mask=keep_mask,
+        out=out_buffer,
+    )
+
+    assert grad_input.untyped_storage().data_ptr() == out_buffer.untyped_storage().data_ptr()
+    torch.testing.assert_close(grad_input, grad_input_ref)
+    torch.testing.assert_close(grad_probs, grad_probs_ref)


### PR DESCRIPTION
## What this adds

CUDA + Triton/torch MoE token permute, reorder, and unpermute-backward kernels used to route tokens to experts and gather their outputs:

- `kernels/moe_chunk_reorder.py` — chunked permute/unpermute by row-id map, with caller-provided `out=`/backward-grad buffers for comm-buffer reuse.
- `kernels/moe_permute_drop.py` — fused permute-with-drop.
- `kernels/moe_unpermute_bwd.py` — unpermute backward kernel.
- `kernels/cuda/*` — the C++/CUDA sources, built lazily via the JIT extension loader.

The Python wrappers are CPU-import-safe; the CUDA path builds lazily on first use.

## Testing

- `src/test/kernels/moe_chunk_reorder_test.py` — CPU reference-path tests for the torch chunk permute/unpermute (out-of-range row zeroing, `out=` buffer honoring).
- `src/test/kernels/moe_unpermute_bwd_test.py` — GPU test (`@requires_gpu`) checking the unpermute-backward kernel matches an autograd reference with an `out=` buffer.

`make checks` passes; CPU tests pass locally; the GPU test skips cleanly without a GPU.