### PR TITLE
CI: cache HuggingFace models for the CPU Test job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,10 @@ jobs:
     name: ${{ matrix.task.name }}
     runs-on: [ubuntu-latest]
     timeout-minutes: 15
+    env:
+      # HF models downloaded by the HF roundtrip tests are cached here across runs
+      # (see the "Cache HuggingFace models" step) to avoid re-downloading every run.
+      HF_HOME: ${{ github.workspace }}/.cache/huggingface
     strategy:
       fail-fast: false
       matrix:
@@ -131,6 +135,16 @@ jobs:
           restore-keys: |
             mypy-${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}-${{ github.ref }}
             mypy-${{ env.CACHE_PREFIX }}-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('pyproject.toml') }}
+
+      - name: Cache HuggingFace models
+        # The "Test" task runs the HF roundtrip tests, which download Qwen3-0.6B and
+        # Gemma-3-270m. Persist HF_HOME so they're only downloaded once. Bump the key
+        # suffix when the set of models pulled by these tests changes.
+        if: matrix.task.name == 'Test'
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.HF_HOME }}
+          key: hf-models-${{ env.CACHE_PREFIX }}-${{ runner.os }}-qwen3-0.6b-gemma3-270m
 
       - name: ${{ matrix.task.name }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The CPU `Test` CI job now caches `HF_HOME` across runs so the HuggingFace roundtrip tests (Qwen3-0.6B, Gemma-3-270m) don't re-download their checkpoints every run.
 - Excluded `mark_dynamic` from `torch.compile` tracing (`@torch.compiler.disable`).
 - Clearer error messages (now include the offending values) when a rank batch size isn't divisible by the sequence length, or `max_target_sequence_length` isn't a multiple of `sequence_length`.
 - S3 uploads/downloads now also retry on transient SSL errors (`ssl.SSLError`, botocore/urllib3 `SSLError`).


### PR DESCRIPTION
The CPU `Test` CI job runs the HF roundtrip tests, which download Qwen3-0.6B and Gemma-3-270m. Persist `HF_HOME` across runs with `actions/cache` so they're only downloaded once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)