### PR TITLE
Compare Qwen3.5 GPU test against the real official checkpoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,6 +238,10 @@ jobs:
           echo "COMMIT_SHA=$GITHUB_SHA" >> $GITHUB_ENV
           echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
 
+      # The '--weka' mount + 'HF_HOME' below point HuggingFace at a checkpoint cache on Weka so
+      # the Qwen3.5 comparison test reads the official weights from the mount instead of
+      # downloading them and timing out. Populate the cache once from a Weka-mounted machine via:
+      #   HF_HOME=/weka/oe-training-default/test-fixtures/hf hf download Qwen/Qwen3.5-0.8B
       - name: GPU Tests
         if: env.BEAKER_TOKEN != ''
         run: |
@@ -259,9 +263,11 @@ jobs:
             --gpu-type a100 \
             --system-python \
             --dataset-secret 'GOOGLE_CREDENTIALS:/.google/credentials.json' \
+            --weka 'oe-training-default:/weka/oe-training-default' \
             --env 'GOOGLE_APPLICATION_CREDENTIALS=/.google/credentials.json' \
             --env 'TOKENIZERS_PARALLELISM=false' \
             --env 'CUBLAS_WORKSPACE_CONFIG=:16:8' \
+            --env 'HF_HOME=/weka/oe-training-default/test-fixtures/hf' \
             --env-secret 'AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID' \
             --env-secret 'AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY' \
             -- ${{ matrix.task.run }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Qwen3.5 GPU comparison test now validates against the real official `Qwen/Qwen3.5-0.8B` checkpoint instead of a synthetic random-weight config. The GPU CI job reads it from an `HF_HOME` cache on a mounted Weka folder so it doesn't download (and time out) on every run.
 - Excluded `mark_dynamic` from `torch.compile` tracing (`@torch.compiler.disable`).
 - Clearer error messages (now include the offending values) when a rank batch size isn't divisible by the sequence length, or `max_target_sequence_length` isn't a multiple of `sequence_length`.
 - S3 uploads/downloads now also retry on transient SSL errors (`ssl.SSLError`, botocore/urllib3 `SSLError`).

--- a/src/test/nn/hf/qwen3_5_test.py
+++ b/src/test/nn/hf/qwen3_5_test.py
@@ -6,6 +6,8 @@ from olmo_core.nn.hf.convert import convert_state_from_hf
 from olmo_core.nn.transformer import TransformerConfig
 from olmo_core.testing.utils import requires_fla, requires_gpu
 
+QWEN3_5_MODEL_ID = "Qwen/Qwen3.5-0.8B"
+
 
 def _has_qwen3_5_transformers() -> bool:
     try:
@@ -41,6 +43,19 @@ def _get_qwen3_5_config(hf_config) -> TransformerConfig:
     )
 
 
+def _load_pretrained(model_cls, **kwargs):
+    """Load the official Qwen3.5 checkpoint, skipping the test if it can't be obtained.
+
+    CI serves the checkpoint from an ``HF_HOME`` cache on Weka, so this loads from
+    the local mount rather than downloading (a download here can blow past the GPU
+    job's task timeout). Local runs fall back to a normal download.
+    """
+    try:
+        return model_cls.from_pretrained(QWEN3_5_MODEL_ID, **kwargs)
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"could not load {QWEN3_5_MODEL_ID}: {e}")
+
+
 @pytest.mark.skipif(not _has_qwen3_5_transformers(), reason="transformers lacks Qwen3.5 support")
 @requires_gpu
 @requires_fla
@@ -50,24 +65,13 @@ def test_qwen3_5_matches_huggingface():
     torch.manual_seed(0)
     device = torch.device("cuda")
 
-    hf_config = transformers.Qwen3_5TextConfig(
-        vocab_size=64,
-        hidden_size=16,
-        intermediate_size=32,
-        num_hidden_layers=4,
-        num_attention_heads=2,
-        num_key_value_heads=1,
-        head_dim=8,
-        linear_num_key_heads=2,
-        linear_key_head_dim=4,
-        linear_num_value_heads=2,
-        linear_value_head_dim=4,
-        linear_conv_kernel_dim=4,
-        layer_types=["linear_attention", "linear_attention", "linear_attention", "full_attention"],
-        tie_word_embeddings=True,
+    hf_model = _load_pretrained(
+        transformers.Qwen3_5ForCausalLM,
+        torch_dtype=torch.float32,
+        attn_implementation="eager",
     )
-    hf_model = transformers.Qwen3_5ForCausalLM(hf_config)
     hf_model.eval().to(device)
+    tokenizer = _load_pretrained(transformers.AutoTokenizer)
 
     olmo_config = _get_qwen3_5_config(hf_model.config)
     olmo_model = olmo_config.build(init_device="cpu").eval().to(device)
@@ -78,7 +82,8 @@ def test_qwen3_5_matches_huggingface():
     )
     olmo_model.load_state_dict(converted_state, strict=True)
 
-    input_ids = torch.randint(0, hf_config.vocab_size, (2, 8), device=device)
+    prompt = "Hello! I am a test prompt."
+    input_ids = tokenizer.encode(prompt, return_tensors="pt").to(device)
 
     with torch.no_grad():
         hf_logits = hf_model(input_ids=input_ids).logits


### PR DESCRIPTION
The Qwen3.5 GPU comparison test previously built a synthetic random-weight `Qwen3_5TextConfig`. This restores a real-checkpoint comparison: it loads the official `Qwen/Qwen3.5-0.8B` weights and tokenizer and compares logits on a real prompt.

The test just calls `from_pretrained("Qwen/Qwen3.5-0.8B")` as-is (skipping if the checkpoint can't be obtained). To keep the GPU job from downloading the gated checkpoint in-job (which can exceed the 10-minute task timeout), the gantry run mounts Weka (`oe-training-default`) and points `HF_HOME` at a checkpoint cache there, so the weights are read from the local mount.

**Required data (already done)** populate the cache once from a Weka-mounted machine (with `HF_TOKEN`):
```
HF_HOME=/weka/oe-training-default/test-fixtures/hf hf download Qwen/Qwen3.5-0.8B
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)