### PR TITLE
Fix TypeError when saving checkpoints with torch 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The CPU `Test` CI job now caches `HF_HOME` across runs so the HuggingFace roundtrip tests (Qwen3-0.6B, Gemma-3-270m) don't re-download their checkpoints every run.
+- Fixed a `TypeError` when saving checkpoints with torch 2.6 — `enable_plan_caching` is now only passed to `DefaultSavePlanner` when supported (torch 2.7+), and a warning is logged if it's requested but unsupported.
 - Excluded `mark_dynamic` from `torch.compile` tracing (`@torch.compiler.disable`).
 - Clearer error messages (now include the offending values) when a rank batch size isn't divisible by the sequence length, or `max_target_sequence_length` isn't a multiple of `sequence_length`.
 - S3 uploads/downloads now also retry on transient SSL errors (`ssl.SSLError`, botocore/urllib3 `SSLError`).

--- a/src/olmo_core/distributed/checkpoint/__init__.py
+++ b/src/olmo_core/distributed/checkpoint/__init__.py
@@ -25,6 +25,7 @@ API Reference
 
 from __future__ import annotations
 
+import inspect
 import logging
 from concurrent.futures import Future
 from dataclasses import dataclass
@@ -43,7 +44,7 @@ from torch.distributed.checkpoint.metadata import Metadata, TensorStorageMetadat
 from olmo_core.aliases import PathOrStr
 from olmo_core.config import StrEnum
 from olmo_core.io import clear_directory, dir_is_empty, is_url, normalize_path
-from olmo_core.utils import gc_cuda, get_element_size, wait_for
+from olmo_core.utils import gc_cuda, get_element_size, log_once, wait_for
 
 from ..utils import barrier, get_fs_local_rank, is_distributed
 from .filesystem import RemoteFileSystemReader, RemoteFileSystemWriter
@@ -101,9 +102,7 @@ def save_state_dict(
     """
     if not _skip_prepare:
         dir = _prepare_env_for_save(dir, process_group=process_group, save_overwrite=save_overwrite)
-    planner = DefaultSavePlanner(
-        dedup_save_to_lowest_rank=True, enable_plan_caching=enable_plan_caching
-    )
+    planner = _new_save_planner(enable_plan_caching=enable_plan_caching)
     dist_cp.state_dict_saver.save(
         state_dict,
         storage_writer=RemoteFileSystemWriter(
@@ -138,9 +137,7 @@ def async_save_state_dict(
     """
     if not _skip_prepare:
         dir = _prepare_env_for_save(dir, process_group=process_group, save_overwrite=save_overwrite)
-    planner = DefaultSavePlanner(
-        dedup_save_to_lowest_rank=True, enable_plan_caching=enable_plan_caching
-    )
+    planner = _new_save_planner(enable_plan_caching=enable_plan_caching)
     return dist_cp.state_dict_saver.async_save(
         state_dict,
         storage_writer=RemoteFileSystemWriter(
@@ -238,9 +235,7 @@ def save_model_and_optim_state(
         process_group=process_group,
         flatten_optimizer_state=flatten_optimizer_state,
     )
-    planner = DefaultSavePlanner(
-        dedup_save_to_lowest_rank=True, enable_plan_caching=enable_plan_caching
-    )
+    planner = _new_save_planner(enable_plan_caching=enable_plan_caching)
     dist_cp.state_dict_saver.save(
         state_dict,
         storage_writer=RemoteFileSystemWriter(
@@ -281,9 +276,7 @@ def async_save_model_and_optim_state(
         process_group=process_group,
         flatten_optimizer_state=flatten_optimizer_state,
     )
-    planner = DefaultSavePlanner(
-        dedup_save_to_lowest_rank=True, enable_plan_caching=enable_plan_caching
-    )
+    planner = _new_save_planner(enable_plan_caching=enable_plan_caching)
     return dist_cp.state_dict_saver.async_save(
         state_dict,
         storage_writer=RemoteFileSystemWriter(
@@ -663,6 +656,21 @@ def get_checkpoint_metadata(dir: PathOrStr) -> Metadata:
     dir = normalize_path(dir)
     storage_reader = RemoteFileSystemReader(dir)
     return storage_reader.read_metadata()
+
+
+def _new_save_planner(enable_plan_caching: bool = False) -> DefaultSavePlanner:
+    kwargs: Dict[str, Any] = dict(dedup_save_to_lowest_rank=True)
+    # The 'enable_plan_caching' option was only added to 'DefaultSavePlanner' in torch 2.7.
+    if "enable_plan_caching" in inspect.signature(DefaultSavePlanner.__init__).parameters:
+        kwargs["enable_plan_caching"] = enable_plan_caching
+    elif enable_plan_caching:
+        log_once(
+            log,
+            "Ignoring 'enable_plan_caching=True' since it's not supported by this version of "
+            "torch (requires torch>=2.7)",
+            level=logging.WARNING,
+        )
+    return DefaultSavePlanner(**kwargs)
 
 
 def _prepare_env_for_save(

--- a/src/test/distributed/checkpoint_test.py
+++ b/src/test/distributed/checkpoint_test.py
@@ -11,6 +11,7 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
 )
 
+from olmo_core.distributed import checkpoint
 from olmo_core.distributed.checkpoint import (
     UnshardStrategy,
     async_save_model_and_optim_state,
@@ -493,3 +494,29 @@ def test_merge_state_dicts():
     }
     merge_state_dicts(state_dict, {"model": {"e": 3}})
     assert state_dict["model"]["e"] == 3
+
+
+def test_new_save_planner_with_plan_caching_support(monkeypatch):
+    # Simulate torch>=2.7, where 'DefaultSavePlanner' accepts 'enable_plan_caching'.
+    class ModernSavePlanner:
+        def __init__(
+            self, dedup_save_to_lowest_rank: bool = False, enable_plan_caching: bool = False
+        ):
+            self.dedup_save_to_lowest_rank = dedup_save_to_lowest_rank
+            self.enable_plan_caching = enable_plan_caching
+
+    monkeypatch.setattr(checkpoint, "DefaultSavePlanner", ModernSavePlanner)
+    planner = checkpoint._new_save_planner(enable_plan_caching=True)
+    assert planner.dedup_save_to_lowest_rank
+    assert planner.enable_plan_caching
+
+
+def test_new_save_planner_without_plan_caching_support(monkeypatch):
+    # Simulate torch<2.7, where 'DefaultSavePlanner' doesn't accept 'enable_plan_caching'.
+    class LegacySavePlanner:
+        def __init__(self, dedup_save_to_lowest_rank: bool = False):
+            self.dedup_save_to_lowest_rank = dedup_save_to_lowest_rank
+
+    monkeypatch.setattr(checkpoint, "DefaultSavePlanner", LegacySavePlanner)
+    planner = checkpoint._new_save_planner(enable_plan_caching=True)
+    assert planner.dedup_save_to_lowest_rank


### PR DESCRIPTION
Fixes #632.

`enable_plan_caching` only exists on `DefaultSavePlanner` from torch 2.7 ([default_planner.py:78 at v2.7.0](https://github.com/pytorch/pytorch/blob/v2.7.0/torch/distributed/checkpoint/default_planner.py#L78)), but it's passed unconditionally at all four save call sites in `olmo_core.distributed.checkpoint`, and the trainer's `Checkpointer` requests `enable_plan_caching=True` — so every checkpoint save crashes on torch 2.6, which `pyproject.toml` still allows.

This builds the planner through a small helper that forwards `enable_plan_caching` only when the installed torch's `DefaultSavePlanner` accepts it, and logs a one-time warning when caching is requested but unsupported. Verified with torch 2.6.0 on the issue's repro path (`TypeError` before, clean save after) and with torch 2.12 (option still forwarded). Added unit tests that monkeypatch the planner with both signatures so the old-torch path stays covered in CI regardless of the torch version installed.

An alternative is bumping the floor in `pyproject.toml` instead — but note it would need to go all the way to `torch>=2.8`, since `torch.compiler.disable(reason=...)` in `nn/attention/backend.py` requires 2.8 (the `reason` kwarg landed there) and already breaks imports on older torch. Happy to rework in that direction if you'd rather raise the floor.
