### PR TITLE
Add token permute/unpermute helpers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,7 +182,7 @@ jobs:
               # silently skips. Fail loudly if CUDA is still unavailable.
               pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
                 torch==2.9.1 torchvision torchaudio
-              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
+              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 --ignore-glob='src/test/distributed/checkpoint*' \
                 --ignore-glob='src/test/nn/transformer*' \
@@ -196,10 +196,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
               pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
                 torch==2.9.1 torchvision torchaudio
-              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
+              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/distributed/checkpoint*
 
@@ -207,10 +207,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
               pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
                 torch==2.9.1 torchvision torchaudio
-              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
+              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/nn/transformer*
 
@@ -218,10 +218,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
               pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
                 torch==2.9.1 torchvision torchaudio
-              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
+              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/nn/attention*
 
@@ -229,10 +229,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
               pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
                 torch==2.9.1 torchvision torchaudio
-              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
+              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/nn/moe*
 
@@ -240,10 +240,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
               pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
                 torch==2.9.1 torchvision torchaudio
-              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
+              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/optim*
 
@@ -251,10 +251,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
               pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
                 torch==2.9.1 torchvision torchaudio
-              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
+              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes -m gpu \
                 src/integration_tests/
 
@@ -272,7 +272,7 @@ jobs:
               # if CUDA is still unavailable.
               pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
                 torch==2.10.0 torchvision torchaudio
-              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
+              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/kernels/
     steps:
@@ -332,7 +332,7 @@ jobs:
             --env 'CUBLAS_WORKSPACE_CONFIG=:16:8' \
             --env-secret 'AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID' \
             --env-secret 'AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY' \
-            -- ${{ matrix.task.run }}
+            -- bash -ec "${{ matrix.task.run }}"
 
   release:
     name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,7 +233,7 @@ jobs:
           # image with both torch 2.10 and the CUDA toolkit (nvcc). Their tests are
           # version-gated and skip on the torch 2.9 image above.
           - name: Test MoE kernels (GPU, torch 2.10)
-            image: tianhuat/olmo-core-torch210-2404-cu128
+            image: petew/olmo-core-tch2100cu130-2026-01-23 # tianhuat/olmo-core-torch210-2404-cu128
             gpus: 2
             run: |
               pytest -v --color=yes --durations=3 -m gpu \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,6 +177,12 @@ jobs:
             image: &gpu_test_image tylerr/olmo-core-tch291cu128-2025-11-25
             gpus: 2
             run: |
+              # TEMP: force cu128 torch to match the Beaker CUDA 12.8 driver; the default
+              # torch 2.10 wheel is a CUDA-13 build that fails CUDA init, so every GPU test
+              # silently skips. Fail loudly if CUDA is still unavailable.
+              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
+                torch==2.9.1 torchvision torchaudio
+              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
               pytest -v --color=yes --durations=3 -m gpu \
                 --ignore-glob='src/test/distributed/checkpoint*' \
                 --ignore-glob='src/test/nn/transformer*' \
@@ -190,6 +196,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
+                torch==2.9.1 torchvision torchaudio
+              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/distributed/checkpoint*
 
@@ -197,6 +207,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
+                torch==2.9.1 torchvision torchaudio
+              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/nn/transformer*
 
@@ -204,6 +218,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
+                torch==2.9.1 torchvision torchaudio
+              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/nn/attention*
 
@@ -211,6 +229,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
+                torch==2.9.1 torchvision torchaudio
+              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/nn/moe*
 
@@ -218,6 +240,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
+                torch==2.9.1 torchvision torchaudio
+              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/optim*
 
@@ -225,6 +251,10 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
+              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see "Test (GPU)".
+              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
+                torch==2.9.1 torchvision torchaudio
+              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
               pytest -v --color=yes -m gpu \
                 src/integration_tests/
 
@@ -236,6 +266,14 @@ jobs:
             image: petew/olmo-core-tch2100cu130-2026-01-23 # tianhuat/olmo-core-torch210-2404-cu128
             gpus: 2
             run: |
+              # TEMP: the image is a CUDA-13 build (cu130) but the Beaker driver is CUDA
+              # 12.8, so torch can't init CUDA and every test silently skips. Override torch
+              # with the cu128 build (2.10.0, still has torch.nn.functional.grouped_mm) to
+              # match the driver, and fail loudly if CUDA is still unavailable. Proper fix:
+              # run on newer-driver nodes or use a cu128 image.
+              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
+                torch==2.10.0 torchvision torchaudio
+              python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/kernels/
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,12 +177,6 @@ jobs:
             image: &gpu_test_image tylerr/olmo-core-tch291cu128-2025-11-25
             gpus: 2
             run: |
-              # TEMP: force cu128 torch to match the Beaker CUDA 12.8 driver; the default
-              # torch 2.10 wheel is a CUDA-13 build that fails CUDA init, so every GPU test
-              # silently skips. Fail loudly if CUDA is still unavailable.
-              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
-                torch==2.9.1 torchvision torchaudio
-              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 --ignore-glob='src/test/distributed/checkpoint*' \
                 --ignore-glob='src/test/nn/transformer*' \
@@ -196,10 +190,6 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
-              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
-                torch==2.9.1 torchvision torchaudio
-              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/distributed/checkpoint*
 
@@ -207,10 +197,6 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
-              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
-                torch==2.9.1 torchvision torchaudio
-              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/nn/transformer*
 
@@ -218,10 +204,6 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
-              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
-                torch==2.9.1 torchvision torchaudio
-              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/nn/attention*
 
@@ -229,10 +211,6 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
-              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
-                torch==2.9.1 torchvision torchaudio
-              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/nn/moe*
 
@@ -240,10 +218,6 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
-              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
-                torch==2.9.1 torchvision torchaudio
-              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/optim*
 
@@ -251,10 +225,6 @@ jobs:
             image: *gpu_test_image
             gpus: 2
             run: |
-              # TEMP: force cu128 torch (matches Beaker CUDA 12.8 driver); see Test (GPU) job.
-              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
-                torch==2.9.1 torchvision torchaudio
-              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes -m gpu \
                 src/integration_tests/
 
@@ -266,13 +236,6 @@ jobs:
             image: tianhuat/olmo-core-torch210-2404-cu128
             gpus: 2
             run: |
-              # TEMP: force cu128 torch to match the Beaker CUDA 12.8 driver; the default
-              # torch 2.10 wheel is a CUDA-13 build that fails CUDA init, so every test
-              # silently skips. 2.10.0 still has torch.nn.functional.grouped_mm. Fail loudly
-              # if CUDA is still unavailable.
-              pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
-                torch==2.10.0 torchvision torchaudio
-              python -c 'import torch; assert torch.cuda.is_available()'
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/kernels/
     steps:
@@ -332,7 +295,7 @@ jobs:
             --env 'CUBLAS_WORKSPACE_CONFIG=:16:8' \
             --env-secret 'AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID' \
             --env-secret 'AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY' \
-            -- bash -ec "${{ matrix.task.run }}"
+            -- ${{ matrix.task.run }}
 
   release:
     name: Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,14 +263,13 @@ jobs:
           # image with both torch 2.10 and the CUDA toolkit (nvcc). Their tests are
           # version-gated and skip on the torch 2.9 image above.
           - name: Test MoE kernels (GPU, torch 2.10)
-            image: petew/olmo-core-tch2100cu130-2026-01-23 # tianhuat/olmo-core-torch210-2404-cu128
+            image: tianhuat/olmo-core-torch210-2404-cu128
             gpus: 2
             run: |
-              # TEMP: the image is a CUDA-13 build (cu130) but the Beaker driver is CUDA
-              # 12.8, so torch can't init CUDA and every test silently skips. Override torch
-              # with the cu128 build (2.10.0, still has torch.nn.functional.grouped_mm) to
-              # match the driver, and fail loudly if CUDA is still unavailable. Proper fix:
-              # run on newer-driver nodes or use a cu128 image.
+              # TEMP: force cu128 torch to match the Beaker CUDA 12.8 driver; the default
+              # torch 2.10 wheel is a CUDA-13 build that fails CUDA init, so every test
+              # silently skips. 2.10.0 still has torch.nn.functional.grouped_mm. Fail loudly
+              # if CUDA is still unavailable.
               pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 \
                 torch==2.10.0 torchvision torchaudio
               python -c "import torch; assert torch.cuda.is_available(), 'CUDA unavailable after cu128 reinstall'"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,8 +210,11 @@ jobs:
           - name: Test MoE (GPU)
             image: *gpu_test_image
             gpus: 2
+            # The v2 MoE GPU tests need TransformerEngine + torch 2.10, which this image
+            # lacks, so they run in the "Test MoE kernels" job below; exclude them here.
             run: |
               pytest -v --color=yes --durations=3 -m gpu \
+                --ignore-glob='src/test/nn/moe/v2*' \
                 src/test/nn/moe*
 
           - name: Test optim (GPU)
@@ -231,7 +234,9 @@ jobs:
           # The MoE kernels require torch >= 2.10 (torch.nn.functional.grouped_mm,
           # F.ScalingType/F.SwizzleType) and JIT-build .cu extensions, so they need an
           # image with both torch 2.10 and the CUDA toolkit (nvcc). Their tests are
-          # version-gated and skip on the torch 2.9 image above.
+          # version-gated and skip on the torch 2.9 image above. The v2 MoE GPU tests
+          # (src/test/nn/moe/v2) also run here since they need TransformerEngine + the same
+          # custom kernels, which the torch 2.9 image lacks.
           - name: Test MoE kernels (GPU, torch 2.10)
             image: tianhuat/olmo-core-torch210-2404-cu128
             gpus: 2
@@ -244,7 +249,7 @@ jobs:
               bash -ec '
                 pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 torch==2.10.0
                 python -c "import torch; assert torch.cuda.is_available()"
-                pytest -v --color=yes --durations=3 -m gpu src/test/kernels/
+                pytest -v --color=yes --durations=3 -m gpu src/test/kernels/ src/test/nn/moe/v2/
               '
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,9 +235,17 @@ jobs:
           - name: Test MoE kernels (GPU, torch 2.10)
             image: tianhuat/olmo-core-torch210-2404-cu128
             gpus: 2
+            # TEMP: this image's torch is a CUDA-13 build the Beaker CUDA 12.8 driver cannot
+            # initialize, so the kernel tests silently skip. Reinstall the cu128 torch 2.10
+            # build (still provides torch.nn.functional.grouped_mm) to match the driver. The
+            # kernel tests don't import torchvision/torchaudio, so pin only torch and leave
+            # those untouched (avoids an ABI mismatch). Remove once the image ships cu128 torch.
             run: |
-              pytest -v --color=yes --durations=3 -m gpu \
-                src/test/kernels/
+              bash -ec '
+                pip install --force-reinstall --index-url https://download.pytorch.org/whl/cu128 torch==2.10.0
+                python -c "import torch; assert torch.cuda.is_available()"
+                pytest -v --color=yes --durations=3 -m gpu src/test/kernels/
+              '
     steps:
       - uses: actions/checkout@v5
         with:

--- a/src/olmo_core/kernels/mxfp8_utils.py
+++ b/src/olmo_core/kernels/mxfp8_utils.py
@@ -13,7 +13,7 @@ except ImportError:
 try:
     import triton
     import triton.language as tl
-except Exception:  # pragma: no cover - Triton may be unavailable in some test envs.
+except ImportError:
     triton = None
     tl = None
 
@@ -88,7 +88,7 @@ def _get_te_mxfp8_state():
             MXFP8Quantizer,
             MXFP8Tensor,
         )
-    except Exception:
+    except ImportError:
         _TE_MXFP8_STATE = None
         return None
 

--- a/src/olmo_core/nn/moe/utils.py
+++ b/src/olmo_core/nn/moe/utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Tuple, cast
+from typing import Optional, cast
 
 import torch
 
@@ -36,24 +36,29 @@ except Exception:  # pragma: no cover - import guard
     moe_unpermute = None  # type: ignore[assignment]
 
 
-# LAST_STREAM_ID = None
-@torch.compiler.disable  # helper runs eagerly,
+@torch.compiler.disable  # helper runs eagerly
 def async_copy_to_cpu(
     gpu_buf, event=None, return_event=True
-) -> Tuple[torch.Tensor, torch.cuda.Stream, Optional[torch.cuda.Event]]:
-    # *** async copy to CPU for future GroupedGEMM ***
-    # start a new stream for the copy
-    dtoh_stream = get_or_init_stream(id="dtoh", priority=-5)  # TODO: check any id that's not 0?
+) -> tuple[torch.Tensor, torch.cuda.Stream, Optional[torch.cuda.Event]]:
+    """
+    Asynchronously copy ``gpu_buf`` to a pinned CPU buffer on a dedicated stream.
 
-    # global LAST_STREAM_ID
-    # if LAST_STREAM_ID is None:
-    #     LAST_STREAM_ID = id(dtoh_stream)
-    #     print(f"Initialized LAST_STREAM_ID: {LAST_STREAM_ID}")
-    # else:
-    #     assert LAST_STREAM_ID == id(dtoh_stream), f"Expected stream id {LAST_STREAM_ID}, got {id(dtoh_stream)}"
+    Used to bring per-expert split sizes to the host without blocking the default
+    stream; the copy is ordered after work already queued there.
 
-    # Make the copy_stream start after everything already queued on the
-    # current stream (default) that touches batch_size_per_expert.
+    :param gpu_buf: The device tensor to copy.
+    :param event: An optional pre-allocated CUDA event to record completion on.
+    :param return_event: Whether to return the recorded completion event.
+
+    :returns: ``(cpu_buf, copy_stream, event)`` — the pinned CPU tensor, the stream
+        the copy runs on, and the completion event (``None`` if ``return_event`` is
+        ``False``).
+    """
+    # Start the device->host copy on a dedicated low-priority stream.
+    dtoh_stream = get_or_init_stream(id="dtoh", priority=-5)
+
+    # Make the copy stream start after everything already queued on the
+    # current (default) stream that touches the source buffer.
     dtoh_stream.wait_stream(torch.cuda.current_stream())
 
     with torch.cuda.stream(dtoh_stream):
@@ -65,16 +70,15 @@ def async_copy_to_cpu(
     dtoh_event = dtoh_stream.record_event(event)
     dtoh_event = cast(torch.cuda.Event, dtoh_event)
 
-    # cpu_buf = gpu_buf.to(torch.device("cpu"), non_blocking=True)
-    # Keep the source tensor alive until the copy_stream is done
-    # gpu_buf.record_stream(dtoh_stream) # NOTE: does not work with compile
+    # NOTE: gpu_buf.record_stream(dtoh_stream) would keep the source alive until the
+    # copy finishes, but does not work under torch.compile.
     if return_event:
         return cpu_buf, dtoh_stream, dtoh_event
 
     return cpu_buf, dtoh_stream, None
 
 
-@torch.compiler.disable  # helper runs eagerly,
+@torch.compiler.disable  # helper runs eagerly
 def wait_stream_no_compile(this_stream: torch.cuda.Stream, other_stream: torch.cuda.Stream):
     this_stream.wait_stream(other_stream)
 
@@ -90,7 +94,6 @@ def wait_event_no_compile(stream: torch.cuda.Stream, event: torch.cuda.Event):
     stream.wait_event(event)
 
 
-# disable compile for permute
 @torch.compiler.disable
 def moe_permute_no_compile(*args, **kwargs):
     return moe_permute(*args, **kwargs)
@@ -193,6 +196,17 @@ def moe_reorder_rows_permutation(
     inverse_reorder_indices: torch.Tensor,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    """
+    Reorder the rows of ``inp`` by ``reorder_indices`` (autograd-aware; backward
+    scatters gradients back via ``inverse_reorder_indices``).
+
+    :param inp: A rank-2 tensor ``(rows, hidden)``.
+    :param reorder_indices: Rank-1 permutation of the rows.
+    :param inverse_reorder_indices: The inverse permutation, used in backward.
+    :param out: Optional pre-allocated output buffer.
+
+    :returns: The row-reordered tensor.
+    """
     if inp.ndim != 2:
         raise ValueError(f"Expected rank-2 input, got shape={tuple(inp.shape)}")
     if reorder_indices.ndim != 1:
@@ -597,14 +611,25 @@ def moe_sort_chunks_by_index_no_compile(*args, **kwargs):
     return moe_sort_chunks_by_index(*args, **kwargs)
 
 
-# build_chunk_te_routing_map(torch.tensor([[3,2,1], [1,2,1]]), rows=12)
-# out = [[0, 0, 0, 1, 1, 2, 0, 1, 1, 2, 2, 2]].T
-# the pad tokens will be assigned to the last local expert so that they can be easily masked out at tail
 def build_chunk_te_routing_map(
     recv_splits_by_src_local: torch.Tensor,
     *,
     rows: int,
 ) -> torch.Tensor:
+    """
+    Build a per-row local-expert index map from per-(source-rank, local-expert) split
+    sizes, for chunk reordering after an expert-parallel all-to-all.
+
+    Padding rows beyond the total received tokens are assigned to the last local expert
+    so they can be masked out at the tail. Construction stays on-device to avoid a host
+    sync. Example: ``recv_splits=[[3,2,1],[1,2,1]], rows=12`` →
+    ``[0,0,0,1,1,2,0,1,1,2,2,2]`` (as a column).
+
+    :param recv_splits_by_src_local: Rank-2 ``(source_rank, local_expert)`` split counts.
+    :param rows: The total number of rows in the destination buffer.
+
+    :returns: A ``(rows, 1)`` int32 tensor of local-expert indices.
+    """
     if recv_splits_by_src_local.ndim != 2:
         raise ValueError(
             "recv_splits_by_src_local must be rank-2 [source_rank, local_expert], "
@@ -617,7 +642,6 @@ def build_chunk_te_routing_map(
 
     # Keep routing-map construction tensorized on CUDA to avoid host sync.
     rows_t = flat_splits_raw.new_full((1,), rows, dtype=torch.long)
-    # flat_splits_nonneg = torch.clamp_min(flat_splits_raw, 0)
     split_starts = torch.zeros_like(flat_splits_raw, dtype=torch.long)
     split_starts[1:] = torch.cumsum(flat_splits_raw[:-1], dim=0, dtype=torch.long)
     split_remaining = torch.clamp(rows_t - split_starts, min=0)
@@ -714,6 +738,25 @@ def moe_chunk_reorder_no_compile(
     backend: str = "auto",
     backward_grad_input_buffer: Optional[torch.Tensor] = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """
+    Reorder rows into per-local-expert chunks (and back), outside the compiled graph.
+
+    Provide exactly one of ``routing_map`` (forward permute, also returns the row-id map)
+    or ``row_id_map`` (reuse a previously built map). ``backend`` selects the kernel
+    backend (``"auto"`` resolves to the available CUDA implementation).
+
+    :param inp: The rows to reorder.
+    :param routing_map: Per-row local-expert assignment for a forward permute.
+    :param row_id_map: A previously returned row-id map (mutually exclusive with
+        ``routing_map``).
+    :param num_out_tokens: Output row count (defaults to ``inp.shape[0]``).
+    :param out: Optional pre-allocated output buffer.
+    :param backend: Backend selector (``"auto"`` / ``"cuda"``).
+    :param backward_grad_input_buffer: Optional caller-provided gradient buffer for backward.
+
+    :returns: The reordered tensor, or ``(reordered, row_id_map)`` when a ``routing_map``
+        is given.
+    """
     if (routing_map is None) == (row_id_map is None):
         raise ValueError(
             "Exactly one of routing_map or row_id_map must be provided to "

--- a/src/olmo_core/nn/moe/utils.py
+++ b/src/olmo_core/nn/moe/utils.py
@@ -773,6 +773,8 @@ def moe_chunk_reorder_no_compile(
         )
 
         if resolved_backend == "te":
+            # TODO: revisit — the TE chunk-reorder backend is currently deprecated; the
+            # dead call below is kept for reference until we re-enable or remove it.
             raise RuntimeError("TE backend Deprecated.")
             return _moe_chunk_permute_te(
                 inp=inp,
@@ -801,6 +803,8 @@ def moe_chunk_reorder_no_compile(
     )
 
     if resolved_backend == "te":
+        # TODO: revisit — the TE chunk-reorder backend is currently deprecated; the
+        # dead call below is kept for reference until we re-enable or remove it.
         raise RuntimeError("TE backend Deprecated.")
         return _moe_chunk_unpermute_te(
             inp=inp,

--- a/src/olmo_core/nn/moe/utils.py
+++ b/src/olmo_core/nn/moe/utils.py
@@ -6,12 +6,9 @@ import torch
 try:
     import triton  # type: ignore
     import triton.language as tl  # type: ignore
-
-    _HAS_TRITON = True
 except ImportError:
     triton = None  # type: ignore[assignment]
     tl = None  # type: ignore[assignment]
-    _HAS_TRITON = False
 
 from olmo_core.kernels.moe_chunk_reorder import moe_chunk_permute, moe_chunk_unpermute
 from olmo_core.kernels.moe_permute_drop import moe_permute_drop_fwd
@@ -338,7 +335,7 @@ def moe_permute_1d_fused_drop_no_compile(
     return dropped, row_id_map
 
 
-if _HAS_TRITON:
+if triton is not None:
 
     @triton.jit
     def _fused_unpermute_row_id_remap_kernel(
@@ -400,7 +397,12 @@ def _build_fused_unpermute_row_id_map(
     if n_rows == 0:
         return out
 
-    if _HAS_TRITON and row_id_map_i32.is_cuda and inverse_reorder_i64.is_cuda and num_kept.is_cuda:
+    if (
+        triton is not None
+        and row_id_map_i32.is_cuda
+        and inverse_reorder_i64.is_cuda
+        and num_kept.is_cuda
+    ):
         block = 1024
         grid = (triton.cdiv(n_rows, block),)
         _fused_unpermute_row_id_remap_kernel[grid](

--- a/src/olmo_core/nn/moe/utils.py
+++ b/src/olmo_core/nn/moe/utils.py
@@ -33,6 +33,11 @@ except ImportError:
     moe_unpermute = None  # type: ignore[assignment]
 
 
+def has_triton() -> bool:
+    """Whether Triton is available."""
+    return triton is not None
+
+
 @torch.compiler.disable  # helper runs eagerly
 def async_copy_to_cpu(
     gpu_buf, event=None, return_event=True
@@ -335,7 +340,7 @@ def moe_permute_1d_fused_drop_no_compile(
     return dropped, row_id_map
 
 
-if triton is not None:
+if has_triton():
 
     @triton.jit
     def _fused_unpermute_row_id_remap_kernel(
@@ -397,12 +402,7 @@ def _build_fused_unpermute_row_id_map(
     if n_rows == 0:
         return out
 
-    if (
-        triton is not None
-        and row_id_map_i32.is_cuda
-        and inverse_reorder_i64.is_cuda
-        and num_kept.is_cuda
-    ):
+    if has_triton() and row_id_map_i32.is_cuda and inverse_reorder_i64.is_cuda and num_kept.is_cuda:
         block = 1024
         grid = (triton.cdiv(n_rows, block),)
         _fused_unpermute_row_id_remap_kernel[grid](

--- a/src/olmo_core/nn/moe/utils.py
+++ b/src/olmo_core/nn/moe/utils.py
@@ -8,7 +8,7 @@ try:
     import triton.language as tl  # type: ignore
 
     _HAS_TRITON = True
-except Exception:  # pragma: no cover - import guard
+except ImportError:
     triton = None  # type: ignore[assignment]
     tl = None  # type: ignore[assignment]
     _HAS_TRITON = False
@@ -28,7 +28,7 @@ try:
         moe_sort_chunks_by_index,
         moe_unpermute,
     )
-except Exception:  # pragma: no cover - import guard
+except ImportError:
     tex = None  # type: ignore[assignment]
     TE_DType = None  # type: ignore[assignment]
     moe_permute = None  # type: ignore[assignment]

--- a/src/olmo_core/nn/moe/utils.py
+++ b/src/olmo_core/nn/moe/utils.py
@@ -1,0 +1,777 @@
+import os
+from typing import Optional, Tuple, cast
+
+import torch
+
+try:
+    import triton  # type: ignore
+    import triton.language as tl  # type: ignore
+
+    _HAS_TRITON = True
+except Exception:  # pragma: no cover - import guard
+    triton = None  # type: ignore[assignment]
+    tl = None  # type: ignore[assignment]
+    _HAS_TRITON = False
+
+from olmo_core.kernels.moe_chunk_reorder import moe_chunk_permute, moe_chunk_unpermute
+from olmo_core.kernels.moe_permute_drop import moe_permute_drop_fwd
+from olmo_core.kernels.moe_unpermute_bwd import (
+    moe_unpermute_bwd as moe_unpermute_bwd_cuda,
+)
+from olmo_core.utils import get_or_init_stream
+
+try:
+    import transformer_engine_torch as tex
+    from transformer_engine.pytorch.constants import TE_DType
+    from transformer_engine.pytorch.permutation import (
+        moe_permute,
+        moe_sort_chunks_by_index,
+        moe_unpermute,
+    )
+except Exception:  # pragma: no cover - import guard
+    tex = None  # type: ignore[assignment]
+    TE_DType = None  # type: ignore[assignment]
+    moe_permute = None  # type: ignore[assignment]
+    moe_sort_chunks_by_index = None  # type: ignore[assignment]
+    moe_unpermute = None  # type: ignore[assignment]
+
+
+# LAST_STREAM_ID = None
+@torch.compiler.disable  # helper runs eagerly,
+def async_copy_to_cpu(
+    gpu_buf, event=None, return_event=True
+) -> Tuple[torch.Tensor, torch.cuda.Stream, Optional[torch.cuda.Event]]:
+    # *** async copy to CPU for future GroupedGEMM ***
+    # start a new stream for the copy
+    dtoh_stream = get_or_init_stream(id="dtoh", priority=-5)  # TODO: check any id that's not 0?
+
+    # global LAST_STREAM_ID
+    # if LAST_STREAM_ID is None:
+    #     LAST_STREAM_ID = id(dtoh_stream)
+    #     print(f"Initialized LAST_STREAM_ID: {LAST_STREAM_ID}")
+    # else:
+    #     assert LAST_STREAM_ID == id(dtoh_stream), f"Expected stream id {LAST_STREAM_ID}, got {id(dtoh_stream)}"
+
+    # Make the copy_stream start after everything already queued on the
+    # current stream (default) that touches batch_size_per_expert.
+    dtoh_stream.wait_stream(torch.cuda.current_stream())
+
+    with torch.cuda.stream(dtoh_stream):
+        cpu_buf = torch.empty_like(
+            gpu_buf, device="cpu", pin_memory=True
+        )  # compile does not work with pin_memory
+        cpu_buf.copy_(gpu_buf, non_blocking=True)
+
+    dtoh_event = dtoh_stream.record_event(event)
+    dtoh_event = cast(torch.cuda.Event, dtoh_event)
+
+    # cpu_buf = gpu_buf.to(torch.device("cpu"), non_blocking=True)
+    # Keep the source tensor alive until the copy_stream is done
+    # gpu_buf.record_stream(dtoh_stream) # NOTE: does not work with compile
+    if return_event:
+        return cpu_buf, dtoh_stream, dtoh_event
+
+    return cpu_buf, dtoh_stream, None
+
+
+@torch.compiler.disable  # helper runs eagerly,
+def wait_stream_no_compile(this_stream: torch.cuda.Stream, other_stream: torch.cuda.Stream):
+    this_stream.wait_stream(other_stream)
+
+
+@torch.compiler.disable
+def record_stream_event_no_compile(stream: torch.cuda.Stream) -> torch.cuda.Event:
+    event = stream.record_event()
+    return cast(torch.cuda.Event, event)
+
+
+@torch.compiler.disable
+def wait_event_no_compile(stream: torch.cuda.Stream, event: torch.cuda.Event):
+    stream.wait_event(event)
+
+
+# disable compile for permute
+@torch.compiler.disable
+def moe_permute_no_compile(*args, **kwargs):
+    return moe_permute(*args, **kwargs)
+
+
+@torch.compiler.disable
+def moe_unpermute_no_compile(*args, **kwargs):
+    return moe_unpermute(*args, **kwargs)
+
+
+class _RowPermutationReorderAutograd(torch.autograd.Function):
+    """Reorder rows by a permutation; backward uses inverse gather."""
+
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        inp: torch.Tensor,
+        reorder_indices: torch.Tensor,
+        inverse_reorder_indices: torch.Tensor,
+        out: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if out is not None:
+            output = torch.index_select(inp, 0, reorder_indices, out=out)
+            ctx.mark_dirty(output)
+        else:
+            output = torch.index_select(inp, 0, reorder_indices)
+
+        # Store directly on ctx (matches other autograd wrappers in this module).
+        ctx.inverse_reorder_indices = inverse_reorder_indices
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):  # type: ignore[override]
+        grad_inp = None
+        if ctx.needs_input_grad[0]:
+            if not grad_output.is_contiguous():
+                grad_output = grad_output.contiguous()
+            grad_inp = torch.index_select(grad_output, 0, ctx.inverse_reorder_indices)
+        return grad_inp, None, None, None
+
+
+class _MoePermuteDropIndexMapAutograd(torch.autograd.Function):
+    """Custom CUDA one-shot permute+drop with TE-compatible packed row_id_map."""
+
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        inp: torch.Tensor,
+        routing_map: torch.Tensor,
+        requested_splits: torch.Tensor,
+        keep_splits: torch.Tensor,
+        num_out_tokens: int,
+        out: Optional[torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        requested_i64 = requested_splits.to(dtype=torch.long).contiguous()
+        keep_i64 = keep_splits.to(dtype=torch.long).contiguous()
+        requested_offsets = torch.cumsum(requested_i64, dim=0) - requested_i64
+        keep_offsets = torch.cumsum(keep_i64, dim=0) - keep_i64
+
+        dropped, row_id_map = moe_permute_drop_fwd(
+            inp=inp,
+            routing_map=routing_map,
+            requested_offsets=requested_offsets,
+            keep_offsets=keep_offsets,
+            keep_splits=keep_i64,
+            num_out_tokens=num_out_tokens,
+            out=out,
+        )
+        if out is not None and dropped is out:
+            ctx.mark_dirty(dropped)
+
+        ctx.row_id_map = row_id_map
+        ctx.num_tokens = routing_map.shape[0]
+        ctx.topK = routing_map.shape[1]
+        ctx.mark_non_differentiable(row_id_map)
+        return dropped, row_id_map
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor, grad_row_id_map: torch.Tensor):  # type: ignore[override]
+        del grad_row_id_map
+        grad_inp = None
+        if ctx.needs_input_grad[0]:
+            if not grad_output.is_contiguous():
+                grad_output = grad_output.contiguous()
+            grad_inp = tex.moe_permute_bwd(
+                grad_output,
+                TE_DType[grad_output.dtype],
+                ctx.row_id_map,
+                torch.empty(0),
+                ctx.num_tokens,
+                ctx.topK,
+            )
+        return grad_inp, None, None, None, None, None
+
+
+def moe_reorder_rows_permutation(
+    *,
+    inp: torch.Tensor,
+    reorder_indices: torch.Tensor,
+    inverse_reorder_indices: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if inp.ndim != 2:
+        raise ValueError(f"Expected rank-2 input, got shape={tuple(inp.shape)}")
+    if reorder_indices.ndim != 1:
+        raise ValueError(
+            f"Expected rank-1 reorder_indices, got shape={tuple(reorder_indices.shape)}"
+        )
+    if inverse_reorder_indices.ndim != 1:
+        raise ValueError(
+            "Expected rank-1 inverse_reorder_indices, "
+            f"got shape={tuple(inverse_reorder_indices.shape)}"
+        )
+    if reorder_indices.numel() != inp.shape[0]:
+        raise ValueError(
+            f"reorder_indices size ({reorder_indices.numel()}) must equal input rows ({inp.shape[0]})"
+        )
+    if inverse_reorder_indices.numel() != inp.shape[0]:
+        raise ValueError(
+            f"inverse_reorder_indices size ({inverse_reorder_indices.numel()}) must equal input rows ({inp.shape[0]})"
+        )
+    if reorder_indices.device != inp.device:
+        raise ValueError(
+            f"reorder_indices/input device mismatch: reorder_indices={reorder_indices.device} inp={inp.device}"
+        )
+    if inverse_reorder_indices.device != inp.device:
+        raise ValueError(
+            "inverse_reorder_indices/input device mismatch: "
+            f"inverse_reorder_indices={inverse_reorder_indices.device} inp={inp.device}"
+        )
+    if out is not None:
+        if out.shape != inp.shape:
+            raise ValueError(f"out shape mismatch: out={tuple(out.shape)} inp={tuple(inp.shape)}")
+        if out.dtype != inp.dtype:
+            raise ValueError(f"out dtype mismatch: out={out.dtype} inp={inp.dtype}")
+        if out.device != inp.device:
+            raise ValueError(f"out device mismatch: out={out.device} inp={inp.device}")
+
+    reorder_i64 = (
+        reorder_indices
+        if reorder_indices.dtype == torch.long
+        else reorder_indices.to(dtype=torch.long)
+    )
+    inverse_i64 = (
+        inverse_reorder_indices
+        if inverse_reorder_indices.dtype == torch.long
+        else inverse_reorder_indices.to(dtype=torch.long)
+    )
+    reorder_i64 = reorder_i64.contiguous()
+    inverse_i64 = inverse_i64.contiguous()
+    return _RowPermutationReorderAutograd.apply(inp, reorder_i64, inverse_i64, out)
+
+
+def moe_permute_1d_fused_drop_no_compile(
+    *,
+    inp: torch.Tensor,
+    routing_map: torch.Tensor,
+    num_out_tokens: int,
+    reorder_indices: torch.Tensor,
+    inverse_reorder_indices: torch.Tensor,
+    requested_splits: Optional[torch.Tensor] = None,
+    keep_splits: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+    map_type: str = "index",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """TE permute + drop-token reorder with optional one-shot custom CUDA backend."""
+    if map_type != "index":
+        raise ValueError(
+            f"moe_permute_1d_fused_drop_no_compile only supports map_type='index' (got {map_type})"
+        )
+
+    if (requested_splits is None) != (keep_splits is None):
+        raise ValueError(
+            "requested_splits and keep_splits must both be provided for one-shot permute+drop"
+        )
+
+    if requested_splits is not None and keep_splits is not None:
+        if requested_splits.ndim != 1:
+            raise ValueError(
+                f"Expected rank-1 requested_splits, got shape={tuple(requested_splits.shape)}"
+            )
+        if keep_splits.ndim != 1:
+            raise ValueError(f"Expected rank-1 keep_splits, got shape={tuple(keep_splits.shape)}")
+        if requested_splits.numel() != keep_splits.numel():
+            raise ValueError(
+                f"requested_splits/keep_splits size mismatch: {requested_splits.numel()} vs {keep_splits.numel()}"
+            )
+        if requested_splits.device != inp.device:
+            raise ValueError(
+                f"requested_splits/input device mismatch: requested_splits={requested_splits.device} inp={inp.device}"
+            )
+        if keep_splits.device != inp.device:
+            raise ValueError(
+                f"keep_splits/input device mismatch: keep_splits={keep_splits.device} inp={inp.device}"
+            )
+        if not inp.is_cuda:
+            raise ValueError("one-shot permute+drop path requires CUDA input")
+        dropped, row_id_map = _MoePermuteDropIndexMapAutograd.apply(
+            inp,
+            routing_map,
+            requested_splits,
+            keep_splits,
+            num_out_tokens,
+            out,
+        )
+        return dropped, row_id_map
+
+    reorder_i64 = (
+        reorder_indices
+        if reorder_indices.dtype == torch.long
+        else reorder_indices.to(dtype=torch.long)
+    )
+    inverse_i64 = (
+        inverse_reorder_indices
+        if inverse_reorder_indices.dtype == torch.long
+        else inverse_reorder_indices.to(dtype=torch.long)
+    )
+
+    permuted, row_id_map = moe_permute_no_compile(
+        inp=inp,
+        routing_map=routing_map,  # indices of experts. shape: [token_cnt, topK]
+        num_out_tokens=num_out_tokens,
+        map_type="index",
+    )
+    dropped = moe_reorder_rows_permutation(
+        inp=permuted,
+        reorder_indices=reorder_i64,  # shape: [token_cnt * topK]
+        inverse_reorder_indices=inverse_i64,  # shape: [token_cnt * topK]
+        out=out,
+    )
+    return dropped, row_id_map
+
+
+if _HAS_TRITON:
+
+    @triton.jit
+    def _fused_unpermute_row_id_remap_kernel(
+        row_id_map_ptr,
+        inverse_reorder_ptr,
+        num_kept_ptr,
+        out_ptr,
+        n_rows,
+        inverse_n_rows,
+        BLOCK: tl.constexpr,
+    ):
+        pid = tl.program_id(0)
+        offs = pid * BLOCK + tl.arange(0, BLOCK)
+        in_bounds = offs < n_rows
+
+        row = tl.load(row_id_map_ptr + offs, mask=in_bounds, other=-1)
+        valid_row = (row >= 0) & (row < inverse_n_rows)
+        safe_row = tl.where(valid_row, row, 0)
+
+        packed_idx = tl.load(inverse_reorder_ptr + safe_row, mask=in_bounds, other=0)
+        num_kept = tl.load(num_kept_ptr)
+        valid_kept = packed_idx < num_kept
+        out_row = tl.where(valid_row & valid_kept, packed_idx, -1)
+
+        tl.store(out_ptr + offs, out_row.to(tl.int32), mask=in_bounds)
+
+
+def _normalize_num_kept_tensor(
+    *,
+    num_kept: Optional[torch.Tensor],
+    packed_keep_mask: torch.Tensor,
+) -> torch.Tensor:
+    if num_kept is None:
+        return packed_keep_mask.to(dtype=torch.long).sum(dtype=torch.long).view(1)
+    if num_kept.numel() != 1:
+        raise ValueError(
+            f"num_kept must contain a single element, got shape={tuple(num_kept.shape)}"
+        )
+    if num_kept.device != packed_keep_mask.device:
+        raise ValueError(
+            f"num_kept/passed_keep_mask device mismatch: num_kept={num_kept.device} "
+            f"packed_keep_mask={packed_keep_mask.device}"
+        )
+    return num_kept.to(dtype=torch.long).reshape(1)
+
+
+def _build_fused_unpermute_row_id_map(
+    *,
+    row_id_map_i32: torch.Tensor,
+    inverse_reorder_i64: torch.Tensor,
+    num_kept: torch.Tensor,
+) -> torch.Tensor:
+    row_id_map_i32 = row_id_map_i32.contiguous()
+    inverse_reorder_i64 = inverse_reorder_i64.contiguous()
+    num_kept = num_kept.contiguous()
+
+    out = torch.empty_like(row_id_map_i32, dtype=torch.int32)
+    n_rows = row_id_map_i32.numel()
+    if n_rows == 0:
+        return out
+
+    if _HAS_TRITON and row_id_map_i32.is_cuda and inverse_reorder_i64.is_cuda and num_kept.is_cuda:
+        block = 1024
+        grid = (triton.cdiv(n_rows, block),)
+        _fused_unpermute_row_id_remap_kernel[grid](
+            row_id_map_i32,
+            inverse_reorder_i64,
+            num_kept,
+            out,
+            n_rows,
+            inverse_reorder_i64.numel(),
+            BLOCK=block,
+        )
+        return out
+
+    valid = row_id_map_i32 >= 0
+    safe_src = torch.where(
+        valid,
+        row_id_map_i32.to(dtype=torch.long),
+        torch.zeros_like(row_id_map_i32, dtype=torch.long),
+    )
+    packed_idx = inverse_reorder_i64.index_select(0, safe_src)
+    fused_valid = valid & (packed_idx < num_kept.view(()))
+    return torch.where(
+        fused_valid,
+        packed_idx.to(dtype=torch.int32),
+        torch.full_like(row_id_map_i32, -1),
+    )
+
+
+class _TEUnpermuteIndexMapMaskedAutograd(torch.autograd.Function):
+    """TE index-map unpermute forward + custom CUDA backward."""
+
+    @staticmethod
+    def forward(  # type: ignore[override]
+        ctx,
+        inp: torch.Tensor,
+        row_id_map: torch.Tensor,
+        merging_probs: torch.Tensor,
+        packed_keep_mask: torch.Tensor,
+        backward_grad_input_buffer: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if row_id_map.dtype != torch.int32:
+            row_id_map = row_id_map.to(dtype=torch.int32)
+        probs = merging_probs
+        if probs.dtype != torch.float32:
+            probs = probs.to(dtype=torch.float32)
+        output = tex.moe_unpermute_fwd(
+            inp,
+            TE_DType[inp.dtype],
+            row_id_map,
+            probs,
+            probs.shape[0],
+            probs.shape[1],
+        )
+        ctx.save_for_backward(inp, row_id_map, probs, packed_keep_mask)
+        ctx.backward_grad_input_buffer = backward_grad_input_buffer
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):  # type: ignore[override]
+        if not grad_output.is_contiguous():
+            grad_output = grad_output.contiguous()
+
+        inp, row_id_map, probs, packed_keep_mask = ctx.saved_tensors
+        grad_inp = None
+        grad_probs = None
+        if ctx.needs_input_grad[0]:
+            grad_inp, grad_probs = moe_unpermute_bwd_cuda(
+                grad_output=grad_output,
+                input_fwd=inp,
+                row_id_map=row_id_map,
+                probs=probs,
+                keep_mask=packed_keep_mask,
+                out=(
+                    None
+                    if (
+                        ctx.needs_input_grad[2]
+                        and ctx.backward_grad_input_buffer is not None
+                        and ctx.backward_grad_input_buffer.untyped_storage().data_ptr()
+                        == inp.untyped_storage().data_ptr()
+                    )
+                    else ctx.backward_grad_input_buffer
+                ),
+            )
+            if ctx.backward_grad_input_buffer is not None:
+                grad_inp_uses_buffer = (
+                    grad_inp.untyped_storage().data_ptr()
+                    == ctx.backward_grad_input_buffer.untyped_storage().data_ptr()
+                )
+                input_aliases_buffer = (
+                    ctx.backward_grad_input_buffer.untyped_storage().data_ptr()
+                    == inp.untyped_storage().data_ptr()
+                )
+                if not (ctx.needs_input_grad[2] and input_aliases_buffer):
+                    assert (
+                        grad_inp_uses_buffer
+                    ), "Expected moe_unpermute_bwd to write to backward_grad_input_buffer"
+
+        if not ctx.needs_input_grad[2]:
+            grad_probs = None
+        return grad_inp, None, grad_probs, None, None
+
+
+# @torch.compiler.disable
+def moe_unpermute_1d_fused_drop_no_compile(
+    *,
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    local_inverse_reorder_indices: torch.Tensor,
+    packed_keep_mask: torch.Tensor,
+    merging_probs: torch.Tensor,
+    num_kept: Optional[torch.Tensor] = None,
+    row_id_map_is_packed: bool = False,
+    backward_grad_input_buffer: Optional[torch.Tensor] = None,
+    map_type: str = "index",
+) -> torch.Tensor:
+    """
+    Fused 1D restore-drop + TE index-map unpermute forward.
+    Backward uses a custom CUDA kernel equivalent to TE moe_unpermute_bwd with dropped-row zeroing.
+    """
+    if map_type != "index":
+        raise ValueError(
+            f"moe_unpermute_1d_fused_drop_no_compile only supports map_type='index' (got {map_type})"
+        )
+    if inp.ndim != 2:
+        raise ValueError(f"Expected rank-2 input, got shape={tuple(inp.shape)}")
+    if row_id_map.ndim != 1:
+        raise ValueError(f"Expected rank-1 row_id_map, got shape={tuple(row_id_map.shape)}")
+    if local_inverse_reorder_indices.ndim != 1:
+        raise ValueError(
+            "Expected rank-1 local_inverse_reorder_indices, "
+            f"got shape={tuple(local_inverse_reorder_indices.shape)}"
+        )
+    if packed_keep_mask.ndim != 1:
+        raise ValueError(
+            f"Expected rank-1 packed_keep_mask, got shape={tuple(packed_keep_mask.shape)}"
+        )
+    if row_id_map.numel() != local_inverse_reorder_indices.numel():
+        raise ValueError(
+            "row_id_map/local_inverse_reorder_indices size mismatch: "
+            f"{row_id_map.numel()} vs {local_inverse_reorder_indices.numel()}"
+        )
+    if packed_keep_mask.numel() != local_inverse_reorder_indices.numel():
+        raise ValueError(
+            "packed_keep_mask/local_inverse_reorder_indices size mismatch: "
+            f"{packed_keep_mask.numel()} vs {local_inverse_reorder_indices.numel()}"
+        )
+    if inp.shape[0] != packed_keep_mask.numel():
+        raise ValueError(
+            f"input rows ({inp.shape[0]}) must equal packed_keep_mask size ({packed_keep_mask.numel()})"
+        )
+    if backward_grad_input_buffer is not None:
+        if tuple(backward_grad_input_buffer.shape) != tuple(inp.shape):
+            raise ValueError(
+                "backward_grad_input_buffer shape mismatch: "
+                f"expected={tuple(inp.shape)} got={tuple(backward_grad_input_buffer.shape)}"
+            )
+        if backward_grad_input_buffer.dtype != inp.dtype:
+            raise ValueError(
+                "backward_grad_input_buffer dtype mismatch: "
+                f"buffer={backward_grad_input_buffer.dtype} inp={inp.dtype}"
+            )
+        if backward_grad_input_buffer.device != inp.device:
+            raise ValueError(
+                "backward_grad_input_buffer device mismatch: "
+                f"buffer={backward_grad_input_buffer.device} inp={inp.device}"
+            )
+    if num_kept is not None and not torch.is_tensor(num_kept):
+        raise ValueError(f"num_kept must be a scalar tensor when provided, got {type(num_kept)}")
+
+    row_map_i32 = (
+        row_id_map if row_id_map.dtype == torch.int32 else row_id_map.to(dtype=torch.int32)
+    )
+    inverse_i64 = (
+        local_inverse_reorder_indices
+        if local_inverse_reorder_indices.dtype == torch.long
+        else local_inverse_reorder_indices.to(dtype=torch.long)
+    )
+    keep_mask = (
+        packed_keep_mask
+        if packed_keep_mask.dtype == torch.bool
+        else packed_keep_mask.to(dtype=torch.bool)
+    )
+    num_kept_t = _normalize_num_kept_tensor(num_kept=num_kept, packed_keep_mask=keep_mask)
+
+    if row_id_map_is_packed:
+        remapped_row_id_map = row_map_i32
+    else:
+        # Equivalent: packed_idx = inverse_reorder[row_id_map] (for valid rows)
+        # keep only entries with packed_idx < num_kept
+        # else set to -1
+        remapped_row_id_map = _build_fused_unpermute_row_id_map(
+            row_id_map_i32=row_map_i32,  # TE unpermute map in pre-drop row order)
+            inverse_reorder_i64=inverse_i64,  # Applies inverse_reorder_i64 to convert each referenced row into packed order (kept rows first, dropped rows after).
+            num_kept=num_kept_t,
+        )
+
+    return _TEUnpermuteIndexMapMaskedAutograd.apply(
+        inp,
+        remapped_row_id_map,
+        merging_probs,
+        keep_mask,
+        backward_grad_input_buffer,
+    )
+
+
+@torch.compiler.disable
+def moe_sort_chunks_by_index_no_compile(*args, **kwargs):
+    return moe_sort_chunks_by_index(*args, **kwargs)
+
+
+# build_chunk_te_routing_map(torch.tensor([[3,2,1], [1,2,1]]), rows=12)
+# out = [[0, 0, 0, 1, 1, 2, 0, 1, 1, 2, 2, 2]].T
+# the pad tokens will be assigned to the last local expert so that they can be easily masked out at tail
+def build_chunk_te_routing_map(
+    recv_splits_by_src_local: torch.Tensor,
+    *,
+    rows: int,
+) -> torch.Tensor:
+    if recv_splits_by_src_local.ndim != 2:
+        raise ValueError(
+            "recv_splits_by_src_local must be rank-2 [source_rank, local_expert], "
+            f"got shape={tuple(recv_splits_by_src_local.shape)}"
+        )
+
+    flat_splits_raw = recv_splits_by_src_local.reshape(-1).to(dtype=torch.long)
+
+    num_local_experts = recv_splits_by_src_local.shape[1]
+
+    # Keep routing-map construction tensorized on CUDA to avoid host sync.
+    rows_t = flat_splits_raw.new_full((1,), rows, dtype=torch.long)
+    # flat_splits_nonneg = torch.clamp_min(flat_splits_raw, 0)
+    split_starts = torch.zeros_like(flat_splits_raw, dtype=torch.long)
+    split_starts[1:] = torch.cumsum(flat_splits_raw[:-1], dim=0, dtype=torch.long)
+    split_remaining = torch.clamp(rows_t - split_starts, min=0)
+    flat_splits = torch.minimum(flat_splits_raw, split_remaining)
+
+    pos = torch.arange(rows, device=recv_splits_by_src_local.device, dtype=torch.long)
+
+    chunk_ends = torch.cumsum(flat_splits, dim=0)
+    total_rows = chunk_ends[-1].view(1)
+
+    valid_mask = pos < total_rows
+    safe_pos = torch.where(valid_mask, pos, torch.zeros_like(pos))
+    max_chunk_idx = flat_splits.numel() - 1
+    chunk_ids = torch.searchsorted(chunk_ends, safe_pos, right=True).clamp_max(max_chunk_idx)
+    local_expert_indices = torch.remainder(chunk_ids, num_local_experts).to(dtype=torch.int32)
+    local_expert_indices = torch.where(
+        valid_mask,
+        local_expert_indices,
+        torch.full_like(local_expert_indices, num_local_experts - 1),
+    )
+    return local_expert_indices.view(-1, 1)
+
+
+def _moe_chunk_permute_te(
+    inp: torch.Tensor,
+    routing_map: torch.Tensor,
+    *,
+    num_out_tokens: int,
+    out: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if inp.ndim != 2:
+        raise ValueError(f"moe_chunk_reorder_no_compile expects 2D input, got {tuple(inp.shape)}")
+
+    permuted, row_id_map = moe_permute_no_compile(
+        inp=inp,
+        routing_map=routing_map,
+        num_out_tokens=num_out_tokens,
+        map_type="index",
+    )
+
+    if out is not None:
+        out.copy_(permuted)
+        permuted = out
+
+    return permuted, row_id_map
+
+
+def _moe_chunk_unpermute_te(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    *,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    if inp.ndim != 2:
+        raise ValueError(f"moe_chunk_reorder_no_compile expects 2D input, got {tuple(inp.shape)}")
+
+    restored = moe_unpermute_no_compile(
+        inp=inp,
+        row_id_map=row_id_map,
+        merging_probs=None,
+        restore_shape=None,
+        map_type="index",
+    )
+
+    if out is not None:
+        out.copy_(restored)
+        return out
+    return restored
+
+
+def _resolve_chunk_reorder_backend(backend: str) -> str:
+    if backend == "auto":
+        resolved = os.getenv("OLMO_MOE_CHUNK_REORDER_BACKEND", "cuda")
+    else:
+        resolved = backend
+    resolved = resolved.lower()
+    if resolved == "auto":
+        resolved = "cuda"
+    if resolved not in ("cuda", "triton", "te"):
+        raise ValueError(
+            "Invalid backend for moe_chunk_reorder_no_compile: "
+            f"{resolved}. Expected one of cuda|triton|te (or auto -> cuda)"
+        )
+    return resolved
+
+
+def moe_chunk_reorder_no_compile(
+    inp: torch.Tensor,
+    *,
+    routing_map: Optional[torch.Tensor] = None,
+    row_id_map: Optional[torch.Tensor] = None,
+    num_out_tokens: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+    backend: str = "auto",
+    backward_grad_input_buffer: Optional[torch.Tensor] = None,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    if (routing_map is None) == (row_id_map is None):
+        raise ValueError(
+            "Exactly one of routing_map or row_id_map must be provided to "
+            "moe_chunk_reorder_no_compile"
+        )
+
+    resolved_backend = _resolve_chunk_reorder_backend(backend)
+
+    if routing_map is not None:
+        if num_out_tokens is None:
+            num_out_tokens = inp.shape[0]
+        routing_map_i32 = (
+            routing_map if routing_map.dtype == torch.int32 else routing_map.to(dtype=torch.int32)
+        )
+
+        if resolved_backend == "te":
+            raise RuntimeError("TE backend Deprecated.")
+            return _moe_chunk_permute_te(
+                inp=inp,
+                routing_map=routing_map_i32,
+                num_out_tokens=num_out_tokens,
+                out=out,
+            )
+
+        if resolved_backend in ("cuda", "triton"):
+            return moe_chunk_permute(
+                inp=inp,
+                routing_map=routing_map_i32,
+                num_out_tokens=num_out_tokens,
+                out=out,
+                backend=resolved_backend,  # type: ignore[arg-type]
+                backward_grad_input_buffer=backward_grad_input_buffer,
+            )
+        raise RuntimeError(f"Unhandled chunk reorder backend: {resolved_backend}")
+
+    assert row_id_map is not None
+    if num_out_tokens is not None:
+        raise ValueError("num_out_tokens is only valid for permute (routing_map) calls")
+
+    row_id_map_i32 = (
+        row_id_map if row_id_map.dtype == torch.int32 else row_id_map.to(dtype=torch.int32)
+    )
+
+    if resolved_backend == "te":
+        raise RuntimeError("TE backend Deprecated.")
+        return _moe_chunk_unpermute_te(
+            inp=inp,
+            row_id_map=row_id_map_i32,
+            out=out,
+        )
+
+    if resolved_backend in ("cuda", "triton"):
+        return moe_chunk_unpermute(
+            inp=inp,
+            row_id_map=row_id_map_i32,
+            num_tokens=row_id_map_i32.numel(),
+            out=out,
+            backend=resolved_backend,  # type: ignore[arg-type]
+            backward_grad_input_buffer=backward_grad_input_buffer,
+        )
+    raise RuntimeError(f"Unhandled chunk reorder backend: {resolved_backend}")

--- a/src/olmo_core/nn/moe/utils.py
+++ b/src/olmo_core/nn/moe/utils.py
@@ -72,8 +72,13 @@ def async_copy_to_cpu(
     dtoh_event = dtoh_stream.record_event(event)
     dtoh_event = cast(torch.cuda.Event, dtoh_event)
 
-    # NOTE: gpu_buf.record_stream(dtoh_stream) would keep the source alive until the
-    # copy finishes, but does not work under torch.compile.
+    # NOTE: gpu_buf.record_stream(dtoh_stream) would tell the caching allocator the source
+    # is still in use on dtoh_stream and keep it alive until the copy finishes, but it does
+    # not work under torch.compile. Without it, a source whose storage is freed on the
+    # default stream before the event is waited on could be recycled mid-copy. Real callers
+    # pass persistent buffers (not temporaries) for gpu_buf, so this does not arise today;
+    # revisit (record the source on dtoh_stream, or keep it alive) if a caller ever passes
+    # a transient source.
     if return_event:
         return cpu_buf, dtoh_stream, dtoh_event
 
@@ -155,6 +160,13 @@ class _MoePermuteDropIndexMapAutograd(torch.autograd.Function):
         requested_offsets = torch.cumsum(requested_i64, dim=0) - requested_i64
         keep_offsets = torch.cumsum(keep_i64, dim=0) - keep_i64
 
+        # NOTE: the CUDA wrapper treats num_out_tokens <= 0 as the sentinel "use
+        # expanded_rows", so an all-dropped microbatch (every kept split zero ->
+        # num_out_tokens == 0) would get a full-size buffer back instead of an empty one,
+        # and downstream expert compute could read unwritten rows. Real callers always pass
+        # the full num_tokens*top_k count and size the output buffer accordingly, so this
+        # does not arise today; special-case the zero-kept path (or use a non-colliding
+        # sentinel) here if that ever changes.
         dropped, row_id_map = moe_permute_drop_fwd(
             inp=inp,
             routing_map=routing_map,
@@ -556,6 +568,11 @@ def moe_unpermute_1d_fused_drop_no_compile(
             "packed_keep_mask/local_inverse_reorder_indices size mismatch: "
             f"{packed_keep_mask.numel()} vs {local_inverse_reorder_indices.numel()}"
         )
+    # NOTE: the EP dispatch/combine paths keep full-size buffers and represent drops via
+    # reorder-to-tail + packed_keep_mask, so inp always carries the full expanded row count
+    # (num_tokens*top_k) rather than only the kept rows. If a future path ever passes
+    # kept-only input (num_kept rows), relax this to compare against num_kept and have the
+    # row-id remap mark dropped entries as -1.
     if inp.shape[0] != packed_keep_mask.numel():
         raise ValueError(
             f"input rows ({inp.shape[0]}) must equal packed_keep_mask size ({packed_keep_mask.numel()})"

--- a/src/olmo_core/nn/moe/utils.py
+++ b/src/olmo_core/nn/moe/utils.py
@@ -468,25 +468,30 @@ class _TEUnpermuteIndexMapMaskedAutograd(torch.autograd.Function):
         inp, row_id_map, probs, packed_keep_mask = ctx.saved_tensors
         grad_inp = None
         grad_probs = None
-        if ctx.needs_input_grad[0]:
+        # Run the unpermute backward when either the expert outputs (input 0) or the
+        # merging probabilities (input 2) need gradients. The kernel produces both
+        # gradients in one pass, so gating only on input 0 would drop the prob
+        # gradients when the experts are frozen but the router is still trained.
+        if ctx.needs_input_grad[0] or ctx.needs_input_grad[2]:
+            # Only write into the caller's gradient buffer when the input-0 gradient was
+            # actually requested, and never when that buffer aliases ``inp`` (which the
+            # prob-gradient path still reads).
+            out_buffer = ctx.backward_grad_input_buffer if ctx.needs_input_grad[0] else None
+            if (
+                out_buffer is not None
+                and ctx.needs_input_grad[2]
+                and out_buffer.untyped_storage().data_ptr() == inp.untyped_storage().data_ptr()
+            ):
+                out_buffer = None
             grad_inp, grad_probs = moe_unpermute_bwd_cuda(
                 grad_output=grad_output,
                 input_fwd=inp,
                 row_id_map=row_id_map,
                 probs=probs,
                 keep_mask=packed_keep_mask,
-                out=(
-                    None
-                    if (
-                        ctx.needs_input_grad[2]
-                        and ctx.backward_grad_input_buffer is not None
-                        and ctx.backward_grad_input_buffer.untyped_storage().data_ptr()
-                        == inp.untyped_storage().data_ptr()
-                    )
-                    else ctx.backward_grad_input_buffer
-                ),
+                out=out_buffer,
             )
-            if ctx.backward_grad_input_buffer is not None:
+            if ctx.needs_input_grad[0] and ctx.backward_grad_input_buffer is not None:
                 grad_inp_uses_buffer = (
                     grad_inp.untyped_storage().data_ptr()
                     == ctx.backward_grad_input_buffer.untyped_storage().data_ptr()
@@ -500,6 +505,8 @@ class _TEUnpermuteIndexMapMaskedAutograd(torch.autograd.Function):
                         grad_inp_uses_buffer
                     ), "Expected moe_unpermute_bwd to write to backward_grad_input_buffer"
 
+        if not ctx.needs_input_grad[0]:
+            grad_inp = None
         if not ctx.needs_input_grad[2]:
             grad_probs = None
         return grad_inp, None, grad_probs, None, None

--- a/src/olmo_core/testing/__init__.py
+++ b/src/olmo_core/testing/__init__.py
@@ -11,6 +11,7 @@ from .utils import (
     LOW_PRECISION_DTYPES,
     MULTI_GPU_MARKS,
     TE_MARKS,
+    TRITON_MARKS,
     has_cuda,
     has_flash_attn_2,
     has_flash_attn_4,
@@ -19,6 +20,7 @@ from .utils import (
     has_quack,
     has_torch_grouped_mm,
     has_torchao,
+    has_triton,
     requires_flash_attn_2,
     requires_flash_attn_4,
     requires_gpu,
@@ -27,6 +29,7 @@ from .utils import (
     requires_quack,
     requires_te,
     requires_torch_grouped_mm,
+    requires_triton,
 )
 
 __all__ = [
@@ -41,6 +44,7 @@ __all__ = [
     "INIT_DEVICES",
     "LOW_PRECISION_DTYPES",
     "MULTI_GPU_MARKS",
+    "TRITON_MARKS",
     "has_cuda",
     "has_flash_attn_2",
     "has_flash_attn_4",
@@ -48,6 +52,7 @@ __all__ = [
     "has_multiple_gpus",
     "has_torch_grouped_mm",
     "has_torchao",
+    "has_triton",
     "has_quack",
     "requires_flash_attn_2",
     "requires_flash_attn_4",
@@ -55,6 +60,7 @@ __all__ = [
     "requires_gpu",
     "requires_grouped_gemm",
     "requires_torch_grouped_mm",
+    "requires_triton",
     "requires_quack",
     "requires_multi_gpu",
     "run_distributed_test",

--- a/src/olmo_core/testing/utils.py
+++ b/src/olmo_core/testing/utils.py
@@ -6,6 +6,7 @@ import torch
 
 import olmo_core.nn.attention.flash_attn_api as flash_attn_api
 import olmo_core.nn.attention.flash_linear_attn_api as flash_linear_attn_api
+import olmo_core.nn.moe.utils as moe_utils
 
 log = logging.getLogger(__name__)
 
@@ -23,6 +24,7 @@ has_flash_attn_2 = flash_attn_api.has_flash_attn_2()
 has_flash_attn_3 = flash_attn_api.has_flash_attn_3()
 has_flash_attn_4 = flash_attn_api.has_flash_attn_4()
 has_fla = flash_linear_attn_api.has_fla()
+has_triton = moe_utils.has_triton()
 has_torchao = False
 has_grouped_gemm = False
 has_te = False
@@ -146,6 +148,18 @@ FLA_MARKS = (
 
 def requires_fla(func):
     for mark in FLA_MARKS:
+        func = mark(func)
+    return func
+
+
+TRITON_MARKS = (
+    pytest.mark.gpu,
+    pytest.mark.skipif(not has_triton, reason="Requires triton"),
+)
+
+
+def requires_triton(func):
+    for mark in TRITON_MARKS:
         func = mark(func)
     return func
 

--- a/src/test/nn/moe/v2/chunk_reorder_test.py
+++ b/src/test/nn/moe/v2/chunk_reorder_test.py
@@ -1,0 +1,38 @@
+import torch
+
+from olmo_core.kernels.moe_chunk_reorder import (
+    _chunk_unpermute_torch,
+    _dispatch_permute_by_row_id_map,
+)
+
+
+def test_chunk_unpermute_torch_zeros_out_of_range_rows():
+    inp = torch.arange(3 * 512, dtype=torch.float32).view(3, 512)
+    row_id_map = torch.tensor([0, 3, -1, 2], dtype=torch.int32)
+
+    out = _chunk_unpermute_torch(inp, row_id_map, num_tokens=4, out=None)
+
+    expected = torch.zeros(4, 512)
+    expected[0].copy_(inp[0])
+    expected[3].copy_(inp[2])
+    torch.testing.assert_close(out, expected)
+
+
+def test_chunk_permute_by_row_id_map_torch_honors_out_buffer():
+    inp = torch.arange(3 * 512, dtype=torch.float32).view(3, 512)
+    row_id_map = torch.tensor([2, -1, 0], dtype=torch.int32)
+    out_buffer = torch.empty((3, 512), dtype=inp.dtype)
+
+    out = _dispatch_permute_by_row_id_map(
+        inp,
+        row_id_map,
+        num_out_tokens=3,
+        backend="triton",
+        out=out_buffer,
+    )
+
+    assert out.data_ptr() == out_buffer.data_ptr()
+    expected = torch.zeros(3, 512)
+    expected[0].copy_(inp[2])
+    expected[2].copy_(inp[0])
+    torch.testing.assert_close(out, expected)

--- a/src/test/nn/moe/v2/permute_drop_fused_test.py
+++ b/src/test/nn/moe/v2/permute_drop_fused_test.py
@@ -1,0 +1,96 @@
+import torch
+
+from olmo_core.nn.moe.utils import (
+    moe_permute_1d_fused_drop_no_compile,
+    moe_permute_no_compile,
+)
+from olmo_core.testing import requires_gpu, requires_te
+
+
+@requires_gpu
+@requires_te
+def test_permute_drop_1d_one_shot_custom_cuda_matches_reference_kept_rows():
+    torch.manual_seed(29)
+    device = torch.device("cuda")
+    num_tokens = 96
+    top_k = 2
+    d_model = 512
+    num_experts = 8
+    num_out_tokens = num_tokens * top_k
+
+    x = torch.randn(num_tokens, d_model, device=device, dtype=torch.float16)
+    routing_map = torch.randint(
+        low=0,
+        high=num_experts,
+        size=(num_tokens, top_k),
+        device=device,
+        dtype=torch.int32,
+    )
+
+    requested_splits = torch.bincount(
+        routing_map.reshape(-1).to(dtype=torch.long),
+        minlength=num_experts,
+    ).to(dtype=torch.long)
+    keep_fraction = 0.55
+    keep_splits = torch.floor(requested_splits.to(dtype=torch.float32) * keep_fraction).to(
+        dtype=torch.long
+    )
+    keep_splits = torch.minimum(keep_splits, requested_splits)
+    num_kept = int(keep_splits.sum().item())
+
+    requested_ends = torch.cumsum(requested_splits, dim=0)
+    token_ids = torch.arange(num_out_tokens, device=device, dtype=torch.long)
+    expert_ids = torch.searchsorted(requested_ends, token_ids, right=True).clamp_max(
+        requested_splits.numel() - 1
+    )
+    starts = requested_ends - requested_splits
+    pos_in_chunk = token_ids - starts.index_select(0, expert_ids)
+    keep_mask = pos_in_chunk < keep_splits.index_select(0, expert_ids)
+    keep_i64 = keep_mask.to(dtype=torch.long)
+    drop_i64 = (~keep_mask).to(dtype=torch.long)
+    keep_rank = torch.cumsum(keep_i64, dim=0) - 1
+    drop_rank = torch.cumsum(drop_i64, dim=0) - 1
+    packed_pos = torch.where(keep_mask, keep_rank, keep_i64.sum(dtype=torch.long) + drop_rank)
+
+    reorder_indices = torch.empty_like(token_ids)
+    reorder_indices.scatter_(0, packed_pos, token_ids)
+    inverse_reorder_indices = packed_pos
+
+    x_reference = x.detach().clone().requires_grad_(True)
+    permuted_reference, _ = moe_permute_no_compile(
+        inp=x_reference,
+        routing_map=routing_map,
+        num_out_tokens=num_out_tokens,
+        map_type="index",
+    )
+    dropped_reference = permuted_reference.index_select(0, reorder_indices)
+
+    x_fused = x.detach().clone().requires_grad_(True)
+    out_buffer = torch.empty((num_out_tokens, d_model), device=device, dtype=x.dtype)
+    dropped_fused, _ = moe_permute_1d_fused_drop_no_compile(
+        inp=x_fused,
+        routing_map=routing_map,
+        num_out_tokens=num_out_tokens,
+        reorder_indices=reorder_indices,
+        inverse_reorder_indices=inverse_reorder_indices,
+        requested_splits=requested_splits,
+        keep_splits=keep_splits,
+        out=out_buffer,
+        map_type="index",
+    )
+
+    torch.testing.assert_close(
+        dropped_fused[:num_kept],
+        dropped_reference[:num_kept],
+        atol=5e-3,
+        rtol=5e-3,
+    )
+
+    grad_out = torch.randn_like(dropped_reference)
+    grad_out[num_kept:].zero_()
+    (dropped_reference * grad_out).sum().backward()
+    (dropped_fused * grad_out).sum().backward()
+
+    assert x_reference.grad is not None
+    assert x_fused.grad is not None
+    torch.testing.assert_close(x_fused.grad, x_reference.grad, atol=5e-3, rtol=5e-3)

--- a/src/test/nn/moe/v2/restore_unpermute_fused_test.py
+++ b/src/test/nn/moe/v2/restore_unpermute_fused_test.py
@@ -1,0 +1,121 @@
+import torch
+
+from olmo_core.nn.moe.utils import moe_unpermute_1d_fused_drop_no_compile
+from olmo_core.testing import requires_gpu, requires_te
+
+
+def _reference_unpermute(
+    *,
+    input_fwd: torch.Tensor,
+    row_id_map: torch.Tensor,
+    probs: torch.Tensor,
+) -> torch.Tensor:
+    """Differentiable pure-torch unpermute-and-combine matching the TE row-id layout."""
+    num_tokens, top_k = probs.shape
+    out = input_fwd.new_zeros((num_tokens, input_fwd.shape[-1]))
+    for token_idx in range(num_tokens):
+        for topk_idx in range(top_k):
+            row_idx = int(row_id_map[topk_idx * num_tokens + token_idx].item())
+            if row_idx >= 0:
+                out[token_idx] = out[token_idx] + input_fwd[row_idx] * probs[
+                    token_idx, topk_idx
+                ].to(dtype=input_fwd.dtype)
+    return out
+
+
+@requires_gpu
+@requires_te
+def test_restore_unpermute_1d_packed_backward_buffer_does_not_corrupt_prob_grads():
+    torch.manual_seed(31)
+    device = torch.device("cuda")
+    num_tokens = 8
+    top_k = 2
+    d_model = 512
+    num_rows = num_tokens * top_k
+
+    row_id_map = torch.arange(num_rows, device=device, dtype=torch.int32)
+    local_inverse_reorder_indices = torch.arange(num_rows, device=device, dtype=torch.long)
+    packed_keep_mask = torch.ones(num_rows, device=device, dtype=torch.bool)
+    probs = torch.rand(num_tokens, top_k, device=device, dtype=torch.float32)
+    grad_out = torch.randn(num_tokens, d_model, device=device, dtype=torch.float32)
+
+    inp_ref = torch.randn(num_rows, d_model, device=device, dtype=torch.float16, requires_grad=True)
+    probs_ref = probs.detach().clone().requires_grad_(True)
+    out_ref = moe_unpermute_1d_fused_drop_no_compile(
+        inp=inp_ref,
+        row_id_map=row_id_map,
+        local_inverse_reorder_indices=local_inverse_reorder_indices,
+        packed_keep_mask=packed_keep_mask,
+        merging_probs=probs_ref,
+        num_kept=torch.tensor(num_rows, device=device),
+        row_id_map_is_packed=True,
+        backward_grad_input_buffer=None,
+        map_type="index",
+    )
+    (out_ref * grad_out.to(out_ref.dtype)).sum().backward()
+
+    inp_alias = inp_ref.detach().clone().requires_grad_(True)
+    probs_alias = probs.detach().clone().requires_grad_(True)
+    out_alias = moe_unpermute_1d_fused_drop_no_compile(
+        inp=inp_alias,
+        row_id_map=row_id_map,
+        local_inverse_reorder_indices=local_inverse_reorder_indices,
+        packed_keep_mask=packed_keep_mask,
+        merging_probs=probs_alias,
+        num_kept=torch.tensor(num_rows, device=device),
+        row_id_map_is_packed=True,
+        backward_grad_input_buffer=inp_alias.detach(),
+        map_type="index",
+    )
+    (out_alias * grad_out.to(out_alias.dtype)).sum().backward()
+
+    assert inp_ref.grad is not None
+    assert inp_alias.grad is not None
+    assert probs_ref.grad is not None
+    assert probs_alias.grad is not None
+    torch.testing.assert_close(inp_alias.grad, inp_ref.grad, atol=5e-3, rtol=5e-3)
+    torch.testing.assert_close(probs_alias.grad, probs_ref.grad, atol=5e-3, rtol=5e-3)
+
+
+@requires_gpu
+@requires_te
+def test_restore_unpermute_1d_prob_grads_with_frozen_experts():
+    """
+    Router-probability gradients must still flow when the expert outputs (input 0)
+    are frozen but ``merging_probs`` (input 2) requires grad. Regression test for the
+    unpermute backward gating prob-gradient computation on ``needs_input_grad[0]``.
+    """
+    torch.manual_seed(37)
+    device = torch.device("cuda")
+    num_tokens = 8
+    top_k = 2
+    d_model = 512
+    num_rows = num_tokens * top_k
+
+    row_id_map = torch.arange(num_rows, device=device, dtype=torch.int32)
+    local_inverse_reorder_indices = torch.arange(num_rows, device=device, dtype=torch.long)
+    packed_keep_mask = torch.ones(num_rows, device=device, dtype=torch.bool)
+    grad_out = torch.randn(num_tokens, d_model, device=device, dtype=torch.float32)
+
+    # Expert outputs are frozen; only the router probabilities are trainable.
+    inp = torch.randn(num_rows, d_model, device=device, dtype=torch.float32)
+    probs = torch.rand(num_tokens, top_k, device=device, dtype=torch.float32, requires_grad=True)
+
+    out = moe_unpermute_1d_fused_drop_no_compile(
+        inp=inp,
+        row_id_map=row_id_map,
+        local_inverse_reorder_indices=local_inverse_reorder_indices,
+        packed_keep_mask=packed_keep_mask,
+        merging_probs=probs,
+        num_kept=torch.tensor(num_rows, device=device),
+        row_id_map_is_packed=True,
+        map_type="index",
+    )
+    (out * grad_out).sum().backward()
+
+    probs_ref = probs.detach().clone().requires_grad_(True)
+    out_ref = _reference_unpermute(input_fwd=inp, row_id_map=row_id_map, probs=probs_ref)
+    (out_ref * grad_out).sum().backward()
+
+    assert probs.grad is not None
+    torch.testing.assert_close(probs.grad, probs_ref.grad, atol=5e-3, rtol=5e-3)


### PR DESCRIPTION
Adds `nn/moe/utils.py`: the autograd-aware, `torch.compile`-safe wrapper layer over the MoE token permute / unpermute / chunk-reorder CUDA kernels (with optional Triton and TransformerEngine backends). These move tokens between the router's assignment order and the experts' grouped (per-expert-contiguous) order, in both forward and backward.

Contents:
- **Permute / unpermute with custom autograd** — including fused capacity-drop and row-id-map variants (`moe_permute_1d_fused_drop_no_compile`, `moe_unpermute_1d_fused_drop_no_compile`, `moe_reorder_rows_permutation`).
- **Chunk reordering** for the grouped-expert layout, with TE / CUDA backend selection (`moe_chunk_reorder_no_compile`, `build_chunk_te_routing_map`).
- Small `@torch.compiler.disable` stream/event sync helpers and eager kernel passthroughs.

It depends only on the permute/reorder kernels already in `olmo_core.kernels` plus `olmo_core.utils.get_or_init_stream`; Triton and TransformerEngine are optional, guarded imports, so the module imports on CPU.

Also includes a CPU test for the chunk-reorder torch reference paths (`_chunk_unpermute_torch` zeroing out-of-range rows; `_dispatch_permute_by_row_id_map` honoring an `out=` buffer). The fused permute/unpermute correctness tests are GPU + TransformerEngine gated and will follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)