### PR TITLE
Add fused MoE transformer block and model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `olmo_core.nn.fp8_weight.FP8WeightStore` (beta), a logical weight store for fp32-main / FP8-model training that caches prequantized MXFP8 expert weights and presents a tensor-like surface to the fused optimizer.
 - Added MoE token permute/reorder kernels (`olmo_core.kernels.moe_chunk_reorder`, `moe_permute_drop`, `moe_unpermute_bwd`) for routing tokens to experts (with capacity dropping) and combining the expert outputs.
 - Added symmetric-memory and NCCL-RMA point-to-point communication kernels (`olmo_core.kernels.symm_mem_vdev2d`, `olmo_symm_mem`, `nccl_rma_p2p`) for expert-parallel all-to-all and one-sided RMA transport.
+- Added a fused Mixture-of-Experts transformer block and model (`MoEFusedV2TransformerBlock` / `MoEFusedV2Transformer`, configured via `MoEFusedV2TransformerConfig` and `MoEFusedV2TransformerBlockConfig`), wired into the transformer build dispatch (`TransformerType.moe_fused_v2` / `TransformerBlockType.moe_fused_v2`) and weight initialization (`InitMethod.init_moe_v2`). This first drop runs the single-process (no expert-parallel) forward path; the expert-parallel dispatch families are imported lazily and land in follow-up changes.
 
 
 ### Fixed

--- a/src/olmo_core/nn/moe/v2/block.py
+++ b/src/olmo_core/nn/moe/v2/block.py
@@ -1,0 +1,1297 @@
+import os
+import threading
+import weakref
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Iterator, Optional, Tuple, Union, cast
+
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.tensor import Placement
+from torch.utils.checkpoint import checkpoint
+
+import olmo_core.nn.transformer.block
+
+try:
+    import torch.distributed._symmetric_memory as _symm_mem
+except ImportError:
+    _symm_mem = None  # type: ignore[assignment]
+
+from olmo_core.distributed.utils import get_rank, get_world_size
+from olmo_core.exceptions import OLMoConfigurationError
+from olmo_core.kernels import ScaledGroupedMMPrequantizedRHS, olmo_symm_mem
+from olmo_core.nn.fp8_weight import FP8WeightCacheSpec, FP8WeightStore
+from olmo_core.nn.transformer.config import TransformerBlockConfig, TransformerBlockType
+from olmo_core.ops import attach_auxiliary_loss
+from olmo_core.utils import get_or_init_stream
+
+from ...attention.base import SequenceMixerConfig
+from ...buffer_cache import BufferCache
+from ...layer_norm import LayerNormConfig
+from .checkpointing import get_rowwise_checkpoint_state, is_checkpoint_recomputing
+
+# NOTE: the expert-parallel "no-sync" strategy families (async VDev + rowwise-FP8) and the
+# activation-debug helper are imported lazily at their dispatch sites below, so this module
+# imports cleanly without those files present (they ship in later, stacked PRs). See the
+# combined_forward_ep_no_sync_* wrapper methods and the rowwise metric/symm helper sites.
+from .fp8 import MoERowwiseFP8Config
+from .fp8 import invalidate_rowwise_fp8_cache as _invalidate_rowwise_fp8_cache
+from .fp8 import normalize_rowwise_fp8_config
+from .fp8 import refresh_rowwise_fp8_cache as _refresh_rowwise_fp8_cache
+from .no_ep import combined_forward_no_ep as _combined_forward_no_ep
+from .routed_experts import RoutedExperts, RoutedExpertsConfig
+from .router import MoERouterConfigV2, MoERouterV2
+from .shared_experts import SharedExperts, SharedExpertsConfig
+
+# The synchronous expert-parallel dispatch (ep_sync_1d / ep_sync_tbo) is imported lazily at
+# its wrapper methods below, so this module imports cleanly without those files present
+# (they ship in a later PR). See combined_forward_ep_1d / combined_forward_ep_tbo.
+# from .ep_sync_1d import combined_forward_ep_1d as _combined_forward_ep_1d
+# from .ep_sync_tbo import combined_forward_ep_tbo as _combined_forward_ep_tbo
+
+
+# Process-local cache for the EP->group "0" symmetric-memory alias.
+# This makes repeated calls from multiple MoE blocks idempotent when they use
+# the same EP group.
+_EP_SYMM_GROUP0_ALIAS_LOCK = threading.Lock()
+_EP_SYMM_GROUP0_ALIAS_RANKS: Optional[Tuple[int, ...]] = None
+
+
+def _shared_up_gate_rhs(weight: torch.Tensor) -> torch.Tensor:
+    return weight.unsqueeze(0)
+
+
+def _shared_up_gate_rhs_for_dgrad(weight: torch.Tensor) -> torch.Tensor:
+    return weight.transpose(0, 1).unsqueeze(0)
+
+
+def _shared_down_rhs(weight: torch.Tensor) -> torch.Tensor:
+    return weight
+
+
+def _shared_down_rhs_for_dgrad(weight: torch.Tensor) -> torch.Tensor:
+    return weight.transpose(1, 2)
+
+
+_SHARED_UP_GATE_FP8_CACHE_SPECS = (
+    FP8WeightCacheSpec("rhs", _shared_up_gate_rhs),
+    FP8WeightCacheSpec("rhs_for_dgrad", _shared_up_gate_rhs_for_dgrad),
+)
+_SHARED_DOWN_FP8_CACHE_SPECS = (
+    FP8WeightCacheSpec("rhs", _shared_down_rhs),
+    FP8WeightCacheSpec("rhs_for_dgrad", _shared_down_rhs_for_dgrad),
+)
+
+
+@dataclass
+class MoEFusedV2TransformerBlockConfig(TransformerBlockConfig):
+    shared_experts: Optional[SharedExpertsConfig] = None
+
+    routed_experts: Optional[RoutedExpertsConfig] = None
+
+    shared_experts_router: Optional[MoERouterConfigV2] = None
+
+    routed_experts_router: Optional[MoERouterConfigV2] = None
+
+    use_peri_norm: bool = False
+    checkpoint_attn: bool = False
+    checkpoint_permute_moe_unpermute: bool = False
+    checkpoint_combined_ep_tbo: bool = False
+    checkpoint_second_unpermute: bool = False
+    ep_no_sync: bool = False
+    ep_no_sync_use_2d_all_to_all: bool = False
+    ep_no_sync_use_rowwise_all_to_all: bool = False
+    ep_no_sync_rowwise_nblocks: int = 256
+    ep_no_sync_share_dispatch_out: bool = False
+    ep_no_sync_capacity_factor: float = 1.25
+    ep_no_sync_shared_slots: int = 1
+    ep_no_sync_share_combine_out: bool = False
+    ep_no_sync_major_align: int = 1
+    ep_no_sync_restore_unpermute_backend: str = "te_fused"
+    ep_no_sync_rowwise_symm_dispatch_in: Optional[bool] = None
+    ep_no_sync_rowwise_symm_combine_out: Optional[bool] = None
+    ep_no_sync_rowwise_symm_combine_gather: Optional[bool] = None
+    rowwise_fp8: Optional[MoERowwiseFP8Config] = None
+
+    def build(
+        self,
+        *,
+        d_model: int,
+        block_idx: int,
+        n_layers: int,
+        init_device: str = "cpu",
+        cache: Optional[BufferCache] = None,
+    ) -> olmo_core.nn.transformer.block.TransformerBlockBase:
+        assert (
+            self.feed_forward is None and self.feed_forward_moe is None
+        ), "MoEFusedV2TransformerBlock does not support `feed_forward` or `feed_forward_moe` (use TransformerBlockConfig instead). Set `shared_experts` and `routed_experts` instead."
+
+        kwargs = self.as_dict(exclude_none=False, recurse=False)
+        kwargs.pop("name")
+        kwargs.pop("feed_forward")  # from parent config
+        kwargs.pop("feed_forward_moe")  # from parent config
+        # The MoE-v2 block takes separate attention / feed-forward norm configs; source
+        # both from the single `layer_norm` field (builds two identical norm modules).
+        layer_norm = kwargs.pop("layer_norm")
+        if layer_norm is None:
+            raise OLMoConfigurationError(
+                "MoEFusedV2TransformerBlockConfig requires `layer_norm` to be set."
+            )
+        kwargs["attention_norm"] = layer_norm
+        kwargs["feed_forward_norm"] = layer_norm
+        kwargs.update(
+            d_model=d_model,
+            block_idx=block_idx,
+            n_layers=n_layers,
+            init_device=init_device,
+            cache=cache,
+        )
+
+        if self.name == TransformerBlockType.moe_fused_v2:
+            return MoEFusedV2TransformerBlock(**kwargs)
+        else:
+            raise NotImplementedError(self.name)
+
+    def num_params(self, d_model: int) -> int:
+        block_params = 0
+
+        block_params += self.sequence_mixer.num_params(d_model)
+        # `layer_norm` is used for both the attention and feed-forward norms.
+        if self.layer_norm is not None:
+            block_params += self.layer_norm.num_params(d_model)
+        if self.shared_experts is not None:
+            block_params += self.shared_experts.num_params()
+        if self.routed_experts is not None:
+            block_params += self.routed_experts.num_params()
+        if self.routed_experts_router is not None:
+            block_params += self.routed_experts_router.num_params()
+        if self.shared_experts_router is not None:
+            block_params += self.shared_experts_router.num_params()
+        if self.layer_norm is not None:
+            block_params += self.layer_norm.num_params(d_model)
+        if self.use_peri_norm:
+            if self.layer_norm is not None:
+                block_params += 2 * self.layer_norm.num_params(d_model)
+
+        return block_params
+
+    def num_active_params(self, d_model: int) -> int:
+        block_params = 0
+
+        block_params += self.sequence_mixer.num_params(d_model)
+        # `layer_norm` is used for both the attention and feed-forward norms.
+        if self.layer_norm is not None:
+            block_params += self.layer_norm.num_params(d_model)
+        if self.shared_experts is not None:
+            block_params += self.shared_experts.num_params()
+        if self.routed_experts is not None:
+            assert self.routed_experts_router is not None, "routed_experts must have a router"
+            block_params += self.routed_experts.num_active_params(self.routed_experts_router.top_k)
+        if self.routed_experts_router is not None:
+            block_params += self.routed_experts_router.num_params()
+        if self.shared_experts_router is not None:
+            block_params += self.shared_experts_router.num_params()
+        if self.layer_norm is not None:
+            block_params += self.layer_norm.num_params(d_model)
+        if self.use_peri_norm:
+            if self.layer_norm is not None:
+                block_params += 2 * self.layer_norm.num_params(d_model)
+
+        return block_params
+
+    def flops_per_seq(self, d_model: int, seqlen: int) -> int:
+        flops = 0
+
+        # attention
+        if hasattr(self.sequence_mixer, "flops_per_seq"):
+            flops += self.sequence_mixer.flops_per_seq(d_model, seqlen)  # type: ignore[attr-defined]
+        else:
+            flops += (
+                self.sequence_mixer.build(
+                    d_model,
+                    layer_idx=0,
+                    n_layers=1,
+                    init_device="meta",
+                ).num_flops_per_token(seqlen)
+                * seqlen
+            )
+
+        # router
+        # (seq_len * d_model) * (d_model * num_total_experts)
+        flops += (
+            6
+            * seqlen
+            * d_model
+            * (
+                (
+                    self.routed_experts_router.num_experts
+                    if self.routed_experts_router is not None
+                    else 0
+                )
+                + (
+                    self.shared_experts_router.num_experts
+                    if self.shared_experts_router is not None
+                    else 0
+                )
+            )
+        )
+
+        # routed experts
+        # (seq_len, d_model) * (d_model, expert_hidden_size) * top_k
+        # x3 for swiglu (up, down, gate)
+        # x3 for fwd+bwd
+        # x2 for GEMM
+        if self.routed_experts is not None:
+            assert self.routed_experts_router is not None
+            flops += (
+                (3 * 3 * 2)
+                * seqlen
+                * d_model
+                * self.routed_experts.hidden_size
+                * self.routed_experts_router.top_k
+            )
+
+        # shared experts
+        # (seq_len, d_model) * (d_model, expert_hidden_size) * num_experts
+        # x3 for swiglu (up, down, gate)
+        # x3 for fwd+bwd
+        # x2 for GEMM
+        if self.shared_experts is not None:
+            flops += (
+                (3 * 3 * 2)
+                * seqlen
+                * d_model
+                * self.shared_experts.hidden_size
+                * self.shared_experts.num_experts
+            )
+
+        return flops
+
+
+if TYPE_CHECKING:
+    from olmo_core.train.common import ReduceType
+
+    from .ep_no_sync_buffers import _NoSyncSymmSharedPool
+
+
+class MoEFusedV2TransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBase):
+    def __init__(
+        self,
+        *,
+        d_model: int,
+        block_idx: int,
+        n_layers: int,
+        sequence_mixer: SequenceMixerConfig,
+        attention_norm: LayerNormConfig,
+        routed_experts_router: Optional[MoERouterConfigV2],
+        shared_experts_router: Optional[MoERouterConfigV2],
+        shared_experts: Optional[SharedExpertsConfig],
+        routed_experts: Optional[RoutedExpertsConfig],
+        feed_forward_norm: LayerNormConfig,
+        use_peri_norm: bool = False,
+        dropout: float = 0.0,
+        attention_residual_alpha: Optional[float] = None,
+        feed_forward_residual_alpha: Optional[float] = None,
+        checkpoint_attn=False,
+        checkpoint_permute_moe_unpermute=False,
+        checkpoint_combined_ep_tbo=False,
+        checkpoint_second_unpermute=False,
+        ep_no_sync: bool = False,
+        ep_no_sync_use_2d_all_to_all: bool = False,
+        ep_no_sync_use_rowwise_all_to_all: bool = False,
+        ep_no_sync_rowwise_nblocks: int = 256,
+        ep_no_sync_share_dispatch_out: bool = False,
+        ep_no_sync_capacity_factor: float = 1.25,
+        ep_no_sync_shared_slots: int = 1,
+        ep_no_sync_share_combine_out: bool = False,
+        ep_no_sync_major_align: int = 1,
+        ep_no_sync_restore_unpermute_backend: str = "te_fused",
+        ep_no_sync_rowwise_symm_dispatch_in: Optional[bool] = None,
+        ep_no_sync_rowwise_symm_combine_out: Optional[bool] = None,
+        ep_no_sync_rowwise_symm_combine_gather: Optional[bool] = None,
+        rowwise_fp8: Optional[MoERowwiseFP8Config] = None,
+        init_device: str = "cpu",
+        cache: Optional[BufferCache] = None,
+    ):
+        super().__init__(n_layers=n_layers)
+
+        assert (
+            dropout == 0.0 or dropout is None
+        ), "MoEFusedV2TransformerBlock does not support dropout"
+        self.d_model = d_model
+        self.block_idx = block_idx
+
+        if attention_residual_alpha is not None:
+            raise OLMoConfigurationError(
+                "MoEFusedV2TransformerBlock does not support attention_residual_alpha"
+            )
+        if feed_forward_residual_alpha is not None:
+            raise OLMoConfigurationError(
+                "MoEFusedV2TransformerBlock does not support feed_forward_residual_alpha"
+            )
+
+        self.routed_experts: Optional[RoutedExperts]
+        self.routed_experts_router: Optional[MoERouterV2]
+        self.shared_experts: Optional[SharedExperts]
+        self.shared_experts_router: Optional[MoERouterV2]
+        self.rowwise_fp8 = normalize_rowwise_fp8_config(rowwise_fp8)
+        self._rowwise_fp8_checked = False
+        self._shared_rowwise_fp8_up_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
+        self._shared_rowwise_fp8_down_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
+        self._shared_rowwise_fp8_up_prequant_t: Optional[ScaledGroupedMMPrequantizedRHS] = None
+        self._shared_rowwise_fp8_down_prequant_t: Optional[ScaledGroupedMMPrequantizedRHS] = None
+        self._shared_rowwise_fp8_weight_versions: Optional[Tuple[int, int]] = None
+        self._shared_rowwise_fp8_up_gate_weight: Optional[FP8WeightStore] = None
+        self._shared_rowwise_fp8_down_weight: Optional[FP8WeightStore] = None
+        self.use_peri_norm = use_peri_norm
+
+        ######## START: Attention ########
+        self.attention = sequence_mixer.build(
+            d_model, layer_idx=block_idx, n_layers=n_layers, init_device=init_device, cache=cache
+        )
+        self.attention_norm = attention_norm.build(d_model, init_device=init_device)
+        self.attention_input_norm = None
+        if self.use_peri_norm:
+            self.attention_input_norm = attention_norm.build(d_model, init_device=init_device)
+
+        ######## END: Attention ########
+
+        ######## START: MLP ########
+        assert (routed_experts is not None) or (
+            shared_experts is not None
+        ), "At least one of routed_experts or shared_experts must be provided"
+
+        #### Optional: routed experts ####
+        if routed_experts:
+            # Routed Experts enabled
+            assert (
+                routed_experts_router is not None
+            ), "Need routed_experts_router when using routed experts"
+            routed_experts.rowwise_fp8 = normalize_rowwise_fp8_config(routed_experts.rowwise_fp8)
+            if self.rowwise_fp8 is not None and routed_experts.rowwise_fp8 is None:
+                routed_experts.rowwise_fp8 = self.rowwise_fp8
+            self.routed_experts = routed_experts.build(init_device=init_device)
+            owner_ref = weakref.ref(self)
+            self.routed_experts.w_up_gate._moe_rowwise_fp8_cache_owner = owner_ref  # type: ignore[attr-defined]
+            self.routed_experts.w_down._moe_rowwise_fp8_cache_owner = owner_ref  # type: ignore[attr-defined]
+            self.routed_experts_router = routed_experts_router.build(init_device=init_device)
+        else:
+            # Routed Experts not enabled
+            assert (
+                routed_experts_router is None
+            ), "Should not set routed_experts_router when not using routed experts"
+            self.routed_experts = None
+            self.routed_experts_router = None
+        #### END: Optional: routed experts ####
+
+        #### Optional: shared experts ####
+        if shared_experts:
+            # Shared Experts enabled
+            self.shared_experts = shared_experts.build(init_device=init_device)
+            owner_ref = weakref.ref(self)
+            self.shared_experts.w_up_gate._moe_rowwise_fp8_cache_owner = owner_ref  # type: ignore[attr-defined]
+            self.shared_experts.w_down._moe_rowwise_fp8_cache_owner = owner_ref  # type: ignore[attr-defined]
+            self._shared_rowwise_fp8_up_gate_weight = FP8WeightStore(
+                logical_name="shared_experts.w_up_gate",
+                logical_shape=tuple(self.shared_experts.w_up_gate.shape),
+                cache_specs=_SHARED_UP_GATE_FP8_CACHE_SPECS,
+                anchor_param=self.shared_experts.w_up_gate,
+                optimizer_enabled=(
+                    self.rowwise_fp8 is not None
+                    and self.rowwise_fp8.enabled
+                    and self.rowwise_fp8.fp8_only_params
+                ),
+            )
+            self._shared_rowwise_fp8_down_weight = FP8WeightStore(
+                logical_name="shared_experts.w_down",
+                logical_shape=tuple(self.shared_experts.w_down.shape),
+                cache_specs=_SHARED_DOWN_FP8_CACHE_SPECS,
+                anchor_param=self.shared_experts.w_down,
+                optimizer_enabled=(
+                    self.rowwise_fp8 is not None
+                    and self.rowwise_fp8.enabled
+                    and self.rowwise_fp8.fp8_only_params
+                ),
+            )
+            # Shared Experts Router
+            if shared_experts.num_experts > 1:
+                # Need router if more than one experts
+                assert (
+                    shared_experts_router is not None
+                ), "Need shared_experts_router when using shared experts with more than one expert"
+                self.shared_experts_router = shared_experts_router.build(init_device=init_device)
+            else:
+                assert (
+                    shared_experts_router is None
+                ), "Should not set shared_experts_router when using only one shared expert"
+                # No router if just one
+                self.shared_experts_router = None
+        else:
+            # Shared Experts not enabled
+            assert (
+                shared_experts_router is None
+            ), "Should not set shared_experts_router when not using shared experts"
+            self.shared_experts = None
+            self.shared_experts_router = None
+        #### END: Optional: shared experts ####
+
+        self.feed_forward_norm = feed_forward_norm.build(d_model, init_device=init_device)
+        self.feed_forward_input_norm = None
+        if self.use_peri_norm:
+            self.feed_forward_input_norm = feed_forward_norm.build(d_model, init_device=init_device)
+        ######## END: MLP ########
+
+        self.ep_pg = None
+        self._ep_enabled = False
+        self.tp_pg = None
+        self._tp_enabled = False
+
+        # reuse the same event so that torch.compile can see the same object id and will not break the guard.
+        self._dtoh_event: torch.cuda.Event = cast(
+            torch.cuda.Event, torch.cuda.Event()
+        )  # cast to make pylance happy
+        self._dtoh_event_send: torch.cuda.Event = cast(torch.cuda.Event, torch.cuda.Event())
+        self._dtoh_event_recv: torch.cuda.Event = cast(torch.cuda.Event, torch.cuda.Event())
+        self._before_rev_all2all_event: torch.cuda.Event = cast(
+            torch.cuda.Event, torch.cuda.Event()
+        )
+
+        # same for tbo1
+        self._dtoh_event1: torch.cuda.Event = cast(torch.cuda.Event, torch.cuda.Event())
+        self._dtoh_event_send1: torch.cuda.Event = cast(torch.cuda.Event, torch.cuda.Event())
+        self._dtoh_event_recv1: torch.cuda.Event = cast(torch.cuda.Event, torch.cuda.Event())
+        self._before_rev_all2all_event1: torch.cuda.Event = cast(
+            torch.cuda.Event, torch.cuda.Event()
+        )
+
+        self.num_local_routed_experts: Optional[int] = (
+            self.routed_experts.num_experts if self.routed_experts else None
+        )
+
+        self.checkpoint_attn = checkpoint_attn
+        self.checkpoint_permute_moe_unpermute = checkpoint_permute_moe_unpermute
+        self.checkpoint_combined_ep_tbo = checkpoint_combined_ep_tbo
+        self.checkpoint_second_unpermute = checkpoint_second_unpermute
+        self.ep_no_sync = ep_no_sync
+        self.ep_no_sync_use_2d_all_to_all = ep_no_sync_use_2d_all_to_all
+        self.ep_no_sync_use_rowwise_all_to_all = ep_no_sync_use_rowwise_all_to_all
+        self.ep_no_sync_rowwise_nblocks = int(ep_no_sync_rowwise_nblocks)
+        self.ep_no_sync_share_dispatch_out = ep_no_sync_share_dispatch_out
+        if self.ep_no_sync_use_2d_all_to_all:
+            raise OLMoConfigurationError(
+                "ep_no_sync_use_2d_all_to_all=True is no longer supported: "
+                "the 2D all_to_all path was removed due to correctness/performance issues."
+            )
+        self.ep_no_sync_capacity_factor = ep_no_sync_capacity_factor
+        self.ep_no_sync_shared_slots = ep_no_sync_shared_slots
+        self.ep_no_sync_share_combine_out = ep_no_sync_share_combine_out
+        self.ep_no_sync_major_align = ep_no_sync_major_align
+        self.ep_no_sync_restore_unpermute_backend = ep_no_sync_restore_unpermute_backend.lower()
+        self.ep_no_sync_rowwise_symm_dispatch_in = ep_no_sync_rowwise_symm_dispatch_in
+        self.ep_no_sync_rowwise_symm_combine_out = ep_no_sync_rowwise_symm_combine_out
+        self.ep_no_sync_rowwise_symm_combine_gather = ep_no_sync_rowwise_symm_combine_gather
+        self._ep_symm_group_name: Optional[str] = None
+        self._ep_no_sync_symm_cache: Dict[str, torch.Tensor] = {}
+        self._ep_no_sync_static_buffer_cache: Dict[Tuple[object, ...], object] = {}
+        self._ep_no_sync_rowwise_fp8_static_buffer_cache: Dict[Tuple[object, ...], object] = {}
+        self._ep_no_sync_rowwise_static_checkpoint_state: Optional[Tuple[bool, bool]] = None
+        self._ep_no_sync_force_scratch_lifetime_buffers = False
+        self._ep_no_sync_symm_lease_pools: Dict[str, object] = {}
+        self._ep_no_sync_last_debug: Dict[str, torch.Tensor] = {}
+        self._ep_no_sync_shared_pool: Optional["_NoSyncSymmSharedPool"] = None
+        self._ep_no_sync_shared_slot: int = 0
+        self._ep_no_sync_te_backend_warned: bool = False
+        # Row-wise EP no-sync metrics (populated only by combined_forward_ep_no_sync_rowwise()).
+        self._ep_no_sync_rowwise_drop_tokens_sum: Optional[torch.Tensor] = None
+        self._ep_no_sync_rowwise_total_tokens_sum: Optional[torch.Tensor] = None
+        self._ep_no_sync_rowwise_symm_util_max: Optional[torch.Tensor] = None
+        # self._ep_no_sync_forward_call_count: int = 0
+
+        if self.ep_no_sync_capacity_factor <= 0:
+            raise OLMoConfigurationError(
+                f"ep_no_sync_capacity_factor must be > 0 (got {self.ep_no_sync_capacity_factor})"
+            )
+        if self.ep_no_sync_shared_slots < 1:
+            raise OLMoConfigurationError(
+                f"ep_no_sync_shared_slots must be >= 1 (got {self.ep_no_sync_shared_slots})"
+            )
+        if self.ep_no_sync_major_align < 1:
+            raise OLMoConfigurationError(
+                f"ep_no_sync_major_align must be >= 1 (got {self.ep_no_sync_major_align})"
+            )
+        if self.ep_no_sync_rowwise_nblocks < 0:
+            raise OLMoConfigurationError(
+                f"ep_no_sync_rowwise_nblocks must be >= 0 (got {self.ep_no_sync_rowwise_nblocks})"
+            )
+        if self.ep_no_sync_restore_unpermute_backend not in ("te_fused", "te_unfused", "cuda"):
+            raise OLMoConfigurationError(
+                "ep_no_sync_restore_unpermute_backend must be one of "
+                "'te_fused'|'te_unfused'|'cuda' "
+                f"(got {self.ep_no_sync_restore_unpermute_backend!r})"
+            )
+
+    def invalidate_rowwise_fp8_cache(self) -> None:
+        _invalidate_rowwise_fp8_cache(self)
+
+    def refresh_rowwise_fp8_cache(self) -> None:
+        _refresh_rowwise_fp8_cache(self)
+
+    def _shared_fp8_only_params_enabled(self) -> bool:
+        cfg = self.rowwise_fp8
+        return cfg is not None and cfg.enabled and cfg.fp8_only_params
+
+    def _sync_shared_rowwise_fp8_weight_anchors(self) -> None:
+        if (
+            self.shared_experts is None
+            or self._shared_rowwise_fp8_up_gate_weight is None
+            or self._shared_rowwise_fp8_down_weight is None
+        ):
+            return
+        fp8_only_params = self._shared_fp8_only_params_enabled()
+        owner_ref = weakref.ref(self)
+        self.shared_experts.w_up_gate._moe_rowwise_fp8_cache_owner = owner_ref  # type: ignore[attr-defined]
+        self.shared_experts.w_down._moe_rowwise_fp8_cache_owner = owner_ref  # type: ignore[attr-defined]
+        self._shared_rowwise_fp8_up_gate_weight.anchor_param = self.shared_experts.w_up_gate
+        self._shared_rowwise_fp8_up_gate_weight.logical_shape = tuple(
+            self.shared_experts.w_up_gate.shape
+        )
+        self._shared_rowwise_fp8_up_gate_weight.optimizer_enabled = fp8_only_params
+        self._shared_rowwise_fp8_down_weight.anchor_param = self.shared_experts.w_down
+        self._shared_rowwise_fp8_down_weight.logical_shape = tuple(self.shared_experts.w_down.shape)
+        self._shared_rowwise_fp8_down_weight.optimizer_enabled = fp8_only_params
+        if fp8_only_params:
+            self.shared_experts.w_up_gate.requires_grad_(False)
+            self.shared_experts.w_down.requires_grad_(False)
+
+    def named_fp8_weight_stores(self) -> Iterator[tuple[str, FP8WeightStore]]:
+        if self.routed_experts is not None:
+            for name, weight in self.routed_experts.named_fp8_weight_stores():
+                yield f"routed_experts.{name}", weight
+        self._sync_shared_rowwise_fp8_weight_anchors()
+        if self._shared_rowwise_fp8_up_gate_weight is not None:
+            yield "shared_experts.w_up_gate", self._shared_rowwise_fp8_up_gate_weight
+        if self._shared_rowwise_fp8_down_weight is not None:
+            yield "shared_experts.w_down", self._shared_rowwise_fp8_down_weight
+
+    def named_mxfp8_expert_weights(self) -> Iterator[tuple[str, object]]:
+        yield from self.named_fp8_weight_stores()
+
+    def zero_fp8_weight_store_grads(self, set_to_none: bool = True) -> None:
+        for _, weight in self.named_fp8_weight_stores():
+            weight.zero_grad(set_to_none=set_to_none)
+
+    def zero_mxfp8_expert_weight_grads(self, set_to_none: bool = True) -> None:
+        self.zero_fp8_weight_store_grads(set_to_none=set_to_none)
+
+    def set_fp8_weight_store_main_grads_to_none(self) -> None:
+        for _, weight in self.named_fp8_weight_stores():
+            weight.set_main_grad_to_none()
+
+    def set_mxfp8_expert_weight_main_grads_to_none(self) -> None:
+        self.set_fp8_weight_store_main_grads_to_none()
+
+    def disable_fp8_weight_anchor_grads(self) -> None:
+        if self.routed_experts is not None:
+            self.routed_experts.disable_mxfp8_expert_anchor_grads()
+        if self._shared_fp8_only_params_enabled() and self.shared_experts is not None:
+            self._sync_shared_rowwise_fp8_weight_anchors()
+            self.shared_experts.w_up_gate.grad = None
+            self.shared_experts.w_down.grad = None
+            if hasattr(self.shared_experts.w_up_gate, "_main_grad_fp32"):
+                self.shared_experts.w_up_gate._main_grad_fp32 = None  # type: ignore[attr-defined]
+            if hasattr(self.shared_experts.w_down, "_main_grad_fp32"):
+                self.shared_experts.w_down._main_grad_fp32 = None  # type: ignore[attr-defined]
+
+    def disable_mxfp8_expert_anchor_grads(self) -> None:
+        self.disable_fp8_weight_anchor_grads()
+
+    def release_fp8_weight_anchor_storage(self) -> None:
+        if self.routed_experts is not None:
+            self.routed_experts.release_mxfp8_expert_anchor_storage()
+        if not self._shared_fp8_only_params_enabled() or self.shared_experts is None:
+            return
+        self._sync_shared_rowwise_fp8_weight_anchors()
+        if self._shared_rowwise_fp8_up_gate_weight is not None:
+            self._shared_rowwise_fp8_up_gate_weight.release_anchor_storage()
+        if self._shared_rowwise_fp8_down_weight is not None:
+            self._shared_rowwise_fp8_down_weight.release_anchor_storage()
+        self.shared_experts._fp8_anchor_storage_released = True
+
+    def release_mxfp8_expert_anchor_storage(self) -> None:
+        self.release_fp8_weight_anchor_storage()
+
+    def _sync_fp8_weight_store_grad_from_anchor(
+        self,
+        weight: FP8WeightStore,
+        anchor: torch.nn.Parameter,
+    ) -> None:
+        anchor_grad = getattr(anchor, "_main_grad_fp32", None)
+        if anchor_grad is None:
+            anchor_grad = anchor.grad
+        if anchor_grad is None:
+            return
+        weight.replace_wgrad(anchor_grad)
+
+    def sync_fp8_weight_store_grads_from_anchor(self) -> None:
+        if self.routed_experts is not None:
+            self.routed_experts.sync_mxfp8_expert_weight_grads_from_anchor()
+        if (
+            self._shared_fp8_only_params_enabled()
+            and self.shared_experts is not None
+            and self._shared_rowwise_fp8_up_gate_weight is not None
+            and self._shared_rowwise_fp8_down_weight is not None
+        ):
+            self._sync_fp8_weight_store_grad_from_anchor(
+                self._shared_rowwise_fp8_up_gate_weight,
+                self.shared_experts.w_up_gate,
+            )
+            self._sync_fp8_weight_store_grad_from_anchor(
+                self._shared_rowwise_fp8_down_weight,
+                self.shared_experts.w_down,
+            )
+
+    def sync_mxfp8_expert_weight_grads_from_anchor(self) -> None:
+        self.sync_fp8_weight_store_grads_from_anchor()
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        super().zero_grad(set_to_none=set_to_none)
+        self.zero_mxfp8_expert_weight_grads(set_to_none=set_to_none)
+
+    def purge_cuda_events(self):
+        # set all events to None (so that the model can be deepcopied)
+        self._dtoh_event = None  # type: ignore[assignment]
+        self._dtoh_event_send = None  # type: ignore[assignment]
+        self._dtoh_event_recv = None  # type: ignore[assignment]
+        self._before_rev_all2all_event = None  # type: ignore[assignment]
+
+        self._dtoh_event1 = None  # type: ignore[assignment]
+        self._dtoh_event_send1 = None  # type: ignore[assignment]
+        self._dtoh_event_recv1 = None  # type: ignore[assignment]
+        self._before_rev_all2all_event1 = None  # type: ignore[assignment]
+
+    def install_cuda_events(self):
+        self._dtoh_event = cast(torch.cuda.Event, torch.cuda.Event())
+        self._dtoh_event_send = cast(torch.cuda.Event, torch.cuda.Event())
+        self._dtoh_event_recv = cast(torch.cuda.Event, torch.cuda.Event())
+        self._before_rev_all2all_event = cast(torch.cuda.Event, torch.cuda.Event())
+
+        self._dtoh_event1 = cast(torch.cuda.Event, torch.cuda.Event())
+        self._dtoh_event_send1 = cast(torch.cuda.Event, torch.cuda.Event())
+        self._dtoh_event_recv1 = cast(torch.cuda.Event, torch.cuda.Event())
+        self._before_rev_all2all_event1 = cast(torch.cuda.Event, torch.cuda.Event())
+
+    def compute_metrics(
+        self, reset: bool = True
+    ) -> Dict[str, Tuple[torch.Tensor, Optional["ReduceType"]]]:
+        from olmo_core.train.common import ReduceType
+
+        # compute shared and routed experts metrics
+        # metrics_shared = self.shared_experts.compute_metrics(reset=reset)
+        if self.routed_experts_router:
+            metrics_routed = self.routed_experts_router.compute_metrics(reset=reset)
+        else:
+            metrics_routed = {}
+        out = dict(metrics_routed)
+
+        from .ep_no_sync_rowwise_helpers import (
+            add_ep_no_sync_rowwise_metrics,
+            reset_ep_no_sync_rowwise_metrics,
+        )
+
+        add_ep_no_sync_rowwise_metrics(self, out, ReduceType)
+
+        if reset:
+            reset_ep_no_sync_rowwise_metrics(self)
+
+        # metrics = {
+        #     "shared": metrics_shared,
+        #     "routed": metrics_routed,
+        # }
+        return out
+
+    def reset_metrics(self):
+        # if self.shared_experts_router:
+        #     self.shared_experts_router.reset_metrics()
+        if self.routed_experts_router:
+            self.routed_experts_router.reset_metrics()
+        from .ep_no_sync_rowwise_helpers import reset_ep_no_sync_rowwise_metrics
+
+        reset_ep_no_sync_rowwise_metrics(self)
+
+    def num_flops_per_token(self, seq_len: int) -> int:
+        """
+        Per-token forward+backward FLOPs estimate for this block.
+
+        Mirrors :meth:`MoEFusedV2TransformerBlockConfig.flops_per_seq` divided by ``seqlen``
+        — every term in that formula is linear in ``seqlen``, so this is exact.
+        """
+        d_model = self.d_model
+        flops = 0
+
+        # attention
+        flops += self.attention.num_flops_per_token(seq_len)
+
+        # router(s): (d_model) * (num_experts) per token, x6 (fwd + bwd, GEMM x2)
+        num_router_experts = 0
+        if self.routed_experts_router is not None:
+            num_router_experts += self.routed_experts_router.num_experts
+        if self.shared_experts_router is not None:
+            num_router_experts += self.shared_experts_router.num_experts
+        flops += 6 * d_model * num_router_experts
+
+        # routed experts: top_k active per token; SwiGLU has 3 matmuls; fwd+bwd x3; GEMM x2.
+        if self.routed_experts is not None:
+            assert self.routed_experts_router is not None
+            flops += (
+                (3 * 3 * 2)
+                * d_model
+                * self.routed_experts.hidden_size
+                * self.routed_experts_router.top_k
+            )
+
+        # shared experts: all `num_experts` are always active per token.
+        if self.shared_experts is not None:
+            flops += (
+                (3 * 3 * 2)
+                * d_model
+                * self.shared_experts.hidden_size
+                * self.shared_experts.num_experts
+            )
+
+        return flops
+
+    @property
+    def is_moe(self) -> bool:
+        return True
+
+    @property
+    def ep_enabled(self) -> bool:
+        return self._ep_enabled
+
+    @property
+    def tp_enabled(self) -> bool:
+        return self._tp_enabled
+
+    def get_dense_stream(self, for_x1=False) -> torch.cuda.Stream:
+        if for_x1:  # not used for now
+            return get_or_init_stream(id="dense_x1", priority=20)
+        else:
+            return get_or_init_stream(id="dense", priority=20)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if self.routed_experts:
+            if self.ep_enabled:
+                if (
+                    self.ep_no_sync and self.training
+                ):  # in eval mode, different ranks might get different input token counts, and no-sync can freeze
+                    no_sync_forward = (
+                        self.combined_forward_ep_no_sync_rowwise
+                        if self.ep_no_sync_use_rowwise_all_to_all
+                        else self.combined_forward_ep_no_sync_1d
+                    )
+                    from .activation_debug import (
+                        maybe_dump_ep_no_sync_saved_activations,
+                    )
+
+                    debug_out = maybe_dump_ep_no_sync_saved_activations(
+                        self,
+                        x,
+                        loss_div_factor=loss_div_factor,
+                        forward_kwargs=kwargs,
+                        no_sync_forward=no_sync_forward,
+                    )
+                    if debug_out is not None:
+                        return debug_out
+                    return no_sync_forward(x, loss_div_factor=loss_div_factor, **kwargs)
+                return self.combined_forward_ep_1d(x, loss_div_factor=loss_div_factor, **kwargs)
+            else:
+                return self.combined_forward_no_ep(x, loss_div_factor=loss_div_factor, **kwargs)
+        else:
+            # only shared_experts
+            return self.combined_forward_shared_only(x, loss_div_factor=loss_div_factor, **kwargs)
+
+    def apply_pp(self, pp_mesh: DeviceMesh):
+        pass  # nothing to do
+
+    def _ensure_ep_no_sync_symm_backend(self):
+        if olmo_symm_mem.is_enabled():
+            if not torch.cuda.is_available():
+                raise RuntimeError("EP no-sync requires CUDA")
+            return
+
+        if _symm_mem is None:
+            raise RuntimeError(
+                "EP no-sync requires torch.distributed._symmetric_memory, but it is unavailable"
+            )
+
+        if not torch.cuda.is_available():
+            raise RuntimeError("EP no-sync requires CUDA")
+
+        device = torch.device("cuda", torch.cuda.current_device())
+        current_backend = _symm_mem.get_backend(device)
+        if current_backend is not None and current_backend.upper() == "NVSHMEM":
+            return
+
+        if not _symm_mem.is_nvshmem_available():
+            raise RuntimeError(
+                "EP no-sync requires NVSHMEM-backed symmetric memory for "
+                "all_to_all_vdev, but NVSHMEM is not available in this "
+                "PyTorch build/environment."
+            )
+
+        try:
+            _symm_mem.set_backend("NVSHMEM")
+        except Exception as e:
+            try:
+                backend_after = _symm_mem.get_backend(device)
+            except Exception:
+                backend_after = None
+            raise RuntimeError(
+                "EP no-sync requires NVSHMEM-backed symmetric memory for "
+                "all_to_all_vdev. Failed to switch backend to NVSHMEM "
+                f"(current={current_backend}, after_error={backend_after}): {e}. "
+                "Call torch.distributed._symmetric_memory.set_backend('NVSHMEM') "
+                "before any symmetric-memory allocations."
+            ) from e
+
+    def _try_alias_ep_group_as_world_for_symm_mem(self) -> bool:
+        """
+        Try to alias EP group metadata as symmetric-memory group "0".
+
+        NVSHMEM-backed ``symm_mem.empty()`` bootstraps through group "0" before
+        the later tensor rendezvous sees the EP process group. Each process can
+        safely alias its local EP island as group "0" before the first symmetric
+        allocation.
+        """
+        global _EP_SYMM_GROUP0_ALIAS_RANKS
+        if _symm_mem is None or self.ep_pg is None:
+            return False
+        if dist.group.WORLD is None:
+            return False
+        if self.ep_pg.group_name == dist.group.WORLD.group_name:
+            return True
+
+        try:
+            import torch.distributed.distributed_c10d as c10d
+        except Exception:
+            return False
+
+        try:
+            alias_ranks = tuple(sorted(c10d._world.pg_group_ranks[self.ep_pg].keys()))
+            with _EP_SYMM_GROUP0_ALIAS_LOCK:
+                # Idempotent success: alias already installed for the same EP group.
+                if _EP_SYMM_GROUP0_ALIAS_RANKS == alias_ranks:
+                    return True
+
+                # If group "0" is already registered by a different context,
+                # do not overwrite global process state.
+                if _symm_mem.is_symm_mem_enabled_for_group("0"):
+                    return False
+
+                if not self._register_process_group_for_symm_mem(self.ep_pg, "0"):
+                    return False
+                _EP_SYMM_GROUP0_ALIAS_RANKS = alias_ranks
+                return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def _register_process_group_for_symm_mem(
+        group: dist.ProcessGroup,
+        group_name: str,
+    ) -> bool:
+        if _symm_mem is None:
+            return False
+        if _symm_mem.is_symm_mem_enabled_for_group(group_name):
+            return True
+        try:
+            import torch.distributed.distributed_c10d as c10d
+            from torch._C._distributed_c10d import _SymmetricMemory
+        except Exception:
+            return False
+
+        try:
+            global_ranks = sorted(c10d._world.pg_group_ranks[group].keys())
+            global_ranks_str = "_".join(map(str, global_ranks))
+            store = c10d.PrefixStore(
+                f"symmetric_memory-{global_ranks_str}",
+                c10d._get_process_group_store(group),
+            )
+            _SymmetricMemory.set_group_info(
+                group_name,
+                dist.get_rank(group),
+                dist.get_world_size(group),
+                store,
+            )
+            group_to_store = getattr(_symm_mem, "_group_name_to_store", None)
+            if isinstance(group_to_store, dict):
+                group_to_store[group_name] = store
+            return True
+        except Exception:
+            return False
+
+    def apply_ep(self, ep_mesh: DeviceMesh, **kwargs):
+        assert (
+            self.routed_experts is not None
+        ), "ep can only be applied when routed_experts is enabled"
+        # ep_dp_mesh = ep_mesh["ep_dp"]
+        ep_mp_mesh = ep_mesh["ep_mp"]
+        ep_pg = kwargs.get("ep_pg")
+        self.ep_mesh = ep_mesh
+        self.routed_experts.apply_ep(ep_mesh)
+        owner_ref = weakref.ref(self)
+        self.routed_experts.w_up_gate._moe_rowwise_fp8_cache_owner = owner_ref  # type: ignore[attr-defined]
+        self.routed_experts.w_down._moe_rowwise_fp8_cache_owner = owner_ref  # type: ignore[attr-defined]
+        _invalidate_rowwise_fp8_cache(self)
+        self.num_local_routed_experts = self.routed_experts.num_local_experts
+        self._ep_enabled = True
+        self.ep_pg = ep_pg if ep_pg is not None else ep_mp_mesh.get_group()
+
+        if self.ep_no_sync:
+            if olmo_symm_mem.is_enabled() and not self.ep_no_sync_use_rowwise_all_to_all:
+                raise RuntimeError(
+                    "OLMo-owned symmetric memory currently supports only the rowwise "
+                    "EP no-sync path. Set OLMO_USE_OWN_SYMM_MEM=0 to use the legacy "
+                    "torch.ops.symm_mem.all_to_all_vdev path."
+                )
+            if _symm_mem is None and not olmo_symm_mem.is_enabled():
+                raise RuntimeError(
+                    "EP no-sync requires torch.distributed._symmetric_memory, but it is unavailable"
+                )
+            self._ensure_ep_no_sync_symm_backend()
+            assert self.ep_pg is not None
+            group_name = self.ep_pg.group_name
+            assert (
+                dist.group.WORLD is not None
+            ), "torch.distributed.group.WORLD must be initialized for EP no-sync to work"
+            world_group_name = dist.group.WORLD.group_name
+            alias_group0_active = False
+            try:
+                if olmo_symm_mem.is_enabled():
+                    olmo_symm_mem.register_group(
+                        self.ep_pg, device=torch.device("cuda", torch.cuda.current_device())
+                    )
+                else:
+                    if not self._register_process_group_for_symm_mem(self.ep_pg, group_name):
+                        raise RuntimeError(
+                            f"Failed to register EP group '{group_name}' for symmetric memory support"
+                        )
+                    if os.getenv("OLMO_EP_NO_SYNC_ALIAS_GROUP0", "1").lower() not in (
+                        "",
+                        "0",
+                        "false",
+                        "no",
+                    ):
+                        alias_group0_active = self._try_alias_ep_group_as_world_for_symm_mem()
+                        if not alias_group0_active:
+                            raise RuntimeError(
+                                f"Failed to alias EP group '{group_name}' as group '0' for symmetric memory support"
+                            )
+
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to enable symmetric memory for EP group '{group_name}' "
+                    f"(world='{world_group_name}', alias_group0_active={alias_group0_active}) "
+                    f"(block={self.block_idx}, rank={get_rank(self.ep_pg)}): {e}"
+                ) from e
+            self._ep_symm_group_name = group_name
+            if self.ep_no_sync_use_rowwise_all_to_all:
+                from .ep_no_sync_buffers import resolve_ep_no_sync_rowwise_symm_options
+
+                resolve_ep_no_sync_rowwise_symm_options(self)
+            self._ep_no_sync_symm_cache.clear()
+            self._ep_no_sync_static_buffer_cache.clear()
+            self._ep_no_sync_rowwise_fp8_static_buffer_cache.clear()
+            self._ep_no_sync_symm_lease_pools.clear()
+            self._ep_no_sync_shared_pool = None
+            self._ep_no_sync_shared_slot = 0
+            self._ep_no_sync_te_backend_warned = False
+
+    def apply_tp(
+        self, tp_mesh: DeviceMesh, *, input_layout: Placement, float8_enabled: bool = False
+    ):
+        raise NotImplementedError("TP is not supported in MoEFusedV1TransformerBlock")
+
+    def apply_cp(self, cp_mesh: DeviceMesh, ring=None, uly=None):
+        del cp_mesh, ring, uly
+        raise NotImplementedError("CP is not supported in MoEFusedV2TransformerBlock")
+
+    def apply_fsdp(
+        self,
+        *args,
+        **kwargs,
+    ):
+        raise NotImplementedError("FSDP is not supported in MoEFusedV2TransformerBlock")
+
+    def apply_compile(self):
+        self.compile(
+            fullgraph=False,
+            # dynamic=False
+        )
+
+        # NOTE: the tbo might be called by the outer model directly (by block.combined_forward_ep_tbo(x, ...) instead of block(x, ...)), so need to compile it here as well
+        self.combined_forward_ep_tbo = torch.compile(self.combined_forward_ep_tbo)  # type: ignore[method-assign]
+        self._res_norm_attn = torch.compile(self._res_norm_attn)  # type: ignore[method-assign]
+
+    @property
+    def ep_world_size(self) -> int:
+        if self.ep_pg is not None:
+            return get_world_size(self.ep_pg)
+        else:
+            return 1
+
+    def _attach_routed_aux_loss(
+        self,
+        x: torch.Tensor,
+        routed_expert_router_aux_loss_info: Optional[Tuple[object, ...]],
+        *,
+        accumulate_metrics: Optional[bool] = None,
+    ) -> torch.Tensor:
+        if routed_expert_router_aux_loss_info is None:
+            return x
+        assert self.routed_experts_router is not None
+        if accumulate_metrics is None:
+            accumulate_metrics = not is_checkpoint_recomputing()
+        routed_expert_router_aux_loss = self.routed_experts_router.compute_aux_loss(
+            *routed_expert_router_aux_loss_info,
+            accumulate_metrics=accumulate_metrics,
+        )
+        if routed_expert_router_aux_loss is None:
+            return x
+        return attach_auxiliary_loss(x, routed_expert_router_aux_loss)
+
+    @torch.compiler.disable
+    def sync_dtoh_event(self):
+        assert self._dtoh_event is not None
+        dtoh_event = cast(torch.cuda.Event, self._dtoh_event)
+        dtoh_event.synchronize()
+
+    # -------------------------------------------------------------------------
+    # Forward path entry points
+    # -------------------------------------------------------------------------
+    def combined_forward_shared_only(
+        self,
+        x: torch.Tensor,
+        *,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Reserved for no-routed-experts case (only shared experts), equivalent to a dense model"""
+        assert self.routed_experts is None
+        assert self.routed_experts_router is None
+        assert self.shared_experts is not None
+        raise NotImplementedError("combined_forward_shared_only is not implemented")
+
+    def combined_forward_no_ep(
+        self,
+        x: torch.Tensor,
+        *,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        return _combined_forward_no_ep(
+            self,
+            x,
+            loss_div_factor=loss_div_factor,
+            **kwargs,
+        )
+
+    def combined_forward_ep_no_sync_1d(
+        self,
+        x: torch.Tensor,
+        *,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        from .ep_no_sync_1d import (
+            combined_forward_ep_no_sync_1d as _combined_forward_ep_no_sync_1d,
+        )
+
+        return _combined_forward_ep_no_sync_1d(
+            self,
+            x,
+            loss_div_factor=loss_div_factor,
+            **kwargs,
+        )
+
+    def combined_forward_ep_no_sync_rowwise(
+        self,
+        x: torch.Tensor,
+        *,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        checkpoint_state = self._ep_no_sync_rowwise_static_checkpoint_state
+        if checkpoint_state is None:
+            checkpoint_state = get_rowwise_checkpoint_state()
+        activation_checkpointing, accumulate_routed_aux_loss_metrics = checkpoint_state
+        from .ep_no_sync_rowwise import (
+            combined_forward_ep_no_sync_rowwise as _combined_forward_ep_no_sync_rowwise,
+        )
+
+        return _combined_forward_ep_no_sync_rowwise(
+            self,
+            x,
+            activation_checkpointing=activation_checkpointing,
+            accumulate_routed_aux_loss_metrics=accumulate_routed_aux_loss_metrics,
+            loss_div_factor=loss_div_factor,
+            **kwargs,
+        )
+
+    def combined_forward_ep_no_sync_tbo(
+        self,
+        x0: torch.Tensor,
+        x1_ctx: object,
+        x1_is_fresh: bool,
+        *,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, object]:
+        if self.ep_no_sync_use_rowwise_all_to_all:
+            from .ep_no_sync_tbo_rowwise import (
+                combined_forward_ep_no_sync_tbo_rowwise as _combined_forward_ep_no_sync_tbo_rowwise,
+            )
+
+            return _combined_forward_ep_no_sync_tbo_rowwise(
+                self,
+                x0,
+                x1_ctx,
+                x1_is_fresh,
+                loss_div_factor=loss_div_factor,
+                **kwargs,
+            )
+        from .ep_no_sync_tbo_1d import (
+            combined_forward_ep_no_sync_tbo as _combined_forward_ep_no_sync_tbo,
+        )
+
+        return _combined_forward_ep_no_sync_tbo(
+            self,
+            x0,
+            x1_ctx,
+            x1_is_fresh,
+            loss_div_factor=loss_div_factor,
+            **kwargs,
+        )
+
+    def combined_forward_ep_1d(
+        self,
+        x: torch.Tensor,
+        *,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        from .ep_sync_1d import combined_forward_ep_1d as _combined_forward_ep_1d
+
+        return _combined_forward_ep_1d(
+            self,
+            x,
+            loss_div_factor=loss_div_factor,
+            **kwargs,
+        )
+
+    def combined_forward_ep_tbo(
+        self,
+        x0: torch.Tensor,
+        x1_ctx: object,
+        x1_is_fresh: bool,
+        *,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, object]:
+        from .ep_sync_tbo import combined_forward_ep_tbo as _combined_forward_ep_tbo
+
+        return _combined_forward_ep_tbo(
+            self,
+            x0,
+            x1_ctx,
+            x1_is_fresh,
+            loss_div_factor=loss_div_factor,
+            **kwargs,
+        )
+
+    def checkpointed_combined_forward_ep_tbo(
+        self,
+        x0: torch.Tensor,
+        x1_ctx: object,
+        x1_is_fresh: bool,
+        *,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, object]:
+        if self.checkpoint_combined_ep_tbo:
+            out = checkpoint(
+                self.combined_forward_ep_tbo,
+                x0,
+                x1_ctx,
+                x1_is_fresh,
+                loss_div_factor=loss_div_factor,
+                use_reentrant=False,
+                **kwargs,
+            )
+            return cast(Tuple[torch.Tensor, object], out)
+        else:
+            return self.combined_forward_ep_tbo(
+                x0,
+                x1_ctx,
+                x1_is_fresh,
+                loss_div_factor=loss_div_factor,
+                **kwargs,
+            )
+
+    # -------------------------------------------------------------------------
+    # Shared forward helpers
+    # -------------------------------------------------------------------------
+    def _prepare_moe_input(self, x: torch.Tensor) -> torch.Tensor:
+        if self.use_peri_norm:
+            assert self.feed_forward_input_norm is not None
+            return self.feed_forward_input_norm(x)
+        return x
+
+    def _merge_routed_and_shared(
+        self,
+        routed_out: torch.Tensor,
+        mixed_shared_out: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if self.shared_experts is None:
+            return routed_out
+        if mixed_shared_out is None:
+            raise RuntimeError("shared_experts is enabled but mixed_shared_out is missing")
+        return routed_out + mixed_shared_out
+
+    def _res_norm_mlp(self, residual: torch.Tensor, mlp_out: torch.Tensor) -> torch.Tensor:
+        return residual + self.feed_forward_norm(mlp_out)
+
+    def _res_norm_attn(self, block_inp, **kwargs) -> torch.Tensor:
+        attn_in = block_inp
+        if self.use_peri_norm:
+            assert self.attention_input_norm is not None
+            attn_in = self.attention_input_norm(block_inp)
+        attn_res_out = block_inp + self.attention_norm(self.attention(attn_in, **kwargs))
+        return attn_res_out
+
+    def _checkpointed_res_norm_attn(self, block_inp, **kwargs) -> torch.Tensor:
+        if self.checkpoint_attn:
+            out = checkpoint(
+                self._res_norm_attn,
+                block_inp,
+                use_reentrant=False,
+                **kwargs,
+            )
+            return cast(torch.Tensor, out)
+        else:
+            return self._res_norm_attn(block_inp, **kwargs)
+
+    def post_batch(self, dry_run: bool = False):
+        """
+        Should be called right after the final backward of a complete batch but before the optimizer step.
+        """
+        if self.shared_experts_router:
+            self.shared_experts_router.post_batch(dry_run=dry_run)
+        if self.routed_experts_router:
+            self.routed_experts_router.post_batch(dry_run=dry_run)

--- a/src/olmo_core/nn/moe/v2/block.py
+++ b/src/olmo_core/nn/moe/v2/block.py
@@ -693,20 +693,20 @@ class MoEFusedV2TransformerBlock(olmo_core.nn.transformer.block.TransformerBlock
             metrics_routed = {}
         out = dict(metrics_routed)
 
-        from .ep_no_sync_rowwise_helpers import (
-            add_ep_no_sync_rowwise_metrics,
-            reset_ep_no_sync_rowwise_metrics,
-        )
+        # Row-wise EP metrics are only produced by the no-sync rowwise all-to-all path; that
+        # helper module is not present unless the rowwise dispatch family is installed, so only
+        # import it when the rowwise path is actually configured.
+        if self.ep_no_sync_use_rowwise_all_to_all:
+            from .ep_no_sync_rowwise_helpers import (
+                add_ep_no_sync_rowwise_metrics,
+                reset_ep_no_sync_rowwise_metrics,
+            )
 
-        add_ep_no_sync_rowwise_metrics(self, out, ReduceType)
+            add_ep_no_sync_rowwise_metrics(self, out, ReduceType)
 
-        if reset:
-            reset_ep_no_sync_rowwise_metrics(self)
+            if reset:
+                reset_ep_no_sync_rowwise_metrics(self)
 
-        # metrics = {
-        #     "shared": metrics_shared,
-        #     "routed": metrics_routed,
-        # }
         return out
 
     def reset_metrics(self):
@@ -714,9 +714,10 @@ class MoEFusedV2TransformerBlock(olmo_core.nn.transformer.block.TransformerBlock
         #     self.shared_experts_router.reset_metrics()
         if self.routed_experts_router:
             self.routed_experts_router.reset_metrics()
-        from .ep_no_sync_rowwise_helpers import reset_ep_no_sync_rowwise_metrics
+        if self.ep_no_sync_use_rowwise_all_to_all:
+            from .ep_no_sync_rowwise_helpers import reset_ep_no_sync_rowwise_metrics
 
-        reset_ep_no_sync_rowwise_metrics(self)
+            reset_ep_no_sync_rowwise_metrics(self)
 
     def num_flops_per_token(self, seq_len: int) -> int:
         """

--- a/src/olmo_core/nn/moe/v2/block.py
+++ b/src/olmo_core/nn/moe/v2/block.py
@@ -150,6 +150,16 @@ class MoEFusedV2TransformerBlockConfig(TransformerBlockConfig):
     # Expert-parallel knobs. These configure the expert-parallel dispatch families, which are
     # imported lazily and land in follow-up changes; they have no effect on the no-expert-parallel
     # path and are documented when those families land.
+    #
+    # TODO(ep-config): revisit and potentially refactor these into per-mode configs. Right now this
+    # is a flat bag of `ep_no_sync_*` flags that conflates *mode selection* (the family is chosen by
+    # the `(ep_no_sync, ep_no_sync_use_rowwise_all_to_all)` pair) with *per-mode tuning* (capacity,
+    # alignment, symm-mem slots) and *rowwise-only* options (`ep_no_sync_rowwise_*`), so many
+    # combinations are meaningless and one flag (`ep_no_sync_use_2d_all_to_all`) is already dead.
+    # The rest of the codebase models this kind of polymorphism with a Registrable base config that
+    # resolves to a per-variant subclass (see e.g. the attention/optimizer/scheduler configs); an
+    # EP-mode config (sync / no-sync VDev / no-sync rowwise) holding only its own fields would be
+    # clearer and self-validating. Do this when the EP families land (PR-M2/M3).
     ep_no_sync: bool = False
     ep_no_sync_use_2d_all_to_all: bool = False
     ep_no_sync_use_rowwise_all_to_all: bool = False

--- a/src/olmo_core/nn/moe/v2/block.py
+++ b/src/olmo_core/nn/moe/v2/block.py
@@ -85,19 +85,71 @@ _SHARED_DOWN_FP8_CACHE_SPECS = (
 
 @dataclass
 class MoEFusedV2TransformerBlockConfig(TransformerBlockConfig):
+    """
+    Configuration for a :class:`MoEFusedV2TransformerBlock`.
+
+    Unlike :class:`~olmo_core.nn.transformer.config.TransformerBlockConfig`, this block does not
+    use the ``feed_forward`` / ``feed_forward_moe`` fields; the feed-forward sublayer is described
+    by :data:`routed_experts` (+ :data:`routed_experts_router`) and the optional
+    :data:`shared_experts` (+ :data:`shared_experts_router`). The inherited ``layer_norm`` field is
+    used for both the attention and feed-forward norms.
+    """
+
     shared_experts: Optional[SharedExpertsConfig] = None
+    """
+    The optional shared (always-on) experts applied to every token.
+    """
 
     routed_experts: Optional[RoutedExpertsConfig] = None
+    """
+    The routed experts that each token is dispatched to via :data:`routed_experts_router`.
+    """
 
     shared_experts_router: Optional[MoERouterConfigV2] = None
+    """
+    The router that produces the (gated) combine weights for the shared experts. Only needed when
+    there is more than one shared expert.
+    """
 
     routed_experts_router: Optional[MoERouterConfigV2] = None
+    """
+    The router that selects the top-k routed experts for each token and produces their combine
+    weights.
+    """
 
     use_peri_norm: bool = False
+    """
+    Apply a "peri-norm" — an additional input norm on the attention and feed-forward sublayers.
+    """
+
     checkpoint_attn: bool = False
+    """
+    Activation-checkpoint the attention sublayer.
+    """
+
     checkpoint_permute_moe_unpermute: bool = False
+    """
+    Activation-checkpoint the permute → experts → unpermute region of the MoE sublayer.
+    """
+
     checkpoint_combined_ep_tbo: bool = False
+    """
+    Activation-checkpoint the combined expert-parallel two-batch-overlap forward.
+    """
+
     checkpoint_second_unpermute: bool = False
+    """
+    Activation-checkpoint the second (combine) unpermute.
+    """
+
+    rowwise_fp8: Optional[MoERowwiseFP8Config] = None
+    """
+    Optional rowwise-FP8 configuration for the shared experts (beta).
+    """
+
+    # Expert-parallel knobs. These configure the expert-parallel dispatch families, which are
+    # imported lazily and land in follow-up changes; they have no effect on the no-expert-parallel
+    # path and are documented when those families land.
     ep_no_sync: bool = False
     ep_no_sync_use_2d_all_to_all: bool = False
     ep_no_sync_use_rowwise_all_to_all: bool = False
@@ -111,7 +163,6 @@ class MoEFusedV2TransformerBlockConfig(TransformerBlockConfig):
     ep_no_sync_rowwise_symm_dispatch_in: Optional[bool] = None
     ep_no_sync_rowwise_symm_combine_out: Optional[bool] = None
     ep_no_sync_rowwise_symm_combine_gather: Optional[bool] = None
-    rowwise_fp8: Optional[MoERowwiseFP8Config] = None
 
     def build(
         self,
@@ -275,6 +326,16 @@ if TYPE_CHECKING:
 
 
 class MoEFusedV2TransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBase):
+    """
+    A fused Mixture-of-Experts transformer block: it owns both the attention sublayer and the MoE
+    feed-forward sublayer (routed experts + optional shared experts) so their compute and
+    communication can be overlapped. Built from a :class:`MoEFusedV2TransformerBlockConfig`.
+
+    The forward path is selected at runtime from the block's expert-parallel configuration; this
+    drop ships the no-expert-parallel path (:func:`~olmo_core.nn.moe.v2.no_ep.combined_forward_no_ep`),
+    with the expert-parallel dispatch families imported lazily and landing in follow-up changes.
+    """
+
     def __init__(
         self,
         *,

--- a/src/olmo_core/nn/moe/v2/fp8.py
+++ b/src/olmo_core/nn/moe/v2/fp8.py
@@ -1,10 +1,25 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional
 
 import torch
 
+try:
+    import nvtx
+except ImportError:
+    from olmo_core._nvtx import nvtx
+
 from olmo_core.config import Config, StrEnum
 from olmo_core.doc_utils import beta_feature
+from olmo_core.kernels import (
+    prequantize_scaled_grouped_mm_rhs,
+    scaled_grouped_mm_q,
+    scaled_grouped_mm_q_fp8_weight,
+)
+
+if TYPE_CHECKING:
+    from .block import MoEFusedV2TransformerBlock
 
 
 class MoERowwiseFP8ScaleMode(StrEnum):
@@ -65,3 +80,317 @@ def normalize_rowwise_fp8_config(
     raise TypeError(
         "rowwise_fp8 must be MoERowwiseFP8Config, mapping/dict, or None " f"(got {type(value)!r})"
     )
+
+
+def reset_shared_rowwise_fp8_cache(block: MoEFusedV2TransformerBlock) -> None:
+    block._shared_rowwise_fp8_up_prequant = None
+    block._shared_rowwise_fp8_down_prequant = None
+    block._shared_rowwise_fp8_up_prequant_t = None
+    block._shared_rowwise_fp8_down_prequant_t = None
+    block._shared_rowwise_fp8_weight_versions = None
+    up_weight = getattr(block, "_shared_rowwise_fp8_up_gate_weight", None)
+    down_weight = getattr(block, "_shared_rowwise_fp8_down_weight", None)
+    if up_weight is not None:
+        up_weight.invalidate()
+    if down_weight is not None:
+        down_weight.invalidate()
+
+
+def _rowwise_fp8_enabled(cfg: Optional[MoERowwiseFP8Config]) -> bool:
+    return cfg is not None and cfg.enabled
+
+
+def invalidate_rowwise_fp8_cache(block: MoEFusedV2TransformerBlock) -> None:
+    if block.routed_experts is not None:
+        block.routed_experts.invalidate_rowwise_fp8_cache()
+    reset_shared_rowwise_fp8_cache(block)
+
+
+@torch.no_grad()
+def refresh_shared_rowwise_fp8_cache(block: MoEFusedV2TransformerBlock) -> None:
+    cfg = block.rowwise_fp8
+    if not _rowwise_fp8_enabled(cfg):
+        reset_shared_rowwise_fp8_cache(block)
+        return
+    assert cfg is not None
+    if block.shared_experts is None:
+        reset_shared_rowwise_fp8_cache(block)
+        return
+    sync_shared_weights = getattr(block, "_sync_shared_rowwise_fp8_weight_anchors", None)
+    if sync_shared_weights is not None:
+        sync_shared_weights()
+    up_weight = getattr(block, "_shared_rowwise_fp8_up_gate_weight", None)
+    down_weight = getattr(block, "_shared_rowwise_fp8_down_weight", None)
+    if (
+        cfg.fp8_only_params
+        and up_weight is not None
+        and down_weight is not None
+        and (up_weight.anchor_storage_released or down_weight.anchor_storage_released)
+    ):
+        if (
+            up_weight.prequantized_rhs is None
+            or up_weight.prequantized_rhs_for_dgrad is None
+            or down_weight.prequantized_rhs is None
+            or down_weight.prequantized_rhs_for_dgrad is None
+        ):
+            raise RuntimeError(
+                "Cannot refresh rowwise FP8 shared expert caches from released bf16 anchors. "
+                "The optimizer must refresh FP8 stores directly from fp32 main params."
+            )
+        block._shared_rowwise_fp8_up_prequant = up_weight.prequantized_rhs
+        block._shared_rowwise_fp8_up_prequant_t = up_weight.prequantized_rhs_for_dgrad
+        block._shared_rowwise_fp8_down_prequant = down_weight.prequantized_rhs
+        block._shared_rowwise_fp8_down_prequant_t = down_weight.prequantized_rhs_for_dgrad
+        block._shared_rowwise_fp8_weight_versions = None
+        return
+    if block.shared_experts.w_up_gate.device.type != "cuda":
+        reset_shared_rowwise_fp8_cache(block)
+        return
+
+    with nvtx.annotate("moe_rowwise_fp8_param_refresh_shared_weight_prequant"):
+        if up_weight is not None and down_weight is not None:
+            up_weight.refresh_from_logical_weight(
+                block.shared_experts.w_up_gate,
+                version_tensors=(block.shared_experts.w_up_gate,),
+            )
+            down_weight.refresh_from_logical_weight(
+                block.shared_experts.w_down,
+                version_tensors=(block.shared_experts.w_down,),
+            )
+            block._shared_rowwise_fp8_up_prequant = up_weight.prequantized_rhs
+            block._shared_rowwise_fp8_up_prequant_t = up_weight.prequantized_rhs_for_dgrad
+            block._shared_rowwise_fp8_down_prequant = down_weight.prequantized_rhs
+            block._shared_rowwise_fp8_down_prequant_t = down_weight.prequantized_rhs_for_dgrad
+        else:
+            up_rhs = block.shared_experts.w_up_gate.unsqueeze(0)
+            down_rhs = block.shared_experts.w_down
+            up_rhs_t = block.shared_experts.w_up_gate.transpose(0, 1).unsqueeze(0)
+            down_rhs_t = block.shared_experts.w_down.transpose(1, 2)
+            block._shared_rowwise_fp8_up_prequant = prequantize_scaled_grouped_mm_rhs(
+                up_rhs,
+                check_mat_b_version=False,
+            )
+            block._shared_rowwise_fp8_down_prequant = prequantize_scaled_grouped_mm_rhs(
+                down_rhs,
+                check_mat_b_version=False,
+            )
+            block._shared_rowwise_fp8_up_prequant_t = prequantize_scaled_grouped_mm_rhs(
+                up_rhs_t,
+                check_mat_b_version=False,
+            )
+            block._shared_rowwise_fp8_down_prequant_t = prequantize_scaled_grouped_mm_rhs(
+                down_rhs_t,
+                check_mat_b_version=False,
+            )
+        block._shared_rowwise_fp8_weight_versions = (
+            int(block.shared_experts.w_up_gate._version),
+            int(block.shared_experts.w_down._version),
+        )
+
+
+@torch.no_grad()
+def refresh_rowwise_fp8_cache(block: MoEFusedV2TransformerBlock) -> None:
+    block_cfg = block.rowwise_fp8
+    routed_cfg = block.routed_experts.rowwise_fp8 if block.routed_experts is not None else None
+    shared_enabled = _rowwise_fp8_enabled(block_cfg)
+    routed_enabled = _rowwise_fp8_enabled(routed_cfg)
+    if not shared_enabled and not routed_enabled:
+        invalidate_rowwise_fp8_cache(block)
+        return
+
+    if block.routed_experts is not None:
+        if routed_enabled:
+            with nvtx.annotate("moe_rowwise_fp8_param_refresh_routed_weight_prequant"):
+                block.routed_experts.refresh_rowwise_fp8_cache()
+        else:
+            block.routed_experts.invalidate_rowwise_fp8_cache()
+    refresh_shared_rowwise_fp8_cache(block)
+
+
+def shared_experts_forward1_rowwise_fp8(
+    block: MoEFusedV2TransformerBlock,
+    x: torch.Tensor,
+    *,
+    use_fast_accum: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert block.shared_experts is not None
+    if x.ndim == 3:
+        B, S, D = x.shape
+        x2 = x.reshape(B * S, D)
+    elif x.ndim == 2:
+        x2 = x
+        D = x.shape[1]
+    else:
+        raise RuntimeError(
+            "shared_experts_forward1_rowwise_fp8 expects x to be [B, S, D] or [N, D], "
+            f"got shape={tuple(x.shape)}"
+        )
+    E, H = block.shared_experts.num_experts, block.shared_experts.hidden_size
+    BS = x2.shape[0]
+
+    up_prequant = block._shared_rowwise_fp8_up_prequant
+    up_prequant_t = block._shared_rowwise_fp8_up_prequant_t
+    if up_prequant is None or up_prequant_t is None:
+        raise RuntimeError("shared rowwise FP8 up/gate prequant buffers were not initialized")
+    offs = torch.tensor([BS], device=x.device, dtype=torch.int32)
+    up_kwargs = dict(
+        offs=offs,
+        use_fast_accum=use_fast_accum,
+        prequantized_rhs=up_prequant,
+        prequantized_rhs_for_dgrad=up_prequant_t,
+    )
+    cfg = block.rowwise_fp8
+    fp8_only_params = cfg is not None and cfg.fp8_only_params
+    up_anchor = block.shared_experts.w_up_gate.unsqueeze(0)
+    mm_impl: Callable[..., Any]
+    if fp8_only_params:
+        up_weight = getattr(block, "_shared_rowwise_fp8_up_gate_weight", None)
+        if up_weight is None:
+            raise RuntimeError("shared rowwise FP8 up/gate weight store is not initialized")
+        up_kwargs["wgrad_sink"] = up_weight
+        up_kwargs["wgrad_sink_squeeze_first_dim"] = True
+        up_anchor = up_anchor.detach()
+        mm_impl = scaled_grouped_mm_q_fp8_weight
+    else:
+        mm_impl = scaled_grouped_mm_q
+    up_gate = mm_impl(
+        x2,
+        up_anchor,
+        **up_kwargs,
+    )
+    up_gate = up_gate.view(BS, E, 2, H).permute(1, 0, 2, 3)
+    up, gate = up_gate.unbind(dim=2)
+    return up, gate
+
+
+def shared_experts_forward_rowwise_fp8(
+    block: MoEFusedV2TransformerBlock,
+    x: torch.Tensor,
+    *,
+    use_fast_accum: bool,
+) -> torch.Tensor:
+    assert block.shared_experts is not None
+    if x.ndim != 3:
+        raise RuntimeError(
+            "shared_experts_forward_rowwise_fp8 expects x to be [B, S, D], "
+            f"got shape={tuple(x.shape)}"
+        )
+    B, S, D = x.shape
+    E, H = block.shared_experts.num_experts, block.shared_experts.hidden_size
+    BS = B * S
+
+    x2 = x.reshape(BS, D)
+    up_prequant = block._shared_rowwise_fp8_up_prequant
+    up_prequant_t = block._shared_rowwise_fp8_up_prequant_t
+    if up_prequant is None or up_prequant_t is None:
+        raise RuntimeError("shared rowwise FP8 up/gate prequant buffers were not initialized")
+    up_offs = torch.tensor([BS], device=x.device, dtype=torch.int32)
+    up_kwargs = dict(
+        offs=up_offs,
+        use_fast_accum=use_fast_accum,
+        prequantized_rhs=up_prequant,
+        prequantized_rhs_for_dgrad=up_prequant_t,
+    )
+    cfg = block.rowwise_fp8
+    fp8_only_params = cfg is not None and cfg.fp8_only_params
+    up_anchor = block.shared_experts.w_up_gate.unsqueeze(0)
+    up_mm_impl: Callable[..., Any]
+    if fp8_only_params:
+        up_weight = getattr(block, "_shared_rowwise_fp8_up_gate_weight", None)
+        if up_weight is None:
+            raise RuntimeError("shared rowwise FP8 up/gate weight store is not initialized")
+        up_kwargs["wgrad_sink"] = up_weight
+        up_kwargs["wgrad_sink_squeeze_first_dim"] = True
+        up_anchor = up_anchor.detach()
+        up_mm_impl = scaled_grouped_mm_q_fp8_weight
+    else:
+        up_mm_impl = scaled_grouped_mm_q
+    up_gate = up_mm_impl(
+        x2,
+        up_anchor,
+        **up_kwargs,
+    )
+
+    up_gate = up_gate.view(BS, E, 2, H).permute(1, 0, 2, 3)
+    up, gate = up_gate.unbind(dim=2)
+    gate = torch.nn.functional.silu(gate)
+    hidden = up * gate
+
+    down_prequant = block._shared_rowwise_fp8_down_prequant
+    down_prequant_t = block._shared_rowwise_fp8_down_prequant_t
+    if down_prequant is None or down_prequant_t is None:
+        raise RuntimeError("shared rowwise FP8 down prequant buffers were not initialized")
+    hidden_2d = hidden.reshape(E * BS, -1)
+    down_offs = torch.arange(BS, E * BS + 1, BS, device=hidden.device, dtype=torch.int32)
+    down_kwargs = dict(
+        offs=down_offs,
+        use_fast_accum=use_fast_accum,
+        prequantized_rhs=down_prequant,
+        prequantized_rhs_for_dgrad=down_prequant_t,
+    )
+    down_anchor = block.shared_experts.w_down
+    down_mm_impl: Callable[..., Any]
+    if fp8_only_params:
+        down_weight = getattr(block, "_shared_rowwise_fp8_down_weight", None)
+        if down_weight is None:
+            raise RuntimeError("shared rowwise FP8 down weight store is not initialized")
+        down_kwargs["wgrad_sink"] = down_weight
+        down_anchor = down_anchor.detach()
+        down_mm_impl = scaled_grouped_mm_q_fp8_weight
+    else:
+        down_mm_impl = scaled_grouped_mm_q
+    out_2d = down_mm_impl(
+        hidden_2d,
+        down_anchor,
+        **down_kwargs,
+    )
+    return out_2d.view(E, BS, D).view(E, B, S, D)
+
+
+def shared_experts_forward2_rowwise_fp8(
+    block: MoEFusedV2TransformerBlock,
+    up: torch.Tensor,
+    gate: torch.Tensor,
+    xshape: torch.Size,
+    *,
+    use_fast_accum: bool,
+) -> torch.Tensor:
+    assert block.shared_experts is not None
+    E, _H = block.shared_experts.num_experts, block.shared_experts.hidden_size
+    B, S, D = xshape
+    BS = B * S
+
+    gate = torch.nn.functional.silu(gate)
+    hidden = up * gate
+
+    down_prequant = block._shared_rowwise_fp8_down_prequant
+    down_prequant_t = block._shared_rowwise_fp8_down_prequant_t
+    if down_prequant is None or down_prequant_t is None:
+        raise RuntimeError("shared rowwise FP8 down prequant buffers were not initialized")
+    hidden_2d = hidden.reshape(E * BS, -1)
+    offs = torch.arange(BS, E * BS + 1, BS, device=hidden.device, dtype=torch.int32)
+    down_kwargs = dict(
+        offs=offs,
+        use_fast_accum=use_fast_accum,
+        prequantized_rhs=down_prequant,
+        prequantized_rhs_for_dgrad=down_prequant_t,
+    )
+    cfg = block.rowwise_fp8
+    fp8_only_params = cfg is not None and cfg.fp8_only_params
+    down_anchor = block.shared_experts.w_down
+    mm_impl: Callable[..., Any]
+    if fp8_only_params:
+        down_weight = getattr(block, "_shared_rowwise_fp8_down_weight", None)
+        if down_weight is None:
+            raise RuntimeError("shared rowwise FP8 down weight store is not initialized")
+        down_kwargs["wgrad_sink"] = down_weight
+        down_anchor = down_anchor.detach()
+        mm_impl = scaled_grouped_mm_q_fp8_weight
+    else:
+        mm_impl = scaled_grouped_mm_q
+    out_2d = mm_impl(
+        hidden_2d,
+        down_anchor,
+        **down_kwargs,
+    )
+    return out_2d.view(E, BS, D).view(E, B, S, D)

--- a/src/olmo_core/nn/moe/v2/model.py
+++ b/src/olmo_core/nn/moe/v2/model.py
@@ -1,0 +1,1338 @@
+import logging
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
+
+import nvtx
+import torch
+import torch.distributed as dist
+from torch.distributed._composable.replicate import replicate
+from torch.distributed.device_mesh import DeviceMesh
+from torch.utils.checkpoint import (
+    CheckpointPolicy,
+    SelectiveCheckpointContext,
+    checkpoint,
+    noop_context_fn,
+)
+
+import olmo_core.nn.transformer
+from olmo_core.distributed.parallel import get_pp_mesh
+from olmo_core.distributed.utils import hide_from_torch, unhide_from_torch
+from olmo_core.exceptions import OLMoConfigurationError
+from olmo_core.kernels import olmo_symm_mem
+from olmo_core.ops import moe as ops
+from olmo_core.utils import mark_dynamic
+
+from ...lm_head import LMOutputWithLoss
+from ..utils import moe_unpermute_no_compile
+from .block import MoEFusedV2TransformerBlock
+from .checkpointing import checkpoint_recompute_context_fn
+
+# NOTE: the expert-parallel "no-sync" families (ep_no_sync_buffers / ep_no_sync_tbo_1d /
+# ep_no_sync_tbo_rowwise) are imported lazily inside the methods that use them
+# (prewarm_ep_no_sync_symm_buffers, apply_ep, _tbo_last_step), so this module imports
+# cleanly without those files present. They ship in later, stacked PRs.
+from .tbo_state import SyncedTboPendingContext
+
+if TYPE_CHECKING:
+    from olmo_core.nn.fp8_weight import FP8WeightStore
+    from olmo_core.train.common import ReduceType
+
+    from .ep_no_sync_buffers import _NoSyncSymmSharedPool
+log = logging.getLogger(__name__)
+
+# aten = torch.ops.aten
+# c10d = torch.ops.c10d
+
+should_save_ops = [
+    torch.ops.aten.mm.default,
+    torch.ops.aten.bmm.default,
+    torch.ops.aten.addmm.default,
+    torch.ops.aten.rand_like.default,
+    # torch.ops.c10d.alltoall_base_.default,
+    # torch.ops.flash_attn_3.fwd.default,
+]
+try:
+    should_save_ops.append(torch.ops.flash_attn._flash_attn_forward.default)
+except (AttributeError, RuntimeError):  # pragma: no cover - flash_attn unavailable
+    pass
+
+
+def policy_fn(ctx: SelectiveCheckpointContext, op, *args, **kwargs):
+    # print(f'ctx: {ctx}, op: {op}')
+    if op in should_save_ops:
+        # save outputs of these ops; don't recompute them
+        return CheckpointPolicy.MUST_SAVE
+    else:
+        # everything else can be recomputed
+        return CheckpointPolicy.PREFER_RECOMPUTE
+
+
+# recompute_context_fn = functools.partial(create_selective_checkpoint_contexts, policy_fn)
+recompute_context_fn = checkpoint_recompute_context_fn
+
+# from olmo_core.nn.utils import selective_checkpointing_context_fn
+# recompute_context_fn = selective_checkpointing_context_fn
+
+
+def _fp32_post_grad_acc_hook(param: torch.Tensor):
+    g = param.grad
+    if g is None:
+        return
+    # upcast and accumulate in-place (no graph)
+
+    if param._main_grad_fp32 is None:  # type: ignore[attr-defined]
+        # first time init
+        param._main_grad_fp32 = g.to(torch.float32)  # type: ignore[attr-defined]
+    else:
+        # param._main_grad_fp32.add_(g.to(torch.float32)) # type: ignore[attr-defined]
+        param._main_grad_fp32.add_(g)  # type: ignore[attr-defined]
+    # drop BF16 .grad to avoid double-accum & save memory
+    param.grad = None
+
+
+class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
+    """
+    An MoE transformer implementation, to be used with one of the
+    :class:`MoETransformerBlock` block types.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.tbo = kwargs.pop("two_batch_overlap")
+        self.recompute_all_blocks_by_chunk = kwargs.pop("recompute_all_blocks_by_chunk")
+        self.recompute_each_block = kwargs.pop("recompute_each_block")
+        self.recompute_block_keys: Optional[List[str]] = kwargs.pop("recompute_block_keys")
+        self.checkpoint_tbo_dense_layers = False
+        self.has_grad_accum_fp32_buffer = False  # whether the model has grad accum buffer for fp32 master grad, will be set in `attach_fp32_accum`
+
+        super().__init__(*args, **kwargs)
+        self.ep_enabled = False  # default
+        self._ep_modules = []
+        # Historical padding tensors for single-world symmetric-memory paths:
+        # every PE had to execute the same allocation sequence even when PP
+        # stages owned different numbers of MoE blocks. Current OLMo-owned EP
+        # paths should generally avoid needing these.
+        self._ep_no_sync_dummy_symm_tensors: List[torch.Tensor] = []
+
+        assert not (
+            self.recompute_all_blocks_by_chunk and self.recompute_each_block
+        ), "Only one of recompute_all_blocks_by_chunk and recompute_each_block can be True."
+        assert not (
+            self.tbo and self.recompute_each_block
+        ), "Cannot use TBO when recompute_each_block is True."
+
+        self.cpu_offload = False  # NOTE : CPU activation offload is not useful due to low pcie bandwidth, so disable it for now
+
+        # not used
+        # self.offload_context, self.offload_sync_func = get_cpu_offload_context(
+        #     enabled=self.cpu_offload,
+        #     num_layers=4,
+        #     model_layers=self.n_layers,
+        # )
+
+    # def reset_offload_handler(self): # NOTE: cpu activation offload should not be used
+    #     if self.cpu_offload:
+    #         assert isinstance(self.offload_context, CpuOffloadHook)
+    #         self.offload_context.offload_handler.groupid_reset()
+
+    def _check_tbo_requirements(self):
+        # make sure dense blocks only appear before moe blocks
+        # because TBO requires that moe blocks are consecutive
+        # [dense, dense, moe, moe] is ok
+        # [dense, moe, dense, moe] is not ok
+        found_moe = False
+        first_moe_idx = None
+        for idx, block in enumerate(self.blocks.values()):
+            if found_moe and not block.is_moe:
+                raise OLMoConfigurationError(
+                    "When TBO is enabled, all dense blocks must appear before MoE blocks."
+                )
+            if block.is_moe and not found_moe:
+                found_moe = True
+                first_moe_idx = idx
+            if block.is_moe:
+                moe_block = cast(MoEFusedV2TransformerBlock, block)
+                if moe_block.ep_no_sync and moe_block.ep_no_sync_shared_slots < 2:
+                    raise OLMoConfigurationError(
+                        "When TBO and EP no-sync are enabled, ep_no_sync_shared_slots must be >= 2 "
+                        f"(block={moe_block.block_idx}, got {moe_block.ep_no_sync_shared_slots})."
+                    )
+
+        return first_moe_idx
+
+    def purge_cuda_events(self):
+        # set all events to None (so that the model can be deepcopied in PP split)
+        for layer in self.blocks.values():
+            if layer.is_moe:
+                layer = cast(MoEFusedV2TransformerBlock, layer)
+                layer.purge_cuda_events()
+
+    def install_cuda_events(self):
+        # re-install events after deepcopy
+        for layer in self.blocks.values():
+            if layer.is_moe:
+                layer = cast(MoEFusedV2TransformerBlock, layer)
+                layer.install_cuda_events()
+
+    @property
+    def is_moe(self) -> bool:
+        return True
+
+    def num_flops_per_token(self, seq_len: int) -> int:
+        # TODO: check if it works with PP, does it compute one model part only? or the full model?
+        return super().num_flops_per_token(seq_len)
+
+    def compute_auxiliary_metrics(
+        self, reset: bool = True
+    ) -> Dict[str, Tuple[torch.Tensor, Optional["ReduceType"]]]:
+        from olmo_core.train.common import ReduceType
+
+        mean_offset = 1.0
+        if self.pp_enabled:
+            # Change the divisor to 'world_size // pp_group_size'
+            mean_offset = self._pp_group_size
+
+        out: Dict[str, Tuple[torch.Tensor, Optional["ReduceType"]]] = {}
+        for block_idx, block in self.blocks.items():
+            if not block.is_moe:
+                continue
+            block = cast(MoEFusedV2TransformerBlock, block)
+            block_metrics = block.compute_metrics(reset=reset)
+            for metric_name, (metric_val, reduce_type) in block_metrics.items():
+                out[f"block {int(block_idx):02d}/{metric_name}"] = (metric_val, reduce_type)
+
+                if self.pp_enabled and reduce_type == ReduceType.mean:
+                    metric_val = metric_val.float() * mean_offset
+
+                if metric_name not in out:
+                    out[metric_name] = (metric_val, reduce_type)
+                elif reduce_type in (ReduceType.mean, ReduceType.sum):
+                    out[metric_name] = (
+                        out[metric_name][0] + metric_val,
+                        reduce_type,
+                    )
+                elif reduce_type == ReduceType.max:
+                    out[metric_name] = (torch.max(out[metric_name][0], metric_val), reduce_type)
+                else:
+                    raise NotImplementedError(reduce_type)
+        return out
+
+    def reset_auxiliary_metrics(self):
+        for block in self.blocks.values():
+            if not block.is_moe:
+                continue
+            cast(MoEFusedV2TransformerBlock, block).reset_metrics()
+
+    def count_ep_no_sync_blocks(self) -> int:
+        return sum(
+            1
+            for block in self.blocks.values()
+            if block.is_moe and isinstance(block, MoEFusedV2TransformerBlock) and block.ep_no_sync
+        )
+
+    @torch.no_grad()
+    def refresh_rowwise_fp8_cache(self) -> None:
+        for block in self.blocks.values():
+            if not block.is_moe or not isinstance(block, MoEFusedV2TransformerBlock):
+                continue
+            block.refresh_rowwise_fp8_cache()
+
+    def named_fp8_weight_stores(self) -> Iterator[tuple[str, "FP8WeightStore"]]:
+        for block_key, block in self.blocks.items():
+            if not block.is_moe or not isinstance(block, MoEFusedV2TransformerBlock):
+                continue
+            for name, weight in block.named_fp8_weight_stores():
+                yield f"blocks.{block_key}.{name}", weight
+
+    def named_mxfp8_expert_weights(self) -> Iterator[tuple[str, "FP8WeightStore"]]:
+        yield from self.named_fp8_weight_stores()
+
+    def zero_fp8_weight_store_grads(self, set_to_none: bool = True) -> None:
+        for _, weight in self.named_fp8_weight_stores():
+            weight.zero_grad(set_to_none=set_to_none)
+
+    def zero_mxfp8_expert_weight_grads(self, set_to_none: bool = True) -> None:
+        self.zero_fp8_weight_store_grads(set_to_none=set_to_none)
+
+    def disable_fp8_weight_anchor_grads(self) -> None:
+        for block in self.blocks.values():
+            if not block.is_moe or not isinstance(block, MoEFusedV2TransformerBlock):
+                continue
+            block.disable_fp8_weight_anchor_grads()
+
+    def disable_mxfp8_expert_anchor_grads(self) -> None:
+        self.disable_fp8_weight_anchor_grads()
+
+    def release_fp8_weight_anchor_storage(self) -> None:
+        for block in self.blocks.values():
+            if not block.is_moe or not isinstance(block, MoEFusedV2TransformerBlock):
+                continue
+            block.release_fp8_weight_anchor_storage()
+
+    def release_mxfp8_expert_anchor_storage(self) -> None:
+        self.release_fp8_weight_anchor_storage()
+
+    def sync_fp8_weight_store_grads_from_anchor(self) -> None:
+        for block in self.blocks.values():
+            if not block.is_moe or not isinstance(block, MoEFusedV2TransformerBlock):
+                continue
+            block.sync_fp8_weight_store_grads_from_anchor()
+
+    def sync_mxfp8_expert_weight_grads_from_anchor(self) -> None:
+        self.sync_fp8_weight_store_grads_from_anchor()
+
+    def zero_grad(self, set_to_none: bool = True) -> None:
+        super().zero_grad(set_to_none=set_to_none)
+        self.zero_fp8_weight_store_grads(set_to_none=set_to_none)
+
+    @torch.no_grad()
+    def prewarm_ep_no_sync_symm_buffers(
+        self,
+        *,
+        max_local_microbatch_size: int,
+        pad_to_block_count: int,
+        rowwise_lifetime_lease_slots: Optional[int] = None,
+    ) -> None:
+        from .ep_no_sync_buffers import (
+            compute_ep_no_sync_rank_capacity,
+            get_ep_no_sync_buffers,
+            get_ep_no_sync_rowwise_fp8_buffers,
+            prewarm_ep_no_sync_rowwise_lifetime_leases,
+            use_ep_no_sync_rowwise_symm_combine_gather,
+            use_ep_no_sync_rowwise_symm_combine_out,
+            use_ep_no_sync_rowwise_symm_dispatch_in,
+        )
+
+        ep_blocks = [
+            (block_key, cast(MoEFusedV2TransformerBlock, block))
+            for block_key, block in self.blocks.items()
+            if block.is_moe and isinstance(block, MoEFusedV2TransformerBlock) and block.ep_no_sync
+        ]
+        if not ep_blocks:
+            if pad_to_block_count != 0:
+                raise RuntimeError(
+                    "Cannot pad EP no-sync symmetric allocations for a model part "
+                    "with no EP no-sync blocks"
+                )
+            return
+
+        first_block = ep_blocks[0][1]
+        assert first_block.routed_experts_router is not None
+        if first_block.ep_pg is None:
+            raise RuntimeError("EP no-sync block is missing ep_pg during symmetric prewarm")
+
+        param = next((p for p in self.parameters() if p.is_floating_point()), None)
+        if param is None:
+            raise RuntimeError("Cannot infer dtype/device for EP no-sync symmetric prewarm")
+        dtype = param.dtype
+        device = param.device
+        d_model = self.d_model
+        top_k = first_block.routed_experts_router.top_k
+        prewarm_local_microbatch_size = max_local_microbatch_size
+        if self.tbo:
+            if max_local_microbatch_size % 2 != 0:
+                raise RuntimeError(
+                    "TBO EP no-sync symmetric prewarm requires an even local microbatch size "
+                    f"(got {max_local_microbatch_size})"
+                )
+            prewarm_local_microbatch_size = max_local_microbatch_size // 2
+
+        num_out_tokens = prewarm_local_microbatch_size * top_k
+        rank_capacity = compute_ep_no_sync_rank_capacity(first_block, num_out_tokens)
+
+        for block_key, block in ep_blocks:
+            if block.ep_no_sync_use_rowwise_all_to_all:
+                rowwise_fp8_cfg = block.rowwise_fp8
+                use_rowwise_fp8 = (
+                    rowwise_fp8_cfg is not None
+                    and rowwise_fp8_cfg.enabled
+                    and device.type == "cuda"
+                )
+                use_symm_dispatch_in = (
+                    not use_rowwise_fp8
+                ) and use_ep_no_sync_rowwise_symm_dispatch_in(block)
+                use_symm_combine_out = (
+                    not use_rowwise_fp8
+                ) and use_ep_no_sync_rowwise_symm_combine_out(block)
+                use_symm_combine_gather = (
+                    not use_rowwise_fp8
+                ) and use_ep_no_sync_rowwise_symm_combine_gather(block)
+                block_is_checkpointed = (
+                    self.recompute_all_blocks_by_chunk
+                    or self.recompute_each_block
+                    or (
+                        self.recompute_block_keys is not None
+                        and block_key in self.recompute_block_keys
+                    )
+                )
+                block_uses_checkpointing = (
+                    block_is_checkpointed
+                    or block.checkpoint_attn
+                    or block.checkpoint_permute_moe_unpermute
+                )
+                block._ep_no_sync_rowwise_static_checkpoint_state = (
+                    None if block_uses_checkpointing else (False, True)
+                )
+                # With our checkpoint context, the original checkpointed forward
+                # and its recompute both use scratch buffers; no long-lived lease
+                # is needed. Force the rowwise path into scratch-buffer mode for
+                # checkpointed blocks so compiled checkpoint paths do not depend
+                # on Python-side checkpoint-context detection.
+                block._ep_no_sync_force_scratch_lifetime_buffers = block_is_checkpointed
+                runtime_uses_lifetime_leases = not block._ep_no_sync_force_scratch_lifetime_buffers
+                if not runtime_uses_lifetime_leases:
+                    use_symm_combine_out = False
+                    use_symm_combine_gather = False
+                lease_dispatch_out = runtime_uses_lifetime_leases
+                lease_combine_out = use_symm_combine_out and runtime_uses_lifetime_leases
+                lease_combine_gather = use_symm_combine_gather and runtime_uses_lifetime_leases
+                slot_indices = range(block.ep_no_sync_shared_slots) if self.tbo else (None,)
+                for slot_idx in slot_indices:
+                    get_ep_no_sync_buffers(
+                        block,
+                        dispatch_in_cap=num_out_tokens,
+                        dispatch_out_cap=rank_capacity,
+                        combine_in_cap=rank_capacity,
+                        combine_out_cap=prewarm_local_microbatch_size,
+                        d_model=d_model,
+                        dtype=dtype,
+                        device=device,
+                        slot_idx=slot_idx,
+                        need_dispatch_in=use_symm_dispatch_in,
+                        need_dispatch_meta=False,
+                        need_dispatch_out=(not use_rowwise_fp8) and not lease_dispatch_out,
+                        need_combine_in=not use_rowwise_fp8,
+                        need_combine_meta=False,
+                        need_combine_out=use_symm_combine_out and not lease_combine_out,
+                        need_combine_gather=use_symm_combine_gather and not lease_combine_gather,
+                        combine_gather_cap=prewarm_local_microbatch_size,
+                        combine_gather_top_k=top_k,
+                    )
+                prewarm_ep_no_sync_rowwise_lifetime_leases(
+                    block,
+                    dispatch_out_cap=rank_capacity,
+                    combine_out_cap=prewarm_local_microbatch_size,
+                    combine_gather_cap=prewarm_local_microbatch_size,
+                    combine_gather_top_k=top_k,
+                    d_model=d_model,
+                    dtype=dtype,
+                    device=device,
+                    use_rowwise_fp8=use_rowwise_fp8,
+                    block_size=(rowwise_fp8_cfg.block_size if rowwise_fp8_cfg is not None else 0),
+                    need_dispatch_out=lease_dispatch_out,
+                    need_combine_out=lease_combine_out,
+                    need_combine_gather=lease_combine_gather,
+                    num_slots=rowwise_lifetime_lease_slots,
+                )
+                if use_rowwise_fp8:
+                    assert rowwise_fp8_cfg is not None
+                    rowwise_fp8_cfg.assert_runtime_supported()
+                    get_ep_no_sync_rowwise_fp8_buffers(
+                        block,
+                        dispatch_out_cap=rank_capacity,
+                        combine_in_cap=rank_capacity,
+                        d_model=d_model,
+                        block_size=rowwise_fp8_cfg.block_size,
+                        device=device,
+                        need_dispatch_out=not lease_dispatch_out,
+                    )
+            else:
+                get_ep_no_sync_buffers(
+                    block,
+                    dispatch_in_cap=num_out_tokens,
+                    dispatch_out_cap=rank_capacity,
+                    combine_in_cap=rank_capacity,
+                    combine_out_cap=num_out_tokens,
+                    d_model=d_model,
+                    dtype=dtype,
+                    device=device,
+                )
+
+        # Dummy padding keeps the symmetric allocation sequence aligned in older
+        # single-world designs where different PP stages had different local MoE
+        # block counts. In the current per-model-part prewarm path this should
+        # usually be zero.
+        pad_count = pad_to_block_count - len(ep_blocks)
+        if pad_count < 0:
+            raise RuntimeError(
+                f"pad_to_block_count ({pad_to_block_count}) is smaller than local EP no-sync block count ({len(ep_blocks)})"
+            )
+        if pad_count:
+            torch_symm_mem: Any = None
+            if not olmo_symm_mem.is_enabled():
+                try:
+                    import torch.distributed._symmetric_memory as _torch_symm_mem
+                except ImportError as e:
+                    raise RuntimeError(
+                        "EP no-sync requires torch.distributed._symmetric_memory"
+                    ) from e
+                torch_symm_mem = _torch_symm_mem
+            for _ in range(pad_count):
+                if olmo_symm_mem.is_enabled():
+                    tensor = olmo_symm_mem.empty(
+                        (rank_capacity, d_model),
+                        dtype=dtype,
+                        device=device,
+                        group=first_block.ep_pg,
+                    )
+                    olmo_symm_mem.rendezvous(tensor, group=first_block.ep_pg)
+                else:
+                    assert torch_symm_mem is not None
+                    tensor = torch_symm_mem.empty(
+                        (rank_capacity, d_model),
+                        dtype=dtype,
+                        device=device,
+                    )
+                    torch_symm_mem.rendezvous(tensor, group=first_block.ep_pg)
+                self._ep_no_sync_dummy_symm_tensors.append(tensor)
+
+    # NOTE: shadowed by the real `apply_ep` defined below; kept commented for reference.
+    # def apply_ep(self, ep_mesh: DeviceMesh, **kwargs):
+    #     raise OLMoConfigurationError("Do not use `apply_ep`, use `apply_epdp` instead.")
+
+    def apply_compile(self):
+        super().apply_compile()
+        self._tbo_last_step = torch.compile(self._tbo_last_step)  # type: ignore[method-assign]
+        self.forward_embed = torch.compile(self.forward_embed)  # type: ignore[method-assign]
+        # self._forward_blocks = torch.compile(self._forward_blocks)
+
+    def apply_ddp(
+        self,
+        dp_mesh: Optional[DeviceMesh] = None,
+        param_dtype: Optional[torch.dtype] = None,
+        compile_enabled: bool = False,
+        autograd_compile_enabled: bool = False,
+    ):
+        assert False, "apply_ddp is deprecated"
+        """
+        Apply DDP to the model.
+        """
+
+        # Cast model explicitly to the specified dtype before applying DDP
+        target_dtype = param_dtype or self.dtype
+        if target_dtype != self.dtype:
+            self.to(dtype=target_dtype)
+
+        # TODO: check if this is needed
+        # Adapted from
+        # https://github.com/pytorch/torchtitan/blob/90c889e972b56b9faadebbb78fc985dedc537ed9/torchtitan/parallelisms/parallelize_llama.py#L328
+        # if compile_enabled:
+        #     if autograd_compile_enabled:
+        #         torch._dynamo.config.optimize_ddp = "python_reducer_without_compiled_forward"  # type: ignore
+        #     else:
+        #         torch._dynamo.config.optimize_ddp = "ddp_optimizer"  # type: ignore
+
+        self.to(torch.bfloat16)  # HACK, need fix
+
+        replicate(
+            self,
+            device_mesh=dp_mesh,
+            bucket_cap_mb=100,
+            gradient_as_bucket_view=True,
+            #   mixed_precision=
+        )
+        # Some inputs need to be on CPU initially, but DDP will move everything to model's
+        # device if we don't hide it.
+        self.register_forward_pre_hook(_hide_cpu_inputs_from_torch, prepend=True, with_kwargs=True)
+        self.register_forward_pre_hook(
+            _unhide_cpu_inputs_from_torch, prepend=False, with_kwargs=True
+        )
+
+    def apply_ep(
+        self,
+        dp_mesh: DeviceMesh,
+        ep_mesh: DeviceMesh,
+        ep_mp_group: Optional[dist.ProcessGroup] = None,
+        param_dtype: Optional[torch.dtype] = None,
+        compile_enabled: bool = False,
+        autograd_compile_enabled: bool = False,
+        ep_no_sync_shared_pool: Optional["_NoSyncSymmSharedPool"] = None,
+    ) -> Optional["_NoSyncSymmSharedPool"]:
+        """
+        Apply EP to the model.
+        """
+        from .ep_no_sync_buffers import _NoSyncSymmSharedPool
+
+        shared_pool_to_return = ep_no_sync_shared_pool
+        ep_no_sync_blocks: List[MoEFusedV2TransformerBlock] = []
+        for block in self.blocks.values():
+            if not block.is_moe:
+                continue
+            block = cast(MoEFusedV2TransformerBlock, block)
+            # ep_mp_group is the optional high-priority NCCL group for
+            # synchronized EP collectives that should start promptly while shared
+            # experts run. It is intentionally not used by no-sync blocks.
+            # NVSHMEM symmetric-memory allocation bootstraps from c10d group
+            # metadata. The high-priority NCCL EP group works for small count
+            # collectives, but can hang inside symm_mem.empty() before the
+            # explicit EP rendezvous runs. Use the regular DeviceMesh EP group
+            # for no-sync blocks.
+            block.apply_ep(ep_mesh, ep_pg=None if block.ep_no_sync else ep_mp_group)
+            if block.ep_no_sync:
+                ep_no_sync_blocks.append(block)
+
+        if ep_no_sync_blocks:
+            slot_counts = {block.ep_no_sync_shared_slots for block in ep_no_sync_blocks}
+            if len(slot_counts) != 1:
+                raise OLMoConfigurationError(
+                    "All EP no-sync blocks must use the same ep_no_sync_shared_slots "
+                    f"value, got {sorted(slot_counts)}"
+                )
+            shared_slots = next(iter(slot_counts))
+            first_pg = ep_no_sync_blocks[0].ep_pg
+            if first_pg is None:
+                raise RuntimeError("EP no-sync block is missing ep_pg after apply_ep()")
+            shared_pool = shared_pool_to_return
+            if shared_pool is None:
+                shared_pool = _NoSyncSymmSharedPool(
+                    num_slots=shared_slots,
+                    group=first_pg,
+                )
+            else:
+                if shared_pool.num_slots != shared_slots:
+                    raise RuntimeError(
+                        "Cannot share EP no-sync symmetric scratch pool across model parts "
+                        f"with different slot counts: pool={shared_pool.num_slots}, "
+                        f"model_part={shared_slots}"
+                    )
+                if shared_pool.group is not first_pg:
+                    raise RuntimeError(
+                        "Cannot share EP no-sync symmetric scratch pool across model parts "
+                        "with different EP process groups"
+                    )
+            shared_pool_to_return = shared_pool
+            for block in ep_no_sync_blocks:
+                if block.ep_pg is not first_pg:
+                    raise RuntimeError(
+                        "All EP no-sync blocks in a model part must share the same ep_pg "
+                        f"(block={block.block_idx})"
+                    )
+                # Shared slots are transient scratch shared by model blocks.
+                # Payloads saved for backward must use lifetime leases unless
+                # checkpointing/recompute forces the rowwise path into scratch mode.
+                block._ep_no_sync_shared_pool = shared_pool
+                block._ep_no_sync_shared_slot = block.block_idx % shared_slots
+
+        self.ep_enabled = True
+        return shared_pool_to_return
+
+    def apply_dp(
+        self,
+        dp_mesh: DeviceMesh,
+        ep_mesh: Optional[DeviceMesh],
+        accumulate_grads_in_fp32: bool = True,
+        reduce_grads_in_fp32: bool = True,
+        bucket_cap_mb: Optional[int] = None,
+    ):
+        from olmo_core.nn.parallel.distributed import MultiGroupDistributedDataParallel
+
+        self._ep_modules = [
+            m for m in self.modules() if getattr(m, "_ep_sharded", False)
+        ]  # collect the ep sharded part based on `_ep_sharded` field (will be set to True in `apply_ep`)
+        ep_sharded_params = set()
+        for m in self._ep_modules:
+            for n, p in m.named_parameters():
+                ep_sharded_params.add(p)
+
+        # TODO(dtype): broad bf16 casting is a current MoE V2 shortcut. Replace
+        # this with explicit dtype ownership so FP8 state, optimizer main params,
+        # and normal model params are not coupled to a blanket module cast.
+        self.to(torch.bfloat16)
+        self.disable_mxfp8_expert_anchor_grads()
+
+        dp_group = dp_mesh.get_group()
+
+        if ep_mesh is None:
+            epdp_group = dp_group
+        else:
+            epdp_group = ep_mesh["ep_dp"].get_group()
+
+        def param_process_group_fn(name: str, param: torch.nn.Parameter):
+            # MoE params → EP_DP group
+            if param in ep_sharded_params:
+                return epdp_group
+
+            # Dense params → DP group
+            return dp_group
+
+        ddp_model = MultiGroupDistributedDataParallel(
+            module=self,
+            dim=0,  # for scatter/gather
+            init_sync=True,  # meta device
+            process_group=dp_mesh.get_group(),
+            param_process_group_fn=param_process_group_fn,
+            accumulate_grads_in_fp32=accumulate_grads_in_fp32,
+            reduce_grads_in_fp32=reduce_grads_in_fp32,
+            bucket_cap_mb=bucket_cap_mb,
+        )
+
+        from ...transformer.model import (
+            _hide_cpu_inputs_from_torch,
+            _unhide_cpu_inputs_from_torch,
+        )
+
+        ddp_model.register_forward_pre_hook(
+            _hide_cpu_inputs_from_torch, prepend=True, with_kwargs=True
+        )
+        ddp_model.register_forward_pre_hook(
+            _unhide_cpu_inputs_from_torch, prepend=False, with_kwargs=True
+        )
+
+        return ddp_model
+
+    def prepare_experts_for_fsdp(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        raise OLMoConfigurationError(
+            "prepare_experts_for_fsdp is not supported for MoEFusedV2Transformer. "
+            "Use prepare_experts_for_ddp instead."
+        )
+
+    def prepare_experts_for_ddp(self, world_mesh: DeviceMesh):
+        for block in self.blocks.values():
+            if not block.is_moe:
+                continue
+            pass  # TODO: Anything to do here?
+
+    def post_batch(self, dry_run: bool = False):
+        for block in self.blocks.values():
+            if not block.is_moe:
+                continue
+            block = cast(MoEFusedV2TransformerBlock, block)
+            block.post_batch(dry_run=dry_run)
+
+    @torch.no_grad()
+    def init_weights(
+        self,
+        *,
+        max_seq_len: Optional[int] = None,
+        max_local_microbatch_size: Optional[int] = None,
+        device: Optional[torch.device] = None,
+        world_mesh: Dict[str, Optional[DeviceMesh]],
+        model_part_idx: int = 0,
+    ) -> torch.Generator:
+        from olmo_core.nn.attention import Attention, FusedAttention
+
+        from .block import MoEFusedV2TransformerBlock
+
+        """
+        Initialize the model weights.
+
+        :param max_seq_len: The maximum sequence length expected. This is used
+            to warm up the RoPE cache.
+        :param max_local_microbatch_size: The maximum local (rank) micro-batch size (in tokens)
+            expected. This is used to warm-up some MoE cache.
+        :param device: The device the local copy of the model will be trained on.
+        """
+        device = device or self.device
+        # params = list(self.parameters())
+        # TODO(dtype): materialization currently relies on the same broad bf16
+        # cast as apply_dp(); replace with an explicit precision policy.
+        self.to(torch.bfloat16)
+        self.to_empty(device=device)
+        # new_params = list(self.parameters())
+        for name, module in self.named_modules():
+            if hasattr(module, "reset_parameters"):  # TODO: what's the point of this
+                module.reset_parameters()  # type: ignore
+                # log.info(f"'{name}' called reset_parameters()")
+
+        seed = self.init_seed
+
+        # adjust seed for PP, including
+        # 1. PP stage
+        # 2. model part within the PP stage (eg, interleaved 1F1B)
+        if self.pp_enabled:
+            assert world_mesh["dense"] is not None
+            seed += get_pp_mesh(world_mesh["dense"]).get_local_rank()
+            seed += model_part_idx * 997  # random prime
+
+        # adjust seed for EP_MP, different EP shards should have different init values
+        # but within the same EP_DP group, they should share the same init value
+        ep_generator = None
+        if self.ep_enabled:
+            assert world_mesh["moe"]
+            ep_mp_rank = world_mesh["moe"]["ep_mp"].get_local_rank()
+            ep_seed = (
+                seed + (1 + ep_mp_rank) * 653
+            )  # random prime; +1 so that it will never be the same as the base seed
+            ep_generator = torch.Generator(device).manual_seed(ep_seed)
+
+        generator = torch.Generator(device).manual_seed(seed)
+
+        if self.embeddings is not None:
+            self.init_method.init_embeddings(
+                self.embeddings,
+                d_model=self.d_model,
+                embed_scale=self.embed_scale,
+                std=self.embedding_init_std
+                if self.embedding_init_std is not None
+                else self.init_std,
+                generator=generator,
+            )
+
+        for block in self.blocks.values():
+            # This might fail if it's wrapped.
+            if isinstance(block, MoEFusedV2TransformerBlock):
+                block = cast(MoEFusedV2TransformerBlock, block)
+
+                # v2 MoE blocks.
+                att = cast(Union[Attention, FusedAttention], block.attention)
+
+                # Attention weights.
+                self.init_method.init_attention(
+                    att,
+                    d_model=self.d_model,
+                    block_idx=block.block_idx,
+                    num_blocks=self.n_layers,
+                    std=self.init_std,
+                    generator=generator,
+                )
+                # MoE weights.
+                self.init_method.init_moe_v2(
+                    block,
+                    d_model=self.d_model,
+                    block_idx=block.block_idx,
+                    num_blocks=self.n_layers,
+                    std=self.init_std,
+                    generator=generator,
+                    ep_generator=ep_generator,
+                )
+
+            else:
+                # usually this is for the first dense layer
+                from ...transformer.block import TransformerBlock
+
+                block = cast(TransformerBlock, block)
+                att = cast(Union[Attention, FusedAttention], block.attention)
+
+                # Attention weights.
+                self.init_method.init_attention(
+                    att,
+                    d_model=self.d_model,
+                    block_idx=block.block_idx,
+                    num_blocks=self.n_layers,
+                    std=self.init_std,
+                    generator=generator,
+                )
+
+                # Feed-forward weights.
+                if hasattr(block, "feed_forward"):
+                    self.init_method.init_feed_forward(
+                        block.feed_forward,
+                        d_model=self.d_model,
+                        block_idx=block.block_idx,
+                        num_blocks=self.n_layers,
+                        std=self.init_std,
+                        generator=generator,
+                    )
+
+                # MoE weights.
+                if hasattr(block, "feed_forward_moe"):
+                    raise OLMoConfigurationError("Do not use the old MoE block")
+
+            # Warm up RoPE cache for attention-like sequence mixers. Recurrent
+            # mixers such as GDN do not have RoPE.
+            rope = getattr(att, "rope", None)
+            if max_seq_len is not None and rope is not None:
+                rope.warmup_cache(max_seq_len, device)
+
+        if self.lm_head is not None:
+            self.init_method.init_final_w_out(
+                self.lm_head.w_out, d_model=self.d_model, std=self.init_std, generator=generator
+            )
+        # get one next int from the generator
+        # if everything goes right, all ranks should have the same next int
+        # valid_test = (
+        #     torch.randint(0, 1000000, (1,), generator=generator, device=device).cpu().item()
+        # )  # attach debugger to check
+
+        # call lazy_init to make sure params has the _mp_param and _fp_param fields
+        # replicate.state(self).lazy_init()
+        # for ep_module in self._ep_modules:
+        #     replicate.state(ep_module).lazy_init()
+
+        return generator
+
+    def attach_fp32_accum(self):
+        self.has_grad_accum_fp32_buffer = True
+        for p in self.parameters():
+            if not p.requires_grad:
+                continue
+            # persistent FP32 master grad on the same device
+            p._main_grad_fp32 = None  # type: ignore[attr-defined]
+
+            p.register_post_accumulate_grad_hook(_fp32_post_grad_acc_hook)
+
+    def set_main_grads_to_none(self):
+        for p in self.parameters():
+            if not p.requires_grad:
+                continue
+            if hasattr(p, "_main_grad_fp32"):
+                p._main_grad_fp32 = None  # type: ignore[attr-defined]
+        for _, weight in self.named_fp8_weight_stores():
+            weight.set_main_grad_to_none()
+
+    def forward_tbo(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        labels: Optional[torch.Tensor] = None,
+        ignore_index: int = -100,
+        loss_reduction: Literal["mean", "sum", "none"] = "mean",
+        z_loss_multiplier: Optional[float] = None,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        return_logits: Optional[bool] = None,
+        **kwargs,
+    ) -> Union[torch.Tensor, LMOutputWithLoss]:
+        assert self.ep_enabled, "TBO requires EP to be enabled."
+
+        (
+            input_ids,
+            labels,
+            all_block_kwargs,
+            per_block_kwargs,
+            lm_head_kwargs,
+        ) = self._prepare_inputs(
+            input_ids,
+            labels,
+            ignore_index=ignore_index,
+            loss_reduction=loss_reduction,
+            z_loss_multiplier=z_loss_multiplier,
+            loss_div_factor=loss_div_factor,
+            return_logits=return_logits,
+            **kwargs,
+        )
+        assert input_ids.size(0) % 2 == 0, "When TBO is enabled, the batch size must be even."
+
+        # Get embeddings but pass-through for non-existent layers to allow easy
+        # pipeline parallel configuration.
+        h = self.embeddings(input_ids) if self.embeddings is not None else input_ids
+        if self.embeddings is not None and self.embed_scale is not None:
+            h = h * self.embed_scale
+        if self.embedding_norm is not None:
+            h = self.embedding_norm(h)
+
+        # can only check this in every forward.
+        # We cannot put this in __init__ because of PP might change model layers.
+        first_moe_idx = self._check_tbo_requirements()
+
+        # forward dense blocks
+        for block_idx, (block_key, block) in enumerate(self.blocks.items()):
+            if block.is_moe:
+                assert (
+                    first_moe_idx == block_idx
+                ), f"first_moe_idx {first_moe_idx}, block_idx {block_idx}, block.block_idx {block.block_idx}"
+                break
+            # Mark sizes as dynamic for torch.compile().
+            if self.compile_enabled:
+                mark_dynamic(h, (0, 1), strict=False)
+            with nvtx.annotate(f"fwd_block_{block_idx}", color="blue"):
+                # with self.offload_context:
+                one_block_kwargs = per_block_kwargs.get(block_key, {})
+                if self.checkpoint_tbo_dense_layers:
+                    h = checkpoint(
+                        block,
+                        h,
+                        use_reentrant=False,
+                        **one_block_kwargs,
+                    )
+                    h = cast(torch.Tensor, h)
+                else:
+                    h = block(h, **all_block_kwargs, **one_block_kwargs)
+
+            # commit cpu offload
+            # if torch.is_grad_enabled() and self.offload_sync_func is not None:
+            #     h = self.offload_sync_func(h)
+            #     h = cast(torch.Tensor, h)
+
+        # forward moe blocks with TBO
+        x0, x1 = h.chunk(2, dim=0)  # assume even batch size
+        labels0, labels1 = None, None
+        if labels is not None:
+            labels0, labels1 = labels.chunk(2, dim=0)
+            del labels
+        del h
+        # Mark sizes as dynamic for torch.compile().
+        if self.compile_enabled:
+            mark_dynamic(x0, (0, 1), strict=False)
+            mark_dynamic(x1, (0, 1), strict=False)
+        x1_is_fresh = True  # x1 is always fresh in the beginning
+        x1_ctx: object = {
+            "x1": x1,
+        }
+        for block_idx, block in enumerate(self.blocks.values()):
+            # skip dense blocks
+            if not block.is_moe:
+                continue
+
+            with nvtx.annotate(f"fwd_block_{block_idx}", color="blue"):
+                block = cast(MoEFusedV2TransformerBlock, block)
+                # with self.offload_context:
+                # x0, x1_ctx = block.checkpointed_combined_forward_ep_tbo(x0, x1_ctx, x1_is_fresh, **block_kwargs)
+                x0, x1_ctx = block.combined_forward_ep_tbo(
+                    x0, x1_ctx, x1_is_fresh, **all_block_kwargs
+                )
+                x1_is_fresh = False  # after the first TBO block, x1 is no longer fresh
+
+            # if torch.is_grad_enabled() and self.offload_sync_func is not None:
+            #     x0 = self.offload_sync_func(x0)
+            #     x0 = cast(torch.Tensor, x0)
+
+        # finish x1 last steps
+        h0, h1 = self._tbo_last_step(x0, x1_ctx, lm_head_kwargs, labels0, labels1)
+
+        return self._merge_tbo_outputs(h0, h1, loss_reduction=loss_reduction)
+
+    # @torch.compile
+    def _tbo_last_step(
+        self,
+        x0,
+        x1_ctx: object,
+        lm_head_kwargs: Dict[str, Any],
+        labels0: Optional[torch.Tensor],
+        labels1: Optional[torch.Tensor],
+    ):
+        from .ep_no_sync_tbo_1d import (
+            _NoSyncTboPendingContext,
+            ep_no_sync_stage_c_launch,
+            ep_no_sync_stage_tail,
+        )
+        from .ep_no_sync_tbo_rowwise import (
+            _NoSyncRowwiseTboPendingContext,
+            ep_no_sync_rowwise_tbo_stage_c_launch,
+            ep_no_sync_rowwise_tbo_stage_tail,
+        )
+
+        if isinstance(x1_ctx, _NoSyncRowwiseTboPendingContext):
+            with nvtx.annotate("TBO-1", color="orange"):
+                pending_ctx = ep_no_sync_rowwise_tbo_stage_c_launch(x1_ctx.block, x1_ctx)
+
+            h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
+
+            with nvtx.annotate("TBO-1", color="orange"):
+                x1 = ep_no_sync_rowwise_tbo_stage_tail(x1_ctx.block, pending_ctx)
+
+            h1 = self.maybe_forward_lm_head(x1, lm_head_kwargs, labels=labels1)
+            return h0, h1
+
+        if isinstance(x1_ctx, _NoSyncTboPendingContext):
+            with nvtx.annotate("TBO-1", color="orange"):
+                pending_ctx_1d = ep_no_sync_stage_c_launch(x1_ctx.block, x1_ctx)
+
+            h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
+
+            with nvtx.annotate("TBO-1", color="orange"):
+                x1 = ep_no_sync_stage_tail(x1_ctx.block, pending_ctx_1d)
+
+            h1 = self.maybe_forward_lm_head(x1, lm_head_kwargs, labels=labels1)
+            return h0, h1
+
+        if not isinstance(x1_ctx, SyncedTboPendingContext):
+            raise RuntimeError(
+                "Expected synced TBO context for the final TBO step, " f"got type={type(x1_ctx)}"
+            )
+        with nvtx.annotate("TBO-1", color="orange"):
+            global_x1 = x1_ctx.global_x
+            send_counts1 = x1_ctx.send_counts
+            recv_counts1 = x1_ctx.recv_counts
+            last_block = x1_ctx.last_block
+
+            assert last_block.routed_experts_router is not None
+            # finish reverse all2all and other ops for x1
+            with nvtx.annotate("reverse_all_to_all", color="green"):
+                global_x1 = cast(torch.Tensor, global_x1)
+                # Async all-to-all disabled; use the equivalent synchronous all-to-all.
+                # global_x1, local_x1, local_x_handle1 = ops.all_to_all_async(
+                #     global_x1,
+                #     send_counts1,
+                #     recv_counts1,
+                #     group=last_block.ep_pg,
+                # )
+                local_x1, _ = ops.all_to_all(
+                    global_x1,
+                    send_counts1,
+                    recv_counts1,
+                    group=last_block.ep_pg,
+                )
+
+            reversed_local_x_permutation_mapping1 = x1_ctx.reversed_local_x_permutation_mapping
+            local_x_global_routed_expert_weights1 = x1_ctx.local_x_global_routed_expert_weights
+            hidden_shape_before_permute1 = x1_ctx.hidden_shape_before_permute
+            in_shape1 = x1_ctx.in_shape
+            mixed_shared_out1 = x1_ctx.mixed_shared_out
+            attn_res_out1 = x1_ctx.attn_res_out
+
+            assert last_block is not None
+            assert last_block.routed_experts_router is not None
+
+        # x0 lm head
+        h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
+
+        with nvtx.annotate("TBO-1", color="orange"):
+            # local_x1 = ops.all_to_all_wait(global_x1, local_x1, local_x_handle1)
+
+            ## 9. Unpermute the (local) tokens returned by all-to-all communication ##
+            with nvtx.annotate("Unpermute-Merge local tokens", color="green"):
+                local_x1 = moe_unpermute_no_compile(
+                    inp=local_x1,
+                    row_id_map=reversed_local_x_permutation_mapping1,
+                    merging_probs=local_x_global_routed_expert_weights1.view(
+                        -1, last_block.routed_experts_router.top_k
+                    ),
+                    restore_shape=hidden_shape_before_permute1,
+                    map_type="index",
+                )
+            ## end
+
+            local_x1 = local_x1.view(in_shape1)
+
+            mlp_out1 = last_block._merge_routed_and_shared(local_x1, mixed_shared_out1)
+
+            x1 = attn_res_out1 + last_block.feed_forward_norm(mlp_out1)
+
+        # Get final logits but again pass-through in case of pipeline parallelism.
+        h1 = self.maybe_forward_lm_head(x1, lm_head_kwargs, labels=labels1)
+
+        return h0, h1
+
+    def _merge_tbo_outputs(
+        self,
+        h0: Union[torch.Tensor, LMOutputWithLoss],
+        h1: Union[torch.Tensor, LMOutputWithLoss],
+        *,
+        loss_reduction: Literal["mean", "sum", "none"],
+    ) -> Union[torch.Tensor, LMOutputWithLoss]:
+        if isinstance(h0, torch.Tensor):
+            if not isinstance(h1, torch.Tensor):
+                raise RuntimeError(f"TBO output type mismatch: {type(h0)} vs {type(h1)}")
+            return torch.cat([h0, h1], dim=0)
+
+        if not isinstance(h1, LMOutputWithLoss):
+            raise RuntimeError(f"TBO output type mismatch: {type(h0)} vs {type(h1)}")
+
+        logits: Optional[torch.Tensor]
+        if h0.logits is None:
+            logits = None
+        else:
+            if h1.logits is None:
+                raise RuntimeError(
+                    "TBO output type mismatch: first half has logits, second half does not"
+                )
+            logits = torch.cat([h0.logits, h1.logits], dim=0)
+
+        def merge_loss(
+            lhs: Optional[torch.Tensor],
+            rhs: Optional[torch.Tensor],
+        ) -> Optional[torch.Tensor]:
+            if lhs is None:
+                if rhs is not None:
+                    raise RuntimeError(
+                        "TBO output type mismatch: first half loss is None, second half is not"
+                    )
+                return None
+            if rhs is None:
+                raise RuntimeError(
+                    "TBO output type mismatch: first half loss is set, second half is None"
+                )
+            if loss_reduction == "none":
+                return torch.cat([lhs, rhs], dim=0)
+            if loss_reduction == "mean":
+                return (lhs + rhs) * 0.5
+            if loss_reduction == "sum":
+                return lhs + rhs
+            raise NotImplementedError(loss_reduction)
+
+        loss = merge_loss(h0.loss, h1.loss)
+        ce_loss = merge_loss(h0.ce_loss, h1.ce_loss)
+        z_loss = merge_loss(h0.z_loss, h1.z_loss)
+        assert loss is not None
+        assert ce_loss is not None
+        return LMOutputWithLoss(
+            logits=logits,
+            loss=loss,
+            ce_loss=ce_loss,
+            z_loss=z_loss,
+        )
+
+    def maybe_forward_lm_head(
+        self,
+        x: torch.Tensor,
+        lm_head_kwargs: Dict[str, Any],
+        labels: Optional[torch.Tensor] = None,
+    ):
+        if self.lm_head is not None:
+            if self.compile_enabled:
+                mark_dynamic(x, (0, 1), strict=False)
+                if labels is not None:
+                    mark_dynamic(labels, (0, 1), strict=False)
+            # NOTE: When TP is active we can't pass 'labels=None' or the hook from 'PrepareModuleInput'
+            # will throw an exception.
+            if labels is not None:
+                lm_head_kwargs["labels"] = labels
+            h0 = self.lm_head(x, **lm_head_kwargs)
+        else:
+            h0 = x
+        return h0
+
+    def _forward_blocks(
+        self, h, all_block_kwargs: Dict[str, Any], per_block_kwargs: Dict[Any, Dict[str, Any]]
+    ) -> torch.Tensor:
+        # Run each block.
+        for block_idx, (block_key, block) in enumerate(self.blocks.items()):
+            # Mark sizes as dynamic for torch.compile().
+            if self.compile_enabled:
+                mark_dynamic(h, (0, 1), strict=False)
+            with nvtx.annotate(f"fwd_block_{block_key}", color="blue"):
+                block_kwargs = per_block_kwargs.get(block_key, {})
+                combined_kwargs = {**all_block_kwargs, **block_kwargs}
+                do_not_recompute: List[int] = []  # HACK
+                if (self.recompute_each_block and (block_idx not in do_not_recompute)) or (
+                    self.recompute_block_keys and block_key in self.recompute_block_keys
+                ):
+                    h = checkpoint(
+                        self._forwrad_one_block,
+                        h,
+                        block_key,
+                        combined_kwargs,
+                        use_reentrant=False,
+                        context_fn=(
+                            noop_context_fn if self.compile_enabled else recompute_context_fn
+                        ),
+                        # determinism_check='none',
+                    )
+                    h = cast(torch.Tensor, h)
+                else:
+                    h = self._forwrad_one_block(h, block_key, combined_kwargs)
+
+        return h
+
+    def _forwrad_one_block(self, h, block_key: str, block_kwargs: Dict[str, Any]) -> torch.Tensor:
+        block = self.blocks[block_key]
+        h = block(h, **block_kwargs)
+        return h
+
+    def forward_embed(self, input_ids: torch.Tensor) -> torch.Tensor:
+        # Get embeddings but pass-through for non-existent layers to allow easy
+        # pipeline parallel configuration.
+        h = self.embeddings(input_ids) if self.embeddings is not None else input_ids
+        if self.embeddings is not None and self.embed_scale is not None:
+            h = h * self.embed_scale
+        if self.embedding_norm is not None:
+            assert (
+                self.embeddings is not None
+            )  # PP does not have embedding, should not have embedding norm either
+            h = self.embedding_norm(h)
+        return h
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        labels: Optional[torch.Tensor] = None,
+        ignore_index: int = -100,
+        loss_reduction: Literal["mean", "sum", "none"] = "mean",
+        z_loss_multiplier: Optional[float] = None,
+        loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        return_logits: Optional[bool] = None,
+        **kwargs,
+    ) -> Union[torch.Tensor, LMOutputWithLoss]:
+        """
+        Run the transformer on the token input IDs.
+
+        :param input_ids: The token input IDs, shape ``(batch_size, seq_len)``.
+
+        :returns: The logits if ``labels`` is ``None`` or the losses if ``labels`` is not ``None``.
+        """
+        if self.tbo:
+            return self.forward_tbo(
+                input_ids,
+                labels=labels,
+                ignore_index=ignore_index,
+                loss_reduction=loss_reduction,
+                z_loss_multiplier=z_loss_multiplier,
+                loss_div_factor=loss_div_factor,
+                return_logits=return_logits,
+                **kwargs,
+            )
+
+        (
+            input_ids,
+            labels,
+            all_block_kwargs,
+            per_block_kwargs,
+            lm_head_kwargs,
+        ) = self._prepare_inputs(
+            input_ids,
+            labels,
+            ignore_index=ignore_index,
+            loss_reduction=loss_reduction,
+            z_loss_multiplier=z_loss_multiplier,
+            loss_div_factor=loss_div_factor,
+            return_logits=return_logits,
+            **kwargs,
+        )
+
+        h = self.forward_embed(input_ids)
+
+        if self.recompute_all_blocks_by_chunk:
+            h = checkpoint(
+                self._forward_blocks,
+                h,
+                all_block_kwargs,
+                per_block_kwargs,
+                use_reentrant=False,
+                context_fn=(noop_context_fn if self.compile_enabled else recompute_context_fn),
+            )
+            h = cast(torch.Tensor, h)
+        else:
+            h = self._forward_blocks(h, all_block_kwargs, per_block_kwargs)
+
+        # Get final logits but again pass-through in case of pipeline parallelism.
+        if self.lm_head is not None:
+            if self.compile_enabled:
+                mark_dynamic(h, (0, 1), strict=False)
+                if labels is not None:
+                    mark_dynamic(labels, (0, 1), strict=False)
+            # NOTE: When TP is active we can't pass 'labels=None' or the hook from 'PrepareModuleInput'
+            # will throw an exception.
+            if labels is not None:
+                lm_head_kwargs["labels"] = labels
+
+            with nvtx.annotate("lm_head", color="purple"):
+                out = self.lm_head(h, **lm_head_kwargs)
+
+            # check for nan
+            # if torch.isnan(out.loss).any():
+            #     print('nan')
+
+        else:
+            out = h
+        return out
+
+
+def _hide_cpu_inputs_from_torch(m, args, kwargs) -> Optional[Tuple[Any, Dict[str, Any]]]:
+    del m
+    # Keep CPU-only metadata out of wrappers/hooks that assume every tensor kwarg
+    # belongs on the module device. This came from composable-DDP/FSDP-era
+    # behavior; revalidate under MultiGroupDDP before removing it.
+    if (doc_lens := kwargs.get("doc_lens")) is not None:
+        kwargs["doc_lens"] = hide_from_torch(doc_lens)
+    return (args, kwargs)
+
+
+def _unhide_cpu_inputs_from_torch(m, args, kwargs) -> Optional[Tuple[Any, Dict[str, Any]]]:
+    del m
+    if (doc_lens := kwargs.get("doc_lens")) is not None:
+        kwargs["doc_lens"] = unhide_from_torch(doc_lens)
+    return (args, kwargs)

--- a/src/olmo_core/nn/moe/v2/model.py
+++ b/src/olmo_core/nn/moe/v2/model.py
@@ -12,7 +12,11 @@ from typing import (
     cast,
 )
 
-import nvtx
+try:
+    import nvtx
+except ImportError:
+    from olmo_core._nvtx import nvtx
+
 import torch
 import torch.distributed as dist
 from torch.distributed._composable.replicate import replicate
@@ -719,7 +723,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
         max_seq_len: Optional[int] = None,
         max_local_microbatch_size: Optional[int] = None,
         device: Optional[torch.device] = None,
-        world_mesh: Dict[str, Optional[DeviceMesh]],
+        world_mesh: Optional[Dict[str, Optional[DeviceMesh]]] = None,
         model_part_idx: int = 0,
     ) -> torch.Generator:
         from olmo_core.nn.attention import Attention, FusedAttention
@@ -753,7 +757,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
         # 1. PP stage
         # 2. model part within the PP stage (eg, interleaved 1F1B)
         if self.pp_enabled:
-            assert world_mesh["dense"] is not None
+            assert world_mesh is not None and world_mesh["dense"] is not None
             seed += get_pp_mesh(world_mesh["dense"]).get_local_rank()
             seed += model_part_idx * 997  # random prime
 
@@ -761,7 +765,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
         # but within the same EP_DP group, they should share the same init value
         ep_generator = None
         if self.ep_enabled:
-            assert world_mesh["moe"]
+            assert world_mesh is not None and world_mesh["moe"] is not None
             ep_mp_rank = world_mesh["moe"]["ep_mp"].get_local_rank()
             ep_seed = (
                 seed + (1 + ep_mp_rank) * 653
@@ -847,10 +851,15 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             if max_seq_len is not None and rope is not None:
                 rope.warmup_cache(max_seq_len, device)
 
-        if self.lm_head is not None:
+        if self.lm_head is not None and not self.tie_word_embeddings:
             self.init_method.init_final_w_out(
                 self.lm_head.w_out, d_model=self.d_model, std=self.init_std, generator=generator
             )
+
+        # ``to_empty()`` above gives the embedding and LM-head weights fresh, independent storage,
+        # so re-establish weight tying by re-pointing the LM head at the embedding weight.
+        if self.tie_word_embeddings:
+            self._tie_weights()
         # get one next int from the generator
         # if everything goes right, all ranks should have the same next int
         # valid_test = (
@@ -939,7 +948,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
                 mark_dynamic(h, (0, 1), strict=False)
             with nvtx.annotate(f"fwd_block_{block_idx}", color="blue"):
                 # with self.offload_context:
-                one_block_kwargs = per_block_kwargs.get(block_key, {})
+                one_block_kwargs = per_block_kwargs.get(int(block_key), {})
                 if self.checkpoint_tbo_dense_layers:
                     h = checkpoint(
                         block,
@@ -1194,7 +1203,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             if self.compile_enabled:
                 mark_dynamic(h, (0, 1), strict=False)
             with nvtx.annotate(f"fwd_block_{block_key}", color="blue"):
-                block_kwargs = per_block_kwargs.get(block_key, {})
+                block_kwargs = per_block_kwargs.get(int(block_key), {})
                 combined_kwargs = {**all_block_kwargs, **block_kwargs}
                 do_not_recompute: List[int] = []  # HACK
                 if (self.recompute_each_block and (block_idx not in do_not_recompute)) or (

--- a/src/olmo_core/nn/moe/v2/model.py
+++ b/src/olmo_core/nn/moe/v2/model.py
@@ -106,8 +106,10 @@ def _fp32_post_grad_acc_hook(param: torch.Tensor):
 
 class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
     """
-    An MoE transformer implementation, to be used with one of the
-    :class:`MoETransformerBlock` block types.
+    A fused Mixture-of-Experts transformer, composed of
+    :class:`~olmo_core.nn.moe.v2.block.MoEFusedV2TransformerBlock` blocks (optionally preceded by
+    dense blocks). Built from a
+    :class:`~olmo_core.nn.transformer.config.MoEFusedV2TransformerConfig`.
     """
 
     def __init__(self, *args, **kwargs):
@@ -726,10 +728,6 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
         world_mesh: Optional[Dict[str, Optional[DeviceMesh]]] = None,
         model_part_idx: int = 0,
     ) -> torch.Generator:
-        from olmo_core.nn.attention import Attention, FusedAttention
-
-        from .block import MoEFusedV2TransformerBlock
-
         """
         Initialize the model weights.
 
@@ -739,6 +737,10 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             expected. This is used to warm-up some MoE cache.
         :param device: The device the local copy of the model will be trained on.
         """
+        from olmo_core.nn.attention import Attention, FusedAttention
+
+        from .block import MoEFusedV2TransformerBlock
+
         device = device or self.device
         # params = list(self.parameters())
         # TODO(dtype): materialization currently relies on the same broad bf16

--- a/src/olmo_core/nn/moe/v2/no_ep.py
+++ b/src/olmo_core/nn/moe/v2/no_ep.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Union, cast
+
+import nvtx
+import torch
+
+from ...moe.utils import async_copy_to_cpu, wait_stream_no_compile
+from ..utils import moe_permute_no_compile, moe_unpermute_no_compile
+from .routed_experts import requires_host_side_split_sizes
+
+if TYPE_CHECKING:
+    from .block import MoEFusedV2TransformerBlock
+
+
+def combined_forward_no_ep(
+    block: MoEFusedV2TransformerBlock,
+    x: torch.Tensor,
+    *,
+    loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+    **kwargs,
+) -> torch.Tensor:
+    """Forward function without expert parallelism."""
+    self = block
+    assert self.routed_experts is not None
+    assert self.routed_experts_router is not None
+
+    B, S, D = x.shape
+
+    block_inp = x
+    del x
+
+    attn_res_out = self._res_norm_attn(block_inp, **kwargs)
+    kwargs.pop("max_doc_len", None)
+    kwargs.pop("cu_doc_lens", None)
+    moe_inp = self._prepare_moe_input(attn_res_out)
+
+    (
+        local_x_global_routed_expert_weights,
+        local_x_global_routed_expert_indices,
+        local_batch_size_per_global_routed_expert,
+        routed_expert_router_aux_loss_info,
+    ) = self.routed_experts_router(
+        moe_inp,
+        False,
+        loss_div_factor=loss_div_factor,
+    )
+
+    if requires_host_side_split_sizes():
+        local_batch_size_per_global_routed_expert_cpu, copy_stream, dtoh_event = async_copy_to_cpu(
+            local_batch_size_per_global_routed_expert,
+            event=self._dtoh_event,
+        )
+    else:
+        dtoh_event = None
+        local_batch_size_per_global_routed_expert_cpu = None
+
+    if self.shared_experts_router:
+        (
+            local_x_global_shared_expert_weights,
+            _,
+            _,
+            _,
+        ) = self.shared_experts_router(
+            moe_inp,
+            True,
+            loss_div_factor=loss_div_factor,
+        )
+    else:
+        local_x_global_shared_expert_weights = None
+
+    in_shape = moe_inp.size()
+
+    mixed_shared_out = None
+    if self.shared_experts is not None:
+        wait_stream_no_compile(
+            this_stream=self.get_dense_stream(),
+            other_stream=torch.cuda.current_stream(),
+        )
+
+        with torch.cuda.stream(self.get_dense_stream()):
+            shared_out = self.shared_experts(moe_inp)
+            if self.shared_experts.num_experts == 1:
+                mixed_shared_out = shared_out.squeeze(0)
+            else:
+                assert local_x_global_shared_expert_weights is not None
+                _, _, E_s = local_x_global_shared_expert_weights.shape
+                mixed_shared_out = (
+                    torch.bmm(
+                        local_x_global_shared_expert_weights.to(shared_out.dtype).reshape(
+                            B * S, 1, E_s
+                        ),
+                        shared_out.permute(1, 2, 0, 3).contiguous().view(B * S, E_s, D),
+                    )
+                    .squeeze(1)
+                    .view(B, S, D)
+                )
+
+    moe_inp = moe_inp.view(-1, in_shape[-1])
+
+    routing_map = local_x_global_routed_expert_indices.view(
+        -1, self.routed_experts_router.top_k
+    ).int()
+    num_out_tokens = routing_map.size(0) * self.routed_experts_router.top_k
+    hidden_shape_before_permute = moe_inp.shape
+
+    with nvtx.annotate("Permute", color="green"):
+        permutated_input_tokens, reversed_input_permutation_mapping = moe_permute_no_compile(
+            inp=moe_inp,
+            routing_map=routing_map,
+            num_out_tokens=num_out_tokens,
+            map_type="index",
+        )
+
+    torch._dynamo.mark_dynamic(permutated_input_tokens, 0)
+
+    if requires_host_side_split_sizes():
+        assert dtoh_event is not None
+        dtoh_event = cast(torch.cuda.Event, dtoh_event)
+        dtoh_event.synchronize()
+        mlp_x = self.routed_experts(
+            permutated_input_tokens, local_batch_size_per_global_routed_expert_cpu
+        )
+    else:
+        mlp_x = self.routed_experts(
+            permutated_input_tokens, local_batch_size_per_global_routed_expert
+        )
+
+    with nvtx.annotate("Unpermute", color="green"):
+        unpermutated_x: torch.Tensor = moe_unpermute_no_compile(
+            inp=mlp_x,
+            row_id_map=reversed_input_permutation_mapping,
+            restore_shape=hidden_shape_before_permute,
+            map_type="index",
+            merging_probs=local_x_global_routed_expert_weights.view(
+                -1, self.routed_experts_router.top_k
+            ),
+        )
+
+    x_moe = unpermutated_x.view(in_shape)
+
+    wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
+
+    mlp_out = self._merge_routed_and_shared(x_moe, mixed_shared_out)
+
+    final_out = self._res_norm_mlp(attn_res_out, mlp_out)
+
+    return self._attach_routed_aux_loss(
+        final_out,
+        routed_expert_router_aux_loss_info,
+    )

--- a/src/olmo_core/nn/moe/v2/no_ep.py
+++ b/src/olmo_core/nn/moe/v2/no_ep.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union, cast
 
-import nvtx
 import torch
+
+try:
+    import nvtx
+except ImportError:
+    from olmo_core._nvtx import nvtx
 
 from ...moe.utils import async_copy_to_cpu, wait_stream_no_compile
 from ..utils import moe_permute_no_compile, moe_unpermute_no_compile

--- a/src/olmo_core/nn/moe/v2/tbo_state.py
+++ b/src/olmo_core/nn/moe/v2/tbo_state.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional
+
+import torch
+
+if TYPE_CHECKING:
+    from .block import MoEFusedV2TransformerBlock
+
+
+@dataclass
+class SyncedTboPendingContext:
+    global_x: torch.Tensor
+    send_counts: List[int]
+    recv_counts: List[int]
+    reversed_local_x_permutation_mapping: torch.Tensor
+    local_x_global_routed_expert_weights: torch.Tensor
+    hidden_shape_before_permute: torch.Size
+    in_shape: torch.Size
+    mixed_shared_out: Optional[torch.Tensor]
+    attn_res_out: torch.Tensor
+    last_block: MoEFusedV2TransformerBlock

--- a/src/olmo_core/nn/moe/v2/tbo_state.py
+++ b/src/olmo_core/nn/moe/v2/tbo_state.py
@@ -11,6 +11,12 @@ if TYPE_CHECKING:
 
 @dataclass
 class SyncedTboPendingContext:
+    """
+    Carries the in-flight state between the two stages of the synchronous expert-parallel
+    two-batch-overlap forward, so the second micro-batch's all-to-all can be launched while the
+    first micro-batch's tail (unpermute + combine) is still being computed.
+    """
+
     global_x: torch.Tensor
     send_counts: List[int]
     recv_counts: List[int]

--- a/src/olmo_core/nn/transformer/__init__.py
+++ b/src/olmo_core/nn/transformer/__init__.py
@@ -12,6 +12,7 @@ from .block import (
     TransformerBlockBase,
 )
 from .config import (
+    MoEFusedV2TransformerConfig,
     TransformerActivationCheckpointingMode,
     TransformerBlockConfig,
     TransformerBlockType,
@@ -25,6 +26,7 @@ from .model import MoETransformer, NormalizedTransformer, Transformer
 __all__ = [
     "TransformerType",
     "TransformerConfig",
+    "MoEFusedV2TransformerConfig",
     "Transformer",
     "NormalizedTransformer",
     "MoETransformer",

--- a/src/olmo_core/nn/transformer/config.py
+++ b/src/olmo_core/nn/transformer/config.py
@@ -96,6 +96,11 @@ class TransformerType(StrEnum):
     ➡️ :class:`MoETransformer`
     """
 
+    moe_fused_v2 = "moe_fused_v2"
+    """
+    ➡️ :class:`MoEFusedV2Transformer`
+    """
+
 
 class TransformerBlockType(StrEnum):
     """
@@ -145,6 +150,11 @@ class TransformerBlockType(StrEnum):
     moe_hybrid_reordered_norm = "moe_hybrid_reordered_norm"
     """
     ➡️ :class:`MoEHybridReorderedNormTransformerBlock`
+    """
+
+    moe_fused_v2 = "moe_fused_v2"
+    """
+    ➡️ :class:`MoEFusedV2TransformerBlock`
     """
 
 
@@ -257,6 +267,10 @@ class TransformerBlockConfig(ModuleConfig):
                 return MoEHybridTransformerBlock(**kwargs)
             elif self.name == TransformerBlockType.moe_hybrid_reordered_norm:
                 return MoEHybridReorderedNormTransformerBlock(**kwargs)
+            elif self.name == TransformerBlockType.moe_fused_v2:
+                from ..moe.v2.block import MoEFusedV2TransformerBlock
+
+                return MoEFusedV2TransformerBlock(**kwargs)
             else:
                 raise NotImplementedError(self.name)
         except TypeError as e:
@@ -424,6 +438,8 @@ class TransformerConfig(ModelConfig):
                 block_pattern=self.block_pattern,
                 tie_word_embeddings=self.tie_word_embeddings,
             )
+        elif self.name == TransformerType.moe_fused_v2:
+            raise RuntimeError("Use MoEFusedV2TransformerConfig")
         else:
             raise NotImplementedError(self.name)
 
@@ -2000,6 +2016,97 @@ class TransformerConfig(ModelConfig):
 
         new_config.block_overrides = overrides or None
         return new_config
+
+
+@dataclass
+class MoEFusedV2TransformerConfig(TransformerConfig):
+    """
+    A :class:`TransformerConfig` for the fused MoE-v2 model
+    (:class:`~olmo_core.nn.moe.v2.model.MoEFusedV2Transformer`).
+    """
+
+    two_batch_overlap: bool = False
+    """
+    Overlap compute with the all-to-all communication when expert parallelism is enabled by
+    splitting each micro-batch into two halves. The micro-batch size must be a multiple of 2.
+    """
+
+    recompute_all_blocks_by_chunk: bool = False
+    """
+    Recompute all blocks as a single chunk rather than per-layer. Reduces the activation memory
+    held in early pipeline-parallel stages; should not be used without pipeline parallelism as it
+    adds recomputation overhead for no benefit.
+    """
+
+    recompute_each_block: bool = True
+    """
+    Recompute each block individually. Keeps only one block's activations live at a time at the
+    cost of extra recomputation. Works with or without pipeline parallelism, but is incompatible
+    with :data:`two_batch_overlap`.
+    """
+
+    recompute_block_keys: Optional[List[str]] = None
+    """
+    Restrict block-level recomputation to the named submodules of each block.
+    """
+
+    def build(
+        self,
+        *,
+        init_device: str = "cpu",
+    ) -> "Transformer":
+        """
+        Build the model corresponding to this config.
+
+        :param init_device: The device to put the parameters on during initialization. In a
+            distributed setting it usually makes sense to set this to "meta".
+        """
+        from .model import Transformer
+
+        log.info(
+            f"Building transformer with {self.num_params:,d} total params, "
+            f"{self.num_non_embedding_params:,d} non-embedding params"
+        )
+        model: Transformer
+        if self.name == TransformerType.moe_fused_v2:
+            from ..moe.v2.model import MoEFusedV2Transformer
+
+            model = MoEFusedV2Transformer(
+                d_model=self.d_model,
+                vocab_size=self.vocab_size,
+                n_layers=self.n_layers,
+                block=self.block,
+                lm_head=self.lm_head,
+                dtype=self.dtype.as_pt(),
+                init_method=self.init_method,
+                init_device=init_device,
+                init_seed=self.init_seed,
+                init_std=self.init_std,
+                block_overrides=self.block_overrides,
+                two_batch_overlap=self.two_batch_overlap,
+                recompute_all_blocks_by_chunk=self.recompute_all_blocks_by_chunk,
+                recompute_each_block=self.recompute_each_block,
+                recompute_block_keys=self.recompute_block_keys,
+                embedding_norm=self.embedding_norm,
+                embedding_init_std=self.embedding_init_std,
+                embed_scale=self.embed_scale,
+                block_pattern=self.block_pattern,
+            )
+        else:
+            raise NotImplementedError(self.name)
+
+        if self.freeze_params:
+            for name, param in model.named_parameters():
+                for pattern in self.freeze_params:
+                    if fnmatch(name, pattern):
+                        param.requires_grad = False
+                        log.info(f"Param '{name}' will be frozen")
+                        break
+                else:
+                    log.info(f"Param '{name}' will be trainable")
+
+        log.info("%s", model)
+        return model
 
 
 def validate_block_resolution_config(

--- a/src/olmo_core/nn/transformer/config.py
+++ b/src/olmo_core/nn/transformer/config.py
@@ -2091,6 +2091,7 @@ class MoEFusedV2TransformerConfig(TransformerConfig):
                 embedding_init_std=self.embedding_init_std,
                 embed_scale=self.embed_scale,
                 block_pattern=self.block_pattern,
+                tie_word_embeddings=self.tie_word_embeddings,
             )
         else:
             raise NotImplementedError(self.name)

--- a/src/olmo_core/nn/transformer/init.py
+++ b/src/olmo_core/nn/transformer/init.py
@@ -252,3 +252,98 @@ class InitMethod(StrEnum):
             b=3 * std,
             generator=generator,
         )
+
+    def init_moe_v2(
+        self,
+        b,
+        *,
+        d_model: int,
+        block_idx: int,
+        num_blocks: int,
+        std: float = 0.02,
+        generator: Optional[torch.Generator] = None,
+        ep_generator: Optional[torch.Generator] = None,
+    ):
+        """
+        Initialize the weights of a :class:`~olmo_core.nn.moe.v2.block.MoEFusedV2TransformerBlock`.
+
+        :param ep_generator: An optional separate generator for expert-parallel-sharded weights
+            (the routed expert weights). Falls back to ``generator`` when expert parallelism is
+            not enabled.
+        """
+        from ..moe.v2.block import MoEFusedV2TransformerBlock
+
+        b = cast(MoEFusedV2TransformerBlock, b)
+        if self == InitMethod.llama:
+            std = std / (2 * num_blocks) ** 0.5
+        elif self == InitMethod.llama_depth:
+            std = std / (2 * (block_idx + 1)) ** 0.5
+
+        if ep_generator is None:
+            assert b.ep_enabled is False, "ep_generator should be provided when ep_enabled is True"
+            # Expert parallelism is not in use, so the routed expert weights are not sharded and
+            # can share the default generator.
+            ep_generator = generator
+
+        if b.shared_experts_router:
+            _apply_init(
+                nn.init.trunc_normal_,
+                b.shared_experts_router.weight,
+                mean=0.0,
+                std=std,
+                a=-3 * std,
+                b=3 * std,
+                generator=generator,
+            )
+        if b.routed_experts_router:
+            _apply_init(
+                nn.init.trunc_normal_,
+                b.routed_experts_router.weight,
+                mean=0.0,
+                std=std,
+                a=-3 * std,
+                b=3 * std,
+                generator=generator,
+            )
+
+        if b.routed_experts:
+            # The routed expert weights may be sharded across the expert-parallel mesh, so use the
+            # EP generator to keep initialization consistent across shards.
+            _apply_init(
+                nn.init.trunc_normal_,
+                b.routed_experts.w_up_gate,
+                mean=0.0,
+                std=std,
+                a=-3 * std,
+                b=3 * std,
+                generator=ep_generator,
+            )
+            _apply_init(
+                nn.init.trunc_normal_,
+                b.routed_experts.w_down,
+                mean=0.0,
+                std=std,
+                a=-3 * std,
+                b=3 * std,
+                generator=ep_generator,
+            )
+
+        if b.shared_experts:
+            _apply_init(
+                nn.init.trunc_normal_,
+                b.shared_experts.w_up_gate,
+                mean=0.0,
+                std=std,
+                a=-3 * std,
+                b=3 * std,
+                generator=generator,
+            )
+            _apply_init(
+                nn.init.trunc_normal_,
+                b.shared_experts.w_down,
+                mean=0.0,
+                std=std,
+                a=-3 * std,
+                b=3 * std,
+                generator=generator,
+            )

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -354,6 +354,19 @@ class Transformer(nn.Module):
                     generator=generator,
                 )
 
+            # Fused MoE-v2 weights.
+            from ..moe.v2.block import MoEFusedV2TransformerBlock
+
+            if isinstance(block, MoEFusedV2TransformerBlock):
+                self.init_method.init_moe_v2(
+                    block,
+                    d_model=self.d_model,
+                    block_idx=block.block_idx,
+                    num_blocks=self.n_layers,
+                    std=self.init_std,
+                    generator=generator,
+                )
+
             if isinstance(att, (Attention, FusedAttention)):
                 # Warm up attention backend cache.
                 if max_seq_len is not None and att.backend is not None:

--- a/src/test/nn/moe/v2/block_no_ep_test.py
+++ b/src/test/nn/moe/v2/block_no_ep_test.py
@@ -1,0 +1,218 @@
+import torch
+
+from olmo_core.config import DType
+from olmo_core.nn.attention import AttentionConfig, AttentionType
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.lm_head import LMHeadConfig
+from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.block import (
+    MoEFusedV2TransformerBlock,
+    MoEFusedV2TransformerBlockConfig,
+)
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.nn.transformer import (
+    MoEFusedV2TransformerConfig,
+    TransformerBlockType,
+    TransformerType,
+)
+from olmo_core.testing import requires_gpu, requires_grouped_gemm
+
+
+def test_v2_no_ep_module_names_importable():
+    """The no-EP core ships ``no_ep`` / ``checkpointing`` / ``tbo_state``; the EP families land later."""
+    from olmo_core.nn.moe.v2 import checkpointing, no_ep, tbo_state
+
+    assert hasattr(no_ep, "combined_forward_no_ep")
+    assert hasattr(checkpointing, "checkpoint_recompute_context_fn")
+    assert hasattr(tbo_state, "SyncedTboPendingContext")
+
+
+def _build_block(
+    *,
+    d_model: int = 512,
+    hidden_size: int = 1024,
+    num_experts: int = 4,
+    top_k: int = 1,
+    uniform_expert_assignment: bool = True,
+    init_device: str = "cuda",
+) -> MoEFusedV2TransformerBlock:
+    layer_norm = LayerNormConfig(
+        name=LayerNormType.rms,
+        eps=1e-6,
+        bias=False,
+        dtype=DType.float32,
+    )
+    return MoEFusedV2TransformerBlock(
+        d_model=d_model,
+        block_idx=0,
+        n_layers=1,
+        sequence_mixer=AttentionConfig(
+            name=AttentionType.default,
+            n_heads=2,
+            n_kv_heads=2,
+            bias=False,
+            use_flash=False,
+            dtype=DType.float32,
+        ),
+        attention_norm=layer_norm,
+        routed_experts_router=MoERouterConfigV2(
+            d_model=d_model,
+            num_experts=num_experts,
+            top_k=top_k,
+            gating_function=MoERouterGatingFunction.softmax,
+            uniform_expert_assignment=uniform_expert_assignment,
+            lb_loss_weight=None,
+            z_loss_weight=None,
+            dtype=DType.float32,
+        ),
+        shared_experts_router=None,
+        shared_experts=None,
+        routed_experts=RoutedExpertsConfig(
+            d_model=d_model,
+            hidden_size=hidden_size,
+            num_experts=num_experts,
+            bias=False,
+            dtype=DType.float32,
+        ),
+        feed_forward_norm=layer_norm,
+        ep_no_sync=False,
+        ep_no_sync_major_align=1,
+        init_device=init_device,
+    )
+
+
+def _init_block_params(block: MoEFusedV2TransformerBlock):
+    torch.manual_seed(1234)
+    with torch.no_grad():
+        for p in block.parameters():
+            if p.is_floating_point():
+                p.normal_(mean=0.0, std=0.02)
+
+
+def _install_forced_router(block: MoEFusedV2TransformerBlock):
+    """Force all tokens to expert 0 so the forward is deterministic and doesn't depend on routing."""
+
+    def _make_forced_forward(router):
+        def _forced_forward(local_x, scores_only, loss_div_factor=None):
+            del loss_div_factor
+            B, S, _ = local_x.shape
+            if scores_only:
+                return (
+                    torch.ones(
+                        B, S, router.num_experts, device=local_x.device, dtype=local_x.dtype
+                    ),
+                    None,
+                    None,
+                    None,
+                )
+
+            expert_weights = torch.ones(
+                B, S, router.top_k, device=local_x.device, dtype=local_x.dtype
+            )
+            expert_indices = torch.zeros(
+                B, S, router.top_k, device=local_x.device, dtype=torch.long
+            )
+            batch_size_per_expert = torch.zeros(
+                router.num_experts, device=local_x.device, dtype=torch.long
+            )
+            batch_size_per_expert[0] = B * S * router.top_k
+            return expert_weights, expert_indices, batch_size_per_expert, None
+
+        return _forced_forward
+
+    assert block.routed_experts_router is not None
+    block.routed_experts_router.forward = _make_forced_forward(block.routed_experts_router)
+    if block.shared_experts_router is not None:
+        block.shared_experts_router.forward = _make_forced_forward(block.shared_experts_router)
+
+
+@requires_gpu
+@requires_grouped_gemm
+def test_v2_no_ep_forward_backward_smoke():
+    block = _build_block(init_device="cuda")
+    _init_block_params(block)
+    _install_forced_router(block)
+    block.train()
+
+    x = torch.randn(1, 8, block.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    y = block(x)
+
+    assert y.shape == x.shape
+    assert torch.isfinite(y).all()
+
+    y.square().mean().backward()
+
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+    for p in block.parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all()
+
+
+@requires_gpu
+@requires_grouped_gemm
+def test_v2_no_ep_apply_compile_forward_smoke():
+    block = _build_block(
+        d_model=128,
+        hidden_size=256,
+        num_experts=4,
+        top_k=1,
+        init_device="cuda",
+    )
+    _init_block_params(block)
+    block.to(dtype=torch.bfloat16)
+    _install_forced_router(block)
+    block.train()
+    block.apply_compile()
+
+    x = torch.randn(1, 4, block.d_model, device="cuda", dtype=torch.bfloat16)
+    y = block(x)
+
+    assert y.shape == x.shape
+    assert torch.isfinite(y).all()
+
+
+def _build_model_config(*, d_model: int = 128, n_layers: int = 2) -> MoEFusedV2TransformerConfig:
+    dtype = DType.float32
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=dtype)
+    return MoEFusedV2TransformerConfig(
+        init_seed=0,
+        d_model=d_model,
+        recompute_each_block=False,
+        vocab_size=128,
+        n_layers=n_layers,
+        name=TransformerType.moe_fused_v2,
+        block=MoEFusedV2TransformerBlockConfig(
+            name=TransformerBlockType.moe_fused_v2,
+            attention=AttentionConfig(
+                name=AttentionType.default,
+                n_heads=4,
+                bias=False,
+                use_flash=False,
+                dtype=dtype,
+            ),
+            routed_experts=RoutedExpertsConfig(
+                d_model=d_model, hidden_size=256, num_experts=4, bias=False, dtype=dtype
+            ),
+            routed_experts_router=MoERouterConfigV2(
+                d_model=d_model, num_experts=4, top_k=2, dtype=dtype
+            ),
+            shared_experts=None,
+            layer_norm=layer_norm,
+        ),
+        lm_head=LMHeadConfig(layer_norm=layer_norm, bias=False, dtype=dtype),
+    )
+
+
+@requires_gpu
+@requires_grouped_gemm
+def test_v2_transformer_config_builds_and_initializes():
+    """End-to-end check of the transformer integration: config dispatch + ``init_moe_v2``."""
+    config = _build_model_config()
+    model = config.build(init_device="cuda")
+    assert type(model).__name__ == "MoEFusedV2Transformer"
+
+    model.init_weights(device=torch.device("cuda"))
+    for p in model.parameters():
+        assert torch.isfinite(p).all()


### PR DESCRIPTION
Adds the fused Mixture-of-Experts transformer block and model and wires them into the transformer build dispatch.

## What's added
- **`MoEFusedV2TransformerBlock`** and **`MoEFusedV2Transformer`** — the fused MoE block and model.
- **`no_ep.py`** — the no-expert-parallel forward dispatch (`combined_forward_no_ep`).
- **`tbo_state.py`** — the two-batch-overlap pending-context dataclass.
- **`fp8.py`** — the rowwise-FP8 block machinery (shared-expert prequant cache + forward helpers) added alongside the existing config.
- **Transformer integration** — `moe_fused_v2` entries on `TransformerType` / `TransformerBlockType`, `MoEFusedV2TransformerConfig` (builds the model), the block-build dispatch, and `InitMethod.init_moe_v2` with the per-block init dispatch.

## Notes
- The fused block consumes a single `layer_norm` config and builds identical attention and feed-forward norms from it.
- The expert-parallel dispatch families (sync / no-sync VDev / no-sync rowwise) are imported lazily inside their wrapper methods, so this change imports and runs with only the no-EP path present. Those families land in follow-up changes.

## Testing
`src/test/nn/moe/v2/block_no_ep_test.py`:
- `test_v2_no_ep_module_names_importable` (CPU)
- `test_v2_no_ep_forward_backward_smoke`, `test_v2_no_ep_apply_compile_forward_smoke` (GPU) — forced-router no-EP block forward/backward and compile.
- `test_v2_transformer_config_builds_and_initializes` (GPU) — end-to-end config build + weight init.

Existing tests in `src/test/nn/moe/v2/` continue to pass; `make checks` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)