### PR TITLE
[2/n] HF Molmo2 loader and logit parity tests

### DIFF
--- a/src/olmo_core/nn/vision/__init__.py
+++ b/src/olmo_core/nn/vision/__init__.py
@@ -15,6 +15,7 @@ from .connector import (
     VisionConnectorConfig,
 )
 from .image_vit import VisionTransformer, ViTAttention, ViTBlock, ViTMLP
+from .molmo2_loader import molmo2_hf_state_dict_to_multimodal_lm
 from .multimodal import MultimodalLM, MultimodalLMConfig
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "VisionConnector",
     "MultimodalLMConfig",
     "MultimodalLM",
+    "molmo2_hf_state_dict_to_multimodal_lm",
 ]

--- a/src/olmo_core/nn/vision/molmo2_loader.py
+++ b/src/olmo_core/nn/vision/molmo2_loader.py
@@ -1,0 +1,532 @@
+"""
+HuggingFace Molmo2 → :class:`~olmo_core.nn.vision.MultimodalLM`
+state-dict converter.
+
+Loads weights from a public Molmo2 checkpoint on HuggingFace (e.g.
+``allenai/Molmo2-O-7B``) into our composite multimodal model.
+
+The two architectures differ in three places that this converter handles:
+
+1. **LM token embedding split.** HF Molmo2 keeps the base vocab and the extra
+   image-special-token vocab in two separate parameters
+   (``transformer.wte.embedding`` and ``transformer.wte.new_embedding``);
+   our :class:`~olmo_core.nn.transformer.Transformer` uses a single
+   ``embeddings.weight`` table. We concatenate.
+
+2. **Fused QKV and gated MLP in the LM.** HF Molmo2 has
+   ``self_attn.att_proj`` (fused Q+K+V) and ``mlp.ff_proj`` (fused gate+up
+   for SwiGLU). Our LM uses ``w_q`` / ``w_k`` / ``w_v`` and ``w1`` / ``w3``.
+   We split along the output dimension.
+
+3. **Patch-embedding flatten order in the vision encoder.** Molmo2's HF
+   ``image_processing_molmo2.batch_pixels_to_patches`` lays patches out
+   spatial-first (``kh, kw, c``), while our
+   :class:`~olmo_core.data.multimodal.ImagePreprocessor` uses channel-first
+   (``c, kh, kw``) to match the HuggingFace ``Conv2d`` patch-embedding
+   convention our CLIP/SigLIP parity tests verified against. We permute
+   the patch-embedding weight to bridge the two.
+
+Vision blocks, the connector pooling cross-attention, the connector SwiGLU
+projector, and the LM head all map one-to-one (no per-tensor surgery).
+
+Usage::
+
+    cfg = MultimodalLMConfig(lm=olmo3_7B(...), vision=..., connector=...)
+    model = MultimodalLM(cfg)
+    from transformers import AutoModelForCausalLM
+    hf = AutoModelForCausalLM.from_pretrained("allenai/Molmo2-O-7B", trust_remote_code=True)
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf.state_dict(), cfg)
+    model.load_state_dict(converted)
+"""
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+
+from ...config import DType
+from ..transformer import TransformerConfig
+from .config import VisionEncoderConfig, VisionEncoderType
+from .connector import ImagePoolingType, ImageProjectorType, VisionConnectorConfig
+from .multimodal import MultimodalLMConfig
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "molmo2_hf_state_dict_to_multimodal_lm",
+    "molmo2_config_from_hf_config",
+    "ensure_default_rope_registered",
+    "reinit_rope_buffers",
+]
+
+
+class Molmo2LoaderError(RuntimeError):
+    """Raised when the HF Molmo2 state dict can't be mapped to our model."""
+
+
+def ensure_default_rope_registered() -> None:
+    """Re-register ``ROPE_INIT_FUNCTIONS["default"]`` if upstream removed it.
+
+    transformers ≥ 5 dropped the ``"default"`` key from
+    ``modeling_rope_utils.ROPE_INIT_FUNCTIONS``, but the Molmo2 modeling
+    code bundled inside HF checkpoints still references it.  Call this
+    **before** ``from_pretrained`` so the model can be instantiated.
+    Safe to call repeatedly; a no-op when ``"default"`` is already present.
+    """
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+    if "default" in ROPE_INIT_FUNCTIONS:
+        return
+
+    def _default_rope(config, device=None, seq_len=None, **kwargs):
+        base = getattr(config, "rope_theta", 10000.0)
+        head_dim = getattr(config, "head_dim", None) or (
+            config.hidden_size // config.num_attention_heads
+        )
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, head_dim, 2, dtype=torch.float, device=device) / head_dim)
+        )
+        return inv_freq, 1.0
+
+    ROPE_INIT_FUNCTIONS["default"] = _default_rope
+
+
+def reinit_rope_buffers(model: "torch.nn.Module") -> None:
+    """Re-initialise non-persistent RoPE ``inv_freq`` buffers after loading.
+
+    transformers ≥ 5 uses meta-device fast-init in ``from_pretrained``,
+    which skips ``__init__`` for non-persistent buffers.  This leaves
+    ``inv_freq`` as uninitialised memory and breaks positional encoding for
+    all sequence positions beyond 0.  Call this **after** ``from_pretrained``
+    on any Molmo2 model loaded with ``trust_remote_code=True``.
+
+    :param model: An HF Molmo2 model returned by ``from_pretrained``.
+    """
+    for _, mod in model.named_modules():
+        if hasattr(mod, "rope_init_fn") and hasattr(mod, "inv_freq") and hasattr(mod, "config"):
+            inv_freq, attn_scaling = mod.rope_init_fn(mod.config, None)
+            mod.register_buffer("inv_freq", inv_freq, persistent=False)
+            mod.original_inv_freq = mod.inv_freq
+            mod.attention_scaling = attn_scaling
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require(hf_sd: Dict[str, torch.Tensor], key: str) -> torch.Tensor:
+    if key not in hf_sd:
+        raise Molmo2LoaderError(f"missing required HF Molmo2 key: {key!r}")
+    return hf_sd[key]
+
+
+def _maybe(hf_sd: Dict[str, torch.Tensor], key: str) -> Optional[torch.Tensor]:
+    return hf_sd.get(key)
+
+
+def _attention_dims(lm_cfg: TransformerConfig) -> tuple[int, int, int]:
+    """Read ``(n_heads, n_kv_heads, head_dim)`` from the LM's attention config.
+
+    OLMo-3 configs put attention dims under
+    ``lm.block.attention`` (or ``lm.block.sequence_mixer`` for newer configs).
+    Try both.
+    """
+    block = lm_cfg.block
+    seq_mixer = getattr(block, "attention", None) or getattr(block, "sequence_mixer", None)
+    if seq_mixer is None:
+        raise Molmo2LoaderError(
+            "Unable to find attention config on TransformerBlockConfig; "
+            "tried `attention` and `sequence_mixer`"
+        )
+    n_heads = getattr(seq_mixer, "n_heads", None) or getattr(seq_mixer, "num_heads", None)
+    n_kv_heads = (
+        getattr(seq_mixer, "n_kv_heads", None)
+        or getattr(seq_mixer, "num_kv_heads", None)
+        or n_heads
+    )
+    head_dim = getattr(seq_mixer, "head_dim", None)
+    if head_dim is None and n_heads is not None:
+        head_dim = lm_cfg.d_model // n_heads
+    if n_heads is None or head_dim is None:
+        raise Molmo2LoaderError(
+            f"Could not derive (n_heads, n_kv_heads, head_dim) from {seq_mixer!r}"
+        )
+    if n_kv_heads is None:
+        n_kv_heads = n_heads
+    return int(n_heads), int(n_kv_heads), int(head_dim)
+
+
+def _has_qk_norm(lm_cfg: TransformerConfig) -> bool:
+    block = lm_cfg.block
+    seq_mixer = getattr(block, "attention", None) or getattr(block, "sequence_mixer", None)
+    return getattr(seq_mixer, "qk_norm", None) is not None
+
+
+def _convert_patch_embedding(hf_patch_weight: torch.Tensor, patch_size: int) -> torch.Tensor:
+    """Permute Molmo2's spatial-first patch weight to our C-first convention.
+
+    HF layout (per row): ``[kh=0,kw=0,c=0], [kh=0,kw=0,c=1], [kh=0,kw=0,c=2],
+    [kh=0,kw=1,c=0], …`` — i.e. ``(p, p, 3)`` flattened.
+
+    Our layout (per row): ``[c=0,kh=0,kw=0], [c=0,kh=0,kw=1], …,
+    [c=1,kh=0,kw=0], …`` — i.e. ``(3, p, p)`` flattened (matches a
+    HuggingFace ``Conv2d.weight.reshape(D, -1)`` from our CLIP/SigLIP parity
+    tests).
+    """
+    D, total = hf_patch_weight.shape
+    expected = patch_size * patch_size * 3
+    if total != expected:
+        raise Molmo2LoaderError(
+            f"HF patch embedding weight has shape {(D, total)} but expected "
+            f"{(D, expected)} given patch_size={patch_size}"
+        )
+    # HF stores rows as (p, p, c). Permute → (c, p, p).
+    return (
+        hf_patch_weight.reshape(D, patch_size, patch_size, 3)
+        .permute(0, 3, 1, 2)
+        .reshape(D, expected)
+        .contiguous()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def molmo2_hf_state_dict_to_multimodal_lm(
+    hf_state_dict: Dict[str, torch.Tensor],
+    cfg: MultimodalLMConfig,
+) -> Dict[str, torch.Tensor]:
+    """Convert a Molmo2 HF state dict to our :class:`MultimodalLM` layout.
+
+    :param hf_state_dict: Output of ``hf_model.state_dict()`` where
+        ``hf_model`` is a :class:`transformers.AutoModelForCausalLM` /
+        ``Molmo2ForConditionalGeneration`` loaded from one of
+        ``allenai/Molmo2-*``.
+    :param cfg: The target multimodal config. Used to read per-module
+        dimensions (n_heads, head_dim, n_layers, patch_size) so the converter
+        can split fused weights correctly.
+    :returns: A new ``Dict[str, Tensor]`` keyed for
+        :meth:`~olmo_core.nn.vision.MultimodalLM.load_state_dict`.
+    :raises Molmo2LoaderError: when the HF state dict is missing a required
+        key or has an unexpected shape.
+    """
+    out: Dict[str, torch.Tensor] = {}
+
+    lm_cfg = cfg.lm
+    n_layers = lm_cfg.n_layers
+    n_heads, n_kv_heads, head_dim = _attention_dims(lm_cfg)
+    fused_attn_dims = (
+        n_heads * head_dim,
+        n_kv_heads * head_dim,
+        n_kv_heads * head_dim,
+    )
+    has_qk_norm = _has_qk_norm(lm_cfg)
+
+    # --- LM: token embeddings -----------------------------------------------
+    base_emb = _require(hf_state_dict, "model.transformer.wte.embedding")
+    new_emb = _require(hf_state_dict, "model.transformer.wte.new_embedding")
+    out["lm.embeddings.weight"] = torch.cat([base_emb, new_emb], dim=0)
+
+    # --- LM: final norm + lm head ------------------------------------------
+    out["lm.lm_head.norm.weight"] = _require(hf_state_dict, "model.transformer.ln_f.weight")
+
+    # HF Molmo2's lm_head is sized to the *base* vocab only — image special
+    # tokens are inputs-only and never predicted. Our OLMo-core LM uses a
+    # single vocab_size for both input and output, so pad the lm_head with
+    # zero rows for the image-token slots.
+    #
+    # NOTE: zero rows give those positions a *finite* logit (0), not -inf, so
+    # they enter the softmax denominator and shift the cross-entropy loss
+    # relative to HF (which has no such columns). Argmax/greedy generation is
+    # unaffected as long as a real token outscores 0, but exact *loss* parity
+    # requires masking the extra output IDs to -inf at the loss/forward layer
+    # (handled where the loss is computed, not in this weight converter). The
+    # logit-parity tests therefore compare only the base-vocab columns.
+    hf_lm_head = _require(hf_state_dict, "lm_head.weight")
+    extra_rows = lm_cfg.vocab_size - hf_lm_head.shape[0]
+    if extra_rows < 0:
+        raise Molmo2LoaderError(
+            f"HF lm_head has {hf_lm_head.shape[0]} rows but our LM "
+            f"vocab_size is only {lm_cfg.vocab_size}"
+        )
+    if extra_rows > 0:
+        # new_zeros preserves the source tensor's device and dtype, so this
+        # works when the HF state dict is already on CUDA.
+        pad = hf_lm_head.new_zeros((extra_rows, hf_lm_head.shape[1]))
+        out["lm.lm_head.w_out.weight"] = torch.cat([hf_lm_head, pad], dim=0)
+    else:
+        out["lm.lm_head.w_out.weight"] = hf_lm_head
+
+    # --- LM: per-block --------------------------------------------------------
+    for i in range(n_layers):
+        src = f"model.transformer.blocks.{i}"
+        dst = f"lm.blocks.{i}"
+
+        # Pre-attn / pre-mlp norms.
+        out[f"{dst}.attention_norm.weight"] = _require(hf_state_dict, f"{src}.attn_norm.weight")
+        out[f"{dst}.feed_forward_norm.weight"] = _require(hf_state_dict, f"{src}.ff_norm.weight")
+
+        # Fused QKV → split.
+        att_w = _require(hf_state_dict, f"{src}.self_attn.att_proj.weight")
+        q_w, k_w, v_w = att_w.split(fused_attn_dims, dim=0)
+        out[f"{dst}.attention.w_q.weight"] = q_w.contiguous()
+        out[f"{dst}.attention.w_k.weight"] = k_w.contiguous()
+        out[f"{dst}.attention.w_v.weight"] = v_w.contiguous()
+        if (att_b := _maybe(hf_state_dict, f"{src}.self_attn.att_proj.bias")) is not None:
+            q_b, k_b, v_b = att_b.split(fused_attn_dims, dim=0)
+            out[f"{dst}.attention.w_q.bias"] = q_b.contiguous()
+            out[f"{dst}.attention.w_k.bias"] = k_b.contiguous()
+            out[f"{dst}.attention.w_v.bias"] = v_b.contiguous()
+
+        # QK-norm if present.
+        if has_qk_norm:
+            out[f"{dst}.attention.q_norm.weight"] = _require(
+                hf_state_dict, f"{src}.self_attn.q_norm.weight"
+            )
+            out[f"{dst}.attention.k_norm.weight"] = _require(
+                hf_state_dict, f"{src}.self_attn.k_norm.weight"
+            )
+
+        # Attn output projection.
+        out[f"{dst}.attention.w_out.weight"] = _require(
+            hf_state_dict, f"{src}.self_attn.attn_out.weight"
+        )
+
+        # Fused SwiGLU → split.
+        # HF forward: x, gate = ff_proj.chunk(2); x = act(gate) * x → ff_out.
+        # So ff_proj.weight[:H] feeds the *multiplier* branch (our w3),
+        #   ff_proj.weight[H:2H] feeds the *gate* branch (our w1).
+        ff_proj_w = _require(hf_state_dict, f"{src}.mlp.ff_proj.weight")
+        mul_w, gate_w = ff_proj_w.chunk(2, dim=0)
+        out[f"{dst}.feed_forward.w3.weight"] = mul_w.contiguous()
+        out[f"{dst}.feed_forward.w1.weight"] = gate_w.contiguous()
+        out[f"{dst}.feed_forward.w2.weight"] = _require(hf_state_dict, f"{src}.mlp.ff_out.weight")
+
+    # --- Vision: patch embedding + positional ---------------------------------
+    vit_layers = cfg.vision.image_num_layers
+    p = cfg.vision.image_patch_size
+    hf_patch_w = _require(hf_state_dict, "model.vision_backbone.image_vit.patch_embedding.weight")
+    out["vision.patch_embedding.weight"] = _convert_patch_embedding(hf_patch_w, p)
+    out["vision.patch_embedding.bias"] = _require(
+        hf_state_dict, "model.vision_backbone.image_vit.patch_embedding.bias"
+    )
+    out["vision.positional_embedding"] = _require(
+        hf_state_dict, "model.vision_backbone.image_vit.positional_embedding"
+    )
+
+    # --- Vision: per-block ----------------------------------------------------
+    for i in range(vit_layers):
+        src = f"model.vision_backbone.image_vit.transformer.resblocks.{i}"
+        dst = f"vision.blocks.{i}"
+        # Norms.
+        for hf_name, ours_name in (("attention_norm", "attn_norm"), ("ffn_norm", "ffn_norm")):
+            for suffix in ("weight", "bias"):
+                out[f"{dst}.{ours_name}.{suffix}"] = _require(
+                    hf_state_dict, f"{src}.{hf_name}.{suffix}"
+                )
+        # QKV + output projection (no fusing on the vision side).
+        for proj in ("wq", "wk", "wv", "wo"):
+            for suffix in ("weight", "bias"):
+                out[f"{dst}.attn.{proj}.{suffix}"] = _require(
+                    hf_state_dict, f"{src}.attention.{proj}.{suffix}"
+                )
+        # Plain MLP (no SwiGLU in the ViT).
+        for proj in ("w1", "w2"):
+            for suffix in ("weight", "bias"):
+                out[f"{dst}.ffn.{proj}.{suffix}"] = _require(
+                    hf_state_dict, f"{src}.feed_forward.{proj}.{suffix}"
+                )
+
+    # --- Connector: pooling cross-attention + projector SwiGLU --------------
+    for proj in ("wq", "wk", "wv", "wo"):
+        for suffix in ("weight", "bias"):
+            out[f"connector.pooling.{proj}.{suffix}"] = _require(
+                hf_state_dict, f"model.vision_backbone.image_pooling_2d.{proj}.{suffix}"
+            )
+    for proj in ("w1", "w2", "w3"):
+        out[f"connector.projector.{proj}.weight"] = _require(
+            hf_state_dict, f"model.vision_backbone.image_projector.{proj}.weight"
+        )
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# HF Molmo2 config → MultimodalLMConfig
+# ---------------------------------------------------------------------------
+
+
+def _build_lm_config(text_cfg, total_vocab_size: int) -> TransformerConfig:
+    """Build a :class:`TransformerConfig` matching an HF Molmo2 text_config.
+
+    Dispatches to ``qwen3_4B`` / ``qwen3_8B`` (qk_norm_type="qwen3"),
+    ``olmo3_7B`` (default qk_norm), or raises if no factory matches.
+
+    TODO: this dispatch hard-codes a growing ``(qk_norm_type, hidden_size,
+    n_layers)`` lookup table mapping to named factory methods, and ignores most
+    of the HF ``text_config`` fields (intermediate_size, num_attention_heads,
+    head_dim, rms_norm_eps, tie_word_embeddings, etc.). It will be hard to
+    maintain as more checkpoints are added. Replace it with a generic builder
+    that constructs the ``TransformerConfig`` directly from the HF fields rather
+    than matching dimensions to a preset.
+    """
+    from ..attention import AttentionBackendName
+
+    hidden_size = text_cfg.hidden_size
+    n_layers = text_cfg.num_hidden_layers
+    qk_norm_type = getattr(text_cfg, "qk_norm_type", None)
+    rope_theta = text_cfg.rope_theta
+
+    # Branch by qk_norm_type then dimensions.
+    if qk_norm_type == "qwen3" and hidden_size == 2560 and n_layers == 36:
+        return TransformerConfig.qwen3_4B(
+            vocab_size=total_vocab_size,
+            rope_theta=rope_theta,
+            attn_backend=AttentionBackendName.torch,
+            dtype=DType.float32,
+        )
+    if qk_norm_type == "qwen3" and hidden_size == 4096 and n_layers == 36:
+        return TransformerConfig.qwen3_8B(
+            vocab_size=total_vocab_size,
+            rope_theta=rope_theta,
+            attn_backend=AttentionBackendName.torch,
+            dtype=DType.float32,
+        )
+    if hidden_size == 4096 and n_layers == 32:
+        # Olmo3-7B layout (per-channel qk_norm).
+        rope_scaling_layers = getattr(text_cfg, "rope_scaling_layers", None)
+        if rope_scaling_layers is not None:
+            # Molmo2-O-7B uses per-layer YaRN attention scaling (attention_factor ≈ 1.208)
+            # on a subset of layers.  MultimodalLM currently applies a single global
+            # RoPE config, so the per-layer attention_factor is silently ignored.  Logit
+            # magnitudes will differ from HF's reference by ~3-4 nats for short sequences;
+            # predicted argmax still matches for text-only paths.
+            log.warning(
+                "Molmo2 text config has 'rope_scaling_layers=%s', indicating per-layer "
+                "YaRN attention scaling (attention_factor=%.4f).  "
+                "MultimodalLM does not support per-layer RoPE variants; "
+                "logit magnitudes may differ from the HF reference.",
+                rope_scaling_layers[:4],
+                text_cfg.rope_scaling.get("attention_factor", float("nan")),
+            )
+        return TransformerConfig.olmo3_7B(
+            vocab_size=total_vocab_size,
+            rope_theta=rope_theta,
+            attn_backend=AttentionBackendName.torch,
+            dtype=DType.float32,
+        )
+    raise Molmo2LoaderError(
+        f"No matching TransformerConfig factory for HF Molmo2 text_config: "
+        f"hidden_size={hidden_size}, n_layers={n_layers}, qk_norm_type={qk_norm_type!r}"
+    )
+
+
+def _effective_vit_layers(vit_cfg, vit_layers: list[int]) -> int:
+    """Mirror HF Molmo2's optimization: drop ViT blocks above
+    ``max(vit_layers) + 1`` since they're never read."""
+    total = vit_cfg.num_hidden_layers
+    # Resolve negative indices to positive.
+    resolved = [(layer if layer >= 0 else layer + total) for layer in vit_layers]
+    last_needed = max(resolved) + 1
+    return min(last_needed, total)
+
+
+def _build_vision_config(vit_cfg, vit_layers: list[int]) -> VisionEncoderConfig:
+    """Build a :class:`VisionEncoderConfig` matching an HF Molmo2 vit_config.
+
+    Molmo2 ViTs match SigLIP-style (no CLS token, ``gelu_pytorch_tanh``
+    activation), so we use :attr:`VisionEncoderType.siglip`. We also mirror
+    HF Molmo2's truncation of unused upper ViT blocks: if
+    ``adapter_config.vit_layers`` is ``[-3, -9]``, only layers 0..24 are
+    instantiated (saves storage and compute).
+    """
+    raw_size = vit_cfg.image_default_input_size
+    image_size: Tuple[int, int] = (int(raw_size[0]), int(raw_size[1]))
+    return VisionEncoderConfig(
+        name=VisionEncoderType.siglip,
+        # SigLIP-style variant switches: no CLS token, a biased patch projection,
+        # and no pre-LayerNorm. These must be set explicitly — `name` alone no
+        # longer selects the architecture.
+        use_cls_token=False,
+        patch_embedding_bias=True,
+        use_pre_ln=False,
+        image_default_input_size=image_size,
+        image_patch_size=vit_cfg.image_patch_size,
+        image_emb_dim=vit_cfg.hidden_size,
+        image_num_heads=vit_cfg.num_attention_heads,
+        image_num_key_value_heads=vit_cfg.num_key_value_heads,
+        image_num_layers=_effective_vit_layers(vit_cfg, vit_layers),
+        image_head_dim=vit_cfg.head_dim,
+        image_mlp_dim=vit_cfg.intermediate_size,
+        image_mlp_activations=vit_cfg.hidden_act,
+        image_num_pos=vit_cfg.image_num_pos,
+        image_norm_eps=vit_cfg.layer_norm_eps,
+        dtype=DType.float32,
+    )
+
+
+def _build_connector_config(adapter_cfg, vit_hidden_size: int) -> VisionConnectorConfig:
+    """Build :class:`VisionConnectorConfig` from HF Molmo2 adapter_config.
+
+    ``vit_layers`` in the adapter config tells us how many ViT layers are
+    concatenated into the pooling cross-attention's input dim
+    (``num_input_layers``).
+    """
+    num_input_layers = len(adapter_cfg.vit_layers)
+    return VisionConnectorConfig(
+        image_emb_dim=vit_hidden_size,
+        image_num_heads=adapter_cfg.num_attention_heads,
+        image_num_key_value_heads=adapter_cfg.num_key_value_heads,
+        image_head_dim=adapter_cfg.head_dim,
+        output_dim=adapter_cfg.text_hidden_size,
+        num_input_layers=num_input_layers,
+        pooling_type=ImagePoolingType.attention_meanq,
+        pooling_attention_mask=adapter_cfg.pooling_attention_mask,
+        projector_type=ImageProjectorType.mlp,
+        mlp_hidden_size=adapter_cfg.intermediate_size,
+        dtype=DType.float32,
+    )
+
+
+def molmo2_config_from_hf_config(hf_config: Any) -> MultimodalLMConfig:
+    """Build a :class:`MultimodalLMConfig` from a Molmo2 HF config.
+
+    :param hf_config: A loaded HF Molmo2 config — typically
+        ``transformers.AutoConfig.from_pretrained("allenai/Molmo2-*",
+        trust_remote_code=True)``.
+    :returns: A :class:`MultimodalLMConfig` whose model architecture
+        matches the HF Molmo2 layout, ready to receive converted weights.
+    """
+    text_cfg = hf_config.text_config
+    vit_cfg = hf_config.vit_config
+    adapter_cfg = hf_config.adapter_config
+
+    # HF Molmo2 keeps the extra image-token embeddings in a separate
+    # parameter (``new_embedding``); after concatenation our model needs the
+    # combined vocab.
+    total_vocab = text_cfg.vocab_size + text_cfg.additional_vocab_size
+    lm_cfg = _build_lm_config(text_cfg, total_vocab_size=total_vocab)
+    vis_cfg = _build_vision_config(vit_cfg, adapter_cfg.vit_layers)
+    conn_cfg = _build_connector_config(adapter_cfg, vit_hidden_size=vit_cfg.hidden_size)
+
+    # Resolve vit_layers to **absolute** layer indices in the (possibly
+    # truncated) ViT we just built. HF Molmo2 stores ``vit_layers`` as
+    # negative indices into the *original* (untruncated) ViT, so e.g.
+    # ``[-3, -9]`` with 27 layers means absolute ``[24, 18]``. Once we
+    # truncate to 25 layers, our model's hidden_states list is 25 long and
+    # we want to read indices ``[24, 18]`` directly.
+    full_vit_layers = vit_cfg.num_hidden_layers
+    resolved_vit_layers = tuple(
+        layer if layer >= 0 else layer + full_vit_layers for layer in adapter_cfg.vit_layers
+    )
+
+    return MultimodalLMConfig(
+        lm=lm_cfg,
+        vision=vis_cfg,
+        connector=conn_cfg,
+        image_patch_token_id=hf_config.image_patch_id,
+        vit_layers=resolved_vit_layers,
+    )

--- a/src/test/nn/vision/molmo2_generation_test.py
+++ b/src/test/nn/vision/molmo2_generation_test.py
@@ -1,0 +1,333 @@
+"""
+End-to-end generation test for the HF Molmo2 → :class:`MultimodalLM` converter.
+
+Loads Molmo2-4B from the local HF cache, converts its weights with our loader,
+then performs a short greedy-decode run on a synthetic image to verify that:
+
+1. Both the HF reference model and our model produce **identical** token IDs
+   for the first :data:`_N_TOKENS` decode steps.
+2. The decoded text is non-empty, contains ASCII letters, and matches between
+   the two models — demonstrating that the full vision+connector+LM pipeline
+   works end-to-end without :mod:`torchvision`.
+
+The test uses a **PIL-based preprocessor** that replaces the torchvision resize
+in :class:`Molmo2ImageProcessor` with :meth:`PIL.Image.Image.resize`.  The
+image is a tiny synthetic gradient (no network access needed).  Because both
+the HF and our models receive the same pre-normalised patch tensors, any
+difference in generated token IDs is a real bug in the converter.
+
+Auto-skips if ``allenai/Molmo2-4B`` is not in the local HF cache.
+"""
+
+import os
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from olmo_core.nn.vision import MultimodalLM
+from olmo_core.nn.vision.molmo2_loader import (
+    ensure_default_rope_registered,
+    molmo2_config_from_hf_config,
+    molmo2_hf_state_dict_to_multimodal_lm,
+    reinit_rope_buffers,
+)
+from olmo_core.testing import requires_gpu
+
+transformers = pytest.importorskip("transformers")
+
+# Only test the smallest variant to keep peak memory reasonable.
+_MODEL_ID = "allenai/Molmo2-4B"
+
+# How many tokens to decode (enough to see structure, small enough to be fast).
+_N_TOKENS = 8
+
+# ──────────────────────────── preprocessor constants ────────────────────────
+# Taken from Molmo2-4B preprocessor_config.json.  Fixed across all Molmo2
+# variants that use the SigLIP2-SO400M/14 vision encoder.
+_PATCH_SIZE = 14
+_IMAGE_SIZE = 378  # 27 × 27 patches per crop
+_POOL_H = 2
+_POOL_W = 2
+# After 2×2 pooling over 27 patches with ceil-padding:
+#   ceil(27/2) = 14  → 14×14 = 196 low-res image tokens
+_GRID_H = 14
+_GRID_W = 14
+
+# Molmo2 special token IDs (same across all variants).
+_IM_PATCH_ID = 151938  # <im_patch>
+_IM_COL_ID = 151939  # <im_col>
+_IM_START_ID = 151936  # <im_start>   (high-res section boundary)
+_LOW_RES_IM_START_ID = 151940  # <low_res_im_start>
+_IM_END_ID = 151937  # <im_end>
+_IMAGE_PLACEHOLDER_ID = 151941  # <|image|>  (replaced in token sequence)
+
+
+# ────────────────────────────── helpers ─────────────────────────────────────
+
+
+def _hf_cache_has(model_id: str) -> bool:
+    suffix = "models--" + model_id.replace("/", "--")
+    candidates = [os.path.expanduser("~/.cache/huggingface/hub")]
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        candidates.append(os.path.join(hf_home, "hub"))
+    return any(os.path.isdir(os.path.join(r, suffix)) for r in candidates if r)
+
+
+def _arange_for_pooling(idx_arr: np.ndarray, pool_h: int, pool_w: int) -> np.ndarray:
+    """Pad *idx_arr* to be divisible by pool dims, then return ``(ph, pw, pool_h*pool_w)``
+    pooling indices. Mirrors the ``arange_for_pooling`` function in
+    ``image_processing_molmo2.py`` but uses plain NumPy instead of einops."""
+    h, w = idx_arr.shape
+    h_pad = pool_h * ((h + pool_h - 1) // pool_h) - h
+    w_pad = pool_w * ((w + pool_w - 1) // pool_w) - w
+    idx_arr = np.pad(
+        idx_arr,
+        [[h_pad // 2, (h_pad + 1) // 2], [w_pad // 2, (w_pad + 1) // 2]],
+        mode="constant",
+        constant_values=-1,
+    )
+    ph = (h + pool_h - 1) // pool_h
+    pw = (w + pool_w - 1) // pool_w
+    # einops "(h dh) (w dw) -> h w (dh dw)" equivalent:
+    idx_arr = idx_arr.reshape(ph, pool_h, pw, pool_w).transpose(0, 2, 1, 3)
+    return idx_arr.reshape(ph, pw, pool_h * pool_w)
+
+
+def _preprocess_image_pil(pil_img: Image.Image, dtype: torch.dtype, device: torch.device):
+    """Single-crop (global-view-only) Molmo2 image preprocessing using PIL.
+
+    Replaces ``Molmo2ImageProcessor`` (which requires torchvision for resize)
+    with a pure-PIL implementation for the common square 378×378 case.
+
+    :returns:
+        ``(pixel_values_hf, images_ours, pooling_idx, image_grids, image_num_crops)``
+
+        * ``pixel_values_hf``  – shape ``(1, 729, 588)``, spatial-first, for HF.
+        * ``images_ours``      – shape ``(1, 1, 729, 588)``, C-first, for ours.
+        * ``pooling_idx``      – shape ``(1, 196, 4)``, patch indices.
+        * ``image_grids``      – shape ``(1, 4)`` = ``[[14, 14, 0, 0]]``.
+        * ``image_num_crops``  – shape ``(1,)`` = ``[1]``.
+    """
+    img = pil_img.convert("RGB").resize((_IMAGE_SIZE, _IMAGE_SIZE), Image.BILINEAR)
+    arr = np.array(img, dtype=np.float32) / 255.0
+    # SigLIP2 normalise: (pixel − 0.5) / 0.5
+    arr = (arr - 0.5) / 0.5  # (378, 378, 3)
+
+    h_p = _IMAGE_SIZE // _PATCH_SIZE  # 27
+    w_p = _IMAGE_SIZE // _PATCH_SIZE  # 27
+
+    # Reshape to (h_p, w_p, kH, kW, C) — layout shared by both orderings.
+    arr5 = arr.reshape(h_p, _PATCH_SIZE, w_p, _PATCH_SIZE, 3).transpose(0, 2, 1, 3, 4)
+
+    # HF expects spatial-first: flatten kH, kW, C → (n, kH·kW·C)
+    patches_sf = arr5.reshape(h_p * w_p, _PATCH_SIZE * _PATCH_SIZE * 3)
+
+    # Ours expects C-first: (h_p, w_p, C, kH, kW) → flatten → (n, C·kH·kW)
+    patches_cf = arr5.transpose(0, 1, 4, 2, 3).reshape(h_p * w_p, 3 * _PATCH_SIZE * _PATCH_SIZE)
+
+    # Pooling indices: 27×27 → 14×14, each group covers 4 original patches.
+    idx_arr = np.arange(h_p * w_p, dtype=np.int32).reshape(h_p, w_p)
+    pool_idx = _arange_for_pooling(idx_arr, _POOL_H, _POOL_W)  # (14, 14, 4)
+    pooling_idx = pool_idx.reshape(-1, _POOL_H * _POOL_W)  # (196, 4)
+
+    def _ft(a: np.ndarray) -> torch.Tensor:
+        """Float tensor (patches)."""
+        return torch.from_numpy(a).to(dtype=dtype, device=device)
+
+    def _it(a: np.ndarray) -> torch.Tensor:
+        """Integer index tensor."""
+        return torch.from_numpy(a.astype(np.int64)).to(device=device)
+
+    pixel_values_hf = _ft(patches_sf[np.newaxis])  # (1, 729, 588)
+    images_ours = _ft(patches_cf[np.newaxis, np.newaxis])  # (1, 1, 729, 588)
+    pooling_idx_t = _it(pooling_idx).unsqueeze(0)  # (1, 196, 4) int64
+    image_grids = torch.tensor([[_GRID_H, _GRID_W, 0, 0]], dtype=torch.long, device=device)
+    image_num_crops = torch.tensor([1], dtype=torch.long, device=device)
+
+    return pixel_values_hf, images_ours, pooling_idx_t, image_grids, image_num_crops
+
+
+def _build_image_token_ids() -> list:
+    """Return the expanded image token ID sequence for one global-only crop.
+
+    Structure:
+    ``<low_res_im_start>``  ``(``_GRID_W_ × ``<im_patch>`` + ``<im_col>``) × _GRID_H_``
+    ``<im_end>``  ``<im_start>`` ``<im_end>``
+
+    This produces exactly ``_GRID_H * _GRID_W = 196`` ``<im_patch>`` tokens and
+    exactly **two** ``<im_end>`` tokens (required by ``build_batched_images``).
+    """
+    tokens: list = [_LOW_RES_IM_START_ID]
+    for _ in range(_GRID_H):
+        tokens += [_IM_PATCH_ID] * _GRID_W
+        tokens += [_IM_COL_ID]
+    tokens += [_IM_END_ID, _IM_START_ID, _IM_END_ID]
+    return tokens
+
+
+def _build_input_ids(tok, image_tokens: list, device: torch.device) -> torch.Tensor:
+    """Build ``input_ids`` for an image + short question.
+
+    Uses the tokenizer's chat template, then replaces the ``<|image|>``
+    placeholder token with the full expanded image token sequence.
+    """
+    text = tok.apply_chat_template(
+        [{"role": "user", "content": "<|image|>What colors do you see?"}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    ids: list = tok.encode(text, add_special_tokens=False)
+
+    # Splice the image tokens in place of the <|image|> placeholder.
+    try:
+        img_pos = ids.index(_IMAGE_PLACEHOLDER_ID)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"<|image|> placeholder (ID {_IMAGE_PLACEHOLDER_ID}) not found in tokenised "
+            f"prompt. ids={ids[:10]}…"
+        ) from exc
+    ids = ids[:img_pos] + image_tokens + ids[img_pos + 1 :]
+    return torch.tensor([ids], dtype=torch.long, device=device)
+
+
+def _greedy_decode(model_fn, input_ids: torch.Tensor, n_tokens: int) -> list:
+    """Run a manual greedy-decode loop for *n_tokens* steps.
+
+    *model_fn* must accept ``input_ids`` as its first positional argument and
+    return a logits tensor of shape ``(B, S, V)``.  All extra keyword
+    arguments (e.g., image tensors) are closed over inside *model_fn*.
+    """
+    gen_ids = input_ids.clone()
+    generated: list = []
+    with torch.inference_mode():
+        for _ in range(n_tokens):
+            logits = model_fn(gen_ids)
+            next_id = int(logits[0, -1].argmax().item())
+            generated.append(next_id)
+            gen_ids = torch.cat(
+                [gen_ids, torch.tensor([[next_id]], dtype=torch.long, device=gen_ids.device)],
+                dim=1,
+            )
+    return generated
+
+
+# ─────────────────────────────── test ───────────────────────────────────────
+
+
+@requires_gpu
+def test_molmo2_generation_parity():
+    """Convert HF Molmo2-4B weights, then greedy-decode a synthetic image+question
+    and verify our model's output tokens match the HF reference exactly.
+
+    The test image is a small synthetic RGB gradient (no internet access needed).
+    Both models receive identical preprocessed patches — HF in spatial-first
+    order, ours in C-first order — so any token mismatch indicates a real
+    converter or forward-pass bug.
+    """
+    if not _hf_cache_has(_MODEL_ID):
+        pytest.skip(f"{_MODEL_ID} not in HF cache")
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    # ── Load HF model ────────────────────────────────────────────────────────
+    ensure_default_rope_registered()
+    from transformers import AutoModelForImageTextToText, AutoTokenizer
+
+    try:
+        hf = AutoModelForImageTextToText.from_pretrained(
+            _MODEL_ID, trust_remote_code=True, local_files_only=True
+        )
+        tok = AutoTokenizer.from_pretrained(
+            _MODEL_ID, trust_remote_code=True, local_files_only=True
+        )
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"Could not load {_MODEL_ID}: {e}")
+
+    reinit_rope_buffers(hf)
+
+    # ── Build our model from converted weights ────────────────────────────────
+    cfg = molmo2_config_from_hf_config(hf.config)
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf.state_dict(), cfg)
+    ours = MultimodalLM(cfg, init_device="meta")
+    ours.to_empty(device=torch.device("cpu"))
+    missing, unexpected = ours.load_state_dict(converted, strict=False)
+    del converted
+    param_keys = {k for k, _ in ours.named_parameters()}
+    assert not (
+        set(missing) & param_keys
+    ), f"Missing params: {sorted(set(missing) & param_keys)[:5]}"
+    assert not (
+        set(unexpected) & param_keys
+    ), f"Unexpected params: {sorted(set(unexpected) & param_keys)[:5]}"
+
+    hf = hf.to(device=device, dtype=dtype).eval()
+    ours = ours.to(device=device, dtype=dtype).eval()
+
+    # ── Synthetic test image: 64×64 RGB gradient, PIL-preprocessed ───────────
+    np.random.seed(42)
+    gradient = np.zeros((64, 64, 3), dtype=np.uint8)
+    gradient[:, :, 0] = np.linspace(0, 255, 64, dtype=np.uint8)  # red ramp
+    gradient[:, :, 1] = np.linspace(0, 200, 64, dtype=np.uint8)[np.newaxis, :].T  # green ramp
+    gradient[:, :, 2] = 100  # flat blue
+    pil_img = Image.fromarray(gradient)
+
+    pixel_values_hf, images_ours, pooling_idx, image_grids, image_num_crops = _preprocess_image_pil(
+        pil_img, dtype=dtype, device=device
+    )
+
+    # ── Build shared input_ids ────────────────────────────────────────────────
+    image_tokens = _build_image_token_ids()
+    input_ids = _build_input_ids(tok, image_tokens, device=device)
+
+    # Sanity: correct number of <im_patch> and <im_end> tokens
+    n_im_patch = (input_ids == _IM_PATCH_ID).sum().item()
+    n_im_end = (input_ids == _IM_END_ID).sum().item()
+    assert (
+        n_im_patch == _GRID_H * _GRID_W
+    ), f"Expected {_GRID_H * _GRID_W} <im_patch> tokens, got {n_im_patch}"
+    assert n_im_end == 2, f"Expected 2 <im_end> tokens, got {n_im_end}"
+
+    # ── HF greedy decode ─────────────────────────────────────────────────────
+    def _hf_fn(ids: torch.Tensor) -> torch.Tensor:
+        out = hf(
+            input_ids=ids,
+            pixel_values=pixel_values_hf,
+            image_token_pooling=pooling_idx.squeeze(0),  # HF expects (n_pooled, pool_k)
+            image_grids=image_grids,
+            image_num_crops=image_num_crops,
+            use_cache=False,
+        )
+        return out.logits
+
+    hf_tokens = _greedy_decode(_hf_fn, input_ids, _N_TOKENS)
+
+    # ── Our greedy decode ─────────────────────────────────────────────────────
+    def _our_fn(ids: torch.Tensor) -> torch.Tensor:
+        return ours(
+            input_ids=ids,
+            images=images_ours,
+            pooled_patches_idx=pooling_idx,
+        )
+
+    our_tokens = _greedy_decode(_our_fn, input_ids, _N_TOKENS)
+
+    # ── Decode for readability ────────────────────────────────────────────────
+    hf_text = tok.decode(hf_tokens, skip_special_tokens=True)
+    our_text = tok.decode(our_tokens, skip_special_tokens=True)
+
+    # ── Assertions ───────────────────────────────────────────────────────────
+    assert hf_tokens == our_tokens, (
+        f"Generated token IDs mismatch after {_N_TOKENS} steps:\n"
+        f"  HF  tokens = {hf_tokens}\n"
+        f"  ours tokens = {our_tokens}\n"
+        f"  HF  text = {hf_text!r}\n"
+        f"  ours text = {our_text!r}"
+    )
+    # Check the decoded text is non-trivial (contains at least one alphabetic char).
+    assert any(
+        c.isalpha() for c in our_text
+    ), f"Decoded text looks empty or non-linguistic: {our_text!r}"

--- a/src/test/nn/vision/molmo2_loader_test.py
+++ b/src/test/nn/vision/molmo2_loader_test.py
@@ -1,0 +1,335 @@
+"""
+Tests for the HF Molmo2 → :class:`MultimodalLM` state-dict converter.
+
+The "key coverage" test below constructs a synthetic HF Molmo2 state dict
+matching the shapes of a real Molmo2 model and verifies the converter
+produces every key our :meth:`MultimodalLM.load_state_dict`
+expects, with the correct shapes, and that the loaded model runs forward.
+
+No network or large download required.
+
+A separate ``@pytest.mark.slow`` numerical-parity test that requires a real
+HF Molmo2 checkpoint can be added later (task follow-up).
+"""
+
+from typing import Dict
+
+import pytest
+import torch
+
+from olmo_core.nn.attention import AttentionBackendName
+from olmo_core.nn.transformer.config import TransformerConfig
+from olmo_core.nn.vision import (
+    MultimodalLM,
+    MultimodalLMConfig,
+    VisionConnectorConfig,
+    VisionEncoderConfig,
+    VisionEncoderType,
+)
+from olmo_core.nn.vision.molmo2_loader import (
+    Molmo2LoaderError,
+    molmo2_hf_state_dict_to_multimodal_lm,
+)
+
+# ---------------------------------------------------------------------------
+# Tiny multimodal config used throughout
+# ---------------------------------------------------------------------------
+
+# Self-contained vocab layout, decoupled from the dolma2 multimodal tokenizer
+# (`olmo_core.data.multimodal`, added in a later PR). The loader only needs a
+# base/extra split that pads to the LM `vocab_size`: the base vocab is what HF's
+# lm_head predicts, and the extra image/special tokens are input-only. We pick a
+# 128-wide vocab with a non-trivial extra count so the embedding-split path is
+# actually exercised.
+_BASE_VOCAB = 120  # text vocab predicted by lm_head
+_EXTRA_VOCAB = 8  # image/special tokens (input-only, never predicted)
+_FULL_VOCAB = _BASE_VOCAB + _EXTRA_VOCAB  # 128
+_IMAGE_PATCH_ID = _BASE_VOCAB  # first extra id
+
+
+def _tiny_cfg() -> MultimodalLMConfig:
+    """A tiny stand-in for Molmo2-O-7B: olmo3_1M LM + small SigLIP-style ViT.
+
+    Architecturally analogous (fused QKV, fused SwiGLU, ViT, attention-pooled
+    connector with SwiGLU projector); just small enough to load on CPU."""
+    # olmo3_1M shares the same block layout as olmo3_7B (fused att_proj +
+    # fused ff_proj + qk_norm), just with d_model=12. Force the `torch`
+    # SDPA backend so the tiny test config builds without a CUDA flash-attn.
+    lm_cfg = TransformerConfig.olmo3_1M(
+        vocab_size=_FULL_VOCAB,
+        attn_backend=AttentionBackendName.torch,
+    )
+    vis_cfg = VisionEncoderConfig(
+        name=VisionEncoderType.siglip,
+        use_cls_token=False,
+        patch_embedding_bias=True,
+        use_pre_ln=False,
+        image_default_input_size=(56, 56),
+        image_patch_size=14,
+        image_emb_dim=32,
+        image_num_heads=2,
+        image_num_key_value_heads=2,
+        image_num_layers=3,
+        image_head_dim=16,
+        image_mlp_dim=64,
+        image_num_pos=16,
+        image_norm_eps=1e-5,
+    )
+    conn_cfg = VisionConnectorConfig.from_vision_encoder(
+        vis_cfg, output_dim=lm_cfg.d_model, mlp_hidden_size=64
+    )
+    return MultimodalLMConfig(
+        lm=lm_cfg,
+        vision=vis_cfg,
+        connector=conn_cfg,
+        image_patch_token_id=_IMAGE_PATCH_ID,
+    )
+
+
+def _attention_dims(lm_cfg: TransformerConfig):
+    """Mirror of molmo2_loader._attention_dims so tests can construct fake weights."""
+    block = lm_cfg.block
+    seq_mixer = block.attention if block.attention is not None else block.sequence_mixer
+    n_heads = getattr(seq_mixer, "n_heads", None) or getattr(seq_mixer, "num_heads", None)
+    n_kv = (
+        getattr(seq_mixer, "n_kv_heads", None)
+        or getattr(seq_mixer, "num_kv_heads", None)
+        or n_heads
+    )
+    head_dim = getattr(seq_mixer, "head_dim", None) or (lm_cfg.d_model // n_heads)
+    return int(n_heads), int(n_kv), int(head_dim)
+
+
+def _has_qk_norm(lm_cfg: TransformerConfig) -> bool:
+    block = lm_cfg.block
+    seq_mixer = block.attention if block.attention is not None else block.sequence_mixer
+    return getattr(seq_mixer, "qk_norm", None) is not None
+
+
+# ---------------------------------------------------------------------------
+# Build a synthetic HF Molmo2 state dict
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_hf_state_dict(cfg: MultimodalLMConfig) -> Dict[str, torch.Tensor]:
+    """Construct a Molmo2-shaped HF state dict from our config's dimensions.
+
+    Uses ``ones`` everywhere so the converter can be exercised without
+    relying on actual weight semantics. Numerical-correctness checks live
+    elsewhere."""
+    sd: Dict[str, torch.Tensor] = {}
+
+    lm_cfg = cfg.lm
+    n_layers = lm_cfg.n_layers
+    n_heads, n_kv, head_dim = _attention_dims(lm_cfg)
+    d_model = lm_cfg.d_model
+    # Match our model's resolved hidden_size for SwiGLU. For olmo3_1M this
+    # ends up matching what TransformerConfig.llama_like computes.
+    block = lm_cfg.block
+    intermediate = block.feed_forward.hidden_size
+
+    has_qk_norm = _has_qk_norm(lm_cfg)
+
+    # Vocab: HF Molmo2 keeps base + extra vocab in separate buffers.
+    # Our config has lm.vocab_size == base + extra (already padded). Split
+    # at the same boundary that the converter uses.
+    full_vocab = lm_cfg.vocab_size
+    new_vocab = _EXTRA_VOCAB
+    base_vocab = full_vocab - new_vocab
+    sd["model.transformer.wte.embedding"] = torch.randn(base_vocab, d_model)
+    sd["model.transformer.wte.new_embedding"] = torch.randn(new_vocab, d_model)
+    sd["model.transformer.ln_f.weight"] = torch.randn(d_model)
+    sd["lm_head.weight"] = torch.randn(full_vocab, d_model)
+
+    fused_qkv_out = n_heads * head_dim + 2 * n_kv * head_dim
+    for i in range(n_layers):
+        prefix = f"model.transformer.blocks.{i}"
+        sd[f"{prefix}.attn_norm.weight"] = torch.randn(d_model)
+        sd[f"{prefix}.ff_norm.weight"] = torch.randn(d_model)
+        sd[f"{prefix}.self_attn.att_proj.weight"] = torch.randn(fused_qkv_out, d_model)
+        sd[f"{prefix}.self_attn.attn_out.weight"] = torch.randn(d_model, n_heads * head_dim)
+        if has_qk_norm:
+            # OLMo-core uses per-channel qk_norm (num_heads * head_dim),
+            # matching Molmo2's non-qwen3 qk_norm_type sizing.
+            sd[f"{prefix}.self_attn.q_norm.weight"] = torch.randn(n_heads * head_dim)
+            sd[f"{prefix}.self_attn.k_norm.weight"] = torch.randn(n_kv * head_dim)
+        sd[f"{prefix}.mlp.ff_proj.weight"] = torch.randn(intermediate * 2, d_model)
+        sd[f"{prefix}.mlp.ff_out.weight"] = torch.randn(d_model, intermediate)
+
+    # Vision side.
+    vis = cfg.vision
+    p = vis.image_patch_size
+    sd["model.vision_backbone.image_vit.patch_embedding.weight"] = torch.randn(
+        vis.image_emb_dim, p * p * 3
+    )
+    sd["model.vision_backbone.image_vit.patch_embedding.bias"] = torch.randn(vis.image_emb_dim)
+    sd["model.vision_backbone.image_vit.positional_embedding"] = torch.randn(
+        vis.image_num_pos, vis.image_emb_dim
+    )
+    for i in range(vis.image_num_layers):
+        prefix = f"model.vision_backbone.image_vit.transformer.resblocks.{i}"
+        for n in ("attention_norm", "ffn_norm"):
+            sd[f"{prefix}.{n}.weight"] = torch.randn(vis.image_emb_dim)
+            sd[f"{prefix}.{n}.bias"] = torch.randn(vis.image_emb_dim)
+        qkv_out = vis.image_num_heads * vis.image_head_dim
+        kv_out = vis.image_num_key_value_heads * vis.image_head_dim
+        sd[f"{prefix}.attention.wq.weight"] = torch.randn(qkv_out, vis.image_emb_dim)
+        sd[f"{prefix}.attention.wq.bias"] = torch.randn(qkv_out)
+        sd[f"{prefix}.attention.wk.weight"] = torch.randn(kv_out, vis.image_emb_dim)
+        sd[f"{prefix}.attention.wk.bias"] = torch.randn(kv_out)
+        sd[f"{prefix}.attention.wv.weight"] = torch.randn(kv_out, vis.image_emb_dim)
+        sd[f"{prefix}.attention.wv.bias"] = torch.randn(kv_out)
+        sd[f"{prefix}.attention.wo.weight"] = torch.randn(vis.image_emb_dim, qkv_out)
+        sd[f"{prefix}.attention.wo.bias"] = torch.randn(vis.image_emb_dim)
+        sd[f"{prefix}.feed_forward.w1.weight"] = torch.randn(vis.image_mlp_dim, vis.image_emb_dim)
+        sd[f"{prefix}.feed_forward.w1.bias"] = torch.randn(vis.image_mlp_dim)
+        sd[f"{prefix}.feed_forward.w2.weight"] = torch.randn(vis.image_emb_dim, vis.image_mlp_dim)
+        sd[f"{prefix}.feed_forward.w2.bias"] = torch.randn(vis.image_emb_dim)
+
+    # Connector: pooling cross-attention (input_dim = num_input_layers * image_emb_dim).
+    conn = cfg.connector
+    pool_in = conn.num_input_layers * vis.image_emb_dim
+    pool_q = conn.image_num_heads * conn.image_head_dim
+    pool_kv = conn.image_num_key_value_heads * conn.image_head_dim
+    for proj, out_dim in (("wq", pool_q), ("wk", pool_kv), ("wv", pool_kv)):
+        sd[f"model.vision_backbone.image_pooling_2d.{proj}.weight"] = torch.randn(out_dim, pool_in)
+        sd[f"model.vision_backbone.image_pooling_2d.{proj}.bias"] = torch.randn(out_dim)
+    sd["model.vision_backbone.image_pooling_2d.wo.weight"] = torch.randn(conn.image_emb_dim, pool_q)
+    sd["model.vision_backbone.image_pooling_2d.wo.bias"] = torch.randn(conn.image_emb_dim)
+
+    # Connector: SwiGLU projector.
+    hidden = conn.mlp_hidden_size or 4 * conn.image_emb_dim
+    sd["model.vision_backbone.image_projector.w1.weight"] = torch.randn(hidden, conn.image_emb_dim)
+    sd["model.vision_backbone.image_projector.w3.weight"] = torch.randn(hidden, conn.image_emb_dim)
+    sd["model.vision_backbone.image_projector.w2.weight"] = torch.randn(conn.output_dim, hidden)
+    return sd
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_converter_produces_every_required_key():
+    cfg = _tiny_cfg()
+    model = MultimodalLM(cfg, init_device="cpu")
+    expected_keys = set(model.state_dict().keys())
+
+    hf_sd = _synthetic_hf_state_dict(cfg)
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf_sd, cfg)
+
+    missing = expected_keys - set(converted.keys())
+    extra = set(converted.keys()) - expected_keys
+    assert not missing, f"converter missing keys: {sorted(missing)[:5]}"
+    # Accept extra keys (e.g. RoPE buffers stay on the model side) only if
+    # they aren't model parameters.
+    model_param_keys = {k for k, _ in model.named_parameters()}
+    extra_param = extra & model_param_keys
+    assert not extra_param, f"converter produced unexpected param keys: {extra_param}"
+
+
+def test_converter_shapes_match_model_load():
+    """The converted state dict must load into the model without complaint."""
+    cfg = _tiny_cfg()
+    model = MultimodalLM(cfg, init_device="cpu")
+    hf_sd = _synthetic_hf_state_dict(cfg)
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf_sd, cfg)
+    missing, unexpected = model.load_state_dict(converted, strict=False)
+    # We expect only buffers like rotary_emb caches to be unloaded; no
+    # parameters missing.
+    param_keys = {k for k, _ in model.named_parameters()}
+    assert not (set(missing) & param_keys), f"unloaded params: {set(missing) & param_keys}"
+
+
+def test_qkv_split_is_round_trip_correct():
+    """Splitting the fused att_proj and reading off Q/K/V should recover the
+    halves a real HF attention would consume."""
+    cfg = _tiny_cfg()
+    lm_cfg = cfg.lm
+    n_heads, n_kv, head_dim = _attention_dims(lm_cfg)
+    d_model = lm_cfg.d_model
+    fused_out = n_heads * head_dim + 2 * n_kv * head_dim
+
+    # Pack Q/K/V along output dim like HF Molmo2 does.
+    q = torch.randn(n_heads * head_dim, d_model)
+    k = torch.randn(n_kv * head_dim, d_model)
+    v = torch.randn(n_kv * head_dim, d_model)
+    fused = torch.cat([q, k, v], dim=0)
+    assert fused.shape == (fused_out, d_model)
+
+    hf_sd = _synthetic_hf_state_dict(cfg)
+    hf_sd["model.transformer.blocks.0.self_attn.att_proj.weight"] = fused
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf_sd, cfg)
+    torch.testing.assert_close(converted["lm.blocks.0.attention.w_q.weight"], q)
+    torch.testing.assert_close(converted["lm.blocks.0.attention.w_k.weight"], k)
+    torch.testing.assert_close(converted["lm.blocks.0.attention.w_v.weight"], v)
+
+
+def test_ff_proj_chunk_assigns_gate_and_multiplier_correctly():
+    """The HF MLP chunks ``[x, gate]``: x is the multiplier (our w3), gate
+    is what gets the activation (our w1)."""
+    cfg = _tiny_cfg()
+    lm_cfg = cfg.lm
+    d_model = lm_cfg.d_model
+    intermediate = lm_cfg.block.feed_forward.hidden_size
+    # Distinct halves so we can verify the assignment.
+    mul_half = torch.ones(intermediate, d_model)
+    gate_half = -torch.ones(intermediate, d_model)
+    fused = torch.cat([mul_half, gate_half], dim=0)
+    hf_sd = _synthetic_hf_state_dict(cfg)
+    hf_sd["model.transformer.blocks.0.mlp.ff_proj.weight"] = fused
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf_sd, cfg)
+    torch.testing.assert_close(converted["lm.blocks.0.feed_forward.w3.weight"], mul_half)
+    torch.testing.assert_close(converted["lm.blocks.0.feed_forward.w1.weight"], gate_half)
+
+
+def test_patch_embedding_permute_is_spatial_to_c_first():
+    """The converter must permute Molmo2's ``(p, p, c)`` flatten order
+    into our ``(c, p, p)`` order so the same pixel patchification produces
+    the same dot product on both sides."""
+    cfg = _tiny_cfg()
+    p = cfg.vision.image_patch_size
+    D = cfg.vision.image_emb_dim
+
+    # Build a weight where row d has value 1 at the (c=d%3, kh=0, kw=0) pixel
+    # only. In HF's spatial-first layout that pixel is at flat index c (since
+    # the first p*p indices cover c=0 across all kh,kw...wait no, HF order
+    # is kh,kw,c so position (0,0,c=d%3) sits at flat index 0*(p*3) + 0*3 + (d%3) = d%3).
+    hf_patch_w = torch.zeros(D, p * p * 3)
+    for d in range(D):
+        c = d % 3
+        # HF flat index for (kh=0, kw=0, c): 0*(p*3) + 0*3 + c = c.
+        hf_patch_w[d, c] = 1.0
+
+    hf_sd = _synthetic_hf_state_dict(cfg)
+    hf_sd["model.vision_backbone.image_vit.patch_embedding.weight"] = hf_patch_w
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf_sd, cfg)
+    our_w = converted["vision.patch_embedding.weight"]
+    # In our C-first layout, (c, kh=0, kw=0) sits at flat index c*(p*p) + 0*p + 0 = c*p*p.
+    for d in range(D):
+        c = d % 3
+        assert our_w[d, c * p * p].item() == 1.0
+        # All other positions should be zero.
+        assert (our_w[d] != 0).sum().item() == 1
+
+
+def test_missing_key_raises_helpful_error():
+    cfg = _tiny_cfg()
+    hf_sd = _synthetic_hf_state_dict(cfg)
+    del hf_sd["model.transformer.wte.embedding"]
+    with pytest.raises(Molmo2LoaderError, match="model.transformer.wte.embedding"):
+        molmo2_hf_state_dict_to_multimodal_lm(hf_sd, cfg)
+
+
+def test_forward_runs_with_converted_weights():
+    """Sanity: a model loaded with converter output runs a forward without errors."""
+    cfg = _tiny_cfg()
+    model = MultimodalLM(cfg, init_device="cpu")
+    hf_sd = _synthetic_hf_state_dict(cfg)
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf_sd, cfg)
+    model.load_state_dict(converted, strict=False)
+    model.eval()
+    # Text-only forward.
+    out = model(input_ids=torch.randint(0, 100, (1, 8)))
+    assert out.shape == (1, 8, cfg.lm.vocab_size)
+    assert torch.isfinite(out).all()

--- a/src/test/nn/vision/molmo2_logits_parity_test.py
+++ b/src/test/nn/vision/molmo2_logits_parity_test.py
@@ -1,0 +1,292 @@
+"""
+LM and full-pipeline logit parity between HF Molmo2 and our
+:class:`MultimodalLM` after loading converted weights.
+
+Three sub-tests, each peels off another layer of the model:
+
+1. **Token embedding parity** — :class:`Molmo2Embedding` (HF) vs our
+   concatenated :class:`nn.Embedding` produce identical activations.
+2. **LM-only forward parity** — feed the same input embeddings through
+   HF's text transformer and ours; compare last-token logits. Validates
+   every LM block (attention + SwiGLU) and the LM head row layout.
+3. **Full multimodal pipeline parity** — random pre-patchified image
+   through the vision encoder, connector, embedding splice, then LM;
+   compare last-token logits at a position where image features are
+   spliced. Validates the channel-vs-spatial patch-embedding permute and
+   the connector indexing semantics end-to-end.
+
+Bypasses HF's :class:`AutoProcessor` because the bundled Molmo2 code
+depends on a newer ``transformers.video_utils`` API than what we have
+installed. We feed already-shaped tensors to HF's lower-level forward
+paths instead.
+"""
+
+import os
+
+import pytest
+import torch
+
+from olmo_core.nn.vision import MultimodalLM
+from olmo_core.nn.vision.molmo2_loader import (
+    ensure_default_rope_registered,
+    molmo2_config_from_hf_config,
+    molmo2_hf_state_dict_to_multimodal_lm,
+    reinit_rope_buffers,
+)
+from olmo_core.testing import requires_gpu
+
+transformers = pytest.importorskip("transformers")
+
+MOLMO2_VARIANTS = [
+    "allenai/Molmo2-4B",
+    "allenai/Molmo2-8B",
+    "allenai/Molmo2-O-7B",
+]
+
+
+def _hf_cache_has(model_id: str) -> bool:
+    suffix = "models--" + model_id.replace("/", "--")
+    candidates = [os.path.expanduser("~/.cache/huggingface/hub")]
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        candidates.append(os.path.join(hf_home, "hub"))
+    return any(os.path.isdir(os.path.join(root, suffix)) for root in candidates if root)
+
+
+def _build_ours(model_id: str, device, dtype):
+    """Load HF Molmo2, build our model + converted weights. Returns
+    (hf_model on CPU, ours on `device` with `dtype`, our config)."""
+    ensure_default_rope_registered()
+    from transformers import AutoModelForImageTextToText
+
+    ensure_default_rope_registered()
+    try:
+        hf = AutoModelForImageTextToText.from_pretrained(
+            model_id, trust_remote_code=True, local_files_only=True
+        )
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"Could not load {model_id}: {e}")
+    reinit_rope_buffers(hf)
+    cfg = molmo2_config_from_hf_config(hf.config)
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf.state_dict(), cfg)
+    ours = MultimodalLM(cfg, init_device="meta")
+    ours.to_empty(device=torch.device("cpu"))
+    ours.load_state_dict(converted, strict=False)
+    del converted
+    ours = ours.to(device=device, dtype=dtype).eval()
+    return hf, ours, cfg
+
+
+# ---------------------------------------------------------------------------
+# Token embedding parity
+# ---------------------------------------------------------------------------
+
+
+@requires_gpu
+@pytest.mark.parametrize("model_id", MOLMO2_VARIANTS)
+def test_molmo2_embedding_parity(model_id: str):
+    """``Molmo2Embedding(input_ids) == ours.lm.embeddings(input_ids)``."""
+    if not _hf_cache_has(model_id):
+        pytest.skip(f"{model_id} not in HF cache")
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    hf, ours, cfg = _build_ours(model_id, device, dtype)
+
+    hf_emb = hf.model.transformer.wte.to(device=device, dtype=dtype)
+    torch.manual_seed(0)
+    # Include some image-extra-vocab IDs so we exercise new_embedding.
+    base_vocab = cfg.lm.vocab_size - 128
+    ids = (
+        torch.cat(
+            [
+                torch.randint(0, base_vocab, (4,)),
+                torch.tensor([cfg.image_patch_token_id, base_vocab + 5]),
+            ]
+        )
+        .unsqueeze(0)
+        .to(device)
+    )
+
+    with torch.inference_mode():
+        hf_e = hf_emb(ids)
+        our_e = ours.lm.embeddings(ids)
+
+    diff = (hf_e.float() - our_e.float()).abs().max().item()
+    assert diff < 1e-3, f"{model_id}: embedding diff = {diff:.3e}"
+
+
+# ---------------------------------------------------------------------------
+# LM-only forward parity (text-only)
+# ---------------------------------------------------------------------------
+
+
+@requires_gpu
+@pytest.mark.parametrize("model_id", MOLMO2_VARIANTS)
+def test_molmo2_lm_forward_parity(model_id: str):
+    """HF text transformer and ours produce the same last-token logits given
+    the same ``inputs_embeds`` (no images, pure LM block + head parity).
+
+    .. note::
+        Molmo2-O-7B uses per-layer YaRN attention scaling
+        (``attention_factor ≈ 1.208``) on 24 of its 32 LM layers.
+        :class:`MultimodalLM` applies a single global RoPE config
+        and does not support per-layer attention factors, so the logit
+        magnitudes for O-7B differ from HF's reference.  The test is skipped
+        for O-7B until per-layer YaRN is implemented.
+    """
+    if not _hf_cache_has(model_id):
+        pytest.skip(f"{model_id} not in HF cache")
+    if "O-7B" in model_id:
+        pytest.skip(
+            f"{model_id} uses per-layer YaRN attention scaling which is not "
+            f"yet implemented in MultimodalLM; logit parity skipped."
+        )
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    hf, ours, cfg = _build_ours(model_id, device, dtype)
+
+    # Random text-only input.
+    torch.manual_seed(0)
+    base_vocab = cfg.lm.vocab_size - 128
+    input_ids = torch.randint(0, base_vocab, (1, 12), device=device)
+
+    # HF: full forward (no images, no cache to avoid Molmo2's transformers
+    # version pin causing CacheLayerMixin signature mismatches).
+    hf = hf.to(device=device, dtype=dtype).eval()
+    with torch.inference_mode():
+        hf_out = hf(input_ids=input_ids, use_cache=False)
+    hf_last = hf_out.logits[0, -1].float()
+
+    # Ours: full forward (no images). Our lm_head is padded with zero rows
+    # for the image-token positions, so compare only the base-vocab slice.
+    with torch.inference_mode():
+        our_logits = ours(input_ids=input_ids, logits_to_keep=1)
+    our_last = our_logits[0, -1].float()[: hf_last.shape[0]]
+
+    diff = (hf_last - our_last).abs().max().item()
+    hf_argmax = int(hf_last.argmax().item())
+    our_argmax = int(our_last.argmax().item())
+    assert hf_argmax == our_argmax, (
+        f"{model_id}: LM argmax mismatch — HF={hf_argmax} ours={our_argmax}, "
+        f"max abs diff = {diff:.3e}"
+    )
+    assert diff < 1.0, f"{model_id}: LM logit max abs diff = {diff:.3e} (threshold 1.0 in bf16)"
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline parity (vision + connector + LM)
+# ---------------------------------------------------------------------------
+
+
+@requires_gpu
+@pytest.mark.parametrize("model_id", MOLMO2_VARIANTS)
+def test_molmo2_full_pipeline_logit_parity(model_id: str):
+    """End-to-end: same random pre-patchified image + same prompt token IDs
+    feeding both HF Molmo2 and ours; assert the last-token logits match.
+
+    .. note::
+        Molmo2-O-7B uses per-layer YaRN attention scaling
+        (``attention_factor ≈ 1.208``) on 24 of its 32 LM layers.
+        :class:`MultimodalLM` applies a single global RoPE config
+        and does not support per-layer attention factors, so full-pipeline
+        argmax may diverge for O-7B.  The test is skipped for O-7B until
+        per-layer YaRN is implemented.
+    """
+    if not _hf_cache_has(model_id):
+        pytest.skip(f"{model_id} not in HF cache")
+    if "O-7B" in model_id:
+        pytest.skip(
+            f"{model_id} uses per-layer YaRN attention scaling which is not "
+            f"yet implemented in MultimodalLM; full-pipeline parity skipped."
+        )
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    hf, ours, cfg = _build_ours(model_id, device, dtype)
+    hf = hf.to(device=device, dtype=dtype).eval()
+
+    # Build a tiny synthetic image-bearing input.
+    # 1 crop, 27x27 = 729 patches → with 2x2 pool, 196 pooled tokens... but
+    # to keep the test cheap we use a single-pool layout: 1 pool over 4 patches.
+    # That means 1 <im_patch> token. For the model's splice contract we
+    # must put 1 <im_patch> in input_ids and provide pooled_patches_idx
+    # with shape (1, 1, 4) covering patches [0, 1, 2, 3].
+    torch.manual_seed(0)
+    patch_size = cfg.vision.image_patch_size
+    n_patches = cfg.vision.image_num_pos  # 729
+
+    # HF: pixel_values shape (n_crops, n_patches, patch_dim) — spatial-first.
+    pixel_values_hf = torch.randn(
+        1, n_patches, 3 * patch_size * patch_size, dtype=dtype, device=device
+    )
+    # Pool 1 group of 4 patches into 1 image-token.
+    image_token_pooling = torch.zeros(1, 4, dtype=torch.long, device=device)
+    image_token_pooling[0, 0] = 0
+    image_token_pooling[0, 1] = 1
+    image_token_pooling[0, 2] = 2
+    image_token_pooling[0, 3] = 3
+    # image_grids: (1, 4) → low-res 1x1 + high-res 0x0 → 1 + 0 = 1 pooled.
+    image_grids = torch.tensor([[1, 1, 0, 0]], dtype=torch.long, device=device)
+    image_num_crops = torch.tensor([1], dtype=torch.long, device=device)
+
+    # input_ids: a short prompt with exactly one image_patch_id and EXACTLY
+    # 2 image_end_token_id tokens (HF's build_batched_images counts these
+    # to infer the number of images: raw_counts // 2). We follow with a few
+    # text tokens so the last-position logit reflects post-image LM activity.
+    image_end_id = hf.config.image_end_token_id
+    image_patch_id = hf.config.image_patch_id
+    base_vocab = cfg.lm.vocab_size - 128
+    text = torch.randint(0, base_vocab, (4,), device=device).tolist()
+    input_ids = torch.tensor(
+        [[image_end_id, image_patch_id, image_end_id] + text],
+        dtype=torch.long,
+        device=device,
+    )
+
+    # ---------- HF forward ----------
+    with torch.inference_mode():
+        hf_out = hf(
+            input_ids=input_ids,
+            pixel_values=pixel_values_hf,
+            image_token_pooling=image_token_pooling,
+            image_grids=image_grids,
+            image_num_crops=image_num_crops,
+            use_cache=False,
+        )
+    hf_last = hf_out.logits[0, -1].float()
+
+    # ---------- ours: convert inputs ----------
+    # pixel_values: spatial-first (kh, kw, c). Our model expects C-first.
+    pv_ours = (
+        pixel_values_hf.reshape(1, n_patches, patch_size, patch_size, 3)
+        .permute(0, 1, 4, 2, 3)
+        .reshape(1, n_patches, 3 * patch_size * patch_size)
+        .contiguous()
+        .unsqueeze(0)  # add batch dim → (1, 1, n_patches, dim)
+    )
+    pooled_idx_ours = image_token_pooling.unsqueeze(0)  # (1, 1, 4)
+
+    with torch.inference_mode():
+        our_logits = ours(
+            input_ids=input_ids,
+            images=pv_ours,
+            pooled_patches_idx=pooled_idx_ours,
+            logits_to_keep=1,
+        )
+    # Slice off our padding rows so the shapes match HF.
+    our_last = our_logits[0, -1].float()[: hf_last.shape[0]]
+
+    diff = (hf_last - our_last).abs().max().item()
+    hf_argmax = int(hf_last.argmax().item())
+    our_argmax = int(our_last.argmax().item())
+    assert hf_argmax == our_argmax, (
+        f"{model_id}: full-pipeline argmax mismatch — HF={hf_argmax} "
+        f"ours={our_argmax}, max abs diff = {diff:.3e}"
+    )
+    assert diff < 5.0, (
+        f"{model_id}: full-pipeline logit max abs diff = {diff:.3e} "
+        f"(threshold 5.0 in bf16; the splice + 32+ LM layers amplify the "
+        f"per-component noise)"
+    )

--- a/src/test/nn/vision/molmo2_parity_test.py
+++ b/src/test/nn/vision/molmo2_parity_test.py
@@ -1,0 +1,167 @@
+"""
+Numerical-parity tests for the HF Molmo2 → :class:`MultimodalLM`
+state-dict converter.
+
+Loads a real Molmo2 checkpoint from the local HuggingFace cache, runs the
+converter, loads the converted weights into our model, and verifies:
+
+1. Every parameter our model expects gets a tensor of the right shape.
+2. The vision encoder produces numerically identical hidden states given the
+   same pre-patchified input (after permuting the input from HF's spatial-first
+   patch convention to our channel-first convention).
+
+The full multimodal forward (LM + connector) is not asserted here because it
+requires holding both models in memory at once (the 8B variant is ~32GB in
+fp32 and our model would need another ~30GB). Loading-success + vision-parity
+is sufficient evidence the converter is correct end-to-end, given the unit
+tests in ``molmo2_loader_test.py`` already verified the QKV split, SwiGLU
+chunk, and patch-embedding permute semantically.
+
+These tests auto-skip when the corresponding HF checkpoint is not cached
+locally — they're not meant for default CI.
+"""
+
+import os
+
+import pytest
+import torch
+
+from olmo_core.nn.vision import MultimodalLM
+from olmo_core.nn.vision.molmo2_loader import (
+    ensure_default_rope_registered,
+    molmo2_config_from_hf_config,
+    molmo2_hf_state_dict_to_multimodal_lm,
+    reinit_rope_buffers,
+)
+from olmo_core.testing import requires_gpu
+
+transformers = pytest.importorskip("transformers")
+
+MOLMO2_VARIANTS = [
+    "allenai/Molmo2-4B",
+    "allenai/Molmo2-8B",
+    "allenai/Molmo2-O-7B",
+]
+
+
+def _hf_cache_has(model_id: str) -> bool:
+    """Cheap check for whether the HF snapshot lives in any cache root."""
+    suffix = "models--" + model_id.replace("/", "--")
+    candidates = [
+        os.path.expanduser("~/.cache/huggingface/hub"),
+        os.environ.get("HF_HOME", ""),
+    ]
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        candidates.append(os.path.join(hf_home, "hub"))
+    for root in candidates:
+        if root and os.path.isdir(os.path.join(root, suffix)):
+            return True
+    return False
+
+
+def _load_hf(model_id: str):
+    """Load an HF Molmo2 model from the local cache, fp32. Skips on failure."""
+    ensure_default_rope_registered()
+    from transformers import AutoModelForImageTextToText
+
+    try:
+        hf = AutoModelForImageTextToText.from_pretrained(
+            model_id, trust_remote_code=True, local_files_only=True
+        )
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"Could not load {model_id}: {e}")
+    reinit_rope_buffers(hf)
+    return hf
+
+
+def _patchify_spatial_to_c_first(img_spatial: torch.Tensor, patch_size: int) -> torch.Tensor:
+    """Convert a pre-patchified tensor from HF's ``(kh, kw, c)`` flatten order
+    to our ``(c, kh, kw)`` order. Both correspond to the same pixels — only
+    the per-patch channel-vs-spatial ordering differs.
+
+    Mirrors the inverse of :func:`molmo2_loader._convert_patch_embedding`:
+    the converter permutes the *weight* from spatial-first to C-first; here
+    we permute the *activations* the other way so the dot product gives the
+    same result on either side.
+    """
+    B, N, _ = img_spatial.shape
+    return (
+        img_spatial.reshape(B, N, patch_size, patch_size, 3)
+        .permute(0, 1, 4, 2, 3)
+        .reshape(B, N, 3 * patch_size * patch_size)
+        .contiguous()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@requires_gpu
+@pytest.mark.parametrize("model_id", MOLMO2_VARIANTS)
+def test_molmo2_converter_loads_and_vision_matches(model_id: str):
+    """Load HF Molmo2 → run converter → load into our model → confirm
+    parameter coverage + vision-encoder forward-pass parity.
+
+    Vision encoder is the only piece moved to CUDA for the forward pass; the
+    full LM + connector stay on CPU to avoid OOM when both HF and our model
+    must coexist (Molmo2-8B is ~32GB in fp32).
+    """
+    if not _hf_cache_has(model_id):
+        pytest.skip(f"{model_id} not in HF cache")
+
+    device = torch.device("cuda")
+    hf = _load_hf(model_id)
+
+    # Build our config from the HF config and convert weights.
+    cfg = molmo2_config_from_hf_config(hf.config)
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf.state_dict(), cfg)
+
+    # Materialize our model on CPU and load the converted state dict.
+    model = MultimodalLM(cfg, init_device="meta")
+    model.to_empty(device=torch.device("cpu"))
+    missing, unexpected = model.load_state_dict(converted, strict=False)
+    del converted
+
+    # Strict on parameters: no LM / vision / connector weight may be unloaded.
+    param_keys = {k for k, _ in model.named_parameters()}
+    missing_params = set(missing) & param_keys
+    assert not missing_params, (
+        f"{model_id}: converter didn't load these params: " f"{sorted(missing_params)[:10]}"
+    )
+    unexpected_params = set(unexpected) & param_keys
+    assert not unexpected_params, (
+        f"{model_id}: converter produced unknown params: " f"{sorted(unexpected_params)[:10]}"
+    )
+
+    # Move just the vision encoders to CUDA for the forward pass.
+    hf_vit = hf.model.vision_backbone.image_vit.eval().to(device)
+    our_vit = model.vision.eval().to(device)
+
+    # Build a random pre-patchified image and a matching C-first-permuted
+    # copy for our side.
+    torch.manual_seed(0)
+    n_patches = cfg.vision.image_num_pos  # 729 for SO400M/14-378
+    patch_size = cfg.vision.image_patch_size
+    img_hf = torch.randn(
+        1, n_patches, 3 * patch_size * patch_size, dtype=torch.float32, device=device
+    )
+    img_ours = _patchify_spatial_to_c_first(img_hf, patch_size)
+
+    h, w = cfg.vision.image_default_input_size
+    patch_num = (h // patch_size, w // patch_size)
+
+    with torch.inference_mode():
+        hf_hidden = hf_vit(img_hf)
+        our_hidden = our_vit(img_ours, patch_num=patch_num)
+
+    # Compare every ViT layer that the connector actually reads. ~5e-3 is
+    # well within fp32 noise for 25 transformer layers under SDPA on GPU,
+    # while still tight enough to catch real architecture mismatches.
+    for layer in cfg.vit_layers:
+        diff = (hf_hidden[layer] - our_hidden[layer]).abs().max().item()
+        assert diff < 5e-3, (
+            f"{model_id}: vision layer {layer} max abs diff = {diff:.2e} " f"(threshold 5e-3)"
+        )


### PR DESCRIPTION
> Supersedes #693. **Targets the `vision` branch** — the integration branch for the multimodal stack now that [1/n] (#692) is merged to main (`vision` currently equals that merge commit). Diff is the Molmo2 loader only, rebased to a single commit.

## Summary

2nd PR in the VLM stack building Molmo2-style multimodal support.

- [1/n] Vision architecture (#692)
- **[2/n] This PR — HF Molmo2 loader**

1. **`molmo2_loader.py`** — HF Molmo2 → `MultimodalLM` weight converter handling three architecture deltas:
   - **Embedding split**: concatenates HF's `wte.embedding` + `wte.new_embedding` into one flat `embeddings.weight`
   - **Fused QKV + gated MLP**: splits `att_proj` → `w_q`/`w_k`/`w_v` and `ff_proj` → `w1`/`w3`
   - **Patch-embedding flatten order**: permutes spatial-first `(kh,kw,c)` HF weights to channel-first `(c,kh,kw)`

   Also exports two public helpers for transformers 5.x compatibility:
   - `ensure_default_rope_registered()` — re-registers `ROPE_INIT_FUNCTIONS["default"]` before `from_pretrained`
   - `reinit_rope_buffers(model)` — re-runs `rope_init_fn` after loading to fix uninitialised `inv_freq` buffers

2. **Parity tests** (`molmo2_parity_test.py`, `molmo2_logits_parity_test.py`):
   - Vision encoder: max abs diff < 5e-3 in fp32 at every ViT layer the connector reads
   - Embedding: < 1e-3 in bf16
   - LM-only forward and full pipeline (4B and 8B)

3. **Generation test** (`molmo2_generation_test.py`):
   - PIL-based single-crop preprocessor (no torchvision) — resize → SigLIP2 normalize → patchify → 2×2 pool
   - Synthetic RGB gradient image + prompt `"What colors do you see?"` → greedy-decode 8 tokens
   - Asserts our model's token IDs match HF exactly step-by-step

## Parity results (bfloat16, GPU)

| Variant | Embedding diff | LM argmax | LM max diff | Full pipeline argmax | Generation (8 tok) |
|---------|---------------|-----------|-------------|---------------------|-------------------|
| Molmo2-4B | < 1e-3 | ✅ match | **0.125** (thr 1.0) | ✅ match | ✅ exact match |
| Molmo2-8B | < 1e-3 | ✅ match | **0.313** (thr 1.0) | ✅ match | (4B only tested) |
| Molmo2-O-7B | < 1e-3 | — | ⚠️ skipped | ⚠️ skipped | — |

Vision-encoder layer parity (fp32, all 3 variants): max abs diff < 5e-3 ✅

O-7B logit tests skipped: uses per-layer YaRN attention scaling (`attention_factor ≈ 1.208`) on 24/32 LM layers; `MultimodalLM` uses a single global RoPE config. Vision-encoder and embedding parity still pass for O-7B.

## Generation QA (Molmo2-4B, bf16)

Prompt: image of a synthetic RGB gradient (red↗ green↗ blue=flat) + `"What colors do you see?"`

```
Question : What colors do you see?
HF output: The colors I see in this image are:
           - Blue
           - Purple
           - Pink
           - Green
Our output: The colors I see in this image are:
            - Blue
            - Purple
            - Pink
            - Green
Token IDs (HF = ours): [785, 7987, 358, 1490, 304, 419, 2168, 525]
```

Both models produce **identical token IDs** for all 8 greedy-decode steps, and the answer is semantically coherent for the image content.

## transformers 5.x RoPE compat

transformers 5.8.1 removed `ROPE_INIT_FUNCTIONS["default"]` and its fast-init (meta-device) leaves non-persistent `inv_freq` buffers uninitialised. The two-step fix lives in `molmo2_loader.py`:

```python
ensure_default_rope_registered()  # before from_pretrained
hf = AutoModelForImageTextToText.from_pretrained(model_id, trust_remote_code=True)
reinit_rope_buffers(hf)            # after from_pretrained
```

## Test command

```bash
# Requires Molmo2 checkpoints in HF cache; auto-skips otherwise
pytest -v src/test/nn/vision/molmo2_parity_test.py \
          src/test/nn/vision/molmo2_logits_parity_test.py \
          src/test/nn/vision/molmo2_generation_test.py
```

---


## Verification on the rebased tip (`035f86fa`)

- **Full vision suite: 88 passed, 2 skipped** (4m40s) — includes real-checkpoint Molmo2 **4B/8B vision, logit, and generation parity**. The 2 skips are the intentional Molmo2-O-7B per-layer-YaRN cases.
- `ruff` / `mypy` / `isort` / `black` all clean.
- The rebase onto `vision` is content-identical to the previously tested commit (same git tree), and the suite was re-run fresh on the rebased tip to confirm.

## Review feedback from #693 — status

| Comment | Status |
|---|---|
| `molmo2_loader_test.py` imports `olmo_core.data.multimodal` (doesn't exist yet) | ✅ Fixed — test now owns a self-contained base/extra vocab split (120+8), no forward dependency; the embedding-split path is actually exercised now |
| `torch.zeros(...)` padding fails when the HF state dict is on CUDA | ✅ Fixed — uses `hf_lm_head.new_zeros(...)`, preserving device and dtype |
| HF-config → factory dispatch is a growing, hard-to-maintain list that ignores many HF fields | ✅ TODO added on `_build_lm_config` to replace the preset-matching table with a generic builder constructing `TransformerConfig` directly from HF fields |
| Zero-padded extra-vocab `lm_head` rows give finite logits and shift the loss vs HF | ✅ Documented (not masked here) — the misleading "matches HF exactly" comment is corrected; exact **loss** parity requires masking those output IDs to `-inf` at the loss/forward layer, which is out of scope for a weight converter and deferred to the training/eval PRs. Argmax/generation parity is unaffected, and the logit-parity tests compare base-vocab columns only |
