### PR TITLE
Fix thread leak in threaded_generator when consumers exit early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Excluded `mark_dynamic` from `torch.compile` tracing (`@torch.compiler.disable`).
+- Fixed a thread leak in `threaded_generator()`: the producer thread would block forever on a full queue when the consumer was abandoned before exhaustion (e.g. whenever a data loader's epoch iterator isn't fully consumed), leaking threads over the course of training.
 - Clearer error messages (now include the offending values) when a rank batch size isn't divisible by the sequence length, or `max_target_sequence_length` isn't a multiple of `sequence_length`.
 - S3 uploads/downloads now also retry on transient SSL errors (`ssl.SSLError`, botocore/urllib3 `SSLError`).
 - Distributed checkpoint writes now clone each tensor before serialization to avoid accidentally writing the full backing storage of a view/shared tensor, with a guard that raises `OLMoCheckpointError` if a written tensor is unexpectedly larger than its `nbytes`.

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -12,8 +12,8 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from functools import lru_cache
 from itertools import cycle, islice
-from queue import Queue
-from threading import Thread
+from queue import Empty, Full, Queue
+from threading import Event, Thread
 from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar, Union, cast
 
 import rich
@@ -587,25 +587,50 @@ def threaded_generator(g, maxsize: int = 16, thread_name: Optional[str] = None):
     q: Queue = Queue(maxsize=maxsize)
 
     sentinel = object()
+    stop = Event()
+
+    def put(item) -> bool:
+        # Put an item on the queue while periodically checking that the consumer is still
+        # around, otherwise an abandoned consumer would leave us blocking on a full queue
+        # forever, leaking this thread.
+        while not stop.is_set():
+            try:
+                q.put(item, timeout=0.1)
+                return True
+            except Full:
+                continue
+        return False
 
     def fill_queue():
         try:
             for value in g:
-                q.put(value)
+                if not put(value):
+                    return
         except Exception as e:
-            q.put(e)
+            put(e)
         finally:
-            q.put(sentinel)
+            put(sentinel)
 
     thread_name = thread_name or repr(g)
     thread = Thread(name=thread_name, target=fill_queue, daemon=True)
     thread.start()
 
-    for x in iter(q.get, sentinel):
-        if isinstance(x, Exception):
-            raise OLMoThreadError(f"generator thread {thread_name} failed") from x
-        else:
-            yield x
+    try:
+        for x in iter(q.get, sentinel):
+            if isinstance(x, Exception):
+                raise OLMoThreadError(f"generator thread {thread_name} failed") from x
+            else:
+                yield x
+    finally:
+        # Runs when the generator is exhausted, but also when the consumer abandons it early
+        # (via ``GeneratorExit``). Signal the thread to shut down and drain the queue to
+        # unblock it right away if it's stuck on a put.
+        stop.set()
+        while True:
+            try:
+                q.get_nowait()
+            except Empty:
+                break
 
 
 def roundrobin(*iterables):

--- a/src/test/utils_test.py
+++ b/src/test/utils_test.py
@@ -1,9 +1,18 @@
+import gc
+import threading
+import time
 from dataclasses import dataclass
 
 import pytest
 import torch
 
-from olmo_core.utils import apply_to_tensors, flatten_dict, format_float
+from olmo_core.exceptions import OLMoThreadError
+from olmo_core.utils import (
+    apply_to_tensors,
+    flatten_dict,
+    format_float,
+    threaded_generator,
+)
 
 
 @dataclass
@@ -47,6 +56,46 @@ def test_flatten_dict():
         "a.bar.baz": 2,
         "b": 2,
     }
+
+
+def test_threaded_generator():
+    assert list(threaded_generator(iter(range(100)), maxsize=4)) == list(range(100))
+
+
+def test_threaded_generator_raises_on_failure():
+    def bad_generator():
+        yield 0
+        raise ValueError("oh no")
+
+    with pytest.raises(OLMoThreadError):
+        list(threaded_generator(bad_generator()))
+
+
+def test_threaded_generator_abandoned_consumer_does_not_leak_thread():
+    def infinite_source():
+        i = 0
+        while True:
+            yield i
+            i += 1
+
+    thread_names = [f"test_threaded_generator_leak {i}" for i in range(8)]
+    for name in thread_names:
+        gen = threaded_generator(infinite_source(), maxsize=2, thread_name=name)
+        # Take a single item, then abandon the generator before it's exhausted.
+        assert next(gen) == 0
+        gen.close()
+
+    del gen
+    gc.collect()
+
+    # The producer threads should shut down promptly once their consumers are gone.
+    deadline = time.monotonic() + 5.0
+    while True:
+        leaked = [t.name for t in threading.enumerate() if t.name in thread_names]
+        if not leaked or time.monotonic() >= deadline:
+            break
+        time.sleep(0.05)
+    assert not leaked, f"threaded_generator leaked threads: {leaked}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #703.

The issue correctly pinpoints `threaded_generator`. The mechanism: its `fill_queue` daemon thread feeds a bounded queue (`maxsize=16` by default) with a plain blocking `q.put` and has no stop signal, so if the consumer drops the wrapper generator before exhausting it, the thread blocks on `put` forever once the queue fills.

What makes this grow steadily during training: the data loaders (`data_loader.py` and `composable/data_loader.py`) create `num_threads` of these wrappers per batch-iteration and abandon them whenever an epoch iterator isn't fully consumed — stopping mid-epoch, hitting max duration, recreating the iterator — stranding another batch of threads each time.

This adds a stop event: the producer puts with a short timeout and re-checks the event, and the consumer sets it and drains the queue from a `finally` block, which also runs on `GeneratorExit` when the wrapper is closed or garbage collected. Producer threads now exit promptly once their consumer goes away. Ordering, sentinel termination, and exception forwarding via `OLMoThreadError` are unchanged.

Testing: new regression test in `src/test/utils_test.py` — abandoning wrappers mid-iteration leaks all 8 `fill_queue` threads on main and none with this change — plus coverage for in-order full consumption and exception forwarding. `src/test/data/data_loader_test.py` and `src/test/data/composable/data_loader_test.py` pass.
