### PR TITLE
Add native multimodal Qwen3.5 / Qwen3.6 (VL) support

### DIFF
--- a/src/examples/qwen3_5_vl/infer.py
+++ b/src/examples/qwen3_5_vl/infer.py
@@ -1,0 +1,76 @@
+"""
+Native multimodal **Qwen3.5-VL** image→text inference with OLMo-core.
+
+Loads a HuggingFace ``Qwen3_5ForConditionalGeneration`` checkpoint (default
+``Qwen/Qwen3.5-0.8B``) into the OLMo-core :class:`~olmo_core.nn.vision.qwen3_5_vl.Qwen3_5VL`
+model (native vision tower + Qwen3.5 hybrid LM + M-RoPE) and greedily decodes a
+caption. Image preprocessing reuses the HF ``AutoProcessor``; the model is native.
+
+Usage::
+
+    # Caption the bundled synthetic image (red circle + blue square):
+    python src/examples/qwen3_5_vl/infer.py
+
+    # Caption your own image with a custom prompt:
+    python src/examples/qwen3_5_vl/infer.py --image path/to/img.jpg \\
+        --prompt "What is in this image?"
+"""
+
+import argparse
+
+import torch
+from PIL import Image, ImageDraw
+
+from olmo_core.nn.vision.qwen3_5_vl import load_qwen3_5_vl_from_hf
+
+
+def _synthetic_image() -> Image.Image:
+    img = Image.new("RGB", (448, 448), "white")
+    draw = ImageDraw.Draw(img)
+    draw.ellipse([120, 120, 330, 330], fill="red")
+    draw.rectangle([40, 40, 120, 120], fill="blue")
+    return img
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="Qwen/Qwen3.5-0.8B", help="HF model id / path.")
+    parser.add_argument("--image", default=None, help="Image path (default: synthetic).")
+    parser.add_argument("--prompt", default="Describe this image in one sentence.")
+    parser.add_argument("--max-new-tokens", type=int, default=40)
+    parser.add_argument("--dtype", default="bfloat16", choices=["float32", "bfloat16", "float16"])
+    args = parser.parse_args()
+
+    dtype = getattr(torch, args.dtype)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    print(f"Loading {args.model} into OLMo-core Qwen3_5VL ({args.dtype}) ...", flush=True)
+    model, processor = load_qwen3_5_vl_from_hf(args.model, device=device, dtype=dtype)
+    tok = processor.tokenizer
+
+    image = Image.open(args.image).convert("RGB") if args.image else _synthetic_image()
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image", "image": image}, {"type": "text", "text": args.prompt}],
+        }
+    ]
+    text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    inputs = processor(text=[text], images=[image], return_tensors="pt").to(device)
+
+    eos = tuple(
+        x for x in {tok.eos_token_id, tok.convert_tokens_to_ids("<|im_end|>")} if x is not None
+    )
+    out_ids = model.generate(
+        inputs["input_ids"],
+        inputs["pixel_values"].to(dtype),
+        inputs["image_grid_thw"],
+        max_new_tokens=args.max_new_tokens,
+        eos_token_ids=eos,
+    )
+    print("\n=== Generation ===")
+    print(tok.decode(out_ids, skip_special_tokens=True).strip())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/olmo_core/nn/rope.py
+++ b/src/olmo_core/nn/rope.py
@@ -1,7 +1,7 @@
 import math
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar, Optional, Tuple
+from typing import ClassVar, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -48,6 +48,63 @@ class RoPEType(StrEnum):
 def compute_inv_freqs(theta: int, dim: int, device: torch.device) -> "torch.Tensor":
     inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, device=device, dtype=torch.float) / dim))
     return inv_freq
+
+
+def _apply_interleaved_mrope(freqs: torch.Tensor, mrope_section: List[int]) -> torch.Tensor:
+    """Interleave per-axis frequency chunks ``[AAA..BBB..CCC]`` → ``[ABCABC..]``.
+
+    Axis 0 is the base; for each later axis ``a`` the components at
+    ``a, a + n_axes, a + 2*n_axes, …`` (up to ``mrope_section[a] * n_axes``) are
+    taken from that axis, preserving frequency continuity across axes.
+
+    :param freqs: ``(n_axes, ..., rotary_dim // 2)``.
+    :param mrope_section: Per-axis frequency-component counts.
+    """
+    n = len(mrope_section)
+    out = freqs[0].clone()
+    for axis in range(1, n):
+        idx = slice(axis, mrope_section[axis] * n, n)
+        out[..., idx] = freqs[axis, ..., idx]
+    return out
+
+
+def build_mrope_sin_cos(
+    position_ids: torch.Tensor,
+    *,
+    head_dim: int,
+    partial_rotary_factor: float,
+    theta: int,
+    mrope_section: List[int],
+    device: torch.device,
+    dtype: torch.dtype = torch.float32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Build interleaved multimodal RoPE (M-RoPE) ``(pos_sin, pos_cos)`` buffers.
+
+    M-RoPE gives each token separate position indices along several axes (e.g.
+    temporal / height / width for image tokens) and interleaves their
+    frequencies per ``mrope_section`` so one rotary table mixes the axes. The
+    returned buffers use the same ``cat(freqs, freqs)`` layout as
+    :class:`RotaryEmbedding`, so they can be passed straight to attention as
+    ``pos_sin`` / ``pos_cos``. Supports a single sequence (``B == 1``).
+
+    :param position_ids: ``(n_axes, 1, seq)`` per-axis position indices, where
+        ``n_axes == len(mrope_section)``.
+    :param head_dim: Attention head dimension.
+    :param partial_rotary_factor: Fraction of ``head_dim`` that is rotated.
+    :param theta: RoPE base frequency.
+    :param mrope_section: Number of frequency components taken from each axis.
+    :returns: ``(pos_sin, pos_cos)``, each of shape ``(seq, rotary_dim)``.
+    """
+    rotary_dim = int(head_dim * partial_rotary_factor)
+    inv_freq = compute_inv_freqs(theta, rotary_dim, device)  # (rotary_dim // 2,)
+    n_axes = position_ids.shape[0]
+    pos = position_ids.to(device=device, dtype=torch.float)  # (n_axes, 1, seq)
+    inv = inv_freq[None, None, :, None].expand(n_axes, pos.shape[1], -1, 1)
+    freqs = (inv @ pos[:, :, None, :]).transpose(2, 3)  # (n_axes, 1, seq, rotary_dim // 2)
+    freqs = _apply_interleaved_mrope(freqs, mrope_section)  # (1, seq, rotary_dim // 2)
+    emb = torch.cat((freqs, freqs), dim=-1)  # (1, seq, rotary_dim)
+    return emb.sin()[0].to(dtype), emb.cos()[0].to(dtype)
 
 
 @dataclass
@@ -493,6 +550,7 @@ class RotaryEmbedding(RotaryEmbeddingBase):
         pos_cos: Optional[torch.Tensor] = None,
         freqs_cis: Optional[torch.Tensor] = None,
         cu_doc_lens: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Apply RoPE to query (``q``) and key (``k``) matrices.
@@ -516,6 +574,12 @@ class RotaryEmbedding(RotaryEmbeddingBase):
 
         if cu_doc_lens is not None and start_pos is not None:
             raise RuntimeError("'cu_doc_lens' and 'start_pos' are mutually exclusive")
+
+        if position_ids is not None:
+            if cu_doc_lens is not None:
+                raise RuntimeError("'position_ids' and 'cu_doc_lens' are mutually exclusive")
+            if start_pos is not None:
+                raise RuntimeError("'position_ids' and 'start_pos' are mutually exclusive")
 
         if head_first:
             q_len = q.size(2)
@@ -555,6 +619,24 @@ class RotaryEmbedding(RotaryEmbeddingBase):
                 pos_idx = (flat_idx - cu_doc_lens[doc_id]).view(B, k_len)
                 sin_sel = pos_sin.index_select(0, pos_idx.reshape(-1)).view(B, k_len, -1)
                 cos_sel = pos_cos.index_select(0, pos_idx.reshape(-1)).view(B, k_len, -1)
+                if head_first:
+                    sin_qk = sin_sel.unsqueeze(1)
+                    cos_qk = cos_sel.unsqueeze(1)
+                else:
+                    sin_qk = sin_sel.unsqueeze(2)
+                    cos_qk = cos_sel.unsqueeze(2)
+                q_ = self._apply_rotary_pos_emb(sin_qk, cos_qk, q_)
+                k_ = self._apply_rotary_pos_emb(sin_qk, cos_qk, k_)
+            elif position_ids is not None:
+                # Explicit per-token positions (e.g. subsegment / branch packing where
+                # parallel branches share an overlapping position range). Gather the
+                # precomputed sin/cos for each token's position. ``position_ids`` has
+                # shape ``(B, k_len)`` and every entry must be < ``seq_len_needed``.
+                if q_len != k_len:
+                    raise RuntimeError("'position_ids' requires q_len == k_len")
+                pos_idx = position_ids.to(torch.long)
+                sin_sel = pos_sin.index_select(0, pos_idx.reshape(-1)).view(*pos_idx.shape, -1)
+                cos_sel = pos_cos.index_select(0, pos_idx.reshape(-1)).view(*pos_idx.shape, -1)
                 if head_first:
                     sin_qk = sin_sel.unsqueeze(1)
                     cos_qk = cos_sel.unsqueeze(1)

--- a/src/olmo_core/nn/transformer/config.py
+++ b/src/olmo_core/nn/transformer/config.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import InitVar, dataclass, field
 from fnmatch import fnmatch
 from itertools import cycle, islice
-from typing import TYPE_CHECKING, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from olmo_core.config import UNSET, DType, StrEnum
 from olmo_core.doc_utils import beta_feature
@@ -1624,6 +1624,54 @@ class TransformerConfig(ModelConfig):
             lm_head=LMHeadConfig(layer_norm=layer_norm, bias=False, dtype=dtype),
             dtype=dtype,
             tie_word_embeddings=kwargs.pop("tie_word_embeddings", True),
+            **kwargs,
+        )
+
+    @classmethod
+    def qwen3_5_from_hf_config(
+        cls,
+        hf_config: Any,
+        *,
+        vocab_size: Optional[int] = None,
+        attn_backend: Optional[AttentionBackendName] = None,
+        dtype: DType = DType.float32,
+        **kwargs,
+    ) -> "TransformerConfig":
+        """
+        Build a Qwen3.5 hybrid config from a HuggingFace config.
+
+        Maps the HF fields onto :meth:`qwen3_5_like`. Accepts either a full
+        multimodal config (reads its ``text_config``) or a text config directly,
+        so both the text-only and multimodal (Qwen3.5-VL) load paths can share a
+        single mapping.
+
+        :param hf_config: An HF ``Qwen3_5Config`` / ``Qwen3_5TextConfig`` (or any
+            object exposing the same attributes).
+        :param vocab_size: Override the vocabulary size; defaults to the HF
+            config's ``vocab_size``.
+        :param attn_backend: Attention backend for the full-attention layers.
+        :param dtype: Parameter dtype.
+        """
+        text_cfg = getattr(hf_config, "text_config", hf_config)
+        rope_params = getattr(text_cfg, "rope_parameters", None) or {}
+        return cls.qwen3_5_like(
+            d_model=text_cfg.hidden_size,
+            vocab_size=text_cfg.vocab_size if vocab_size is None else vocab_size,
+            n_layers=text_cfg.num_hidden_layers,
+            n_heads=text_cfg.num_attention_heads,
+            n_kv_heads=text_cfg.num_key_value_heads,
+            head_dim=text_cfg.head_dim,
+            intermediate_size=text_cfg.intermediate_size,
+            linear_num_key_heads=text_cfg.linear_num_key_heads,
+            linear_num_value_heads=text_cfg.linear_num_value_heads,
+            linear_key_head_dim=text_cfg.linear_key_head_dim,
+            linear_value_head_dim=text_cfg.linear_value_head_dim,
+            linear_conv_kernel_dim=text_cfg.linear_conv_kernel_dim,
+            rope_theta=rope_params.get("rope_theta", getattr(text_cfg, "rope_theta", 10_000_000)),
+            partial_rotary_factor=text_cfg.partial_rotary_factor,
+            attn_backend=attn_backend,
+            dtype=dtype,
+            tie_word_embeddings=getattr(text_cfg, "tie_word_embeddings", True),
             **kwargs,
         )
 

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -532,6 +532,8 @@ class Transformer(nn.Module):
         loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
         return_logits: Optional[bool] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
+        pos_sin: Optional[torch.Tensor] = None,
+        pos_cos: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Union[torch.Tensor, LMOutputWithLoss]:
         """
@@ -579,6 +581,22 @@ class Transformer(nn.Module):
             logits_to_keep=logits_to_keep,
             **kwargs,
         )
+
+        # Externally-provided RoPE buffers (e.g. M-RoPE / multimodal 3D rotary). When
+        # supplied, every attention block uses these instead of computing 1D RoPE from
+        # sequential positions. Sequence-mixers that ignore RoPE (e.g. GatedDeltaNet)
+        # simply drop these via ``**kwargs``. Not supported with context parallelism,
+        # which shards/derives its own RoPE buffers.
+        if pos_sin is not None or pos_cos is not None:
+            if self._cp_load_balancer is not None:
+                raise RuntimeError(
+                    "External `pos_sin`/`pos_cos` (e.g. M-RoPE) are not supported with "
+                    "context parallelism."
+                )
+            if pos_sin is not None:
+                all_block_kwargs["pos_sin"] = move_to_device(pos_sin, self.device)
+            if pos_cos is not None:
+                all_block_kwargs["pos_cos"] = move_to_device(pos_cos, self.device)
 
         # Get embeddings but pass-through for non-existent layers to allow easy
         # pipeline parallel configuration.

--- a/src/olmo_core/nn/vision/qwen3_5_vl.py
+++ b/src/olmo_core/nn/vision/qwen3_5_vl.py
@@ -1,0 +1,602 @@
+"""
+Native multimodal **Qwen3.5-VL** support for OLMo-core.
+
+Loads a HuggingFace ``Qwen3_5ForConditionalGeneration`` checkpoint (e.g.
+``Qwen/Qwen3.5-0.8B``) into an OLMo-core model and runs image→text inference.
+
+The architecture has three parts:
+
+1. A **native vision tower** (:class:`Qwen3_5VisionModel`) — a dynamic-resolution
+   ViT with a ``Conv3d`` patch embedding, bilinearly-interpolated learned position
+   embeddings, 2D rotary attention, and a spatial-merge **patch merger** that
+   produces one embedding per ``<image_pad>`` placeholder token. Ported faithfully
+   from ``transformers`` so HF vision weights load 1:1.
+
+2. The existing OLMo-core **Qwen3.5 hybrid LM** (GatedDeltaNet + full attention),
+   reused unchanged. Its weights are converted by
+   :func:`~olmo_core.nn.hf.convert.convert_qwen3_5_state_from_hf` (which already
+   normalizes the ``model.language_model.*`` nesting and skips vision keys).
+
+3. **M-RoPE** — 3D rotary position embeddings. Image tokens get distinct
+   temporal/height/width positions; text tokens collapse to standard 1D RoPE. The
+   cos/sin tables are precomputed here and injected into the LM's full-attention
+   blocks via the ``pos_sin`` / ``pos_cos`` arguments of
+   :meth:`~olmo_core.nn.transformer.Transformer.forward`.
+
+Image preprocessing reuses the HF ``AutoProcessor`` (``pixel_values`` /
+``image_grid_thw`` / ``input_ids``); only the *model* is native OLMo-core.
+
+.. note::
+    The 0.8B checkpoint has ``deepstack_visual_indexes == []`` (deepstack disabled),
+    so vision features are injected only at the embedding layer via a masked scatter.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from typing_extensions import Self
+
+from olmo_core.config import DType
+from olmo_core.nn.attention import AttentionBackendName
+from olmo_core.nn.rope import build_mrope_sin_cos, compute_inv_freqs
+from olmo_core.nn.transformer import Transformer, TransformerConfig
+
+__all__ = [
+    "Qwen3_5VisionConfig",
+    "Qwen3_5VisionModel",
+    "Qwen3_5VL",
+    "qwen3_5_get_rope_index",
+    "load_qwen3_5_vl_from_hf",
+]
+
+
+# ---------------------------------------------------------------------------
+# Vision config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Qwen3_5VisionConfig:
+    """Configuration for the Qwen3.5 native vision tower."""
+
+    depth: int = 12
+    hidden_size: int = 768
+    intermediate_size: int = 3072
+    num_heads: int = 12
+    in_channels: int = 3
+    patch_size: int = 16
+    temporal_patch_size: int = 2
+    spatial_merge_size: int = 2
+    out_hidden_size: int = 1024
+    num_position_embeddings: int = 2304
+    hidden_act: str = "gelu_pytorch_tanh"
+    rms_norm_eps: float = 1e-6
+
+    @classmethod
+    def from_hf(cls, vc: Any) -> Self:
+        get = (
+            (lambda k, d=None: vc.get(k, d))
+            if isinstance(vc, dict)
+            else (lambda k, d=None: getattr(vc, k, d))
+        )
+        return cls(
+            depth=get("depth"),
+            hidden_size=get("hidden_size"),
+            intermediate_size=get("intermediate_size"),
+            num_heads=get("num_heads"),
+            in_channels=get("in_channels", 3),
+            patch_size=get("patch_size"),
+            temporal_patch_size=get("temporal_patch_size"),
+            spatial_merge_size=get("spatial_merge_size"),
+            out_hidden_size=get("out_hidden_size"),
+            num_position_embeddings=get("num_position_embeddings"),
+            hidden_act=get("hidden_act", "gelu_pytorch_tanh"),
+        )
+
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_heads
+
+
+# ---------------------------------------------------------------------------
+# Vision tower (ported from transformers Qwen3_5VisionModel)
+# ---------------------------------------------------------------------------
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _apply_rotary_pos_emb_vision(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    orig_q_dtype, orig_k_dtype = q.dtype, k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.unsqueeze(-2).float(), sin.unsqueeze(-2).float()
+    q_embed = (q * cos) + (_rotate_half(q) * sin)
+    k_embed = (k * cos) + (_rotate_half(k) * sin)
+    return q_embed.to(orig_q_dtype), k_embed.to(orig_k_dtype)
+
+
+class _VisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: int = 10000) -> None:
+        super().__init__()
+        inv_freq = compute_inv_freqs(theta, dim, torch.device("cpu"))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        seq = torch.arange(seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+        return torch.outer(seq, self.inv_freq)
+
+
+class _VisionPatchEmbed(nn.Module):
+    def __init__(self, cfg: Qwen3_5VisionConfig) -> None:
+        super().__init__()
+        self.in_channels = cfg.in_channels
+        self.temporal_patch_size = cfg.temporal_patch_size
+        self.patch_size = cfg.patch_size
+        self.embed_dim = cfg.hidden_size
+        ks = [cfg.temporal_patch_size, cfg.patch_size, cfg.patch_size]
+        self.proj = nn.Conv3d(
+            cfg.in_channels, cfg.hidden_size, kernel_size=ks, stride=ks, bias=True
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.view(-1, self.in_channels, self.temporal_patch_size, self.patch_size, self.patch_size)
+        return self.proj(x.to(self.proj.weight.dtype)).view(-1, self.embed_dim)
+
+
+class _VisionMLP(nn.Module):
+    def __init__(self, cfg: Qwen3_5VisionConfig) -> None:
+        super().__init__()
+        self.linear_fc1 = nn.Linear(cfg.hidden_size, cfg.intermediate_size, bias=True)
+        self.linear_fc2 = nn.Linear(cfg.intermediate_size, cfg.hidden_size, bias=True)
+        self.act_fn = nn.GELU(approximate="tanh")
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear_fc2(self.act_fn(self.linear_fc1(x)))
+
+
+class _VisionAttention(nn.Module):
+    def __init__(self, cfg: Qwen3_5VisionConfig) -> None:
+        super().__init__()
+        self.num_heads = cfg.num_heads
+        self.head_dim = cfg.head_dim
+        self.qkv = nn.Linear(cfg.hidden_size, cfg.hidden_size * 3, bias=True)
+        self.proj = nn.Linear(cfg.hidden_size, cfg.hidden_size, bias=True)
+        self.scaling = self.head_dim**-0.5
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        seq_len = x.shape[0]
+        q, k, v = self.qkv(x).reshape(seq_len, 3, self.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
+        cos, sin = position_embeddings
+        q, k = _apply_rotary_pos_emb_vision(q, k, cos, sin)  # (seq, heads, head_dim)
+
+        # (1, heads, seq, head_dim)
+        q = q.transpose(0, 1).unsqueeze(0)
+        k = k.transpose(0, 1).unsqueeze(0)
+        v = v.transpose(0, 1).unsqueeze(0)
+
+        # Block-diagonal attention by image via cu_seqlens (no causal mask).
+        lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        outs = []
+        for q_i, k_i, v_i in zip(
+            torch.split(q, lengths, dim=2),
+            torch.split(k, lengths, dim=2),
+            torch.split(v, lengths, dim=2),
+        ):
+            outs.append(
+                F.scaled_dot_product_attention(q_i, k_i, v_i, is_causal=False, scale=self.scaling)
+            )
+        attn = torch.cat(outs, dim=2)  # (1, heads, seq, head_dim)
+        attn = attn.squeeze(0).transpose(0, 1).reshape(seq_len, -1)
+        return self.proj(attn)
+
+
+class _VisionBlock(nn.Module):
+    def __init__(self, cfg: Qwen3_5VisionConfig) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(cfg.hidden_size, eps=1e-6)
+        self.norm2 = nn.LayerNorm(cfg.hidden_size, eps=1e-6)
+        self.attn = _VisionAttention(cfg)
+        self.mlp = _VisionMLP(cfg)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        x = x + self.attn(
+            self.norm1(x), cu_seqlens=cu_seqlens, position_embeddings=position_embeddings
+        )
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class _VisionPatchMerger(nn.Module):
+    def __init__(self, cfg: Qwen3_5VisionConfig) -> None:
+        super().__init__()
+        self.hidden_size = cfg.hidden_size * (cfg.spatial_merge_size**2)
+        self.norm = nn.LayerNorm(cfg.hidden_size, eps=1e-6)
+        self.linear_fc1 = nn.Linear(self.hidden_size, self.hidden_size)
+        self.act_fn = nn.GELU()
+        self.linear_fc2 = nn.Linear(self.hidden_size, cfg.out_hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.norm(x).view(-1, self.hidden_size)
+        return self.linear_fc2(self.act_fn(self.linear_fc1(x)))
+
+
+class Qwen3_5VisionModel(nn.Module):
+    """Native Qwen3.5 vision tower (patch embed → blocks → spatial-merge merger)."""
+
+    def __init__(self, cfg: Qwen3_5VisionConfig, init_device: str = "cpu") -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.spatial_merge_size = cfg.spatial_merge_size
+        self.num_grid_per_side = int(cfg.num_position_embeddings**0.5)
+
+        self.patch_embed = _VisionPatchEmbed(cfg)
+        self.pos_embed = nn.Embedding(cfg.num_position_embeddings, cfg.hidden_size)
+        self.rotary_pos_emb = _VisionRotaryEmbedding(cfg.head_dim // 2)
+        self.blocks = nn.ModuleList([_VisionBlock(cfg) for _ in range(cfg.depth)])
+        self.merger = _VisionPatchMerger(cfg)
+        self.to(init_device)
+
+    def rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        merge = self.spatial_merge_size
+        grid = grid_thw.tolist()
+        max_hw = max(max(h, w) for _, h, w in grid)
+        freq_table = self.rotary_pos_emb(max_hw)
+        device = freq_table.device
+
+        total = sum(t * h * w for t, h, w in grid)
+        pos_ids = torch.empty((total, 2), dtype=torch.long, device=device)
+        offset = 0
+        for t, h, w in grid:
+            mh, mw = h // merge, w // merge
+            br = torch.arange(mh, device=device)
+            bc = torch.arange(mw, device=device)
+            ir = torch.arange(merge, device=device)
+            ic = torch.arange(merge, device=device)
+            row = (
+                (br[:, None, None, None] * merge + ir[None, None, :, None])
+                .expand(mh, mw, merge, merge)
+                .reshape(-1)
+            )
+            col = (
+                (bc[None, :, None, None] * merge + ic[None, None, None, :])
+                .expand(mh, mw, merge, merge)
+                .reshape(-1)
+            )
+            coords = torch.stack((row, col), dim=-1)
+            if t > 1:
+                coords = coords.repeat(t, 1)
+            n = coords.shape[0]
+            pos_ids[offset : offset + n] = coords
+            offset += n
+        emb = freq_table[pos_ids].flatten(1)
+        return emb
+
+    def fast_pos_embed_interpolate(self, grid_thw: torch.Tensor) -> torch.Tensor:
+        grid = grid_thw.tolist()
+        device = self.pos_embed.weight.device
+        n_side = self.num_grid_per_side
+        merge = self.spatial_merge_size
+
+        idx_list: List[List[int]] = [[] for _ in range(4)]
+        weight_list: List[List[float]] = [[] for _ in range(4)]
+        for _, h, w in grid:
+            h_idxs = torch.linspace(0, n_side - 1, h)
+            w_idxs = torch.linspace(0, n_side - 1, w)
+            h_floor = h_idxs.int()
+            w_floor = w_idxs.int()
+            h_ceil = (h_idxs.int() + 1).clip(max=n_side - 1)
+            w_ceil = (w_idxs.int() + 1).clip(max=n_side - 1)
+            dh = h_idxs - h_floor
+            dw = w_idxs - w_floor
+            base_h = h_floor * n_side
+            base_h_ceil = h_ceil * n_side
+            indices = [
+                (base_h[None].T + w_floor[None]).flatten(),
+                (base_h[None].T + w_ceil[None]).flatten(),
+                (base_h_ceil[None].T + w_floor[None]).flatten(),
+                (base_h_ceil[None].T + w_ceil[None]).flatten(),
+            ]
+            weights = [
+                ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
+                ((1 - dh)[None].T * dw[None]).flatten(),
+                (dh[None].T * (1 - dw)[None]).flatten(),
+                (dh[None].T * dw[None]).flatten(),
+            ]
+            for i in range(4):
+                idx_list[i].extend(indices[i].tolist())
+                weight_list[i].extend(weights[i].tolist())
+
+        idx_t = torch.tensor(idx_list, dtype=torch.long, device=device)
+        w_t = torch.tensor(weight_list, dtype=self.pos_embed.weight.dtype, device=device)
+        pos = self.pos_embed(idx_t).to(device) * w_t[:, :, None]
+        patch_pos = pos[0] + pos[1] + pos[2] + pos[3]
+        patch_pos = patch_pos.split([h * w for _, h, w in grid])
+
+        out = []
+        for pe, (t, h, w) in zip(patch_pos, grid):
+            pe = pe.repeat(t, 1)
+            pe = (
+                pe.view(t, h // merge, merge, w // merge, merge, -1)
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            out.append(pe)
+        return torch.cat(out)
+
+    def forward(self, pixel_values: torch.Tensor, grid_thw: torch.Tensor) -> torch.Tensor:
+        """Encode patchified pixels into merged per-token image features.
+
+        :param pixel_values: ``(total_patches, in_ch * t_patch * patch * patch)``.
+        :param grid_thw: ``(num_images, 3)`` of ``(t, h, w)`` patch-grid dims.
+        :returns: ``(num_merged_tokens, out_hidden_size)``.
+        """
+        x = self.patch_embed(pixel_values)
+        x = x + self.fast_pos_embed_interpolate(grid_thw)
+
+        rotary = self.rot_pos_emb(grid_thw).reshape(x.shape[0], -1)
+        emb = torch.cat((rotary, rotary), dim=-1)
+        position_embeddings = (emb.cos(), emb.sin())
+
+        cu = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]).cumsum(
+            0, dtype=torch.int32
+        )
+        cu = F.pad(cu, (1, 0), value=0)
+
+        for blk in self.blocks:
+            x = blk(x, cu_seqlens=cu, position_embeddings=position_embeddings)
+        return self.merger(x)
+
+
+# ---------------------------------------------------------------------------
+# M-RoPE
+# ---------------------------------------------------------------------------
+
+
+def qwen3_5_get_rope_index(
+    input_ids: torch.Tensor,
+    image_grid_thw: torch.Tensor,
+    *,
+    image_token_id: int,
+    vision_start_token_id: int,
+    spatial_merge_size: int,
+) -> torch.Tensor:
+    """Compute 3D ``(3, 1, seq)`` position ids for a single ``B==1`` sequence.
+
+    Ported from ``Qwen3_5Model.get_rope_index`` for the image-only path: text spans
+    use a shared running 1D position; each image block lays out temporal/height/width
+    positions over its merged grid.
+    """
+    assert input_ids.shape[0] == 1, "only B==1 supported"
+    device = input_ids.device
+    ids = input_ids[0]
+    # token type: 1 where image placeholder, else 0.
+    is_image = ids == image_token_id
+
+    pos_list = []
+    current = 0
+    img_iter = iter(image_grid_thw.tolist()) if image_grid_thw is not None else iter([])
+    i = 0
+    n = ids.shape[0]
+    while i < n:
+        if is_image[i]:
+            t, h, w = next(img_iter)
+            lt, lh, lw = t, h // spatial_merge_size, w // spatial_merge_size
+            p_t = torch.arange(lt, device=device).repeat_interleave(lh * lw) + current
+            p_h = torch.arange(lh, device=device).repeat_interleave(lw).repeat(lt) + current
+            p_w = torch.arange(lw, device=device).repeat(lh * lt) + current
+            pos_list.append(torch.stack([p_t, p_h, p_w], dim=0))
+            current += max(lh, lw)
+            i += lt * lh * lw
+        else:
+            # contiguous text run
+            j = i
+            while j < n and not is_image[j]:
+                j += 1
+            text_len = j - i
+            rng = torch.arange(text_len, device=device).view(1, -1).expand(3, -1) + current
+            pos_list.append(rng)
+            current += text_len
+            i = j
+    positions = torch.cat(pos_list, dim=1)  # (3, seq)
+    return positions[:, None, :]  # (3, 1, seq)
+
+
+# ---------------------------------------------------------------------------
+# Top-level VL model
+# ---------------------------------------------------------------------------
+
+
+class Qwen3_5VL(nn.Module):
+    """Native multimodal Qwen3.5: vision tower + OLMo-core Qwen3.5 hybrid LM."""
+
+    def __init__(
+        self,
+        vision: Qwen3_5VisionModel,
+        lm: Transformer,
+        *,
+        image_token_id: int,
+        vision_start_token_id: int,
+        spatial_merge_size: int,
+        head_dim: int,
+        partial_rotary_factor: float,
+        rope_theta: int,
+        mrope_section: List[int],
+    ) -> None:
+        super().__init__()
+        self.vision = vision
+        self.lm = lm
+        self.image_token_id = image_token_id
+        self.vision_start_token_id = vision_start_token_id
+        self.spatial_merge_size = spatial_merge_size
+        self.head_dim = head_dim
+        self.partial_rotary_factor = partial_rotary_factor
+        self.rope_theta = rope_theta
+        self.mrope_section = mrope_section
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.parameters()).device
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: Optional[torch.Tensor] = None,
+        image_grid_thw: Optional[torch.Tensor] = None,
+        logits_to_keep: int = 0,
+    ) -> torch.Tensor:
+        device = self.device
+        input_ids = input_ids.to(device)
+        h = self.lm.embeddings(input_ids)  # (B, S, d_model)
+
+        if pixel_values is not None and image_grid_thw is not None:
+            img = self.vision(pixel_values.to(device), image_grid_thw.to(device)).to(h.dtype)
+            mask = input_ids == self.image_token_id  # (B, S)
+            h = h.clone()
+            h[mask] = img
+
+        position_ids = qwen3_5_get_rope_index(
+            input_ids,
+            image_grid_thw,
+            image_token_id=self.image_token_id,
+            vision_start_token_id=self.vision_start_token_id,
+            spatial_merge_size=self.spatial_merge_size,
+        )
+        pos_sin, pos_cos = build_mrope_sin_cos(
+            position_ids,
+            head_dim=self.head_dim,
+            partial_rotary_factor=self.partial_rotary_factor,
+            theta=self.rope_theta,
+            mrope_section=self.mrope_section,
+            device=device,
+            dtype=h.dtype,
+        )
+        return self.lm(
+            input_ids,
+            input_embeddings=h,
+            pos_sin=pos_sin,
+            pos_cos=pos_cos,
+            logits_to_keep=logits_to_keep,
+        )
+
+    @torch.inference_mode()
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: Optional[torch.Tensor],
+        image_grid_thw: Optional[torch.Tensor],
+        *,
+        max_new_tokens: int = 40,
+        eos_token_ids: Tuple[int, ...] = (),
+    ) -> List[int]:
+        """Greedy decode (no KV cache; image is re-encoded each step)."""
+        gen = input_ids.to(self.device)
+        start = gen.shape[1]
+        for _ in range(max_new_tokens):
+            logits = self.forward(gen, pixel_values, image_grid_thw, logits_to_keep=1)
+            nxt = int(logits[0, -1].argmax().item())
+            if nxt in eos_token_ids:
+                break
+            gen = torch.cat([gen, torch.tensor([[nxt]], device=gen.device)], dim=1)
+        return gen[0, start:].tolist()
+
+
+# ---------------------------------------------------------------------------
+# HF loading
+# ---------------------------------------------------------------------------
+
+
+def _load_vision_from_hf(vision: Qwen3_5VisionModel, hf_state: Dict[str, torch.Tensor]) -> None:
+    """Load ``model.visual.*`` HF weights into the native vision tower (1:1 names)."""
+    own = dict(vision.state_dict())
+    mapped: Dict[str, torch.Tensor] = {}
+    for k, v in hf_state.items():
+        if not k.startswith("model.visual."):
+            continue
+        nk = k[len("model.visual.") :]
+        if nk in own:
+            mapped[nk] = v
+    missing = set(own) - set(mapped)
+    # inv_freq is a non-persistent buffer recomputed at init.
+    missing = {m for m in missing if not m.endswith("inv_freq")}
+    if missing:
+        raise RuntimeError(f"vision tower missing weights for: {sorted(missing)[:8]}")
+    vision.load_state_dict(mapped, strict=False)
+
+
+def load_qwen3_5_vl_from_hf(
+    model_id: str = "Qwen/Qwen3.5-0.8B",
+    *,
+    device: str = "cuda",
+    dtype: torch.dtype = torch.float32,
+    hf_model: Optional[Any] = None,
+) -> Tuple["Qwen3_5VL", Any]:
+    """Load a HF ``Qwen3_5ForConditionalGeneration`` checkpoint into :class:`Qwen3_5VL`.
+
+    :param hf_model: An already-loaded HF ``Qwen3_5ForConditionalGeneration`` to
+        convert from. When given, its config/weights are reused instead of
+        instantiating a fresh copy — useful to avoid holding two HF copies in
+        memory (e.g. in parity tests that also keep the HF model for comparison).
+    :returns: ``(model, processor)`` — ``processor`` is the HF ``AutoProcessor`` used
+        for image/text preprocessing.
+    """
+    import transformers
+    from transformers import AutoProcessor
+
+    from olmo_core.nn.hf.convert import convert_qwen3_5_state_from_hf
+
+    if hf_model is None:
+        hf_model = transformers.Qwen3_5ForConditionalGeneration.from_pretrained(
+            model_id, torch_dtype=dtype
+        )
+    hf_config = hf_model.config
+    text_cfg = hf_config.text_config
+    vis_cfg = Qwen3_5VisionConfig.from_hf(hf_config.vision_config)
+
+    hf_state = hf_model.state_dict()
+
+    # --- LM ---
+    lm_cfg = TransformerConfig.qwen3_5_from_hf_config(
+        text_cfg, attn_backend=AttentionBackendName.torch, dtype=DType.float32
+    )
+    lm = lm_cfg.build(init_device="cpu")
+    lm_state = convert_qwen3_5_state_from_hf(text_cfg, hf_state)
+    lm.load_state_dict(lm_state, strict=True)
+
+    # --- Vision ---
+    vision = Qwen3_5VisionModel(vis_cfg, init_device="cpu")
+    _load_vision_from_hf(vision, hf_state)
+
+    rp = getattr(text_cfg, "rope_parameters", None) or {}
+    model = Qwen3_5VL(
+        vision,
+        lm,
+        image_token_id=hf_config.image_token_id,
+        vision_start_token_id=hf_config.vision_start_token_id,
+        spatial_merge_size=vis_cfg.spatial_merge_size,
+        head_dim=text_cfg.head_dim,
+        partial_rotary_factor=text_cfg.partial_rotary_factor,
+        rope_theta=rp.get("rope_theta", getattr(text_cfg, "rope_theta", 10_000_000)),
+        mrope_section=rp.get("mrope_section", [11, 11, 10]),
+    )
+    del hf_model
+    model = model.to(device=device, dtype=dtype).eval()
+    processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+    return model, processor

--- a/src/test/nn/hf/qwen3_5_test.py
+++ b/src/test/nn/hf/qwen3_5_test.py
@@ -19,25 +19,8 @@ def _has_qwen3_5_transformers() -> bool:
 
 
 def _get_qwen3_5_config(hf_config) -> TransformerConfig:
-    text_config = getattr(hf_config, "text_config", hf_config)
-    rope_params = getattr(text_config, "rope_parameters", {}) or {}
-    return TransformerConfig.qwen3_5_like(
-        d_model=text_config.hidden_size,
-        vocab_size=text_config.vocab_size,
-        n_layers=text_config.num_hidden_layers,
-        n_heads=text_config.num_attention_heads,
-        n_kv_heads=text_config.num_key_value_heads,
-        head_dim=text_config.head_dim,
-        intermediate_size=text_config.intermediate_size,
-        linear_num_key_heads=text_config.linear_num_key_heads,
-        linear_num_value_heads=text_config.linear_num_value_heads,
-        linear_key_head_dim=text_config.linear_key_head_dim,
-        linear_value_head_dim=text_config.linear_value_head_dim,
-        linear_conv_kernel_dim=text_config.linear_conv_kernel_dim,
-        rope_theta=rope_params.get("rope_theta", 10_000_000),
-        partial_rotary_factor=text_config.partial_rotary_factor,
-        attn_backend=AttentionBackendName.torch,
-        tie_word_embeddings=text_config.tie_word_embeddings,
+    return TransformerConfig.qwen3_5_from_hf_config(
+        hf_config, attn_backend=AttentionBackendName.torch
     )
 
 

--- a/src/test/nn/vision/qwen3_5_vl_test.py
+++ b/src/test/nn/vision/qwen3_5_vl_test.py
@@ -1,0 +1,179 @@
+"""
+End-to-end parity tests for native multimodal **Qwen3.5-VL** in OLMo-core.
+
+Loads a real HF ``Qwen3_5ForConditionalGeneration`` checkpoint into the OLMo-core
+:class:`~olmo_core.nn.vision.qwen3_5_vl.Qwen3_5VL` and checks, on a synthetic image:
+
+1. **Vision tower parity** — native merger output vs HF ``model.visual`` (exact).
+2. **Full-forward logit parity** — last-token logits with the image present
+   (per-token argmax must match; absolute logit diff is a loose sanity bound,
+   since GatedDeltaNet FLA kernels accumulate fp32 noise that grows with depth).
+3. **Generation parity** — greedy image→text matches HF exactly.
+
+Parametrized over the dense Qwen3.5 / Qwen3.6 VL checkpoints (0.8B / 2B / 4B /
+9B / 27B; both releases share the ``Qwen3_5ForConditionalGeneration``
+architecture). Each case requires a GPU, the FLA kernels (GatedDeltaNet),
+transformers with Qwen3.5
+support, and the checkpoint present in the local HF cache; otherwise it skips
+(no network downloads). Only one model is held on the GPU at a time — HF
+references are captured first, then the HF weights move to CPU and are reused to
+build the OLMo-core model — so peak GPU memory is ~1x the model. dtype is chosen
+to fit (fp32 where possible, bf16 for the largest variants); a variant that
+won't fit even in bf16 is skipped rather than OOMing.
+"""
+
+import os
+
+import pytest
+import torch
+
+from olmo_core.testing.utils import requires_fla, requires_gpu
+
+transformers = pytest.importorskip("transformers")
+
+# Dense Qwen3.5 / Qwen3.6 vision-language checkpoints. Both releases share the
+# same ``Qwen3_5ForConditionalGeneration`` architecture (``model_type: qwen3_5``),
+# so they load through the identical path; the ``-A*`` MoE checkpoints use a
+# different architecture and are intentionally excluded. Values are approximate
+# parameter counts, used only to pick a dtype that fits the GPU.
+MODEL_PARAMS = {
+    "Qwen/Qwen3.5-0.8B": 0.8e9,
+    "Qwen/Qwen3.5-2B": 2.0e9,
+    "Qwen/Qwen3.5-4B": 4.0e9,
+    "Qwen/Qwen3.5-9B": 9.0e9,
+    "Qwen/Qwen3.5-27B": 27.0e9,
+    "Qwen/Qwen3.6-27B": 27.0e9,
+}
+MODEL_IDS = list(MODEL_PARAMS)
+
+
+def _has_qwen3_5_vl() -> bool:
+    return hasattr(transformers, "Qwen3_5ForConditionalGeneration")
+
+
+def _hf_cache_has(model_id: str) -> bool:
+    suffix = "models--" + model_id.replace("/", "--")
+    roots = [os.path.expanduser("~/.cache/huggingface/hub")]
+    if (hf_home := os.environ.get("HF_HOME")) is not None:
+        roots.append(os.path.join(hf_home, "hub"))
+    return any(os.path.isdir(os.path.join(r, suffix)) for r in roots if r)
+
+
+def _synthetic_image():
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", (448, 448), "white")
+    d = ImageDraw.Draw(img)
+    d.ellipse([120, 120, 330, 330], fill="red")
+    d.rectangle([40, 40, 120, 120], fill="blue")
+    return img
+
+
+def _pick_dtype_or_skip(model_id: str) -> torch.dtype:
+    """Largest dtype whose single model copy fits free GPU memory (fp32 preferred).
+
+    The test holds only one model on the GPU at a time, so we budget ~1.4x the
+    raw weight size for activations/generation. ``pytest.skip`` if even bf16
+    won't fit (e.g. 27B on a small GPU).
+    """
+    free, _ = torch.cuda.mem_get_info()
+    params = MODEL_PARAMS[model_id]
+    if params * 4 * 1.4 < free:
+        return torch.float32
+    if params * 2 * 1.4 < free:
+        return torch.bfloat16
+    pytest.skip(f"{model_id} too large for available GPU memory ({free / 1e9:.0f} GB free)")
+
+
+def _build_inputs(processor, device):
+    img = _synthetic_image()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": img},
+                {"type": "text", "text": "Describe this image in one sentence."},
+            ],
+        }
+    ]
+    text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    return processor(text=[text], images=[img], return_tensors="pt").to(device)
+
+
+@requires_gpu
+@requires_fla
+@pytest.mark.parametrize("model_id", MODEL_IDS)
+def test_qwen3_5_vl_image_to_text_parity(model_id: str):
+    if not _has_qwen3_5_vl():
+        pytest.skip("transformers lacks Qwen3.5-VL support")
+    if not _hf_cache_has(model_id):
+        pytest.skip(f"{model_id} not in HF cache")
+
+    from transformers import AutoProcessor, Qwen3_5ForConditionalGeneration
+
+    from olmo_core.nn.vision.qwen3_5_vl import load_qwen3_5_vl_from_hf
+
+    device = torch.device("cuda")
+    dtype = _pick_dtype_or_skip(model_id)
+    is_fp32 = dtype == torch.float32
+    # Vision parity is checked *relatively*: the merger activations are large
+    # (O(100s)), so bf16 rounding over a deep tower yields a big absolute diff
+    # (~few units) that is still only ~1-2% relative. fp32 stays near-exact.
+    vis_rtol = 1e-3 if is_fp32 else 5e-2
+
+    processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+    inputs = _build_inputs(processor, device)
+    pv = inputs["pixel_values"].to(dtype)
+    gthw = inputs["image_grid_thw"]
+    tok = processor.tokenizer
+    eos = tuple(
+        x for x in {tok.eos_token_id, tok.convert_tokens_to_ids("<|im_end|>")} if x is not None
+    )
+
+    # --- Capture HF references, then free the HF model so only one model is on
+    #     the GPU at a time (lets the larger variants, e.g. 27B, fit). ---
+    hf = Qwen3_5ForConditionalGeneration.from_pretrained(model_id, torch_dtype=dtype)
+    hf = hf.to(device).eval()
+    try:
+        with torch.inference_mode():
+            ref_vis = hf.model.visual(pv, grid_thw=gthw).pooler_output.float().cpu()
+            ref_logits = hf(**inputs).logits[0, -1].float().cpu()
+            ref_gen = hf.generate(**inputs, max_new_tokens=40, do_sample=False)
+        ref_text = tok.decode(
+            ref_gen[0][inputs["input_ids"].shape[1] :], skip_special_tokens=True
+        ).strip()
+    finally:
+        # Keep HF weights on CPU (host RAM) so the loader can convert from them
+        # without a second download, but free the GPU for the OLMo-core model.
+        hf = hf.to("cpu")
+        torch.cuda.empty_cache()
+
+    model, _ = load_qwen3_5_vl_from_hf(model_id, device="cuda", dtype=dtype, hf_model=hf)
+    del hf
+    try:
+        # (1) Vision tower parity (relative).
+        with torch.inference_mode():
+            our_vis = model.vision(pv, gthw).float().cpu()
+        vis_rel = (ref_vis - our_vis).abs().max() / ref_vis.abs().max().clamp_min(1e-6)
+        assert vis_rel.item() < vis_rtol, f"{model_id}: vision mismatch (rel={vis_rel.item():.3g})"
+
+        # (2) Full-forward logit parity. Per-token argmax must match exactly; the
+        #     absolute logit bound is an fp32-only sanity check (bf16 logits drift
+        #     freely in magnitude, and exact generation below is the real signal).
+        with torch.inference_mode():
+            our_last = model(inputs["input_ids"], pv, gthw, logits_to_keep=1)[0, -1].float().cpu()
+        n = min(ref_logits.shape[0], our_last.shape[0])
+        assert int(ref_logits.argmax()) == int(our_last.argmax()), f"{model_id}: argmax mismatch"
+        if is_fp32:
+            drift = (ref_logits[:n] - our_last[:n]).abs().max().item()
+            assert drift < 1.0, f"{model_id}: logit drift {drift:.3g}"
+
+        # (3) Generation parity (exact string match — holds in bf16 too).
+        our_ids = model.generate(
+            inputs["input_ids"], pv, gthw, max_new_tokens=40, eos_token_ids=eos
+        )
+        our_text = tok.decode(our_ids, skip_special_tokens=True).strip()
+        assert our_text == ref_text, f"{model_id}: ours={our_text!r} hf={ref_text!r}"
+    finally:
+        del model
+        torch.cuda.empty_cache()


### PR DESCRIPTION
## Summary

Adds **native multimodal Qwen3.5 / Qwen3.6** support to OLMo-core: real HuggingFace checkpoints can be loaded and run **image → text**. Both releases ship the same `Qwen3_5ForConditionalGeneration` architecture (`model_type: qwen3_5`), so they load through one path. All **dense** sizes are supported — 0.8B / 2B / 4B / 9B / 27B (the `-A*` MoE checkpoints are out of scope).

Qwen3.5/3.6 is *natively* multimodal: its own vision tower (`model.visual.*`), a spatial-merge merger, **M-RoPE** (3D rotary), and a hybrid GatedDeltaNet + full-attention text decoder (`model.language_model.*`). This PR reuses the existing OLMo-core Qwen3.5 hybrid LM (from #684) for the decoder and adds the vision stack, M-RoPE, and the multimodal glue.

## Changes

- **`nn/transformer/model.py`** — minimal, backward-compatible hook: `Transformer.forward` accepts external `pos_sin`/`pos_cos` and routes them into `all_block_kwargs`. Full-attention blocks consume them (M-RoPE); GatedDeltaNet layers drop them. No behavior change when unset; rejected under context parallelism. (Only core change.)
- **`nn/rope.py`** — `build_mrope_sin_cos(...)` (+ `_apply_interleaved_mrope`): a generic, N-axis interleaved M-RoPE cos/sin builder living with the other rotary code, reusing `compute_inv_freqs`. Model-agnostic; no Qwen specifics.
- **`nn/transformer/config.py`** — `TransformerConfig.qwen3_5_from_hf_config(...)`: one shared builder mapping an HF Qwen3.5 config (full multimodal *or* text) onto `qwen3_5_like`. Both the text-only load path (`qwen3_5_test`) and the VL load path use it, removing the previously duplicated field mapping.
- **`nn/vision/qwen3_5_vl.py`** (new) — native vision tower (Conv3d patch embed, bilinear learned-pos-embed interpolation, 2D vision RoPE reusing `compute_inv_freqs`, full-attention blocks, spatial-merge merger), the 3D `qwen3_5_get_rope_index` (multimodal token-layout → t/h/w positions), the `Qwen3_5VL` glue model (embed-scatter + M-RoPE, reusing the existing hybrid LM), and `load_qwen3_5_vl_from_hf` (LM via the existing `convert_qwen3_5_state_from_hf`; vision mapped 1:1; accepts a preloaded `hf_model`).
- **`examples/qwen3_5_vl/infer.py`** (new) — runnable image→text demo.
- **`test/nn/vision/qwen3_5_vl_test.py`** (new) — GPU+FLA, cache-gated, parametrized parity test over all dense sizes; `test/nn/hf/qwen3_5_test.py` updated to use the shared config builder.

## Verification (real checkpoints, synthetic image)

Per-variant image→text parity vs HuggingFace — **vision-tower** (relative, exact in fp32), per-token **argmax**, and **exact greedy generation**:

| Variant | dtype | vision (rel) | argmax | generation |
|---|---|---|---|---|
| Qwen3.5-0.8B | fp32 | exact | ✅ | exact match |
| Qwen3.5-2B | fp32 | exact | ✅ | exact match |
| Qwen3.5-4B | fp32 | exact | ✅ | exact match |
| Qwen3.5-9B | fp32 | exact | ✅ | exact match |
| Qwen3.6-27B | bf16 | 1.7% (benign bf16 accum.) | ✅ | exact match |

Generation matches HF token-for-token even at 27B in bf16. (Qwen3.5-27B not cached in CI → skipped; same arch as 3.6-27B.) Existing `qwen3_5_test` and transformer `model_test` pass unchanged. isort/black/ruff/mypy clean.

The test holds **one model on the GPU at a time** (capture HF refs → move HF to CPU → build OLMo-core from those weights), and **picks dtype by free GPU memory** (fp32 where it fits, bf16 for the largest), skipping a variant that won't fit rather than OOMing. Vision parity is checked **relatively** because the merger activations are O(100s), so bf16 rounding over a deep tower gives a large absolute diff that's still ~1–2% relative.

### Run it
```bash
conda activate olmo-core
python src/examples/qwen3_5_vl/infer.py --image img.jpg --prompt "What is in this image?"
pytest -v src/test/nn/vision/qwen3_5_vl_test.py     # GPU+FLA; skips per-variant if not cached
```

## Limitations / follow-ups
- B==1 inference path; greedy decode without KV cache (re-encodes the image each step) — fine for demos.
- Single image (no video / multi-image / timestamps).
- Deepstack not implemented (disabled in all current dense checkpoints: `deepstack_visual_indexes=[]`); a checkpoint that enables it would need multi-layer injection.
- Preprocessing reuses the HF `AutoProcessor`; the model itself is fully native OLMo-core.

(Supersedes the earlier Molmo2-style backbone approach, which could not load the native vision tower / M-RoPE.)
