### PR TITLE
Add Molmo2 eval example scripts and native image preprocessing

### DIFF
--- a/src/examples/molmo2/image_qa_eval.py
+++ b/src/examples/molmo2/image_qa_eval.py
@@ -1,0 +1,362 @@
+"""Molmo2 image-QA benchmark evaluation using OLMo-core.
+
+Runs the 11 Molmo2 image-QA benchmarks (ChartQA, VQA v2, DocVQA, InfoVQA,
+TextVQA, RealWorldQA, MMMU, MathVista, CountBench QA, PixMo Count, AI2D)
+with the OLMo-core ``MultimodalLM`` and scores them with the
+matching tasks from olmo-eval-internal (prompt construction, metrics, and
+data loading all live there — this script only does inference glue).
+
+Usage (GPU smoke test — 8 examples per task into a fresh output dir):
+
+    python image_qa_eval.py --model allenai/Molmo2-4B \\
+        --tasks chart_qa,ai2d,pixmo_count,mmmu --limit 8 --output /tmp/iqa_smoke
+
+Full run of all 11 benchmarks (slow — no KV cache; shard across GPUs):
+
+    torchrun --nproc-per-node=8 image_qa_eval.py --output /path/to/run
+
+Environment variables:
+    MOLMO_DATA_DIR      Data root (default /weka/oe-training-default/mm-olmo).
+    HF_DATASETS_CACHE   HF datasets cache for MMMU / MathVista / RealWorldQA
+                        (point at an offline cache + HF_DATASETS_OFFLINE=1).
+    OPENAI_API_KEY      Only for the ``math_vista:gpt`` variant.
+
+Cache semantics:
+    Model outputs are cached per task under ``--predictions-cache`` (default
+    ``{output}/cache/``).  Outputs found there from *previous runs of this
+    script* are reused and only missing examples are inferenced; pass
+    ``--recompute`` to force fresh inference.  The pre-existing mm_olmo
+    outputs (released ``predictions-ck2000-*`` dumps, shared ``gpt4-cache``)
+    are never read as a cache source and never written to.
+
+Notes:
+    * ``--max-crops`` defaults to 24, matching the original mm_olmo benchmark
+      eval (``eval_molmo2.py``); the released HF processor default is 8.
+    * Prompts use the native Molmo2 layout (image tokens before
+      ``<|im_start|>user``), verified against the released prediction dumps.
+    * Use Molmo2-4B or Molmo2-8B (not Molmo2-O-7B).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import torch
+
+if "LOCAL_RANK" not in os.environ:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+from molmo2_infer import (  # noqa: E402
+    DEFAULT_MODEL_ID,
+    build_input_ids,
+    greedy_decode,
+    hf_generate,
+    load_hf_pipeline,
+    load_model,
+    load_prediction_cache,
+    preprocess_image_multicrop,
+    save_prediction_cache,
+)
+
+DEFAULT_TASKS = (
+    "chart_qa",
+    "vqa2",
+    "doc_qa",
+    "info_qa",
+    "text_vqa",
+    "real_world_qa",
+    "mmmu",
+    "math_vista",
+    "countbench_qa",
+    "pixmo_count",
+    "ai2d",
+)
+DEFAULT_MAX_CROPS = 24  # matches the original mm_olmo benchmark eval
+
+
+def _instance_key(index: int, instance) -> str:
+    """Stable cache key for an instance (index in deterministic task order + id)."""
+    example_id = instance.metadata.get("example_id", "")
+    return f"{index}:{example_id}"
+
+
+def _run_task(
+    spec: str,
+    args,
+    model_state: dict,
+    device: torch.device,
+    dtype: torch.dtype,
+    rank: int,
+    world_size: int,
+) -> None:
+    from olmo_eval.common.types import LMOutput, Response
+    from olmo_eval.evals.tasks.common.image_qa_base import load_instance_image
+    from olmo_eval.evals.tasks.common.registry import get_task
+
+    from olmo_core.distributed.utils import barrier
+
+    task_file = spec.replace(":", "_")
+    cache_path = str(Path(args.predictions_cache) / f"{task_file}.json")
+    rank_cache_path = f"{cache_path}.rank{rank}" if world_size > 1 else cache_path
+
+    overrides = {"limit": args.limit} if args.limit is not None else None
+    task = get_task(spec, overrides)
+    instances = list(task.instances)
+    max_new_tokens = args.max_new_tokens or task.config.sampling_params.max_tokens
+    logger.info("[%s] %d instances, max_new_tokens=%d", spec, len(instances), max_new_tokens)
+
+    # ── Prediction cache (this run's own cache dir; resume unless --recompute) ─
+    cached: dict[str, str] = {}
+    if not args.recompute:
+        cached = load_prediction_cache(cache_path)
+        if world_size > 1:
+            cached.update(load_prediction_cache(rank_cache_path))
+        if cached:
+            logger.info("[%s] %d cached predictions found", spec, len(cached))
+
+    keyed = [(_instance_key(i, inst), inst) for i, inst in enumerate(instances)]
+    needs_inference = [(k, inst) for k, inst in keyed if k not in cached]
+    if args.cache_only and needs_inference:
+        sys.exit(f"[{spec}] {len(needs_inference)} cache misses with --cache-only set")
+    shard = needs_inference[rank::world_size]
+
+    # ── Inference ─────────────────────────────────────────────────────────────
+    predictions: dict[str, str] = dict(cached)
+    if shard:
+        if model_state.get("model") is None:
+            if args.backend == "hf":
+                model_state["model"], model_state["processor"] = load_hf_pipeline(
+                    args.model, device, dtype
+                )
+            else:
+                model_state["model"], model_state["tokenizer"] = load_model(
+                    args.model, device, dtype, hf_config_id=args.hf_config
+                )
+        logger.info("[%s] rank %d/%d: running %d examples", spec, rank, world_size, len(shard))
+        for i, (key, instance) in enumerate(shard):
+            try:
+                pil_img = load_instance_image(instance)
+                if args.backend == "hf":
+                    prediction = hf_generate(
+                        model_state["model"],
+                        model_state["processor"],
+                        instance.question,
+                        pil_img,
+                        device,
+                        max_new_tokens=max_new_tokens,
+                        max_crops=args.max_crops,
+                    )
+                else:
+                    model, tokenizer = model_state["model"], model_state["tokenizer"]
+                    if pil_img is not None:
+                        images_t, pooling_idx_t, image_grid = preprocess_image_multicrop(
+                            pil_img, dtype, device, max_crops=args.max_crops
+                        )
+                    else:
+                        images_t = pooling_idx_t = image_grid = None
+                    input_ids = build_input_ids(tokenizer, instance.question, image_grid, device)
+                    prediction = greedy_decode(
+                        model,
+                        input_ids,
+                        images_t,
+                        pooling_idx_t,
+                        tokenizer,
+                        max_new_tokens=max_new_tokens,
+                    )
+            except Exception as exc:
+                logger.warning("[%s] inference failed for %s: %s", spec, key, exc)
+                prediction = ""
+            predictions[key] = prediction
+            if (i + 1) % 25 == 0 or (i + 1) == len(shard):
+                logger.info("[%s] [%d/%d] %s → %r", spec, i + 1, len(shard), key, prediction[:60])
+            save_prediction_cache(rank_cache_path, predictions)
+
+    barrier()
+    if rank != 0:
+        return
+
+    # ── Rank 0: merge shards, score, write metrics ────────────────────────────
+    if world_size > 1:
+        merged = load_prediction_cache(cache_path)
+        for r in range(world_size):
+            merged.update(load_prediction_cache(f"{cache_path}.rank{r}"))
+        predictions = merged
+        save_prediction_cache(cache_path, predictions)
+
+    missing = [k for k, _ in keyed if k not in predictions]
+    if missing:
+        logger.warning("[%s] %d instances have no prediction (scored as empty)", spec, len(missing))
+
+    import asyncio
+
+    responses = [
+        Response(
+            instance=instance,
+            request=task.format_request(instance),
+            outputs=[LMOutput(text=predictions.get(key, ""))],
+        )
+        for key, instance in keyed
+    ]
+    if any(getattr(s, "requires_async", False) for s in task._get_scorers().values()):
+        from olmo_eval.common.execution import ScoringContext
+
+        responses = asyncio.run(task.score_responses(responses, ScoringContext()))
+    else:
+        responses = asyncio.run(task.score_responses(responses))
+    nested = task.compute_metrics(responses)
+    flat = {name: next(iter(by_scorer.values())) for name, by_scorer in nested.items()}
+
+    print(f"\n=== {spec} ({len(responses)} examples) ===")
+    for name, value in flat.items():
+        print(f"  {name:28s}: {value:.4f}")
+
+    task_out_dir = Path(args.output) / task_file
+    task_out_dir.mkdir(parents=True, exist_ok=True)
+    with open(task_out_dir / "metrics.json", "w") as f:
+        json.dump({"metrics": flat, "nested": nested, "n_examples": len(responses)}, f, indent=2)
+    rows = [
+        {
+            "key": key,
+            "example_id": instance.metadata.get("example_id"),
+            "question": instance.question,
+            "prediction": predictions.get(key, ""),
+        }
+        for key, instance in keyed
+    ]
+    with open(task_out_dir / "predictions.json", "w") as f:
+        json.dump(rows, f, indent=2)
+    logger.info("[%s] wrote %s", spec, task_out_dir / "metrics.json")
+
+    # DocVQA / InfographicVQA test splits have no public answers: also write the
+    # RRC evaluation-server submission file ([{"questionId": ..., "answer": ...}]).
+    # The metrics.json above is meaningless for these (scored vs. placeholder "").
+    from olmo_eval.common.types import Split
+
+    if task.config.name in ("doc_qa", "info_qa") and task.config.split == Split.TEST:
+        submission = [
+            {
+                "questionId": instance.metadata["example_id"],
+                "answer": predictions.get(key, ""),
+            }
+            for key, instance in keyed
+        ]
+        with open(task_out_dir / "submission.json", "w") as f:
+            json.dump(submission, f)
+        logger.info(
+            "[%s] wrote %s (upload to the RRC evaluation server)",
+            spec,
+            task_out_dir / "submission.json",
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Molmo2 image-QA benchmark eval (OLMo-core)")
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL_ID, help="HF model ID or local OLMo-core checkpoint path"
+    )
+    parser.add_argument(
+        "--hf-config",
+        default=DEFAULT_MODEL_ID,
+        metavar="MODEL_ID",
+        help="HF config ID for native .distcp checkpoints (no weights download)",
+    )
+    parser.add_argument(
+        "--tasks",
+        default=",".join(DEFAULT_TASKS),
+        help="Comma-separated task specs (e.g. chart_qa,ai2d:test,math_vista:gpt)",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Max examples per task")
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=None,
+        help="Override per-task max new tokens (default: task-specific)",
+    )
+    parser.add_argument(
+        "--max-crops",
+        type=int,
+        default=DEFAULT_MAX_CROPS,
+        help="Max image crops (24 = original mm_olmo eval; HF default is 8)",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["hf", "olmo_core"],
+        default="hf",
+        help="Inference backend. 'hf' = the released HF Molmo2 pipeline (KV-cached, "
+        "implements bidirectional image attention; reproduces the original eval "
+        "exactly). 'olmo_core' = MultimodalLM (supports native .distcp "
+        "checkpoints, but currently lacks bidirectional image attention — outputs "
+        "can drift from the original eval)",
+    )
+    parser.add_argument(
+        "--dtype",
+        choices=["bf16", "fp32"],
+        default="bf16",
+        help="Model dtype (the original eval ran amp_bf16; fp32 for maximum fidelity)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        metavar="DIR",
+        help="Run output dir: per-task metrics.json + predictions.json",
+    )
+    parser.add_argument(
+        "--predictions-cache",
+        default=None,
+        metavar="DIR",
+        help="Model-output cache dir (default: {output}/cache). Reused across "
+        "this script's own runs; never points at pre-existing mm_olmo outputs.",
+    )
+    parser.add_argument(
+        "--recompute", action="store_true", help="Ignore cached predictions and rerun inference"
+    )
+    parser.add_argument(
+        "--cache-only",
+        action="store_true",
+        help="Fail instead of running inference on cache misses",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        sys.exit("CUDA GPU required.")
+
+    if "LOCAL_RANK" in os.environ:
+        from olmo_core.distributed.utils import init_distributed
+        from olmo_core.utils import prepare_cli_environment
+
+        init_distributed()
+        prepare_cli_environment()
+
+    from olmo_core.distributed.utils import get_local_rank, get_rank, get_world_size
+
+    rank = get_rank()
+    world_size = get_world_size()
+    device = torch.device(f"cuda:{get_local_rank()}")
+    dtype = torch.float32 if args.dtype == "fp32" else torch.bfloat16
+
+    try:
+        import olmo_eval  # noqa: F401
+    except ImportError:
+        sys.exit(
+            "olmo-eval-internal not installed. Run: pip install -e /path/to/olmo-eval-internal"
+        )
+
+    if args.predictions_cache is None:
+        args.predictions_cache = str(Path(args.output) / "cache")
+    if rank == 0:
+        Path(args.predictions_cache).mkdir(parents=True, exist_ok=True)
+        Path(args.output).mkdir(parents=True, exist_ok=True)
+
+    model_state: dict = {"model": None, "tokenizer": None}
+    for spec in [t.strip() for t in args.tasks.split(",") if t.strip()]:
+        _run_task(spec, args, model_state, device, dtype, rank, world_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/examples/molmo2/molmo2_infer.py
+++ b/src/examples/molmo2/molmo2_infer.py
@@ -1,0 +1,494 @@
+"""Shared Molmo2 inference helpers for the example eval scripts.
+
+Extracted from ``pixmo_cap_eval.py`` so multiple evals (dense caption,
+image-QA benchmarks) share one implementation of:
+
+* multi-crop image preprocessing (native OLMo-core, no mm_olmo dependency)
+* image-token sequence construction and prompt building
+* HF / native-``.distcp`` checkpoint loading into ``MultimodalLM``
+* greedy decoding (no KV cache)
+* simple atomic JSON prediction caches
+
+Prompt layouts
+--------------
+Molmo2's native format places the expanded image-token block *before* the
+``<|im_start|>user`` turn::
+
+    <low_res_im_start>…<im_end><im_start>…<im_end><|im_start|>user\\n{TEXT}<|im_end|>\\n<|im_start|>assistant\\n
+
+:func:`build_input_ids` produces this layout (it matches the released
+mm_olmo prediction dumps and the official HF chat template).
+:func:`build_input_ids_placeholder_style` keeps the legacy behavior of
+``pixmo_cap_eval.py`` (placeholder inside the user turn) for backward
+compatibility.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+# ── Preprocessor constants (SigLIP2-SO400M/14, 378×378, multi-crop) ──────────
+PATCH_SIZE = 14
+IMAGE_SIZE = 378  # 27 × 27 patches per crop
+N_PATCHES = 27  # IMAGE_SIZE // PATCH_SIZE
+N_PATCHES_SQ = 729  # N_PATCHES ** 2
+PATCH_DIM = 588  # 3 * PATCH_SIZE ** 2
+POOL_H = 2
+POOL_W = 2
+DEFAULT_MAX_CROPS = 8
+OVERLAP_MARGINS = (4, 4)
+
+# Molmo2 special token IDs (identical across 4B / 8B variants).
+IM_PATCH_ID = 151938  # <im_patch>
+IM_COL_ID = 151939  # <im_col>
+IM_START_ID = 151936  # <im_start>
+LOW_RES_IM_START_ID = 151940  # <low_res_im_start>
+IM_END_ID = 151937  # <im_end>
+IMAGE_PLACEHOLDER_ID = 151941  # <|image|>
+
+DEFAULT_MODEL_ID = "allenai/Molmo2-4B"
+EOS_TOKEN_ID = 151643  # Qwen2.5 <|endoftext|>
+IM_END_TURN_ID = 151645  # Qwen2.5 <|im_end|> (chat end-of-turn)
+
+
+# ---------------------------------------------------------------------------
+# Image preprocessing (multi-crop via OLMo-core native preprocessor)
+# ---------------------------------------------------------------------------
+
+
+def preprocess_image_multicrop(
+    pil_img: Image.Image,
+    dtype: torch.dtype,
+    device: torch.device,
+    max_crops: int = DEFAULT_MAX_CROPS,
+) -> tuple[torch.Tensor, torch.Tensor, np.ndarray]:
+    """Multi-crop Molmo2 preprocessing using the native OLMo-core preprocessor.
+
+    :param max_crops: maximum number of high-res crops (the original mm_olmo
+        benchmark evals used 24; the released HF processor defaults to 8).
+
+    :returns: ``images (1, n_crops, 729, 588)`` channel-first float tensor,
+        ``pooling_idx (1, n_pool_tokens, 4)`` int64 pooling indices, and
+        ``image_grid = [resized_h, resized_w, h, w]`` pooled grid dims.
+    """
+    from olmo_core.nn.vision.molmo2_image_processor import preprocess_image_molmo2
+
+    return preprocess_image_molmo2(
+        pil_img,
+        dtype,
+        device,
+        image_size=IMAGE_SIZE,
+        patch_size=PATCH_SIZE,
+        max_crops=max_crops,
+        overlap_margins=OVERLAP_MARGINS,
+        pool_h=POOL_H,
+        pool_w=POOL_W,
+    )
+
+
+def build_image_token_ids(
+    resized_h: int,
+    resized_w: int,
+    h: int,
+    w: int,
+    low_res_col_tokens: bool = False,
+) -> list[int]:
+    """Return the expanded image token-ID sequence for a multi-crop image.
+
+    Token structure (matching ``Molmo2Processor.get_image_tokens`` — the
+    low-res/global section has **no** ``<im_col>`` separators)::
+
+        <low_res_im_start>
+        resized_h × resized_w × <im_patch>
+        <im_end> <im_start>
+        h × (w × <im_patch> + <im_col>)
+        <im_end>
+
+    ``low_res_col_tokens=True`` reproduces the legacy ``pixmo_cap_eval``
+    layout that also put ``<im_col>`` separators in the low-res section.
+    """
+    tokens: list[int] = [LOW_RES_IM_START_ID]
+    if low_res_col_tokens:
+        for _ in range(resized_h):
+            tokens += [IM_PATCH_ID] * resized_w + [IM_COL_ID]
+    else:
+        tokens += [IM_PATCH_ID] * (resized_h * resized_w)
+    tokens += [IM_END_ID, IM_START_ID]
+    for _ in range(h):
+        tokens += [IM_PATCH_ID] * w + [IM_COL_ID]
+    tokens += [IM_END_ID]
+    return tokens
+
+
+def build_input_ids(
+    tokenizer,
+    prompt: str,
+    image_grid: np.ndarray | None,
+    device: torch.device,
+) -> torch.Tensor:
+    """Tokenize a single-turn user prompt in the native Molmo2 layout.
+
+    Sequence structure (matching mm_olmo's ``molmo2`` message format and the
+    official HF processor: BOS first, image-token block *before*
+    ``<|im_start|>user``, generation header at the end)::
+
+        BOS <image block> <|im_start|>user\\n{prompt}<|im_end|>\\n<|im_start|>assistant\\n
+
+    With ``image_grid=None`` a text-only prompt is built (used e.g. for MMMU
+    questions whose answer options are images).
+    """
+    text = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    ids: list[int] = tokenizer.encode(text, add_special_tokens=False)
+    if image_grid is not None:
+        resized_h, resized_w, h, w = (int(image_grid[i]) for i in range(4))
+        ids = build_image_token_ids(resized_h, resized_w, h, w) + ids
+    # Leading BOS, following Molmo2Processor.insert_bos: bos or eos token —
+    # <|im_end|> (151645) for the released Molmo2 tokenizers, matching the
+    # mm_olmo native eval inputs.
+    bos_id = tokenizer.bos_token_id or tokenizer.eos_token_id
+    ids = [bos_id] + ids
+    return torch.tensor([ids], dtype=torch.long, device=device)
+
+
+def build_input_ids_placeholder_style(
+    tokenizer, prompt: str, image_grid: np.ndarray, device: torch.device
+) -> torch.Tensor:
+    """Legacy ``pixmo_cap_eval`` prompt building (image block inside the user turn)."""
+    resized_h, resized_w, h, w = (int(image_grid[i]) for i in range(4))
+    image_tokens = build_image_token_ids(resized_h, resized_w, h, w, low_res_col_tokens=True)
+    text = tokenizer.apply_chat_template(
+        [{"role": "user", "content": f"<|image|>{prompt}"}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    ids: list[int] = tokenizer.encode(text, add_special_tokens=False)
+    try:
+        img_pos = ids.index(IMAGE_PLACEHOLDER_ID)
+    except ValueError:
+        raise RuntimeError(
+            f"<|image|> placeholder token (ID {IMAGE_PLACEHOLDER_ID}) not found in "
+            f"tokenized prompt. First 20 IDs: {ids[:20]}"
+        )
+    ids = ids[:img_pos] + image_tokens + ids[img_pos + 1 :]
+    return torch.tensor([ids], dtype=torch.long, device=device)
+
+
+# ---------------------------------------------------------------------------
+# Model loading
+# ---------------------------------------------------------------------------
+
+
+def resolve_checkpoint(model_str: str) -> tuple[bool, Path | None]:
+    """Detect whether ``model_str`` is an OLMo-core native ``.distcp`` checkpoint.
+
+    :returns: ``(is_native, step_dir)`` — ``is_native=False`` means treat as an
+        HF model ID / HF local path; otherwise load from
+        ``step_dir/model_and_optim/``.
+    """
+    p = Path(model_str)
+    if not p.exists() or not p.is_dir():
+        return False, None
+    if (p / "model_and_optim").is_dir():
+        return True, p
+    step_dirs = sorted(d for d in p.iterdir() if d.is_dir() and (d / "model_and_optim").is_dir())
+    if step_dirs:
+        step_dir = step_dirs[-1]
+        logger.info("Run root detected; using latest step: %s", step_dir.name)
+        return True, step_dir
+    return False, None
+
+
+def _load_model_hf(model_id: str, device: torch.device, dtype: torch.dtype):
+    """Load HF Molmo2 weights → convert → MultimodalLM. Returns (model, tokenizer)."""
+    from transformers import AutoModelForImageTextToText, AutoTokenizer
+
+    from olmo_core.nn.vision import MultimodalLM
+    from olmo_core.nn.vision.molmo2_loader import (
+        ensure_default_rope_registered,
+        molmo2_config_from_hf_config,
+        molmo2_hf_state_dict_to_multimodal_lm,
+        reinit_rope_buffers,
+    )
+
+    logger.info("Loading HF %s …", model_id)
+    ensure_default_rope_registered()
+    hf = AutoModelForImageTextToText.from_pretrained(model_id, trust_remote_code=True)
+    reinit_rope_buffers(hf)
+    tok = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+
+    logger.info("Converting weights …")
+    cfg = molmo2_config_from_hf_config(hf.config)
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf.state_dict(), cfg)
+    del hf
+
+    logger.info("Loading into MultimodalLM …")
+    model = MultimodalLM(cfg, init_device="meta")
+    model.to_empty(device=torch.device("cpu"))
+    missing, _ = model.load_state_dict(converted, strict=False)
+    del converted
+
+    param_keys = {k for k, _ in model.named_parameters()}
+    if set(missing) & param_keys:
+        logger.warning("Missing params: %s", sorted(set(missing) & param_keys)[:5])
+
+    model = model.to(device=device, dtype=dtype).eval()
+    logger.info("Model ready on %s in %s.", device, dtype)
+    return model, tok
+
+
+_ATTN_PAT = re.compile(r"(model\.transformer\.blocks\.\d+\.)(att_proj|k_norm|q_norm|attn_out)(.*)")
+_MLP_PAT = re.compile(r"(model\.transformer\.blocks\.\d+\.)(ff_proj|ff_out)(.*)")
+
+
+def mm_olmo_sd_to_hf(raw_sd: dict) -> dict:
+    """Remap mm_olmo checkpoint keys to the HF Molmo2 key naming convention.
+
+    The only differences are inside transformer blocks:
+    ``att_proj / k_norm / q_norm / attn_out → self_attn.<name>`` and
+    ``ff_proj / ff_out → mlp.<name>``.  Vision-backbone keys and embeddings
+    are identical between the two formats.
+    """
+    out = {}
+    for k, v in raw_sd.items():
+        m = _ATTN_PAT.fullmatch(k)
+        if m:
+            k = f"{m.group(1)}self_attn.{m.group(2)}{m.group(3)}"
+        else:
+            m = _MLP_PAT.fullmatch(k)
+            if m:
+                k = f"{m.group(1)}mlp.{m.group(2)}{m.group(3)}"
+        out[k] = v
+    return out
+
+
+def _load_model_olmocore(
+    step_dir: Path,
+    hf_config_id: str,
+    device: torch.device,
+    dtype: torch.dtype,
+):
+    """Load a native mm_olmo ``.distcp`` training checkpoint into MultimodalLM."""
+    import pickle
+
+    from transformers import AutoConfig, AutoTokenizer
+
+    from olmo_core.distributed.checkpoint import load_state_dict as olmocore_load_sd
+    from olmo_core.nn.vision import MultimodalLM
+    from olmo_core.nn.vision.molmo2_loader import (
+        ensure_default_rope_registered,
+        molmo2_config_from_hf_config,
+        molmo2_hf_state_dict_to_multimodal_lm,
+    )
+
+    logger.info("Native mm_olmo .distcp checkpoint at %s", step_dir)
+    model_and_optim_dir = step_dir / "model_and_optim"
+
+    logger.info("Reading checkpoint metadata …")
+    with open(model_and_optim_dir / ".metadata", "rb") as f:
+        meta = pickle.load(f)
+
+    # Pre-allocate tensors for every model key in the checkpoint.
+    raw_sd: dict = {}
+    for key, smeta in meta.state_dict_metadata.items():
+        if key.startswith("model."):
+            raw_sd[key] = torch.empty(smeta.size, dtype=smeta.properties.dtype)
+
+    logger.info("Loading %d tensors from .distcp shards …", len(raw_sd))
+    olmocore_load_sd(str(model_and_optim_dir), raw_sd)
+
+    logger.info("Remapping mm_olmo keys → HF keys …")
+    hf_sd = mm_olmo_sd_to_hf(raw_sd)
+    del raw_sd
+    # mm_olmo uses tied embeddings; synthesize the standalone lm_head.weight the
+    # converter expects (= base token embedding; the converter pads image tokens).
+    if "lm_head.weight" not in hf_sd:
+        hf_sd["lm_head.weight"] = hf_sd["model.transformer.wte.embedding"].clone()
+
+    logger.info("Fetching architecture config from %s (no weights download) …", hf_config_id)
+    ensure_default_rope_registered()
+    hf_config = AutoConfig.from_pretrained(hf_config_id, trust_remote_code=True)
+    cfg = molmo2_config_from_hf_config(hf_config)
+
+    logger.info("Converting to OLMo-core format and loading into MultimodalLM …")
+    converted = molmo2_hf_state_dict_to_multimodal_lm(hf_sd, cfg)
+    del hf_sd
+
+    model = MultimodalLM(cfg, init_device="meta")
+    model.to_empty(device=torch.device("cpu"))
+    missing, _ = model.load_state_dict(converted, strict=False)
+    del converted
+
+    param_keys = {k for k, _ in model.named_parameters()}
+    if set(missing) & param_keys:
+        logger.warning("Missing params: %s", sorted(set(missing) & param_keys)[:5])
+
+    tok = AutoTokenizer.from_pretrained(hf_config_id, trust_remote_code=True)
+    model = model.to(device=device, dtype=dtype).eval()
+    logger.info("Model ready on %s in %s.", device, dtype)
+    return model, tok
+
+
+def load_model(
+    model_or_path: str,
+    device: torch.device,
+    dtype: torch.dtype,
+    hf_config_id: str = DEFAULT_MODEL_ID,
+):
+    """Load Molmo2 into MultimodalLM from either an HF model ID or a
+    local OLMo-core ``.distcp`` checkpoint directory. Returns (model, tokenizer).
+    """
+    is_native, step_dir = resolve_checkpoint(model_or_path)
+    if is_native:
+        assert step_dir is not None
+        return _load_model_olmocore(step_dir, hf_config_id, device, dtype)
+    return _load_model_hf(model_or_path, device, dtype)
+
+
+# ---------------------------------------------------------------------------
+# HF released pipeline (exact original-eval behavior)
+# ---------------------------------------------------------------------------
+
+
+def load_hf_pipeline(model_id: str, device: torch.device, dtype: torch.dtype):
+    """Load the released HF Molmo2 model + processor.
+
+    Unlike the OLMo-core ``MultimodalLM`` path, the HF model
+    implements Molmo2's bidirectional attention over image tokens
+    (``token_type_ids`` masking) and KV-cached generation — verified to
+    reproduce the original mm_olmo eval predictions exactly.
+
+    :returns: ``(model, processor)``.
+    """
+    from transformers import AutoModelForImageTextToText, AutoProcessor
+
+    from olmo_core.nn.vision.molmo2_loader import (
+        ensure_default_rope_registered,
+        reinit_rope_buffers,
+    )
+
+    logger.info("Loading HF pipeline %s …", model_id)
+    ensure_default_rope_registered()
+    model = AutoModelForImageTextToText.from_pretrained(
+        model_id, trust_remote_code=True, torch_dtype=dtype
+    )
+    reinit_rope_buffers(model)
+    model = model.to(device).eval()
+    processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+    logger.info("HF pipeline ready on %s in %s.", device, dtype)
+    return model, processor
+
+
+@torch.inference_mode()
+def hf_generate(
+    model,
+    processor,
+    question: str,
+    pil_img,
+    device: torch.device,
+    max_new_tokens: int,
+    max_crops: int = DEFAULT_MAX_CROPS,
+) -> str:
+    """Greedy generation with the released HF pipeline (KV-cached).
+
+    ``question`` is the fully formatted prompt text (style prefix / MC block
+    already baked in); ``pil_img=None`` builds a text-only prompt.
+    """
+    content: list[dict] = []
+    if pil_img is not None:
+        if pil_img.mode != "RGB":
+            pil_img = pil_img.convert("RGB")
+        content.append({"type": "image", "image": pil_img})
+    content.append({"type": "text", "text": question})
+    text = processor.apply_chat_template(
+        [{"role": "user", "content": content}], tokenize=False, add_generation_prompt=True
+    )
+    if pil_img is not None:
+        inputs = processor(images=[pil_img], text=text, max_crops=max_crops, return_tensors="pt")
+    else:
+        inputs = processor(text=text, return_tensors="pt")
+    n_input = inputs["input_ids"].shape[1]
+    inputs = {k: (v.to(device) if hasattr(v, "to") else v) for k, v in inputs.items()}
+    output = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
+    return processor.tokenizer.decode(output[0][n_input:], skip_special_tokens=True).strip()
+
+
+# ---------------------------------------------------------------------------
+# Greedy decode
+# ---------------------------------------------------------------------------
+
+
+@torch.inference_mode()
+def greedy_decode(
+    model,
+    input_ids: torch.Tensor,
+    images: torch.Tensor | None,
+    pooled_patches_idx: torch.Tensor | None,
+    tokenizer,
+    max_new_tokens: int = 448,
+    stop_token_ids: frozenset[int] = frozenset({EOS_TOKEN_ID, IM_END_TURN_ID}),
+) -> str:
+    """Run greedy decoding and return the decoded response string.
+
+    Without KV-cache, images must be passed on every step so the vision
+    encoder re-encodes the image patches at the correct positions each time.
+    This is O(max_new_tokens × ViT_forward); use a small ``max_new_tokens``
+    for fast smoke tests.
+    """
+    gen_ids = input_ids.clone()
+    for _ in range(max_new_tokens):
+        logits = model(
+            input_ids=gen_ids,
+            images=images,
+            pooled_patches_idx=pooled_patches_idx,
+            logits_to_keep=1,
+        )
+        next_id = int(logits[0, -1].argmax().item())
+        if next_id in stop_token_ids:
+            break
+        gen_ids = torch.cat(
+            [gen_ids, torch.tensor([[next_id]], dtype=torch.long, device=gen_ids.device)],
+            dim=1,
+        )
+    new_ids = gen_ids[0, input_ids.shape[1] :]
+    return tokenizer.decode(new_ids.tolist(), skip_special_tokens=True).strip()
+
+
+# ---------------------------------------------------------------------------
+# Prediction caches (atomic JSON, run-owned files only)
+# ---------------------------------------------------------------------------
+
+
+def load_prediction_cache(path: str) -> dict[str, str]:
+    """Load a key→prediction mapping from a predictions cache file."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return {d["image_url"]: d["prediction"] for d in data if "image_url" in d}
+        if isinstance(data, dict):
+            return data
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+    return {}
+
+
+def save_prediction_cache(path: str, key_to_prediction: dict[str, str]) -> None:
+    """Atomically save a key→prediction mapping as JSON."""
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(key_to_prediction, f, indent=2)
+    os.replace(tmp, path)

--- a/src/examples/molmo2/pixmo_cap_eval.py
+++ b/src/examples/molmo2/pixmo_cap_eval.py
@@ -1,0 +1,359 @@
+"""Pixmo-cap dense-caption evaluation using OLMo-core Molmo2.
+
+Loads allenai/Molmo2-4B via the OLMo-core MultimodalLM arch,
+captions a sample of pixmo-cap images with greedy decoding, then scores
+them with the ``dense_caption`` task from olmo-eval-internal.
+
+Usage (smoke test — 12 images):
+    python pixmo_cap_eval.py --limit 12 --output predictions.json
+
+Full run (all 2730 images):
+    python pixmo_cap_eval.py
+
+Environment variables:
+    OPENAI_API_KEY          Required for GPT-judge calls on cache misses.
+    DENSE_CAPTION_EVAL_DIR  Override default eval data root (optional).
+    MOLMO_DATA_DIR          Override default image data root (optional).
+    HF_HOME                 Override HuggingFace cache root (optional).
+
+Multi-GPU usage:
+    torchrun --nproc-per-node=N pixmo_cap_eval.py --predictions-cache /path/preds.json ...
+    Each GPU processes a shard of the dataset. ``--predictions-cache`` is required.
+    GPT scoring and metric aggregation run on rank 0 after all ranks finish.
+
+Notes / known risks:
+    * Shared inference helpers (preprocessing, model loading, decoding) live in
+      ``molmo2_infer.py``; no mm_olmo dependency.
+    * This script keeps its original prompt layout (image block inside the user
+      turn); the image-QA eval uses the native layout — see ``molmo2_infer``.
+    * Use Molmo2-4B or Molmo2-8B (not Molmo2-O-7B), as the O-7B variant uses
+      per-layer YaRN attention scaling not yet supported by MultimodalLM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import torch
+from molmo2_infer import DEFAULT_MODEL_ID as _DEFAULT_MODEL_ID
+from molmo2_infer import build_input_ids_placeholder_style as _build_input_ids
+from molmo2_infer import greedy_decode, load_model
+from molmo2_infer import load_prediction_cache as _load_prediction_cache
+from molmo2_infer import preprocess_image_multicrop
+from PIL import Image
+
+if "LOCAL_RANK" not in os.environ:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+_DEFAULT_HF_CONFIG_ID = _DEFAULT_MODEL_ID
+_MAX_NEW_TOKENS = 448
+
+
+def _preprocess_image_multicrop(pil_img: Image.Image, dtype: torch.dtype, device: torch.device):
+    """Multi-crop preprocessing with this script's original settings (8 crops)."""
+    return preprocess_image_multicrop(pil_img, dtype, device, max_crops=8)
+
+
+def _save_prediction_cache(path: str, url_to_caption: dict[str, str]) -> None:
+    """Save url→caption mapping as a JSON list (same format as predictions.json)."""
+    preds = [{"image_url": url, "prediction": cap} for url, cap in url_to_caption.items()]
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(preds, f, indent=2)
+    os.replace(tmp, path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Pixmo-cap dense-caption eval with Molmo2")
+    parser.add_argument(
+        "--model",
+        default=_DEFAULT_MODEL_ID,
+        help="HF model ID or local OLMo-core checkpoint path "
+        "(step dir or run root containing step*/ subdirs)",
+    )
+    parser.add_argument(
+        "--hf-config",
+        default=_DEFAULT_HF_CONFIG_ID,
+        metavar="MODEL_ID",
+        help="HF model ID used to fetch the architecture config when --model is a "
+        "local OLMo-core .distcp checkpoint. Config JSON only — no weights "
+        "are downloaded. Ignored when --model is an HF model ID. "
+        "(default: %(default)s)",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Max number of images to evaluate")
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=_MAX_NEW_TOKENS,
+        help="Max new tokens per caption (use 64–128 for fast smoke tests)",
+    )
+
+    # ── Output / cache paths ────────────────────────────────────────────────
+    parser.add_argument(
+        "--predictions-cache",
+        default=None,
+        metavar="PATH",
+        help="JSON file for Molmo2 caption cache ({image_url: caption}). "
+        "Captions already present are reused; new ones are appended. "
+        "Use --recompute to ignore and overwrite.",
+    )
+    parser.add_argument(
+        "--gpt-cache-dir",
+        default=None,
+        metavar="DIR",
+        help="Directory for GPT response cache. Defaults to a sibling 'gpt-cache/' "
+        "next to --predictions-cache, or /tmp/dense_caption_gpt_cache.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="Write final scored predictions JSON to this path.",
+    )
+
+    # ── Cache control ───────────────────────────────────────────────────────
+    parser.add_argument(
+        "--recompute",
+        action="store_true",
+        help="Ignore ALL existing caches (Molmo2 predictions and GPT responses) "
+        "and rerun from scratch. New results still overwrite the cache files.",
+    )
+    parser.add_argument("--cache-only", action="store_true", help="Fail on any cache miss")
+
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        sys.exit("CUDA GPU required. Run on a machine with at least one A100/H100.")
+
+    # ── Distributed setup (torchrun sets LOCAL_RANK; absent in single-GPU runs) ─
+    if "LOCAL_RANK" in os.environ:
+        from olmo_core.distributed.utils import init_distributed
+        from olmo_core.utils import prepare_cli_environment
+
+        init_distributed()  # sets torch.cuda device per-rank, inits NCCL
+        prepare_cli_environment()  # rich logging, rank-0-only INFO filter
+
+    from olmo_core.distributed.utils import barrier, get_local_rank, get_rank, get_world_size
+
+    rank = get_rank()
+    world_size = get_world_size()
+    device = torch.device(f"cuda:{get_local_rank()}")
+    dtype = torch.bfloat16
+
+    # ── Resolve cache paths ──────────────────────────────────────────────────
+    pred_cache_path = args.predictions_cache
+    if world_size > 1 and not pred_cache_path:
+        sys.exit("--predictions-cache is required when running with multiple GPUs")
+
+    if args.gpt_cache_dir:
+        gpt_cache_dir = args.gpt_cache_dir
+    elif pred_cache_path:
+        gpt_cache_dir = str(Path(pred_cache_path).parent / "gpt-cache")
+    else:
+        gpt_cache_dir = "/tmp/dense_caption_gpt_cache"
+    if rank == 0:
+        os.makedirs(gpt_cache_dir, exist_ok=True)
+    logger.info("Molmo2 prediction cache: %s", pred_cache_path or "(none, no caching)")
+    logger.info("GPT response cache dir : %s", gpt_cache_dir)
+
+    # Each rank writes to its own shard file; rank 0 merges at the end.
+    rank_cache_path = (
+        (pred_cache_path + f".rank{rank}")
+        if (world_size > 1 and pred_cache_path)
+        else pred_cache_path
+    )
+
+    # ── Load task (data) ─────────────────────────────────────────────────────
+    try:
+        from olmo_eval.common.execution import ScoringContext
+        from olmo_eval.common.scorers.dense_caption_judge import DenseCaptionJudgeScorer
+        from olmo_eval.common.types import LMOutput, Response
+        from olmo_eval.evals.tasks.common.registry import _configs, _tasks
+        from olmo_eval.evals.tasks.dense_caption import (
+            DenseCaptionAvgMetric,
+            DenseCaptionConsistencyMetric,
+            DenseCaptionNumStatementsMetric,
+            DenseCaptionRecallAt10Metric,
+            DenseCaptionRecallMetric,
+        )
+    except ImportError:
+        sys.exit(
+            "olmo-eval-internal not installed. " "Run: pip install -e /path/to/olmo-eval-internal"
+        )
+
+    from dataclasses import replace as dc_replace
+
+    cfg = dc_replace(_configs["dense_caption"], limit=args.limit)
+    task = _tasks["dense_caption"](cfg)
+    instances = list(task.instances)
+    logger.info("Total instances: %d", len(instances))
+
+    # ── Load Molmo2 prediction cache ──────────────────────────────────────────
+    cached_captions: dict[str, str] = {}
+    if pred_cache_path and not args.recompute:
+        cached_captions = _load_prediction_cache(pred_cache_path)
+        if world_size > 1 and rank_cache_path:
+            # Also recover captions from an interrupted previous run on this rank.
+            cached_captions.update(_load_prediction_cache(rank_cache_path))
+        logger.info("Loaded %d cached captions", len(cached_captions))
+
+    # ── Determine which instances need inference, then shard by rank ─────────
+    needs_inference = [inst for inst in instances if inst.metadata["url"] not in cached_captions]
+    needs_inference = needs_inference[rank::world_size]
+
+    model = tokenizer = None
+    if needs_inference:
+        logger.info(
+            "Rank %d/%d: %d images need fresh inference.", rank, world_size, len(needs_inference)
+        )
+        model, tokenizer = load_model(args.model, device, dtype, hf_config_id=args.hf_config)
+    else:
+        logger.info("Rank %d/%d: all captions cached — skipping model load.", rank, world_size)
+
+    # ── Caption each image ────────────────────────────────────────────────────
+    url_to_caption: dict[str, str] = dict(cached_captions)
+    prompt = "Describe this image."
+
+    for i, instance in enumerate(needs_inference):
+        url = instance.metadata["url"]
+        image_path = instance.metadata.get("image_path", "")
+        if not image_path or not Path(image_path).exists():
+            logger.warning("[%d/%d] Image not found: %s", i + 1, len(needs_inference), image_path)
+            caption = ""
+        else:
+            try:
+                pil_img = Image.open(image_path)
+                images_t, pooling_idx_t, image_grid = _preprocess_image_multicrop(
+                    pil_img, dtype, device
+                )
+                input_ids = _build_input_ids(tokenizer, prompt, image_grid, device)
+                caption = greedy_decode(
+                    model,
+                    input_ids,
+                    images_t,
+                    pooling_idx_t,
+                    tokenizer,
+                    max_new_tokens=args.max_new_tokens,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[%d/%d] Inference failed for %s: %s",
+                    i + 1,
+                    len(needs_inference),
+                    image_path,
+                    exc,
+                )
+                caption = ""
+
+        url_to_caption[url] = caption
+        if (i + 1) % 10 == 0 or (i + 1) == len(needs_inference):
+            logger.info(
+                "[%d/%d] %s → %s…",
+                i + 1,
+                len(needs_inference),
+                Path(image_path).name if image_path else "?",
+                caption[:60],
+            )
+        # Checkpoint to this rank's shard file after every image.
+        if rank_cache_path:
+            _save_prediction_cache(rank_cache_path, url_to_caption)
+
+    # ── Barrier: wait for all ranks, then rank 0 merges shards ─────────────────
+    barrier()
+
+    if rank != 0:
+        return  # non-zero ranks are done
+
+    if world_size > 1:
+        merged: dict[str, str] = _load_prediction_cache(pred_cache_path) if pred_cache_path else {}
+        for r in range(world_size):
+            merged.update(_load_prediction_cache(pred_cache_path + f".rank{r}"))
+        url_to_caption = merged
+        if pred_cache_path:
+            _save_prediction_cache(pred_cache_path, url_to_caption)
+        logger.info(
+            "Merged %d total captions from %d rank shards.", len(url_to_caption), world_size
+        )
+
+    # ── Build Response objects ────────────────────────────────────────────────
+    import asyncio
+
+    responses: list[Response] = []
+    for instance in instances:
+        caption = url_to_caption.get(instance.metadata["url"], "")
+        req = task.format_request(instance)
+        output = LMOutput(text=caption)
+        output.extracted_answer = caption
+        output.metadata = {}
+        responses.append(Response(instance=instance, request=req, outputs=[output], scores={}))
+
+    # ── Score with GPT judge ──────────────────────────────────────────────────
+    judge = DenseCaptionJudgeScorer(
+        cache_dir=gpt_cache_dir,
+        cache_only=args.cache_only,
+        recompute=args.recompute,
+    )
+    context = ScoringContext()
+    logger.info("Running GPT judge on %d responses …", len(responses))
+
+    async def _score_all() -> None:
+        sem = asyncio.Semaphore(8)
+
+        async def _score_one(resp: Response) -> None:
+            async with sem:
+                await judge.ascore_with_context(resp.instance, resp.outputs[0], context)
+
+        await asyncio.gather(*[_score_one(r) for r in responses])
+
+    asyncio.run(_score_all())
+
+    # ── Aggregate and print metrics ──────────────────────────────────────────
+    metrics = {
+        "recall": DenseCaptionRecallMetric().compute(responses),
+        "consistency": DenseCaptionConsistencyMetric().compute(responses),
+        "recall_at_10": DenseCaptionRecallAt10Metric().compute(responses),
+        "num_statements": DenseCaptionNumStatementsMetric().compute(responses),
+        "avg": DenseCaptionAvgMetric().compute(responses),
+    }
+    n_valid_recall = sum(
+        1
+        for r in responses
+        for o in r.outputs
+        if o.metadata and o.metadata.get("dense_caption_result", {}).get("recall_valid")
+    )
+    n_valid_cons = sum(
+        1
+        for r in responses
+        for o in r.outputs
+        if o.metadata and o.metadata.get("dense_caption_result", {}).get("consistency_valid")
+    )
+    print("\n=== Dense-Caption Eval Results ===")
+    for k, v in metrics.items():
+        print(f"  {k:20s}: {v:.4f}")
+    print(f"  {'valid_recall':20s}: {n_valid_recall}/{len(responses)}")
+    print(f"  {'valid_consistency':20s}: {n_valid_cons}/{len(responses)}")
+
+    # ── Save final output ────────────────────────────────────────────────────
+    if args.output:
+        out_data = [
+            {
+                "image_url": r.instance.metadata["url"],
+                "prediction": r.outputs[0].text,
+                "dense_caption_result": r.outputs[0].metadata.get("dense_caption_result", {}),
+                "metrics": metrics,
+            }
+            for r in responses
+        ]
+        with open(args.output, "w") as f:
+            json.dump(out_data, f, indent=2)
+        logger.info("Output written to %s", args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/olmo_core/nn/vision/__init__.py
+++ b/src/olmo_core/nn/vision/__init__.py
@@ -15,6 +15,7 @@ from .connector import (
     VisionConnectorConfig,
 )
 from .image_vit import VisionTransformer, ViTAttention, ViTBlock, ViTMLP
+from .molmo2_image_processor import preprocess_image_molmo2
 from .molmo2_loader import molmo2_hf_state_dict_to_multimodal_lm
 from .multimodal import MultimodalLM, MultimodalLMConfig
 
@@ -34,4 +35,5 @@ __all__ = [
     "MultimodalLMConfig",
     "MultimodalLM",
     "molmo2_hf_state_dict_to_multimodal_lm",
+    "preprocess_image_molmo2",
 ]

--- a/src/olmo_core/nn/vision/molmo2_image_processor.py
+++ b/src/olmo_core/nn/vision/molmo2_image_processor.py
@@ -1,0 +1,337 @@
+"""
+Molmo2 image preprocessor — ported from mm_olmo with no mm_olmo/einops/torchvision dependencies.
+
+Drop-in replacement for ``Molmo2ImageProcessor`` from
+``olmo.hf_model.image_processing_molmo2``.  All logic is pure numpy + torch.
+"""
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+if TYPE_CHECKING:
+    from PIL import Image as PILImage
+
+# SigLIP / IMAGENET_STANDARD mean and std (same as transformers.image_utils.IMAGENET_STANDARD_*)
+_IMAGE_MEAN = [0.5, 0.5, 0.5]
+_IMAGE_STD = [0.5, 0.5, 0.5]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (private)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_image(arr: np.ndarray, mean: list, std: list) -> np.ndarray:
+    """In-place normalize (h, w, 3) float32 array."""
+    arr -= np.array(mean, dtype=np.float32)[None, None, :]
+    arr /= np.array(std, dtype=np.float32)[None, None, :]
+    return arr
+
+
+def _resize_image(arr: np.ndarray, target_hw: list) -> np.ndarray:
+    """
+    Resize ``arr`` (h, w, 3) to ``target_hw = [new_h, new_w]``.
+
+    Accepts float32 [0, 1] or uint8 [0, 255]; always returns float32 [0, 1].
+    Uses ``torch.nn.functional.interpolate`` (bilinear, antialias=False) to
+    match the behaviour of ``torchvision.transforms.Resize`` with the same
+    flags used in mm_olmo.
+    """
+    t = torch.from_numpy(arr).permute(2, 0, 1).unsqueeze(0).float()  # (1, 3, h, w)
+    if arr.dtype == np.uint8:
+        t = t / 255.0
+    t = F.interpolate(t, size=target_hw, mode="bilinear", align_corners=False, antialias=False)
+    t = torch.clamp(t, 0.0, 1.0)
+    return t.squeeze(0).permute(1, 2, 0).numpy()  # (h, w, 3) float32 [0, 1]
+
+
+def _select_tiling(h: int, w: int, patch_size: int, max_crops: int) -> np.ndarray:
+    """Return ``(th, tw)`` tiling that best fits an image of size ``(h, w)``."""
+    tilings = []
+    for i in range(1, max_crops + 1):
+        for j in range(1, max_crops + 1):
+            if i * j <= max_crops:
+                tilings.append((i, j))
+    tilings.sort(key=lambda x: (x[0] * x[1], x[0]))
+    candidate_tilings = np.array(tilings, dtype=np.int32)
+    candidate_resolutions = candidate_tilings * patch_size
+
+    original_size = np.array([h, w], dtype=np.float32)
+    with np.errstate(divide="ignore"):
+        required_scale_d = (candidate_resolutions.astype(np.float32) / original_size,)
+    required_scale = np.min(required_scale_d, axis=-1, keepdims=True)
+    if np.all(required_scale < 1):
+        ix = np.argmax(required_scale)
+    else:
+        required_scale = np.where(required_scale < 1.0, 10e9, required_scale)
+        ix = np.argmin(required_scale)
+    return candidate_tilings[ix]
+
+
+def _arange_for_pooling(idx_arr: np.ndarray, pool_h: int, pool_w: int) -> np.ndarray:
+    """
+    Group patch indices for pooling.
+
+    Equivalent to::
+
+        einops.rearrange(idx_arr, "(h dh) (w dw) -> h w (dh dw)", dh=pool_h, dw=pool_w)
+
+    with symmetric -1 padding to make dimensions divisible.
+
+    :param idx_arr: ``(H, W)`` int32 array of patch indices (-1 = padding/mask).
+    :returns: ``(ph, pw, pool_h * pool_w)`` grouped indices.
+    """
+    h_pad = pool_h * ((idx_arr.shape[0] + pool_h - 1) // pool_h) - idx_arr.shape[0]
+    w_pad = pool_w * ((idx_arr.shape[1] + pool_w - 1) // pool_w) - idx_arr.shape[1]
+    idx_arr = np.pad(
+        idx_arr,
+        [[h_pad // 2, (h_pad + 1) // 2], [w_pad // 2, (w_pad + 1) // 2]],
+        mode="constant",
+        constant_values=-1,
+    )
+    H, W = idx_arr.shape
+    ph = H // pool_h
+    pw = W // pool_w
+    return (
+        idx_arr.reshape(ph, pool_h, pw, pool_w)
+        .transpose(0, 2, 1, 3)
+        .reshape(ph, pw, pool_h * pool_w)
+    )
+
+
+def _batch_pixels_to_patches_cf(array: np.ndarray, patch_size: int) -> np.ndarray:
+    """
+    Reshape image crops to patch sequences in **channel-first** order.
+
+    :param array: ``(n_crops, h, w, 3)`` float32.
+    :param patch_size: spatial patch size (e.g. 14).
+    :returns: ``(n_crops, n_patches, c * patch_size * patch_size)`` where the
+              patch dimension is ``(c, kh, kw)`` — channel-first.
+    """
+    n_crops, h, w, c = array.shape
+    hp = h // patch_size
+    wp = w // patch_size
+    array = array.reshape(n_crops, hp, patch_size, wp, patch_size, c)
+    # → (n_crops, hp, wp, c, patch_size, patch_size)  [channel-first per patch]
+    array = array.transpose(0, 1, 3, 5, 2, 4)
+    return array.reshape(n_crops, hp * wp, c * patch_size * patch_size)
+
+
+def _build_resized_image(
+    image: np.ndarray,
+    base_hw: list,
+    mean: list,
+    std: list,
+    patch_size: int,
+) -> tuple:
+    """
+    Build the global (low-res) crop.
+
+    :returns: ``(resized, resize_idx)`` where *resized* is ``(1, h, w, 3)``
+              float32 and *resize_idx* is ``(h_patches, w_patches)`` int32.
+    """
+    resized = _resize_image(image, base_hw)
+    resized = _normalize_image(resized, mean, std)
+    resized = resized[np.newaxis]  # (1, h, w, 3)
+    crop_patch_w = base_hw[1] // patch_size
+    crop_patch_h = base_hw[0] // patch_size
+    resize_idx = np.arange(crop_patch_w * crop_patch_h, dtype=np.int32).reshape(
+        crop_patch_h, crop_patch_w
+    )
+    return resized, resize_idx
+
+
+def _build_overlapping_crops(
+    image: np.ndarray,
+    max_crops: int,
+    margins: list,
+    base_hw: list,
+    mean: list,
+    std: list,
+    patch_size: int,
+) -> tuple:
+    """
+    Decompose ``image`` into overlapping high-res tiles.
+
+    :returns: ``(crop_arr, patch_idx_arr)`` where *crop_arr* is
+              ``(n_crops, h, w, 3)`` and *patch_idx_arr* is
+              ``(resized_h_patches, resized_w_patches)`` int32 (−1 = overlap).
+    """
+    crop_size = base_hw[0]
+    assert base_hw[0] == base_hw[1]
+    left_margin, right_margin = margins
+
+    total_margin_px = patch_size * (left_margin + right_margin)
+    crop_window_patches = crop_size // patch_size - (left_margin + right_margin)
+    crop_window_size = crop_window_patches * patch_size
+    crop_patch_h = base_hw[0] // patch_size
+    crop_patch_w = base_hw[1] // patch_size
+    orig_h, orig_w = image.shape[:2]
+
+    tiling = _select_tiling(
+        orig_h - total_margin_px,
+        orig_w - total_margin_px,
+        crop_window_size,
+        max_crops,
+    )
+
+    src = _resize_image(
+        image,
+        [
+            tiling[0] * crop_window_size + total_margin_px,
+            tiling[1] * crop_window_size + total_margin_px,
+        ],
+    )
+    src = _normalize_image(src, mean, std)
+
+    n_crops = tiling[0] * tiling[1]
+    crop_arr = np.zeros([n_crops, crop_size, crop_size, 3], dtype=src.dtype)
+    patch_idx_arr = np.zeros([n_crops, crop_patch_h, crop_patch_w], dtype=np.int32)
+
+    on_crop = 0
+    for i in range(tiling[0]):
+        y0 = i * crop_window_size
+        for j in range(tiling[1]):
+            x0 = j * crop_window_size
+            crop_arr[on_crop] = src[y0 : y0 + crop_size, x0 : x0 + crop_size]
+            patch_idx = np.arange(crop_patch_w * crop_patch_h, dtype=np.int32).reshape(
+                crop_patch_h, crop_patch_w
+            )
+            patch_idx += on_crop * crop_patch_h * crop_patch_w
+            if i != 0:
+                patch_idx[:left_margin, :] = -1
+            if j != 0:
+                patch_idx[:, :left_margin] = -1
+            if i != tiling[0] - 1:
+                patch_idx[-right_margin:, :] = -1
+            if j != tiling[1] - 1:
+                patch_idx[:, -right_margin:] = -1
+            patch_idx_arr[on_crop] = patch_idx
+            on_crop += 1
+
+    # Reorder patch_idx_arr to left-to-right reading order
+    patch_idx_arr = patch_idx_arr.reshape(tiling[0], tiling[1], crop_patch_h, crop_patch_w)
+    patch_idx_arr = patch_idx_arr.transpose(0, 2, 1, 3)
+    patch_idx_arr = patch_idx_arr.reshape(-1)
+    patch_idx_arr = patch_idx_arr[patch_idx_arr >= 0].reshape(
+        src.shape[0] // patch_size,
+        src.shape[1] // patch_size,
+    )
+    return crop_arr, patch_idx_arr
+
+
+def _image_to_patches_and_grids(
+    image: np.ndarray,
+    max_crops: int,
+    margins: list,
+    base_hw: list,
+    mean: list,
+    std: list,
+    patch_size: int,
+    pool_h: int,
+    pool_w: int,
+) -> tuple:
+    """
+    Full preprocessing pipeline for a single image.
+
+    :returns: ``(image_grid, crops_cf, pooling_idx)`` where
+
+              * *image_grid* — ``(1, 4)`` int32: ``[resized_h, resized_w, h, w]``
+              * *crops_cf*   — ``(n_crops, n_patches, patch_dim)`` channel-first float32
+              * *pooling_idx* — ``(n_pool_tokens, pool_h*pool_w)`` int32
+    """
+    crop_patch_h = base_hw[0] // patch_size
+    crop_patch_w = base_hw[1] // patch_size
+
+    crop_arr, patch_idx_arr = _build_overlapping_crops(
+        image, max_crops, margins, base_hw, mean, std, patch_size
+    )
+
+    pooling_idx = _arange_for_pooling(patch_idx_arr, pool_h, pool_w)
+    h, w = pooling_idx.shape[:2]
+    pooling_idx = pooling_idx.reshape(-1, pool_h * pool_w)
+
+    resized, resize_idx = _build_resized_image(image, base_hw, mean, std, patch_size)
+    all_crops = np.concatenate([resized, crop_arr], 0)  # global crop first
+
+    resize_pooling = _arange_for_pooling(resize_idx, pool_h, pool_w)
+    resized_h, resized_w = resize_pooling.shape[:2]
+    resize_pooling = resize_pooling.reshape(-1, pool_h * pool_w)
+
+    # Offset high-res patch indices past the global crop's patches
+    pooling_idx = np.where(pooling_idx >= 0, pooling_idx + crop_patch_h * crop_patch_w, -1)
+    pooling_idx = np.concatenate([resize_pooling, pooling_idx], 0)
+
+    image_grid = np.stack([np.array([resized_h, resized_w, h, w], dtype=np.int32)], 0)  # (1, 4)
+
+    return image_grid, _batch_pixels_to_patches_cf(all_crops, patch_size), pooling_idx
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def preprocess_image_molmo2(
+    pil_img: "PILImage.Image",
+    dtype: torch.dtype,
+    device: torch.device,
+    *,
+    image_size: int = 378,
+    patch_size: int = 14,
+    max_crops: int = 8,
+    overlap_margins: tuple = (4, 4),
+    pool_h: int = 2,
+    pool_w: int = 2,
+    mean: list = _IMAGE_MEAN,
+    std: list = _IMAGE_STD,
+) -> tuple:
+    """
+    Preprocess a PIL image for Molmo2 :class:`~olmo_core.nn.vision.MultimodalLM`.
+
+    This replaces ``Molmo2ImageProcessor`` from ``mm_olmo`` with no external
+    dependencies beyond numpy, torch, and PIL.
+
+    :param pil_img: Input PIL image (any mode; converted to RGB internally).
+    :param dtype: Floating-point dtype for the returned image tensor.
+    :param device: Target device.
+    :param image_size: Square base crop size in pixels (default 378).
+    :param patch_size: ViT patch size in pixels (default 14).
+    :param max_crops: Maximum number of high-res crops (default 8).
+    :param overlap_margins: ``(left, right)`` overlap margins in patches (default ``(4, 4)``).
+    :param pool_h: Pooling height (default 2).
+    :param pool_w: Pooling width (default 2).
+    :param mean: Per-channel normalisation mean (default SigLIP ``[0.5, 0.5, 0.5]``).
+    :param std: Per-channel normalisation std (default SigLIP ``[0.5, 0.5, 0.5]``).
+
+    :returns images: ``(1, n_crops, n_patches, patch_dim)`` channel-first float tensor.
+    :returns pooling_idx: ``(1, n_pool_tokens, pool_h * pool_w)`` int64 tensor (−1 = pad).
+    :returns image_grid: ``np.ndarray`` of shape ``(4,)`` with
+                         ``[resized_h, resized_w, h, w]`` pooled-grid dimensions.
+    """
+    rgb = pil_img.convert("RGB")
+    arr = np.array(rgb, dtype=np.float32) / 255.0  # (h, w, 3) float32 [0, 1]
+
+    base_hw = [image_size, image_size]
+    margins = list(overlap_margins)
+
+    image_grid_batch, crops_cf, pooling_idx = _image_to_patches_and_grids(
+        arr,
+        max_crops=max_crops,
+        margins=margins,
+        base_hw=base_hw,
+        mean=mean,
+        std=std,
+        patch_size=patch_size,
+        pool_h=pool_h,
+        pool_w=pool_w,
+    )
+
+    # Add batch dimension
+    images_t = torch.from_numpy(crops_cf[np.newaxis]).to(dtype=dtype, device=device)
+    pooling_t = torch.from_numpy(pooling_idx[np.newaxis].astype(np.int64)).to(device=device)
+
+    return images_t, pooling_t, image_grid_batch[0]


### PR DESCRIPTION
## Summary

Adds runnable **Molmo2 evaluation examples** under `src/examples/molmo2/` that run inference with the OLMo-core `MultimodalLM` and score against tasks living in `olmo-eval-internal` (prompt construction, metrics, and data loading stay there — these scripts are inference glue):

- **`image_qa_eval.py`** — the 11 Molmo2 image-QA benchmarks: ChartQA, VQA v2, DocVQA, InfoVQA, TextVQA, RealWorldQA, MMMU, MathVista, CountBench QA, PixMo Count, AI2D.
- **`pixmo_cap_eval.py`** — pixmo-cap dense-caption eval with GPT judging.
- **`molmo2_infer.py`** — shared inference helpers: multi-crop preprocessing, image-token sequence / prompt construction, HF + native `.distcp` checkpoint loading into `MultimodalLM`, greedy decoding, atomic JSON prediction caches.

Also adds **`preprocess_image_molmo2`** in `nn/vision/molmo2_image_processor.py` — a native OLMo-core multi-crop image preprocessor (no `mm_olmo` dependency), exported from `nn.vision`.

## Verification

- Prompt layout (image-token block placed **before** the `<|im_start|>user` turn) and the `--max-crops=24` default were verified against the released **mm_olmo prediction dumps** and the official HF chat template.
- Both eval scripts support multi-GPU sharding via `torchrun` with rank-0 GPT scoring / metric aggregation.
- Per-task / per-image prediction caches reuse prior outputs and only inference missing examples; the released mm_olmo dumps are never read or written as a cache source.

## Notes

- Branched off the current `vision` tip — no rebase conflicts (`vision` had not advanced past the branch point).
- Use Molmo2-4B or Molmo2-8B (not Molmo2-O-7B) with these scripts.