### PR TITLE
Add async all-to-all to ops.moe

### DIFF
--- a/src/olmo_core/ops/moe.py
+++ b/src/olmo_core/ops/moe.py
@@ -289,6 +289,30 @@ class AllToAllAsyncOp(torch.autograd.Function):
     later blocks on the handle. The work handle and the metadata needed by the wait /
     backward passes are stashed as attributes on the output tensor (``_a2a_*``) so they
     travel through autograd without extra ``ctx`` plumbing across the two ops.
+
+    The backward mirrors the forward, so the gradient all-to-all overlaps too:
+    ``AllToAllWaitOp.backward`` launches the reverse all-to-all and ``AllToAllAsyncOp.backward``
+    waits on it. The in-flight handle is handed between them by stashing it on the gradient of
+    the passthrough ``x``.
+
+    That handoff only works if ``x`` has a single consumer (the matching
+    :func:`all_to_all_wait`), because Python attributes don't survive tensor arithmetic.
+    Tracing the gradient of ``x``:
+
+    - One consumer (correct)::
+
+        WaitOp.backward -> x_grad (._a2a_handle attached)
+                        -> AsyncOp.backward gets that same tensor -> handle found, waited
+
+    - Two consumers / fan-out (wrong)::
+
+        WaitOp.backward -> grad_A (._a2a_handle attached)
+        the other op    -> grad_B (no attribute)
+        autograd sums   -> grad_A + grad_B = a NEW tensor (handle lost)
+                        -> AsyncOp.backward gets the new tensor -> handle missing -> raises
+
+    The guard in ``AllToAllAsyncOp.backward`` turns the fan-out case into a clear error instead
+    of a silent desync. The single-consumer contract is not otherwise enforced.
     """
 
     @staticmethod
@@ -322,8 +346,18 @@ class AllToAllAsyncOp(torch.autograd.Function):
     @staticmethod
     def backward(ctx, *grad_outputs):
         x_grad = grad_outputs[0]
-        x_grad_handle = x_grad._a2a_handle
-        x_grad_handle.wait()
+        # The reverse all-to-all handle was stashed on this gradient by AllToAllWaitOp.backward.
+        # If it's missing, the passthrough was fanned out to more than one consumer: autograd
+        # summed the gradients into a fresh tensor, which dropped the attribute (see class doc).
+        handle = getattr(x_grad, "_a2a_handle", None)
+        if handle is None:
+            raise RuntimeError(
+                "all_to_all_async backward could not find its in-flight gradient handle. The "
+                "passthrough tensor returned by all_to_all_async must feed ONLY the matching "
+                "all_to_all_wait; fanning it out to other ops makes autograd accumulate "
+                "gradients into a new tensor that drops the stashed handle."
+            )
+        handle.wait()
         del x_grad._a2a_handle
         return x_grad, None, None, None, None
 

--- a/src/olmo_core/ops/moe.py
+++ b/src/olmo_core/ops/moe.py
@@ -280,6 +280,141 @@ def all_to_all(
     )
 
 
+class AllToAllAsyncOp(torch.autograd.Function):
+    """
+    Autograd function backing :func:`all_to_all_async` / :func:`all_to_all_wait`.
+
+    :func:`all_to_all_async` launches the all-to-all and returns immediately so the
+    caller can overlap unrelated compute with the communication; :func:`all_to_all_wait`
+    later blocks on the handle. The work handle and the metadata needed by the wait /
+    backward passes are stashed as attributes on the output tensor (``_a2a_*``) so they
+    travel through autograd without extra ``ctx`` plumbing across the two ops.
+    """
+
+    @staticmethod
+    def forward(ctx, x, output_split_sizes, input_split_sizes, group):
+        if output_split_sizes is not None:
+            y = torch.empty(
+                (sum(output_split_sizes),) + x.shape[1:], device=x.device, dtype=x.dtype
+            )
+        else:
+            y = torch.empty_like(x)
+
+        ctx.output_split_sizes = output_split_sizes
+        ctx.input_split_sizes = input_split_sizes
+        ctx.group = group
+        y_handle = dist.all_to_all_single(
+            y,
+            x.contiguous(),
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=group,
+            async_op=True,
+        )
+        # Carry the metadata the matching AllToAllWaitOp needs on the output tensor.
+        setattr(y, "_a2a_input_shape", x.shape)
+        setattr(y, "_a2a_output_split_sizes", output_split_sizes)
+        setattr(y, "_a2a_input_split_sizes", input_split_sizes)
+        setattr(y, "_a2a_group", group)
+
+        return x, y, y_handle
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        x_grad = grad_outputs[0]
+        x_grad_handle = x_grad._a2a_handle
+        x_grad_handle.wait()
+        del x_grad._a2a_handle
+        return x_grad, None, None, None, None
+
+
+class AllToAllWaitOp(torch.autograd.Function):
+    """Completion half of :class:`AllToAllAsyncOp` (see :func:`all_to_all_wait`)."""
+
+    @staticmethod
+    def forward(ctx, x, y, y_handle):
+        # y is the output tensor from AllToAllAsyncOp; read the stashed input shape
+        # rather than y.shape (which is the post-all-to-all shape).
+        ctx.input_shape = y._a2a_input_shape
+        ctx.output_split_sizes = y._a2a_output_split_sizes
+        ctx.input_split_sizes = y._a2a_input_split_sizes
+        ctx.group = y._a2a_group
+        del y._a2a_output_split_sizes
+        del y._a2a_input_split_sizes
+        del y._a2a_group
+        del y._a2a_input_shape
+
+        y_handle.wait()
+        return y
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        y_grad = grad_outputs[0]
+        x_grad = torch.empty(
+            ctx.input_shape,
+            device=y_grad.device,
+            dtype=y_grad.dtype,
+        )
+        x_grad_handle = dist.all_to_all_single(
+            x_grad,
+            y_grad.contiguous(),
+            output_split_sizes=ctx.input_split_sizes,
+            input_split_sizes=ctx.output_split_sizes,
+            group=ctx.group,
+            async_op=True,
+        )
+        # Stash the in-flight handle on the gradient; AllToAllAsyncOp.backward waits on it.
+        setattr(x_grad, "_a2a_handle", x_grad_handle)
+        return x_grad, y_grad, None
+
+
+@torch._dynamo.disable()
+def all_to_all_async(
+    x: torch.Tensor,
+    output_split_sizes: Optional[List[int]] = None,
+    input_split_sizes: Optional[List[int]] = None,
+    group: Optional[dist.ProcessGroup] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, dist.Work]:
+    """
+    Launch a non-blocking all-to-all and return without waiting on it.
+
+    Pairs with :func:`all_to_all_wait` to overlap communication with compute::
+
+        x, y, handle = all_to_all_async(x, ...)
+        z = some_independent_compute(x)   # overlaps with the all-to-all
+        y = all_to_all_wait(x, y, handle) # blocks until the transfer is done
+
+    :param x: The local input tensor (sharded along dim 0).
+    :param output_split_sizes: Per-rank receive counts; ``None`` for an even split.
+    :param input_split_sizes: Per-rank send counts; ``None`` for an even split.
+    :param group: The process group to communicate over.
+
+    :returns: ``(x, y, handle)`` — the (unchanged) input ``x``, the output buffer ``y``
+        (not yet valid until waited on), and the in-flight work ``handle``.
+    """
+    return AllToAllAsyncOp.apply(  # type: ignore
+        x,
+        output_split_sizes,
+        input_split_sizes,
+        group,
+    )
+
+
+@torch._dynamo.disable()
+def all_to_all_wait(x: torch.Tensor, y: torch.Tensor, y_handle: dist.Work) -> torch.Tensor:
+    """
+    Block until the all-to-all launched by :func:`all_to_all_async` completes.
+
+    :param x: The original input tensor returned by :func:`all_to_all_async` (kept in the
+        autograd graph so the backward all-to-all is wired correctly).
+    :param y: The output buffer returned by :func:`all_to_all_async`.
+    :param y_handle: The work handle returned by :func:`all_to_all_async`.
+
+    :returns: The completed output tensor ``y``.
+    """
+    return AllToAllWaitOp.apply(x, y, y_handle)  # type: ignore
+
+
 def sum_tensor(x: torch.Tensor, dim: int = 0) -> torch.Tensor:
     if x.shape[dim] == 1:
         return x.squeeze(dim=dim)

--- a/src/olmo_core/ops/moe.py
+++ b/src/olmo_core/ops/moe.py
@@ -391,6 +391,14 @@ def all_to_all_async(
 
     :returns: ``(x, y, handle)`` — the (unchanged) input ``x``, the output buffer ``y``
         (not yet valid until waited on), and the in-flight work ``handle``.
+
+    .. warning::
+        The returned passthrough ``x`` must feed **only** the matching
+        :func:`all_to_all_wait` — do not fan it out to other ops. The backward all-to-all
+        handle is stashed as an attribute on ``x``'s gradient and carried along that single
+        autograd edge from :class:`AllToAllWaitOp` to :class:`AllToAllAsyncOp`. If ``x`` has
+        more than one consumer, autograd sums the incoming gradients into a fresh tensor that
+        drops the stashed handle, breaking the backward pass. This contract is not enforced.
     """
     return AllToAllAsyncOp.apply(  # type: ignore
         x,

--- a/src/olmo_core/ops/moe.py
+++ b/src/olmo_core/ops/moe.py
@@ -415,7 +415,7 @@ def all_to_all_async(
     Pairs with :func:`all_to_all_wait` to overlap communication with compute::
 
         x, y, handle = all_to_all_async(x, ...)
-        z = some_independent_compute(x)   # overlaps with the all-to-all
+        z = some_independent_compute(w)   # overlaps; note: NOT on x (see warning)
         y = all_to_all_wait(x, y, handle) # blocks until the transfer is done
 
     :param x: The local input tensor (sharded along dim 0).
@@ -433,6 +433,22 @@ def all_to_all_async(
         autograd edge from :class:`AllToAllWaitOp` to :class:`AllToAllAsyncOp`. If ``x`` has
         more than one consumer, autograd sums the incoming gradients into a fresh tensor that
         drops the stashed handle, breaking the backward pass. This contract is not enforced.
+
+    .. note::
+        The *only* thing this op adds over the existing ``all_to_all(..., async_op=True)``
+        (which already returns a work handle, giving forward comm/compute overlap) is
+        overlap of the **backward** gradient all-to-all, via the paired-``Function`` design.
+        So it pays off only when ``backward()`` runs. The synchronous EP strategies that use
+        it are, in practice, mostly the **eval/inference** path (no-sync configs fall back to
+        them at eval because no-sync can hang on uneven per-rank token counts) — and eval runs
+        no backward, so there this is equivalent to a plain async ``all_to_all`` but with the
+        passthrough footgun above. Production *training* uses the no-sync (symmetric-memory)
+        path, which doesn't use this op at all; only a few sync-training debug/ablation runs
+        actually exercise the backward overlap.
+
+        TODO: revisit whether this op earns its keep. If the sync EP path can use
+        ``all_to_all(..., async_op=True)`` for its forward overlap, consider dropping
+        ``all_to_all_async`` / ``all_to_all_wait`` (and their passthrough footgun) entirely.
     """
     return AllToAllAsyncOp.apply(  # type: ignore
         x,

--- a/src/test/ops/moe_test.py
+++ b/src/test/ops/moe_test.py
@@ -3,7 +3,12 @@ import pytest
 import torch
 
 from olmo_core.ops import moe as ops
-from olmo_core.testing import DEVICES, requires_gpu, requires_multi_gpu, run_distributed_test
+from olmo_core.testing import (
+    DEVICES,
+    requires_gpu,
+    requires_multi_gpu,
+    run_distributed_test,
+)
 
 
 @requires_gpu

--- a/src/test/ops/moe_test.py
+++ b/src/test/ops/moe_test.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 
 from olmo_core.ops import moe as ops
-from olmo_core.testing import DEVICES, requires_gpu
+from olmo_core.testing import DEVICES, requires_gpu, requires_multi_gpu, run_distributed_test
 
 
 @requires_gpu
@@ -162,3 +162,41 @@ def test_batched_histc(device: torch.device):
     torch.testing.assert_close(
         hist, torch.tensor([[1, 2, 0, 0, 0], [2, 0, 1, 0, 0]], device=device)
     )
+
+
+def _run_all_to_all_async_matches_sync():
+    import torch.distributed as dist
+
+    from olmo_core.distributed.utils import get_local_rank
+
+    rank = dist.get_rank()
+    local_rank = get_local_rank()
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+
+    # Distinct input per rank; the async path and the synchronous reference run on the
+    # same values, so output + gradient must match exactly.
+    torch.manual_seed(42 + rank)
+    x = torch.randn(8, 16, device=device, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_(True)
+
+    # Async path: launch, (a real caller overlaps compute here), then wait. The passthrough
+    # tensor returned first must feed only the wait, so the backward handle survives.
+    x_passthrough, y, handle = ops.all_to_all_async(x)
+    y = ops.all_to_all_wait(x_passthrough, y, handle)
+
+    # Synchronous reference.
+    out_ref, _ = ops.all_to_all(x_ref, async_op=False)
+    torch.testing.assert_close(y, out_ref)
+
+    # Backward parity (the custom autograd does the reverse all-to-all).
+    grad = torch.randn_like(y)
+    y.backward(grad)
+    out_ref.backward(grad)
+    assert x.grad is not None and x_ref.grad is not None
+    torch.testing.assert_close(x.grad, x_ref.grad)
+
+
+@requires_multi_gpu
+def test_all_to_all_async_matches_sync():
+    run_distributed_test(_run_all_to_all_async_matches_sync, world_size=2, backend="nccl")


### PR DESCRIPTION
## Summary

Adds an asynchronous all-to-all to `olmo_core.ops.moe` for overlapping the collective with independent compute:

- `AllToAllAsyncOp` / `all_to_all_async(...)` — launches `dist.all_to_all_single(..., async_op=True)` and returns `(x, y, handle)` immediately, where `y` is the output buffer (not yet valid) and `handle` is the in-flight work.
- `AllToAllWaitOp` / `all_to_all_wait(x, y, handle)` — blocks on the handle and returns the completed `y`.

```python
x, y, handle = all_to_all_async(x, ...)
z = some_independent_compute(...)   # overlaps with the transfer
y = all_to_all_wait(x, y, handle)
```

The work handle and the split/shape metadata are stashed on the output tensor (`_a2a_*`) so they thread through the matching wait and the backward pass without extra `ctx` plumbing. The backward mirrors the forward: it launches the reverse all-to-all in the wait's backward and synchronizes it in the async op's backward, so the gradient path overlaps too.

The existing synchronous `all_to_all` / `AllToAllOp` is unchanged.

## Tests

`test_all_to_all_async_matches_sync` — a 2-GPU NCCL test asserting the async path produces the same output **and** input gradients as the synchronous `all_to_all` on identical inputs. Gated with `@requires_multi_gpu`.
