### PR TITLE
Add activation-checkpoint state tracking

### DIFF
--- a/src/olmo_core/nn/moe/v2/checkpointing.py
+++ b/src/olmo_core/nn/moe/v2/checkpointing.py
@@ -14,20 +14,13 @@ import torch
 _CHECKPOINT_RECOMPUTE_STATE = threading.local()
 _CHECKPOINT_FORWARD_STATE = threading.local()
 
-try:
-    _torch_compile_disable = torch.compiler.disable
-except AttributeError:
 
-    def _torch_compile_disable(fn):
-        return fn
-
-
-@_torch_compile_disable
+@torch.compiler.disable
 def is_checkpoint_forwarding() -> bool:
     return getattr(_CHECKPOINT_FORWARD_STATE, "depth", 0) > 0
 
 
-@_torch_compile_disable
+@torch.compiler.disable
 def is_checkpoint_recomputing() -> bool:
     """Whether execution is inside an activation-checkpoint recompute."""
     if getattr(_CHECKPOINT_RECOMPUTE_STATE, "depth", 0) > 0:
@@ -46,12 +39,12 @@ def is_checkpoint_recomputing() -> bool:
         return False
 
 
-@_torch_compile_disable
+@torch.compiler.disable
 def is_activation_checkpointing() -> bool:
     return is_checkpoint_forwarding() or is_checkpoint_recomputing()
 
 
-@_torch_compile_disable
+@torch.compiler.disable
 def get_rowwise_checkpoint_state() -> tuple[bool, bool]:
     """
     Return ``(checkpointing_active, save_for_recompute)``: whether activation

--- a/src/olmo_core/nn/moe/v2/checkpointing.py
+++ b/src/olmo_core/nn/moe/v2/checkpointing.py
@@ -1,6 +1,13 @@
+"""
+Thread-local state for activation checkpointing.
+
+Tracks whether execution is currently inside a checkpointed forward or a
+recompute, so MoE forwards wrapped in activation checkpointing can avoid
+repeating metric side effects when their forward is recomputed in backward.
+"""
+
 import threading
 from contextlib import contextmanager
-from typing import Tuple
 
 import torch
 
@@ -22,6 +29,7 @@ def is_checkpoint_forwarding() -> bool:
 
 @_torch_compile_disable
 def is_checkpoint_recomputing() -> bool:
+    """Whether execution is inside an activation-checkpoint recompute."""
     if getattr(_CHECKPOINT_RECOMPUTE_STATE, "depth", 0) > 0:
         return True
 
@@ -44,7 +52,12 @@ def is_activation_checkpointing() -> bool:
 
 
 @_torch_compile_disable
-def get_rowwise_checkpoint_state() -> Tuple[bool, bool]:
+def get_rowwise_checkpoint_state() -> tuple[bool, bool]:
+    """
+    Return ``(checkpointing_active, save_for_recompute)``: whether activation
+    checkpointing is active, and whether outputs should be saved (``True`` on the
+    initial forward, ``False`` during recompute so side effects aren't repeated).
+    """
     checkpoint_forwarding = is_checkpoint_forwarding()
     checkpoint_recomputing = is_checkpoint_recomputing()
     return checkpoint_forwarding or checkpoint_recomputing, not checkpoint_recomputing
@@ -52,6 +65,7 @@ def get_rowwise_checkpoint_state() -> Tuple[bool, bool]:
 
 @contextmanager
 def checkpoint_forward_context():
+    """Mark the enclosed block as a checkpointed forward (re-entrant via depth)."""
     depth = getattr(_CHECKPOINT_FORWARD_STATE, "depth", 0)
     _CHECKPOINT_FORWARD_STATE.depth = depth + 1
     try:
@@ -66,6 +80,7 @@ def checkpoint_forward_context():
 
 @contextmanager
 def checkpoint_recompute_context():
+    """Mark the enclosed block as an activation-checkpoint recompute (re-entrant via depth)."""
     depth = getattr(_CHECKPOINT_RECOMPUTE_STATE, "depth", 0)
     _CHECKPOINT_RECOMPUTE_STATE.depth = depth + 1
     try:

--- a/src/olmo_core/nn/moe/v2/checkpointing.py
+++ b/src/olmo_core/nn/moe/v2/checkpointing.py
@@ -1,0 +1,82 @@
+import threading
+from contextlib import contextmanager
+from typing import Tuple
+
+import torch
+
+_CHECKPOINT_RECOMPUTE_STATE = threading.local()
+_CHECKPOINT_FORWARD_STATE = threading.local()
+
+try:
+    _torch_compile_disable = torch.compiler.disable
+except AttributeError:
+
+    def _torch_compile_disable(fn):
+        return fn
+
+
+@_torch_compile_disable
+def is_checkpoint_forwarding() -> bool:
+    return getattr(_CHECKPOINT_FORWARD_STATE, "depth", 0) > 0
+
+
+@_torch_compile_disable
+def is_checkpoint_recomputing() -> bool:
+    if getattr(_CHECKPOINT_RECOMPUTE_STATE, "depth", 0) > 0:
+        return True
+
+    # When torch.compile is enabled, checkpoint() requires context_fn entries to
+    # be TorchDispatchModes, so some call sites use noop_context_fn instead of
+    # checkpoint_recompute_context_fn(). Non-reentrant checkpoint recomputation
+    # still runs while autograd is executing a graph task; use that as a fallback
+    # so recomputed forwards don't repeat metric side effects. With
+    # reduce_overhead/CUDA graph capture this is a best-effort workaround, not a
+    # fully proven signal.
+    try:
+        return torch.is_grad_enabled() and torch._C._current_graph_task_id() != -1
+    except Exception:
+        return False
+
+
+@_torch_compile_disable
+def is_activation_checkpointing() -> bool:
+    return is_checkpoint_forwarding() or is_checkpoint_recomputing()
+
+
+@_torch_compile_disable
+def get_rowwise_checkpoint_state() -> Tuple[bool, bool]:
+    checkpoint_forwarding = is_checkpoint_forwarding()
+    checkpoint_recomputing = is_checkpoint_recomputing()
+    return checkpoint_forwarding or checkpoint_recomputing, not checkpoint_recomputing
+
+
+@contextmanager
+def checkpoint_forward_context():
+    depth = getattr(_CHECKPOINT_FORWARD_STATE, "depth", 0)
+    _CHECKPOINT_FORWARD_STATE.depth = depth + 1
+    try:
+        yield
+    finally:
+        if depth == 0:
+            if hasattr(_CHECKPOINT_FORWARD_STATE, "depth"):
+                delattr(_CHECKPOINT_FORWARD_STATE, "depth")
+        else:
+            _CHECKPOINT_FORWARD_STATE.depth = depth
+
+
+@contextmanager
+def checkpoint_recompute_context():
+    depth = getattr(_CHECKPOINT_RECOMPUTE_STATE, "depth", 0)
+    _CHECKPOINT_RECOMPUTE_STATE.depth = depth + 1
+    try:
+        yield
+    finally:
+        if depth == 0:
+            if hasattr(_CHECKPOINT_RECOMPUTE_STATE, "depth"):
+                delattr(_CHECKPOINT_RECOMPUTE_STATE, "depth")
+        else:
+            _CHECKPOINT_RECOMPUTE_STATE.depth = depth
+
+
+def checkpoint_recompute_context_fn():
+    return checkpoint_forward_context(), checkpoint_recompute_context()

--- a/src/test/nn/moe/v2/checkpointing_test.py
+++ b/src/test/nn/moe/v2/checkpointing_test.py
@@ -1,0 +1,44 @@
+from olmo_core.nn.moe.v2.checkpointing import (
+    checkpoint_forward_context,
+    checkpoint_recompute_context,
+    get_rowwise_checkpoint_state,
+    is_activation_checkpointing,
+    is_checkpoint_forwarding,
+    is_checkpoint_recomputing,
+)
+
+
+def test_forward_context_tracks_depth():
+    assert not is_checkpoint_forwarding()
+    with checkpoint_forward_context():
+        assert is_checkpoint_forwarding()
+        with checkpoint_forward_context():  # nested
+            assert is_checkpoint_forwarding()
+        assert is_checkpoint_forwarding()  # still inside the outer context
+    assert not is_checkpoint_forwarding()  # restored
+
+
+def test_recompute_context_tracks_depth():
+    with checkpoint_recompute_context():
+        assert is_checkpoint_recomputing()
+        with checkpoint_recompute_context():  # nested
+            assert is_checkpoint_recomputing()
+        assert is_checkpoint_recomputing()
+    assert not is_checkpoint_recomputing()
+
+
+def test_is_activation_checkpointing():
+    assert not is_activation_checkpointing()
+    with checkpoint_forward_context():
+        assert is_activation_checkpointing()
+    with checkpoint_recompute_context():
+        assert is_activation_checkpointing()
+
+
+def test_get_rowwise_checkpoint_state():
+    # On the initial checkpointed forward: active, and outputs should be saved.
+    with checkpoint_forward_context():
+        assert get_rowwise_checkpoint_state() == (True, True)
+    # During recompute: active, but outputs should not be re-saved.
+    with checkpoint_recompute_context():
+        assert get_rowwise_checkpoint_state() == (True, False)


### PR DESCRIPTION
Adds `nn/moe/v2/checkpointing.py`: thread-local depth tracking for activation checkpointing.

It reports whether execution is currently inside a checkpointed **forward** or a **recompute** (via re-entrant `checkpoint_forward_context` / `checkpoint_recompute_context` context managers), and exposes `get_rowwise_checkpoint_state()` returning `(checkpointing_active, save_for_recompute)` — so a checkpointed MoE forward can save outputs on the initial pass but avoid repeating metric side effects when it is recomputed in backward.

Pure-Python (`threading` + `contextlib` + `torch`), no MoE/model coupling. Includes CPU unit tests covering the depth tracking (nesting + reset) and the save-on-forward / skip-on-recompute behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)