### PR TITLE
Add configurable determinism_check to activation checkpointing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `OverrideDecay`, a late-stage decay override usable on both `ComposableScheduler` and `SequentialScheduler` via an `override_decay` field. When `current >= override_decay.start`, the main schedule is interrupted mid-flight and the LR decays from the value the main schedule would have produced at `start` to a target LR over `duration` (linear or cosine). `SequentialScheduler` additionally warns that `t_max` is ignored once the override becomes active.
 - `OLMO_RICH_LOGGING` can now explicitly enable *or* disable rich console logging (`0`/`false`/`no`/`off` disables it); previously setting it to any value only force-enabled rich logging.
 - `init_distributed()` now bootstraps a minimal single-process environment (`RANK=0`, `WORLD_SIZE=1`, `MASTER_ADDR`/`MASTER_PORT`) when launch env vars are absent, so scripts can be run directly (without `torchrun`) for single-process debugging.
+- Added a configurable `determinism_check` option to activation checkpointing (default `"default"`); set it to `"none"` to skip torch's recompute metadata check for opaque linear-attention kernels under `torch.compile`.
 
 
 ### Fixed

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -678,6 +678,7 @@ class Transformer(nn.Module):
         block_interval: Optional[int] = None,
         modules: Optional[List[str]] = None,
         activation_memory_budget: Optional[float] = None,
+        determinism_check: str = "default",
     ):
         """
         Apply activation checkpointing to the model.
@@ -691,6 +692,8 @@ class Transformer(nn.Module):
             [0, 1]. 0 corresponds to the memory usage when recomputing all activations, and 1
             corresponds to the memory usage when recomputing no activations (which is the default).
             Requires compilation to be enabled.
+        :param determinism_check: Passed through to torch's ``checkpoint_wrapper``. "default" compares
+            forward vs. recompute tensor metadata; "none" skips the check.
         """
 
         if mode == TransformerActivationCheckpointingMode.budget:
@@ -741,7 +744,11 @@ class Transformer(nn.Module):
                     continue
 
                 parent = self if not parent_name else self.get_submodule(parent_name)
-                module = ptd_checkpoint_wrapper(module, preserve_rng_state=preserve_rng_state)
+                module = ptd_checkpoint_wrapper(
+                    module,
+                    preserve_rng_state=preserve_rng_state,
+                    determinism_check=determinism_check,
+                )
                 parent.register_module(name.split(".")[-1], module)
                 log.info(f"Wrapped '{name}' for activation checkpointing")
                 wrapped_modules.add(name)
@@ -754,18 +761,27 @@ class Transformer(nn.Module):
                             raise OLMoConfigurationError(
                                 "Wrapping MoE blocks for activation checkpointing is not supported."
                             )
-                        block = ptd_checkpoint_wrapper(block, preserve_rng_state=preserve_rng_state)
+                        block = ptd_checkpoint_wrapper(
+                            block,
+                            preserve_rng_state=preserve_rng_state,
+                            determinism_check=determinism_check,
+                        )
                 elif mode == TransformerActivationCheckpointingMode.full:
                     if isinstance(block, MoETransformerBlock):
                         raise OLMoConfigurationError(
                             "Wrapping MoE blocks for activation checkpointing is not supported."
                         )
-                    block = ptd_checkpoint_wrapper(block, preserve_rng_state=preserve_rng_state)
+                    block = ptd_checkpoint_wrapper(
+                        block,
+                        preserve_rng_state=preserve_rng_state,
+                        determinism_check=determinism_check,
+                    )
                 elif mode == TransformerActivationCheckpointingMode.selected_ops:
                     block = ptd_checkpoint_wrapper(
                         block,
                         context_fn=selective_checkpointing_context_fn,
                         preserve_rng_state=preserve_rng_state,
+                        determinism_check=determinism_check,
                     )
 
                 self.blocks.register_module(str(block_idx), block)

--- a/src/olmo_core/train/train_module/transformer/common.py
+++ b/src/olmo_core/train/train_module/transformer/common.py
@@ -99,6 +99,7 @@ def parallelize_model(
                 block_interval=ac_config.block_interval,
                 modules=ac_config.modules,
                 activation_memory_budget=ac_config.activation_memory_budget,
+                determinism_check=ac_config.determinism_check,
             )
         log.info(f"Applied '{ac_config.mode}' activation checkpointing to the model")
 

--- a/src/olmo_core/train/train_module/transformer/config.py
+++ b/src/olmo_core/train/train_module/transformer/config.py
@@ -260,6 +260,13 @@ class TransformerActivationCheckpointingConfig(Config):
     See https://pytorch.org/blog/activation-checkpointing-techniques/ for more details.
     """
 
+    determinism_check: str = "default"
+    """
+    Passed through to torch's ``checkpoint_wrapper``. "default" compares forward vs. recompute
+    tensor metadata; set to "none" to skip the check. Needed for models whose recompute produces
+    spurious metadata mismatches (e.g. opaque linear-attention kernels under ``torch.compile``).
+    """
+
     def __post_init__(self):
         if (
             self.mode == TransformerActivationCheckpointingMode.selected_blocks


### PR DESCRIPTION
## Summary
Adds a `determinism_check` field to `TransformerActivationCheckpointingConfig` (default `"default"`, preserving current behavior) and forwards it through `parallelize_model` → `Transformer.apply_activation_checkpointing` → torch's `checkpoint_wrapper`.

Setting `determinism_check="none"` skips torch's forward-vs-recompute tensor-metadata comparison. This is needed for models whose recompute produces spurious metadata mismatches — e.g. the opaque `fla` Gated DeltaNet kernels used by Olmo hybrid models, which otherwise raise `CheckpointError` under `torch.compile` + `selected_modules` activation checkpointing even though the recomputed values match.

## Why
open-instruct currently monkeypatches torch's `checkpoint_wrapper` to set `determinism_check="none"` so it can train the hybrid 7B model with `selected_modules` AC under compile. This makes that knob a first-class, opt-in config option instead of a global monkeypatch.

## Notes
- Default is unchanged (`"default"`), so existing users see no behavior change.
- The field threads through all `ptd_checkpoint_wrapper(...)` call sites (`selected_modules`, `selected_blocks`, `full`, `selected_ops`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)