### PR TITLE
Add v2 shared experts

### DIFF
--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -1,4 +1,3 @@
-import math
 from dataclasses import dataclass
 
 import torch
@@ -94,13 +93,9 @@ class SharedExperts(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
-        # Setting a=sqrt(5) in kaiming_uniform is the same as initializing with
-        # uniform(-1/sqrt(in_features), 1/sqrt(in_features)). For details, see
-        # https://github.com/pytorch/pytorch/issues/57109
-        # Matches the v1 MoE expert MLPs (nn/moe/mlp.py) so a freshly built module has sane
-        # weights even before any model-level init runs.
+        std = 0.02
         for w in (self.w_up_gate, self.w_down):
-            nn.init.kaiming_uniform_(w, a=math.sqrt(5))
+            nn.init.trunc_normal_(w, mean=0.0, std=std, a=-3 * std, b=3 * std)
 
     def _raise_if_fp8_anchor_storage_released(self) -> None:
         if getattr(self, "_fp8_anchor_storage_released", False):

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -35,6 +35,11 @@ class SharedExpertsConfig(Config):
     dtype: DType
 
     def build(self, init_device: str = "cpu") -> "SharedExperts":
+        """
+        Build the corresponding shared-experts module.
+
+        :param init_device: The device to initialize the parameters on, e.g. "cpu", "meta".
+        """
         kwargs = self.as_dict()
 
         return SharedExperts(init_device=init_device, **kwargs)
@@ -42,8 +47,6 @@ class SharedExpertsConfig(Config):
     def num_params(self) -> int:
         """
         The number of params that the module will have once built.
-
-        :param d_model: The model dimensionality.
         """
 
         params = 3 * self.d_model * self.hidden_size  # up, gate, down

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -12,6 +12,10 @@ except ImportError:
 from olmo_core.config import Config, DType
 
 
+# TODO: unify the SwiGLU implementations. This hardcodes SiLU, whereas the standard
+# FeedForward (nn/feed_forward.py) exposes a configurable `ActivationFunction`; the v1
+# MoE expert MLP (nn/moe/mlp.py) and routed_experts.py each roll their own as well.
+# Consider a shared helper (and a configurable-but-SwiGLU-only activation here).
 def _swiglu(up: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
     gate = F.silu(gate)
     hidden = up * gate

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -1,10 +1,13 @@
 from dataclasses import dataclass
-from typing import Tuple
 
-import nvtx
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+try:
+    import nvtx
+except ImportError:
+    from olmo_core._nvtx import nvtx
 
 from olmo_core.config import Config, DType
 
@@ -17,24 +20,14 @@ def _swiglu(up: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
 
 @dataclass
 class SharedExpertsConfig(Config):
-
     """
     Configuration for shared experts in a MoE block.
     """
 
-    # Input (and output) dimension of the experts
     d_model: int
-
-    # Hidden (intermediate) dimension of the experts
     hidden_size: int
-
-    # Number of shared experts (can be >= 1)
     num_experts: int
-
-    # Whether to use bias in the experts
     bias: bool
-
-    # default dtype for the experts
     dtype: DType
 
     def build(self, init_device: str = "cpu") -> "SharedExperts":
@@ -134,7 +127,7 @@ class SharedExperts(nn.Module):
         return out.view(E, B, S, D)
 
     @nvtx.annotate("SharedExperts.forward1", color="purple")
-    def forward1(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward1(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Split the forward pass into two parts for better overlap in EP.
         """

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -26,6 +26,15 @@ def _swiglu(up: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
 class SharedExpertsConfig(Config):
     """
     Configuration for shared experts in a MoE block.
+
+    .. note::
+        Unlike the rest of the codebase, this config stores dimension-related fields
+        (e.g. ``d_model``, ``hidden_size``, ``num_experts``) directly. Other configs keep
+        such dimensions out of the config and instead receive them only as arguments to
+        :meth:`build` (e.g. ``AttentionConfig.build(d_model, ...)``), so the dimensions live
+        in a single place and flow down from the top-level transformer config. The v2 configs
+        deviate by duplicating the dimensions here. This should be unified in the future to
+        follow the dimension-agnostic ``build(d_model, ...)`` convention.
     """
 
     d_model: int

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 
 import torch
@@ -89,6 +90,17 @@ class SharedExperts(nn.Module):
         )
         # Per-expert down: (E, H, D)
         self.w_down = nn.Parameter(torch.empty(E, H, D, device=init_device, dtype=dtype.as_pt()))
+
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        # Setting a=sqrt(5) in kaiming_uniform is the same as initializing with
+        # uniform(-1/sqrt(in_features), 1/sqrt(in_features)). For details, see
+        # https://github.com/pytorch/pytorch/issues/57109
+        # Matches the v1 MoE expert MLPs (nn/moe/mlp.py) so a freshly built module has sane
+        # weights even before any model-level init runs.
+        for w in (self.w_up_gate, self.w_down):
+            nn.init.kaiming_uniform_(w, a=math.sqrt(5))
 
     def _raise_if_fp8_anchor_storage_released(self) -> None:
         if getattr(self, "_fp8_anchor_storage_released", False):

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -13,9 +13,9 @@ from olmo_core.config import Config, DType
 
 
 # SwiGLU is intentionally SiLU-gated here, matching the fused fast paths (forward1/forward2)
-# and the routed-expert kernels, which also hardcode SiLU. Folding the codebase's several
-# SwiGLU sites (the configurable FeedForward, the v1 MoE MLP, routed_experts) into one shared
-# helper is a general cross-module refactor, tracked separately rather than done here.
+# and the routed-expert kernels, which also hardcode SiLU.
+# TODO: fold the codebase's several SwiGLU sites (the configurable FeedForward, the v1 MoE
+# MLP, routed_experts) into one shared helper — a general cross-module refactor.
 def _swiglu(up: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
     return up * F.silu(gate)
 

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -12,14 +12,12 @@ except ImportError:
 from olmo_core.config import Config, DType
 
 
-# TODO: unify the SwiGLU implementations. This hardcodes SiLU, whereas the standard
-# FeedForward (nn/feed_forward.py) exposes a configurable `ActivationFunction`; the v1
-# MoE expert MLP (nn/moe/mlp.py) and routed_experts.py each roll their own as well.
-# Consider a shared helper (and a configurable-but-SwiGLU-only activation here).
+# SwiGLU is intentionally SiLU-gated here, matching the fused fast paths (forward1/forward2)
+# and the routed-expert kernels, which also hardcode SiLU. Folding the codebase's several
+# SwiGLU sites (the configurable FeedForward, the v1 MoE MLP, routed_experts) into one shared
+# helper is a general cross-module refactor, tracked separately rather than done here.
 def _swiglu(up: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
-    gate = F.silu(gate)
-    hidden = up * gate
-    return hidden
+    return up * F.silu(gate)
 
 
 @dataclass

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -1,0 +1,178 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+import nvtx
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from olmo_core.config import Config, DType
+
+
+def _swiglu(up: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+    gate = F.silu(gate)
+    hidden = up * gate
+    return hidden
+
+
+@dataclass
+class SharedExpertsConfig(Config):
+
+    """
+    Configuration for shared experts in a MoE block.
+    """
+
+    # Input (and output) dimension of the experts
+    d_model: int
+
+    # Hidden (intermediate) dimension of the experts
+    hidden_size: int
+
+    # Number of shared experts (can be >= 1)
+    num_experts: int
+
+    # Whether to use bias in the experts
+    bias: bool
+
+    # default dtype for the experts
+    dtype: DType
+
+    def build(self, init_device: str = "cpu") -> "SharedExperts":
+        kwargs = self.as_dict()
+
+        return SharedExperts(init_device=init_device, **kwargs)
+
+    def num_params(self) -> int:
+        """
+        The number of params that the module will have once built.
+
+        :param d_model: The model dimensionality.
+        """
+
+        params = 3 * self.d_model * self.hidden_size  # up, gate, down
+        if self.bias:
+            params += 2 * self.hidden_size  # up and gate bias
+            params += self.d_model  # down bias
+
+        params *= self.num_experts  # for each expert
+
+        return params
+
+
+class SharedExperts(nn.Module):
+    """
+    Shared experts module for MoE blocks.
+
+    Shared experts work like a regular feed-forward but can support more than 1 expert.
+    All experts will have the same number of input tokens, so it's possible that we concatenate
+    the weights of all experts and use a single linear layer to process the input.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        hidden_size: int,
+        num_experts: int,
+        bias: bool,
+        dtype: DType,
+        init_device: str = "cpu",
+    ):
+        super().__init__()
+        self.d_model = d_model
+        self.hidden_size = hidden_size
+        self.num_experts = num_experts
+
+        assert not bias, "Shared experts do not support bias for now."
+
+        E, D, H = num_experts, d_model, hidden_size
+
+        # One big column-packed weight for up+gate: (D, E*2H)
+        self.w_up_gate = nn.Parameter(
+            torch.empty(D, E * 2 * H, device=init_device, dtype=dtype.as_pt())
+        )
+        # Per-expert down: (E, H, D)
+        self.w_down = nn.Parameter(torch.empty(E, H, D, device=init_device, dtype=dtype.as_pt()))
+
+    def _raise_if_fp8_anchor_storage_released(self) -> None:
+        if getattr(self, "_fp8_anchor_storage_released", False):
+            raise RuntimeError(
+                "SharedExperts bf16 fallback cannot run after fp8-only anchor storage has been released"
+            )
+
+    @nvtx.annotate("SharedExperts.forward", color="pink")
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        x: (B, S, D) -> out: (E, B, S, D)
+        Fast path:
+          1) [BS, D] @ [D, E*2H] -> [BS, E*2H]
+          2) reshape+permute -> (E, BS, 2, H)
+          3) in-place SiLU on gate, elementwise multiply
+          4) bmm with per-expert down: (E, BS, H) x (E, H, D) -> (E, BS, D)
+        """
+        self._raise_if_fp8_anchor_storage_released()
+        B, S, D = x.shape
+        E, H = self.num_experts, self.hidden_size
+        BS = B * S
+
+        # 1) One big GEMM (best utilization, contiguous out in last dim)
+        x2 = x.reshape(BS, D)  # (BS, D)
+        up_gate = x2 @ self.w_up_gate  # (BS, E*2H)
+
+        # 2) Reshape to separate experts and [up|gate], then make per-expert leading dim
+        #    Shapes: (BS, E, 2, H) -> (E, BS, 2, H)
+        up_gate = up_gate.view(BS, E, 2, H).permute(1, 0, 2, 3)
+
+        # 3) SwiGLU: split into up / gate; materialize gate once and do in-place SiLU
+        up, gate = up_gate.unbind(dim=2)  # each (E, BS, H) views
+
+        hidden = _swiglu(up, gate)  # (E, BS, H)
+
+        # 4) Per-expert down-proj as grouped GEMM
+        #    hidden: (E, BS, H), w_down: (E, H, D) -> out: (E, BS, D)
+        out = torch.bmm(hidden, self.w_down)
+
+        return out.view(E, B, S, D)
+
+    @nvtx.annotate("SharedExperts.forward1", color="purple")
+    def forward1(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Split the forward pass into two parts for better overlap in EP.
+        """
+        self._raise_if_fp8_anchor_storage_released()
+        B, S, D = x.shape
+        E, H = self.num_experts, self.hidden_size
+        BS = B * S
+
+        # 1) One big GEMM (best utilization, contiguous out in last dim)
+        x2 = x.reshape(BS, D)  # (BS, D)
+        up_gate = x2 @ self.w_up_gate  # (BS, E*2H)
+
+        # 2) Reshape to separate experts and [up|gate], then make per-expert leading dim
+        #    Shapes: (BS, E, 2, H) -> (E, BS, 2, H)
+        up_gate = up_gate.view(BS, E, 2, H).permute(1, 0, 2, 3)
+
+        # 3) SwiGLU: split into up / gate; materialize gate once and do in-place SiLU
+        up, gate = up_gate.unbind(dim=2)  # each (E, BS, H) views
+
+        return up, gate
+
+    @nvtx.annotate("SharedExperts.forward2", color="purple")
+    def forward2(self, up: torch.Tensor, gate: torch.Tensor, xshape: torch.Size) -> torch.Tensor:
+        """
+        Split the forward pass into two parts for better overlap in EP.
+        """
+        self._raise_if_fp8_anchor_storage_released()
+        E = self.num_experts
+        B, S, D = xshape
+        # 3) SwiGLU: split into up / gate; materialize gate once and do in-place SiLU
+
+        hidden = _swiglu(up, gate)  # (E, BS, H)
+
+        # 4) Per-expert down-proj as grouped GEMM
+        #    hidden: (E, BS, H), w_down: (E, H, D) -> out: (E, BS, D)
+        out = torch.bmm(hidden, self.w_down)
+
+        return out.view(E, B, S, D)
+
+    def extra_repr(self):
+        return f"num_experts={self.num_experts}, hidden_size={self.hidden_size}, d_model={self.d_model}"

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -93,6 +93,7 @@ class SharedExperts(nn.Module):
         self.reset_parameters()
 
     def reset_parameters(self) -> None:
+        # Standalone default; the model-level init may override this with a depth-scaled std.
         std = 0.02
         for w in (self.w_up_gate, self.w_down):
             nn.init.trunc_normal_(w, mean=0.0, std=std, a=-3 * std, b=3 * std)

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -75,6 +75,12 @@ class SharedExperts(nn.Module):
     Shared experts work like a regular feed-forward but can support more than 1 expert.
     All experts will have the same number of input tokens, so it's possible that we concatenate
     the weights of all experts and use a single linear layer to process the input.
+
+    :meth:`forward` runs the whole module. :meth:`forward1` and :meth:`forward2` split it into
+    two numerically-equivalent halves (the input projection producing ``(up, gate)``, then
+    SwiGLU + the down-projection) so an expert-parallel block can run the shared experts on a
+    separate CUDA stream and overlap each half with the routed experts' dispatch/combine
+    all-to-all communication. The non-EP path just calls :meth:`forward`.
     """
 
     def __init__(

--- a/src/test/nn/moe/v2/shared_experts_test.py
+++ b/src/test/nn/moe/v2/shared_experts_test.py
@@ -1,11 +1,12 @@
 import torch
+import torch.nn.functional as F
 
 from olmo_core.config import DType
 from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
 
 
 def _build(*, d_model=16, hidden_size=32, num_experts=2):
-    # build() initializes the weights (kaiming_uniform), so no manual init is needed.
+    # build() initializes the weights, so no manual init is needed.
     return SharedExpertsConfig(
         d_model=d_model,
         hidden_size=hidden_size,
@@ -60,3 +61,23 @@ def test_shared_experts_split_forward_matches_full():
     split = module.forward2(up, gate, x.shape)
 
     torch.testing.assert_close(full, split)
+
+
+def test_shared_experts_forward_matches_per_expert_reference():
+    torch.manual_seed(0)
+    B, S, D, H, E = 2, 4, 16, 32, 3
+    module = _build(d_model=D, hidden_size=H, num_experts=E)
+    x = torch.randn(B, S, D)
+
+    # Explicit per-expert SwiGLU + down-projection reference for the vectorized forward.
+    # w_up_gate is column-packed as [expert, {up, gate}, hidden]; w_down is (E, H, D).
+    x2 = x.reshape(B * S, D)
+    expected = []
+    for e in range(E):
+        up_gate = x2 @ module.w_up_gate[:, e * 2 * H : (e + 1) * 2 * H]  # (BS, 2H)
+        up, gate = up_gate[:, :H], up_gate[:, H:]
+        hidden = F.silu(gate) * up
+        expected.append(hidden @ module.w_down[e])  # (BS, D)
+    expected = torch.stack(expected, dim=0).view(E, B, S, D)
+
+    torch.testing.assert_close(module(x), expected)

--- a/src/test/nn/moe/v2/shared_experts_test.py
+++ b/src/test/nn/moe/v2/shared_experts_test.py
@@ -5,18 +5,26 @@ from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
 
 
 def _build(*, d_model=16, hidden_size=32, num_experts=2):
-    module = SharedExpertsConfig(
+    # build() initializes the weights (kaiming_uniform), so no manual init is needed.
+    return SharedExpertsConfig(
         d_model=d_model,
         hidden_size=hidden_size,
         num_experts=num_experts,
         bias=False,
         dtype=DType.float32,
     ).build(init_device="cpu")
-    # Weights are allocated with torch.empty; initialize them for a deterministic forward.
-    with torch.no_grad():
-        module.w_up_gate.normal_()
-        module.w_down.normal_()
-    return module
+
+
+def test_shared_experts_build_initializes_weights():
+    # Regression: build() must initialize the parameters (they were previously left as raw
+    # torch.empty storage), so a freshly built module yields finite weights and output.
+    module = SharedExpertsConfig(
+        d_model=16, hidden_size=32, num_experts=2, bias=False, dtype=DType.float32
+    ).build(init_device="cpu")
+
+    assert torch.isfinite(module.w_up_gate).all()
+    assert torch.isfinite(module.w_down).all()
+    assert torch.isfinite(module(torch.randn(2, 4, 16))).all()
 
 
 def test_shared_experts_num_params():

--- a/src/test/nn/moe/v2/shared_experts_test.py
+++ b/src/test/nn/moe/v2/shared_experts_test.py
@@ -1,0 +1,54 @@
+import torch
+
+from olmo_core.config import DType
+from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
+
+
+def _build(*, d_model=16, hidden_size=32, num_experts=2):
+    module = SharedExpertsConfig(
+        d_model=d_model,
+        hidden_size=hidden_size,
+        num_experts=num_experts,
+        bias=False,
+        dtype=DType.float32,
+    ).build(init_device="cpu")
+    # Weights are allocated with torch.empty; initialize them for a deterministic forward.
+    with torch.no_grad():
+        module.w_up_gate.normal_()
+        module.w_down.normal_()
+    return module
+
+
+def test_shared_experts_num_params():
+    cfg = SharedExpertsConfig(
+        d_model=16, hidden_size=32, num_experts=2, bias=False, dtype=DType.float32
+    )
+    # up + gate + down weights, per expert (no bias).
+    assert cfg.num_params() == 3 * 16 * 32 * 2
+
+
+def test_shared_experts_forward_shape():
+    torch.manual_seed(0)
+    B, S, D, H, E = 2, 4, 16, 32, 3
+    module = _build(d_model=D, hidden_size=H, num_experts=E)
+    out = module(torch.randn(B, S, D))
+    assert out.shape == (E, B, S, D)
+
+
+def test_shared_experts_single_expert():
+    module = _build(num_experts=1)
+    out = module(torch.randn(2, 4, 16))
+    assert out.shape == (1, 2, 4, 16)
+
+
+def test_shared_experts_split_forward_matches_full():
+    torch.manual_seed(0)
+    B, S, D, H, E = 2, 4, 16, 32, 2
+    module = _build(d_model=D, hidden_size=H, num_experts=E)
+    x = torch.randn(B, S, D)
+
+    full = module(x)
+    up, gate = module.forward1(x)
+    split = module.forward2(up, gate, x.shape)
+
+    torch.testing.assert_close(full, split)


### PR DESCRIPTION
Adds `nn/moe/v2/shared_experts.py`: `SharedExperts` and `SharedExpertsConfig`.

Shared experts act like a feed-forward applied to every token, but support more than one expert. The up/gate projections of all experts are column-packed into one weight so the first projection is a single GEMM `(BS, D) @ (D, E*2H)`; the result is split per-expert into up/gate, run through a SwiGLU nonlinearity, and the per-expert down projection is a grouped (batched) GEMM `(E, BS, H) x (E, H, D) -> (E, BS, D)`. A split `forward1`/`forward2` variant is provided so the projection and the down-GEMM can overlap with expert-parallel communication.

Depends only on `olmo_core.config`; `nvtx` is an optional import with the `olmo_core._nvtx` no-op fallback. Includes CPU unit tests covering num_params, the forward output shape, the single-expert case, and that the split forward matches the fused one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)