### PR TITLE
Add bidirectional image-token attention to MultimodalLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a configurable vision transformer encoder (`VisionTransformer`, configured via `VisionEncoderConfig`), vision-to-LM connector (`VisionConnector`), and `MultimodalLM` — a composite vision-language model that fuses image patch tokens into the LM token stream. Supports OpenAI CLIP, SigLIP, and SigLIP2 encoder variants with factory configs for all standard Molmo2 checkpoints.
+- Added bidirectional image-token attention to `MultimodalLM` via a `token_type_ids` forward argument: image tokens attend to each other bidirectionally while text stays causal, matching HF Molmo2. Implemented as an `or_mask` threaded through `Transformer.forward` and the dense (`torch`) attention backend (OR'd onto the causal/sliding base); flash/TE backends raise rather than silently ignore it.
 - Added `HFConverterCallback`, which can be used to convert models to huggingface format at the end of the training run.
 - Trainer now records checkpoint save and load durations as `train/checkpoint_save_duration_s` and `train/checkpoint_load_duration_s` metrics.
 - Added `PowerLR`, a power-law learning rate scheduler with linear warmup, power-decay phase (`lr = initial_lr * (current / warmup) ** b` for negative `b`, making the LR independent of the training horizon), and an optional linear decay tail. Registered as `"power_lr"`.

--- a/src/olmo_core/nn/attention/__init__.py
+++ b/src/olmo_core/nn/attention/__init__.py
@@ -497,9 +497,15 @@ class Attention(SequenceMixer):
         max_doc_len_k: Optional[int] = None,
         local_k_slice: Optional[slice] = None,
         cache_leftpad: Optional[torch.Tensor] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if self.kv_cache_manager is not None:
             self.kv_cache_manager.record_leftpad(cache_leftpad)
+        if or_mask is not None and not self.backend.SUPPORTS_OR_MASK:
+            raise NotImplementedError(
+                f"'{type(self.backend).__name__}' does not support `or_mask` "
+                "(e.g. bidirectional image-token attention); use the 'torch' attention backend."
+            )
         # shape: (batch_size, seq_len, n_heads, head_dim)
         att = self.backend(
             (q, k, v),
@@ -511,6 +517,7 @@ class Attention(SequenceMixer):
             max_doc_len_k=max_doc_len_k,
             local_k_slice=local_k_slice,
             kv_cache_manager=self.kv_cache_manager,
+            or_mask=or_mask,
         )
         if self.kv_cache_manager is not None:
             self.kv_cache_manager.update_seqlen(q.shape[1])
@@ -560,6 +567,7 @@ class Attention(SequenceMixer):
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
         cache_leftpad: Optional[torch.Tensor] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Apply attention to the input.
@@ -631,6 +639,7 @@ class Attention(SequenceMixer):
             max_doc_len_k=max_doc_len_k,
             local_k_slice=local_k_slice,
             cache_leftpad=cache_leftpad,
+            or_mask=or_mask,
         )
 
         if self.gate is not None:
@@ -879,6 +888,7 @@ class NormalizedAttention(Attention):
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
         cache_leftpad: Optional[torch.Tensor] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if cache_leftpad:
             raise NotImplementedError(
@@ -932,6 +942,7 @@ class NormalizedAttention(Attention):
             max_doc_len_k=max_doc_len_k,
             local_k_slice=local_k_slice,
             cache_leftpad=cache_leftpad,
+            or_mask=or_mask,
         )
 
         # shape: (batch_size, seq_len, d_model)
@@ -1045,6 +1056,7 @@ class FusedAttention(SequenceMixer):
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
         cache_leftpad: Optional[torch.Tensor] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Apply attention to the input.
@@ -1066,6 +1078,12 @@ class FusedAttention(SequenceMixer):
         if cu_doc_lens is not None and self.rope is not None:
             raise NotImplementedError(
                 "Intra-document RoPE (cu_doc_lens) is not yet supported by FusedAttention"
+            )
+
+        if or_mask is not None:
+            raise NotImplementedError(
+                "FusedAttention (flash-attn) does not support `or_mask` "
+                "(e.g. bidirectional image-token attention); use the 'torch' attention backend."
             )
 
         B, T, _ = x.shape

--- a/src/olmo_core/nn/attention/backend.py
+++ b/src/olmo_core/nn/attention/backend.py
@@ -133,6 +133,11 @@ class AttentionBackend(nn.Module):
     Encapsulates a backend for the scaled dot-product attention (SDPA) operation.
     """
 
+    SUPPORTS_OR_MASK: bool = False
+    """Whether :meth:`forward` honors the ``or_mask`` argument (a boolean allow-mask
+    OR'd onto the causal/sliding base, e.g. for bidirectional image-token attention).
+    Only the dense SDPA backend supports it; flash/TE backends do not."""
+
     def __init__(
         self,
         *,
@@ -231,6 +236,7 @@ class AttentionBackend(nn.Module):
         max_doc_len_k: Optional[int] = None,
         local_k_slice: Optional[slice] = None,
         kv_cache_manager: Optional[KVCacheManager] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Run the attention operation.
@@ -263,6 +269,8 @@ class TorchAttentionBackend(AttentionBackend):
     """
     PyTorch's built-in scaled dot-product attention (SDPA) backend.
     """
+
+    SUPPORTS_OR_MASK = True
 
     @classmethod
     def assert_supported(cls):
@@ -307,6 +315,7 @@ class TorchAttentionBackend(AttentionBackend):
         max_doc_len_k: Optional[int] = None,
         local_k_slice: Optional[slice] = None,
         kv_cache_manager: Optional[KVCacheManager] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         del local_k_slice
 
@@ -326,6 +335,17 @@ class TorchAttentionBackend(AttentionBackend):
                 device=q.device,
                 window_size=self.window_size,
             )
+
+        if or_mask is not None:
+            # OR an extra boolean allow-mask (e.g. bidirectional attention among
+            # image tokens) onto the causal/sliding-window base, mirroring HF's
+            # `or_mask_function`. ``True`` entries are additionally allowed to
+            # attend regardless of causal order. Build an explicit causal base
+            # when we don't already have a sliding-window one.
+            base = attn_mask
+            if base is None:
+                base = torch.ones(q.shape[1], k.shape[1], device=q.device, dtype=torch.bool).tril()
+            attn_mask = base | or_mask.to(device=q.device, dtype=torch.bool)
 
         if any(
             opt is not None
@@ -490,6 +510,7 @@ class FlashAttention2Backend(AttentionBackend):
         max_doc_len_k: Optional[int] = None,
         local_k_slice: Optional[slice] = None,
         kv_cache_manager: Optional[KVCacheManager] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if isinstance(qkv, torch.Tensor):
             if kv_cache_manager is not None:
@@ -714,6 +735,7 @@ class FlashAttention3Backend(AttentionBackend):
         max_doc_len_k: Optional[int] = None,
         local_k_slice: Optional[slice] = None,
         kv_cache_manager: Optional[KVCacheManager] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if isinstance(qkv, torch.Tensor):
             if kv_cache_manager is not None:
@@ -910,6 +932,7 @@ class FlashAttention4Backend(AttentionBackend):
         max_doc_len_k: Optional[int] = None,
         local_k_slice: Optional[slice] = None,
         kv_cache_manager: Optional[KVCacheManager] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         assert isinstance(qkv, tuple), f"'{self.__class__.__name__}' requires unpacked QKV"
         assert local_k_slice is None, f"'{self.__class__.__name__}' doesn't support local_k_slice"
@@ -1097,6 +1120,7 @@ class TEAttentionBackend(AttentionBackend):
         max_doc_len_k: Optional[int] = None,
         local_k_slice: Optional[slice] = None,
         kv_cache_manager: Optional[KVCacheManager] = None,
+        or_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         del local_k_slice
 

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -514,6 +514,7 @@ class Transformer(nn.Module):
         loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
         return_logits: Optional[bool] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
+        or_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[torch.Tensor, LMOutputWithLoss]:
         """
@@ -543,6 +544,11 @@ class Transformer(nn.Module):
                 "shards `input_ids`/`labels`/RoPE while `input_embeddings` stays full-size, which "
                 "would misalign the hidden states."
             )
+        if or_mask is not None and self._cp_load_balancer is not None:
+            raise RuntimeError(
+                "`or_mask` is not supported with context parallelism: the full-size "
+                "(seq, seq) mask would misalign with the sequence-sharded hidden states."
+            )
 
         (
             input_ids,
@@ -561,6 +567,12 @@ class Transformer(nn.Module):
             logits_to_keep=logits_to_keep,
             **kwargs,
         )
+
+        # Bidirectional / custom attention allow-mask (e.g. for image tokens),
+        # OR'd onto the causal base inside each block's attention. Passed through
+        # to every block; only the dense SDPA backend honors it.
+        if or_mask is not None:
+            all_block_kwargs["or_mask"] = move_to_device(or_mask, self.device)
 
         # Get embeddings but pass-through for non-existent layers to allow easy
         # pipeline parallel configuration.

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -140,6 +140,7 @@ class MultimodalLM(nn.Module):
         images: Optional[torch.Tensor] = None,
         pooled_patches_idx: Optional[torch.Tensor] = None,
         labels: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[torch.Tensor, LMOutputWithLoss]:
         """
@@ -156,6 +157,11 @@ class MultimodalLM(nn.Module):
             ``None``. ``n_pooled`` must equal the number of
             ``<im_patch>`` tokens per sequence.
         :param labels: Target token IDs, shape ``(B, seq_len)``.
+        :param token_type_ids: Optional ``(B, seq_len)`` tensor marking image tokens
+            (non-zero) vs. text tokens (zero). When provided, image tokens attend to
+            each other **bidirectionally** (causal order is ignored among image
+            tokens) while text stays causal, matching HF Molmo2's attention mask.
+            Requires the dense (``"torch"``) attention backend.
         :returns: Logits or loss (same as
             :meth:`~olmo_core.nn.transformer.Transformer.forward`).
         """
@@ -202,4 +208,13 @@ class MultimodalLM(nn.Module):
             flat = h.view(-1, d)
             flat[is_image_patch] = flat[is_image_patch] + image_features.reshape(-1, d)
 
-        return self.lm(input_ids, input_embeddings=h, labels=labels, **kwargs)
+        # Build a bidirectional allow-mask among image tokens (causal elsewhere),
+        # matching HF Molmo2's `token_type_ids`-based mask. ``or_mask[b, 1, q, k]``
+        # is True where both q and k are image tokens, so they attend regardless of
+        # causal order; it is OR'd onto the causal base inside each attention block.
+        or_mask: Optional[torch.Tensor] = None
+        if token_type_ids is not None:
+            is_image = token_type_ids.to(device) != 0  # (B, S)
+            or_mask = (is_image[:, :, None] & is_image[:, None, :]).unsqueeze(1)  # (B, 1, S, S)
+
+        return self.lm(input_ids, input_embeddings=h, labels=labels, or_mask=or_mask, **kwargs)

--- a/src/test/nn/vision/molmo2_generation_test.py
+++ b/src/test/nn/vision/molmo2_generation_test.py
@@ -331,3 +331,116 @@ def test_molmo2_generation_parity():
     assert any(
         c.isalpha() for c in our_text
     ), f"Decoded text looks empty or non-linguistic: {our_text!r}"
+
+
+@requires_gpu
+def test_molmo2_image_bidirectional_attention_parity():
+    """Pin HF Molmo2's bidirectional image-token attention.
+
+    With multiple image tokens, HF attends **bidirectionally** among them
+    (driven by ``token_type_ids``) while text stays causal. This test feeds the
+    same 196-image-token input to HF and to our converted model and checks the
+    last-token logits:
+
+    * passing ``token_type_ids`` reproduces HF's logits (bidirectional), and
+    * omitting it (pure causal) is measurably *worse* — which is exactly the gap
+      this feature closes. The second assertion guards against the test silently
+      regressing to a causal-vs-causal comparison (the blind spot of the
+      single-image-token full-pipeline parity test).
+    """
+    if not _hf_cache_has(_MODEL_ID):
+        pytest.skip(f"{_MODEL_ID} not in HF cache")
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    ensure_default_rope_registered()
+    from transformers import AutoModelForImageTextToText, AutoTokenizer
+
+    try:
+        hf = AutoModelForImageTextToText.from_pretrained(
+            _MODEL_ID, trust_remote_code=True, local_files_only=True
+        )
+        tok = AutoTokenizer.from_pretrained(
+            _MODEL_ID, trust_remote_code=True, local_files_only=True
+        )
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"Could not load {_MODEL_ID}: {e}")
+
+    reinit_rope_buffers(hf)
+
+    cfg = molmo2_config_from_hf_config(hf.config)
+    ours = MultimodalLM(cfg, init_device="meta")
+    ours.to_empty(device=torch.device("cpu"))
+    ours.load_state_dict(molmo2_hf_state_dict_to_multimodal_lm(hf.state_dict(), cfg), strict=False)
+    hf = hf.to(device=device, dtype=dtype).eval()
+    ours = ours.to(device=device, dtype=dtype).eval()
+
+    # Synthetic image + prompt → 196 <im_patch> tokens.
+    np.random.seed(42)
+    gradient = np.zeros((64, 64, 3), dtype=np.uint8)
+    gradient[:, :, 0] = np.linspace(0, 255, 64, dtype=np.uint8)
+    gradient[:, :, 1] = np.linspace(0, 200, 64, dtype=np.uint8)[np.newaxis, :].T
+    gradient[:, :, 2] = 100
+    pil_img = Image.fromarray(gradient)
+    pixel_values_hf, images_ours, pooling_idx, image_grids, image_num_crops = _preprocess_image_pil(
+        pil_img, dtype=dtype, device=device
+    )
+    input_ids = _build_input_ids(tok, _build_image_token_ids(), device=device)
+
+    # token_type_ids: 1 for image structural tokens (matches HF's image_token_ids
+    # set), 0 for text. This is what triggers HF's bidirectional image mask.
+    image_id_set = torch.tensor(
+        [_IM_PATCH_ID, _IM_COL_ID, _IM_START_ID, _LOW_RES_IM_START_ID, _IM_END_ID],
+        device=device,
+    )
+    token_type_ids = torch.isin(input_ids, image_id_set).long()
+    assert int(token_type_ids.sum()) > 1, "need >1 image token to exercise bidirectionality"
+
+    # HF reference WITH bidirectional image attention.
+    with torch.inference_mode():
+        hf_logits = (
+            hf(
+                input_ids=input_ids,
+                pixel_values=pixel_values_hf,
+                image_token_pooling=pooling_idx.squeeze(0),
+                image_grids=image_grids,
+                image_num_crops=image_num_crops,
+                token_type_ids=token_type_ids,
+                use_cache=False,
+            )
+            .logits[0, -1]
+            .float()
+        )
+    base_vocab = hf_logits.shape[0]
+
+    with torch.inference_mode():
+        our_bidir = ours(
+            input_ids=input_ids,
+            images=images_ours,
+            pooled_patches_idx=pooling_idx,
+            token_type_ids=token_type_ids,
+            logits_to_keep=1,
+        )[0, -1].float()[:base_vocab]
+        our_causal = ours(
+            input_ids=input_ids,
+            images=images_ours,
+            pooled_patches_idx=pooling_idx,
+            logits_to_keep=1,
+        )[0, -1].float()[:base_vocab]
+
+    bidir_diff = (hf_logits - our_bidir).abs().max().item()
+    causal_diff = (hf_logits - our_causal).abs().max().item()
+
+    # (1) Bidirectional reproduces HF.
+    assert bidir_diff < 5.0, (
+        f"bidirectional logits diverge from HF: max abs diff = {bidir_diff:.3e} "
+        f"(threshold 5.0 in bf16)"
+    )
+    # (2) The gap is real: pure-causal is measurably worse than bidirectional.
+    #     If this fails, the test has regressed to causal-vs-causal and no longer
+    #     exercises image-token bidirectional attention.
+    assert causal_diff > bidir_diff, (
+        f"causal logits match HF as well as bidirectional (causal={causal_diff:.3e}, "
+        f"bidir={bidir_diff:.3e}); test no longer pins the bidirectional gap"
+    )


### PR DESCRIPTION
## Summary

Adds **bidirectional image-token attention** to `MultimodalLM`, matching HF Molmo2.

HF Molmo2 attends **bidirectionally among image tokens** (driven by `token_type_ids`) while text stays causal — image tokens see *all* image tokens in the prefix, not just earlier ones. Our `MultimodalLM` previously ran the LM **fully causal** over the spliced image tokens, so this was a real parity gap.

Targets the `vision` integration branch; stacked on the Molmo2 loader (#715).

## Why this wasn't caught before

The existing full-pipeline logit-parity test used **exactly one** `<im_patch>` token, where causal and bidirectional attention are identical — a structural blind spot. The generation test used 196 image tokens but never passed `token_type_ids` to HF, so HF ran causal too (causal-vs-causal). So the gap was entirely untested.

## What's in this PR

### Fix
- `MultimodalLM.forward` gains an HF-aligned `token_type_ids` argument and builds a `(B, 1, S, S)` boolean **`or_mask`** (`True` where `image[q] & image[k]`).
- `or_mask` is threaded through `Transformer.forward` → block kwargs → `Attention.forward`/`sdpa` → `TorchAttentionBackend`, which **OR's it onto the causal/sliding base** — exactly mirroring HF's `or_mask_function`, and correct even for sliding-window layers.
- Capability-gated by `AttentionBackend.SUPPORTS_OR_MASK` (only the dense `torch` SDPA backend supports it). Flash/TE/Fused backends and context parallelism **raise** rather than silently fall back to causal.
- `token_type_ids=None` → unchanged causal behavior (fully backward compatible).

### Test (pins the gap)
`test_molmo2_image_bidirectional_attention_parity` (196 image tokens, real Molmo2-4B):
- **(1)** with `token_type_ids`, our last-token logits match HF (bidirectional);
- **(2)** pure-causal is **measurably worse** — guards against the test silently regressing to causal-vs-causal.

## Verification

- **Full vision suite: 89 passed, 2 skipped** (the 2 skips are the intentional Molmo2-O-7B per-layer-YaRN cases). The new GPU parity test passes against real Molmo2-4B weights.
- End-to-end smoke confirms the mask flows through the whole stack (`token_type_ids` changes the output) and the causal path (`or_mask=None`) is unchanged.
- `ruff` / `mypy` / `isort` / `black` clean.

## Scope / follow-ups (intentionally out of scope here)

- The parity check compares **last-token** logits (< 5.0 bf16 threshold) and asserts causal-is-worse to prove the gap; it does not yet assert a per-image-token logit bound.
- The `(B, 1, S, S)` mask is O(S²) memory — fine for these models, but a `flex_attention` path would be the scalable follow-up for long sequences and for enabling this on flash backends.
