### PR TITLE
Add the 1D expert-parallel no-sync forward

### DIFF
--- a/src/olmo_core/nn/moe/v2/activation_debug.py
+++ b/src/olmo_core/nn/moe/v2/activation_debug.py
@@ -1,8 +1,16 @@
+"""
+Opt-in activation-memory profiler for the no-sync expert-parallel forward.
+
+When OLMO_EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG is set, runs the no-sync forward under
+torch.autograd saved-tensor hooks to report (once per block) how much memory autograd retains
+for backward, deduplicated by storage. A no-op passthrough otherwise.
+"""
+
 from __future__ import annotations
 
 import os
 import weakref
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, cast
 
 import torch
 
@@ -40,7 +48,7 @@ def maybe_dump_ep_no_sync_saved_activations(
     block: MoEFusedV2TransformerBlock,
     x: torch.Tensor,
     *,
-    loss_div_factor: Optional[Union[torch.Tensor, float]],
+    loss_div_factor: Optional[torch.Tensor | float],
     forward_kwargs: Dict[str, object],
     no_sync_forward: Callable[..., torch.Tensor],
 ) -> Optional[torch.Tensor]:
@@ -53,7 +61,7 @@ def maybe_dump_ep_no_sync_saved_activations(
     ):
         return None
 
-    saved_activations_by_storage: Dict[Tuple[str, int, int], Dict[str, object]] = {}
+    saved_activations_by_storage: Dict[tuple[str, int, int], Dict[str, object]] = {}
     saved_tensor_weakrefs: List[weakref.ReferenceType[torch.Tensor]] = []
     param_storage_keys = {
         (str(param.device), param.untyped_storage().data_ptr(), param.untyped_storage().nbytes())
@@ -105,7 +113,7 @@ def maybe_dump_ep_no_sync_saved_activations(
 
     # Live view: current storage sizes after forward finishes. This reflects
     # storage-discard checkpointing (e.g., resize_(0)).
-    live_saved_activations_by_storage: Dict[Tuple[str, int, int], Dict[str, object]] = {}
+    live_saved_activations_by_storage: Dict[tuple[str, int, int], Dict[str, object]] = {}
     for tensor_ref in saved_tensor_weakrefs:
         tensor = tensor_ref()
         if tensor is None:

--- a/src/olmo_core/nn/moe/v2/activation_debug.py
+++ b/src/olmo_core/nn/moe/v2/activation_debug.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import os
+import weakref
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union, cast
+
+import torch
+
+from olmo_core.distributed.utils import get_rank
+
+if TYPE_CHECKING:
+    from .block import MoEFusedV2TransformerBlock
+
+
+EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENV_VAR = "OLMO_EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG"
+
+
+def _debug_activation_enabled() -> bool:
+    return os.getenv(EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENV_VAR, "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _get_train_global_arg(key: str, default=None):
+    from olmo_core.train.globals import get_global_arg
+
+    return get_global_arg(key, default=default)
+
+
+def _set_train_global_arg(key: str, value) -> None:
+    from olmo_core.train.globals import set_global_arg
+
+    set_global_arg(key, value)
+
+
+def maybe_dump_ep_no_sync_saved_activations(
+    block: MoEFusedV2TransformerBlock,
+    x: torch.Tensor,
+    *,
+    loss_div_factor: Optional[Union[torch.Tensor, float]],
+    forward_kwargs: Dict[str, object],
+    no_sync_forward: Callable[..., torch.Tensor],
+) -> Optional[torch.Tensor]:
+    activation_dump_key = f"ep_no_sync_saved_activations_dumped_block_{block.block_idx}"
+    if not (
+        _get_train_global_arg("dry_run_done", default=False)
+        and block.block_idx == 3
+        and not _get_train_global_arg(activation_dump_key, default=False)
+        and _debug_activation_enabled()
+    ):
+        return None
+
+    saved_activations_by_storage: Dict[Tuple[str, int, int], Dict[str, object]] = {}
+    saved_tensor_weakrefs: List[weakref.ReferenceType[torch.Tensor]] = []
+    param_storage_keys = {
+        (str(param.device), param.untyped_storage().data_ptr(), param.untyped_storage().nbytes())
+        for param in block.parameters()
+    }
+    mem_before_gib = torch.cuda.memory_allocated() / (1024**3)
+
+    def _record_saved_tensor(tensor: torch.Tensor) -> torch.Tensor:
+        storage = tensor.untyped_storage()
+        storage_nbytes = storage.nbytes()
+        key = (str(tensor.device), storage.data_ptr(), storage_nbytes)
+        record = saved_activations_by_storage.get(key)
+        if record is None:
+            saved_activations_by_storage[key] = {
+                "kind": "param" if key in param_storage_keys else "activation",
+                "shape": tuple(tensor.shape),
+                "dtype": str(tensor.dtype),
+                "storage_nbytes": storage_nbytes,
+                "save_count": 1,
+            }
+        else:
+            record["save_count"] = cast(int, record["save_count"]) + 1
+        saved_tensor_weakrefs.append(weakref.ref(tensor))
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(_record_saved_tensor, lambda tensor: tensor):
+        out = no_sync_forward(x, loss_div_factor=loss_div_factor, **forward_kwargs)
+
+    mem_after_gib = torch.cuda.memory_allocated() / (1024**3)
+    total_unique_storage_nbytes_pack = sum(
+        cast(int, record["storage_nbytes"]) for record in saved_activations_by_storage.values()
+    )
+    total_param_storage_nbytes_pack = sum(
+        cast(int, record["storage_nbytes"])
+        for record in saved_activations_by_storage.values()
+        if record["kind"] == "param"
+    )
+    total_activation_storage_nbytes_pack = (
+        total_unique_storage_nbytes_pack - total_param_storage_nbytes_pack
+    )
+    saved_activation_summary_pack = ",\n".join(
+        f"kind={record['kind']} "
+        f"shape={record['shape']} dtype={record['dtype']} "
+        f"storage_nbytes={record['storage_nbytes']} "
+        f"storage_mib={cast(int, record['storage_nbytes']) / (1024**2):.2f} "
+        f"refs={record['save_count']}"
+        for record in saved_activations_by_storage.values()
+    )
+
+    # Live view: current storage sizes after forward finishes. This reflects
+    # storage-discard checkpointing (e.g., resize_(0)).
+    live_saved_activations_by_storage: Dict[Tuple[str, int, int], Dict[str, object]] = {}
+    for tensor_ref in saved_tensor_weakrefs:
+        tensor = tensor_ref()
+        if tensor is None:
+            continue
+        storage = tensor.untyped_storage()
+        storage_nbytes = storage.nbytes()
+        key = (str(tensor.device), storage.data_ptr(), storage_nbytes)
+        record = live_saved_activations_by_storage.get(key)
+        if record is None:
+            live_saved_activations_by_storage[key] = {
+                "kind": "param" if key in param_storage_keys else "activation",
+                "shape": tuple(tensor.shape),
+                "dtype": str(tensor.dtype),
+                "storage_nbytes": storage_nbytes,
+                "live_ref_count": 1,
+            }
+        else:
+            record["live_ref_count"] = cast(int, record["live_ref_count"]) + 1
+
+    total_unique_storage_nbytes_live = sum(
+        cast(int, record["storage_nbytes"]) for record in live_saved_activations_by_storage.values()
+    )
+    total_param_storage_nbytes_live = sum(
+        cast(int, record["storage_nbytes"])
+        for record in live_saved_activations_by_storage.values()
+        if record["kind"] == "param"
+    )
+    total_activation_storage_nbytes_live = (
+        total_unique_storage_nbytes_live - total_param_storage_nbytes_live
+    )
+    saved_activation_summary_live = ",\n".join(
+        f"kind={record['kind']} "
+        f"shape={record['shape']} dtype={record['dtype']} "
+        f"storage_nbytes={record['storage_nbytes']} "
+        f"storage_mib={cast(int, record['storage_nbytes']) / (1024**2):.2f} "
+        f"live_refs={record['live_ref_count']}"
+        for record in live_saved_activations_by_storage.values()
+    )
+    print(
+        f"[EP no-sync saved activations] rank={get_rank()}\n"
+        f"block={block.block_idx} mem_before={mem_before_gib:.2f} GiB\n"
+        f"mem_after={mem_after_gib:.2f} GiB\n"
+        f"delta={mem_after_gib - mem_before_gib:.2f} GiB\n"
+        f"unique_saved_storage_nbytes={total_unique_storage_nbytes_live}\n"
+        f"unique_saved_storage_mib={total_unique_storage_nbytes_live / (1024**2):.2f}\n"
+        f"param_saved_storage_nbytes={total_param_storage_nbytes_live}\n"
+        f"param_saved_storage_mib={total_param_storage_nbytes_live / (1024**2):.2f}\n"
+        f"activation_saved_storage_nbytes={total_activation_storage_nbytes_live}\n"
+        f"activation_saved_storage_mib={total_activation_storage_nbytes_live / (1024**2):.2f}\n"
+        f"saved_at_pack_unique_storage_nbytes={total_unique_storage_nbytes_pack}\n"
+        f"saved_at_pack_unique_storage_mib={total_unique_storage_nbytes_pack / (1024**2):.2f}\n"
+        f"saved_at_pack_param_storage_nbytes={total_param_storage_nbytes_pack}\n"
+        f"saved_at_pack_param_storage_mib={total_param_storage_nbytes_pack / (1024**2):.2f}\n"
+        f"saved_at_pack_activation_storage_nbytes={total_activation_storage_nbytes_pack}\n"
+        f"saved_at_pack_activation_storage_mib={total_activation_storage_nbytes_pack / (1024**2):.2f}\n"
+        f"saved_live=[\n{saved_activation_summary_live}\n]\n"
+        f"saved_at_pack=[\n{saved_activation_summary_pack}\n]"
+    )
+    _set_train_global_arg(activation_dump_key, True)
+    return out

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple, Union, cast
+
+import nvtx
+import torch
+
+from ...moe.utils import wait_stream_no_compile
+from ..utils import (
+    build_chunk_te_routing_map,
+    moe_chunk_reorder_no_compile,
+    moe_permute_1d_fused_drop_no_compile,
+)
+from .comm import _CombineVDevAutograd, _DispatchVDevAutograd
+from .ep_no_sync_buffers import (
+    compute_ep_no_sync_rank_capacity,
+    get_ep_no_sync_buffers,
+    get_ep_no_sync_group_name,
+)
+from .ep_no_sync_common import (
+    build_keep_reorder,
+    restore_drop_unpermute_1d,
+    sync_tail_drop_allowed_splits_single_a2a,
+)
+from .routed_experts import requires_host_side_split_sizes, use_torch_grouped_mm
+
+if TYPE_CHECKING:
+    from .block import MoEFusedV2TransformerBlock
+
+
+def combined_forward_ep_no_sync_1d(
+    block: MoEFusedV2TransformerBlock,
+    x: torch.Tensor,
+    *,
+    loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+    **kwargs,
+) -> torch.Tensor:
+    """Legacy 1D EP no-sync forward using symmetric-memory all_to_all_vdev ops.
+
+    This path is kept primarily because the current TBO implementation still
+    shares its 1D machinery. Row-wise no-sync is the production no-sync path.
+    """
+    self = block
+    assert self.routed_experts is not None
+    assert self.routed_experts_router is not None
+    assert self.ep_enabled
+    assert self.num_local_routed_experts is not None
+    assert use_torch_grouped_mm(), "EP no-sync implementation requires torch.grouped_mm support"
+    assert (
+        not requires_host_side_split_sizes()
+    ), "EP no-sync implementation does not support host-side split size communication"
+    if self.ep_no_sync_use_2d_all_to_all:
+        raise RuntimeError(
+            "ep_no_sync_use_2d_all_to_all=True is no longer supported: "
+            "the 2D all_to_all path was removed due to correctness/performance issues."
+        )
+
+    group_name = get_ep_no_sync_group_name(self)
+    B, S, D = x.shape
+
+    block_inp = x
+    del x
+
+    attn_res_out = self._checkpointed_res_norm_attn(block_inp, **kwargs)
+
+    kwargs.pop("max_doc_len", None)
+    kwargs.pop("cu_doc_lens", None)
+    moe_inp = self._prepare_moe_input(attn_res_out)
+
+    (
+        local_x_global_routed_expert_weights,
+        local_x_global_routed_expert_indices,
+        local_batch_size_per_global_routed_expert,
+        routed_expert_router_aux_loss_info,
+    ) = self.routed_experts_router(
+        moe_inp,
+        False,
+        loss_div_factor=loss_div_factor,
+    )
+
+    wait_stream_no_compile(
+        this_stream=self.get_dense_stream(),
+        other_stream=torch.cuda.current_stream(),
+    )
+
+    with torch.cuda.stream(self.get_dense_stream()):
+        if self.shared_experts_router:
+            (
+                local_x_global_shared_expert_weights,
+                _,
+                _,
+                _,
+            ) = self.shared_experts_router(
+                moe_inp,
+                True,
+                loss_div_factor=loss_div_factor,
+            )
+        else:
+            local_x_global_shared_expert_weights = None
+
+    in_shape = moe_inp.size()
+    moe_inp = moe_inp.view(-1, in_shape[-1])
+
+    num_out_tokens = local_x_global_routed_expert_indices.numel()
+
+    with torch.no_grad():
+        with nvtx.annotate("ConfigCapacity", color="green"):
+            requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
+            rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
+            allowed_splits, recv_splits_by_src_local, _drop_token_cnt = cast(
+                Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+                sync_tail_drop_allowed_splits_single_a2a(
+                    self,
+                    requested_splits,
+                    rank_capacity=rank_capacity,
+                ),
+            )
+            (
+                local_reorder_indices,
+                local_inverse_reorder_indices,
+                packed_keep_mask,
+            ) = build_keep_reorder(
+                requested_splits=requested_splits,
+                keep_splits=allowed_splits,
+                num_out_tokens=num_out_tokens,
+            )
+            num_kept = allowed_splits.sum(dtype=torch.long)
+            dispatch_in_cap = num_out_tokens
+            dispatch_out_cap = rank_capacity
+            combine_in_cap = rank_capacity
+            combine_out_cap = num_out_tokens
+            self._ep_no_sync_last_debug = {
+                "num_dropped": _drop_token_cnt.detach(),
+                "rank_capacity": torch.tensor(
+                    rank_capacity,
+                    device=requested_splits.device,
+                    dtype=torch.long,
+                ),
+                "received_tokens_after_drop": recv_splits_by_src_local.sum(
+                    dtype=torch.long
+                ).detach(),
+                "allowed_splits": allowed_splits.detach(),
+                "local_kept_tokens": num_kept.detach(),
+                "combined_tokens": num_kept.detach(),
+                "zero_rows_after_local_unpermute": (
+                    torch.tensor(
+                        num_out_tokens,
+                        device=requested_splits.device,
+                        dtype=torch.long,
+                    )
+                    - num_kept
+                ).detach(),
+            }
+
+    buffers = get_ep_no_sync_buffers(
+        self,
+        dispatch_in_cap=dispatch_in_cap,
+        dispatch_out_cap=dispatch_out_cap,
+        combine_in_cap=combine_in_cap,
+        combine_out_cap=combine_out_cap,
+        d_model=moe_inp.shape[-1],
+        dtype=moe_inp.dtype,
+        device=moe_inp.device,
+    )
+
+    routing_map = local_x_global_routed_expert_indices.view(
+        -1, self.routed_experts_router.top_k
+    ).int()
+    hidden_shape_before_permute = moe_inp.shape
+
+    with torch.no_grad():
+        padded_batch_size_per_local_expert = recv_splits_by_src_local.sum(
+            dim=0,
+            dtype=torch.long,
+        )
+
+    assert local_reorder_indices is not None
+    assert local_inverse_reorder_indices is not None
+    assert packed_keep_mask is not None
+    assert num_kept is not None
+
+    with nvtx.annotate("Permute local tokens", color="green"):
+        (
+            permutated_local_x,
+            reversed_local_x_permutation_mapping,
+        ) = moe_permute_1d_fused_drop_no_compile(
+            inp=moe_inp,
+            routing_map=routing_map,
+            num_out_tokens=num_out_tokens,
+            reorder_indices=local_reorder_indices,
+            inverse_reorder_indices=local_inverse_reorder_indices,
+            requested_splits=requested_splits,
+            keep_splits=allowed_splits,
+            out=buffers.dispatch_in.detach(),
+            map_type="index",
+        )
+
+    with torch.no_grad():
+        send_rank_splits = allowed_splits.view(
+            self.ep_world_size, self.num_local_routed_experts
+        ).sum(dim=-1, dtype=torch.long)
+
+    if self.shared_experts is not None:
+        wait_stream_no_compile(
+            this_stream=self.get_dense_stream(),
+            other_stream=torch.cuda.current_stream(),
+        )
+        with torch.cuda.stream(self.get_dense_stream()):
+            shared_out_up, shared_out_gate = self.shared_experts.forward1(moe_inp.view(B, S, D))
+    else:
+        shared_out_up, shared_out_gate = None, None
+
+    dispatch_out, dispatch_rank_splits_offsets = _DispatchVDevAutograd.apply(
+        permutated_local_x,
+        send_rank_splits,
+        buffers.dispatch_in,
+        buffers.dispatch_in_rank_splits,
+        buffers.dispatch_out,
+        buffers.dispatch_rank_splits_offsets,
+        buffers.dispatch_tmp_rank_splits_offsets,
+        group_name,
+        self.ep_pg,
+    )
+
+    dispatch_rank_major = dispatch_out
+
+    with nvtx.annotate("Permute global tokens", color="green"):
+        if self.routed_experts.num_local_experts == 1:
+            dispatch_rank_major = dispatch_rank_major.clone()
+            global_chunk_row_id_map = None
+        else:
+            with torch.no_grad():
+                global_chunk_routing_map = build_chunk_te_routing_map(
+                    recv_splits_by_src_local,
+                    rows=dispatch_rank_major.shape[0],
+                )
+            dispatch_rank_major, global_chunk_row_id_map = moe_chunk_reorder_no_compile(
+                dispatch_rank_major,
+                routing_map=global_chunk_routing_map,
+                num_out_tokens=dispatch_rank_major.shape[0],
+                backward_grad_input_buffer=buffers.dispatch_out.detach(),
+            )
+
+    dispatch_rank_major = self.routed_experts(
+        dispatch_rank_major,
+        padded_batch_size_per_local_expert,
+    )
+
+    with nvtx.annotate("Unpermute global tokens", color="green"):
+        if self.routed_experts.num_local_experts == 1:
+            global_x_rank_major = dispatch_rank_major
+        else:
+            assert global_chunk_row_id_map is not None
+            global_x_rank_major = moe_chunk_reorder_no_compile(
+                inp=dispatch_rank_major,
+                row_id_map=global_chunk_row_id_map,
+                out=buffers.combine_in.detach(),
+            )
+
+    wait_stream_no_compile(
+        this_stream=self.get_dense_stream(),
+        other_stream=torch.cuda.current_stream(),
+    )
+
+    combine_out, _combine_rank_splits_offsets = _CombineVDevAutograd.apply(
+        global_x_rank_major,
+        dispatch_rank_splits_offsets[0],
+        buffers.combine_in,
+        buffers.combine_in_rank_splits,
+        buffers.combine_out,
+        buffers.combine_rank_splits_offsets,
+        buffers.combine_tmp_rank_splits_offsets,
+        group_name,
+        self.ep_pg,
+    )
+
+    with nvtx.annotate("Unpermute-Merge local tokens", color="green"):
+        combine_out_for_unpermute = (
+            combine_out.clone() if buffers.combine_out_is_shared else combine_out
+        )
+        local_x = restore_drop_unpermute_1d(
+            self,
+            combine_out=combine_out_for_unpermute,
+            local_inverse_reorder_indices=local_inverse_reorder_indices,
+            packed_keep_mask=packed_keep_mask,
+            num_kept=num_kept,
+            reversed_local_x_permutation_mapping=reversed_local_x_permutation_mapping,
+            local_x_global_routed_expert_weights=local_x_global_routed_expert_weights,
+            hidden_shape_before_permute=hidden_shape_before_permute,
+            row_id_map_is_packed=True,
+            backward_grad_input_buffer=buffers.combine_out.detach(),
+        )
+
+    if self.shared_experts is not None:
+        assert shared_out_up is not None
+        assert shared_out_gate is not None
+
+        with torch.cuda.stream(self.get_dense_stream()):
+            shared_out = self.shared_experts.forward2(
+                shared_out_up, shared_out_gate, attn_res_out.shape
+            )
+            if self.shared_experts_router:
+                assert local_x_global_shared_expert_weights is not None
+                _, _, E_s = local_x_global_shared_expert_weights.shape
+                mixed_shared_out = (
+                    torch.bmm(
+                        local_x_global_shared_expert_weights.to(shared_out.dtype).reshape(
+                            B * S, 1, E_s
+                        ),
+                        shared_out.permute(1, 2, 0, 3).contiguous().view(B * S, E_s, D),
+                    )
+                    .squeeze(1)
+                    .view(B, S, D)
+                )
+            else:
+                mixed_shared_out = shared_out.squeeze(0)
+    else:
+        mixed_shared_out = None
+
+    local_x = local_x.view(in_shape)
+    wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
+
+    mlp_out = self._merge_routed_and_shared(local_x, mixed_shared_out)
+
+    final_out = self._res_norm_mlp(attn_res_out, mlp_out)
+
+    return self._attach_routed_aux_loss(
+        final_out,
+        routed_expert_router_aux_loss_info,
+    )

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Optional, cast
 
-import nvtx
 import torch
 
 from ...moe.utils import wait_stream_no_compile
@@ -11,6 +10,7 @@ from ..utils import (
     moe_chunk_reorder_no_compile,
     moe_permute_1d_fused_drop_no_compile,
 )
+from ._nvtx import annotate
 from .comm import _CombineVDevAutograd, _DispatchVDevAutograd
 from .ep_no_sync_buffers import (
     compute_ep_no_sync_rank_capacity,
@@ -32,7 +32,7 @@ def combined_forward_ep_no_sync_1d(
     block: MoEFusedV2TransformerBlock,
     x: torch.Tensor,
     *,
-    loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+    loss_div_factor: Optional[torch.Tensor | float] = None,
     **kwargs,
 ) -> torch.Tensor:
     """Legacy 1D EP no-sync forward using symmetric-memory all_to_all_vdev ops.
@@ -104,11 +104,11 @@ def combined_forward_ep_no_sync_1d(
     num_out_tokens = local_x_global_routed_expert_indices.numel()
 
     with torch.no_grad():
-        with nvtx.annotate("ConfigCapacity", color="green"):
+        with annotate("config_capacity", "comm"):
             requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
             rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
             allowed_splits, recv_splits_by_src_local, _drop_token_cnt = cast(
-                Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+                tuple[torch.Tensor, torch.Tensor, torch.Tensor],
                 sync_tail_drop_allowed_splits_single_a2a(
                     self,
                     requested_splits,
@@ -179,7 +179,7 @@ def combined_forward_ep_no_sync_1d(
     assert packed_keep_mask is not None
     assert num_kept is not None
 
-    with nvtx.annotate("Permute local tokens", color="green"):
+    with annotate("permute_local_tokens", "comm"):
         (
             permutated_local_x,
             reversed_local_x_permutation_mapping,
@@ -224,7 +224,7 @@ def combined_forward_ep_no_sync_1d(
 
     dispatch_rank_major = dispatch_out
 
-    with nvtx.annotate("Permute global tokens", color="green"):
+    with annotate("permute_global_tokens", "comm"):
         if self.routed_experts.num_local_experts == 1:
             dispatch_rank_major = dispatch_rank_major.clone()
             global_chunk_row_id_map = None
@@ -246,7 +246,7 @@ def combined_forward_ep_no_sync_1d(
         padded_batch_size_per_local_expert,
     )
 
-    with nvtx.annotate("Unpermute global tokens", color="green"):
+    with annotate("unpermute_global_tokens", "comm"):
         if self.routed_experts.num_local_experts == 1:
             global_x_rank_major = dispatch_rank_major
         else:
@@ -274,7 +274,7 @@ def combined_forward_ep_no_sync_1d(
         self.ep_pg,
     )
 
-    with nvtx.annotate("Unpermute-Merge local tokens", color="green"):
+    with annotate("unpermute_merge_local_tokens", "comm"):
         combine_out_for_unpermute = (
             combine_out.clone() if buffers.combine_out_is_shared else combine_out
         )

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
@@ -39,6 +39,10 @@ def combined_forward_ep_no_sync_1d(
 
     This path is kept primarily because the current TBO implementation still
     shares its 1D machinery. Row-wise no-sync is the production no-sync path.
+
+    TODO(ep-legacy): this VDev-1d path only runs on the legacy torch symmetric-memory backend
+    (``OLMO_USE_OWN_SYMM_MEM=0``); OLMo-owned symm-mem supports only the rowwise path. Consider
+    removing it once TBO no longer depends on the 1D machinery and rowwise is the sole no-sync path.
     """
     self = block
     assert self.routed_experts is not None

--- a/src/olmo_core/train/globals.py
+++ b/src/olmo_core/train/globals.py
@@ -1,0 +1,36 @@
+""" A centeral place to store global variables used in training. """
+
+from collections import defaultdict
+from typing import Any, DefaultDict
+
+_GLOBAL_ARGS: DefaultDict[str, Any] = defaultdict(None)
+
+
+def set_global_args(args: dict) -> None:
+    """Set global arguments for training."""
+    global _GLOBAL_ARGS
+    _GLOBAL_ARGS.update(args)
+
+
+def get_global_args() -> dict:
+    """Get global arguments for training."""
+    global _GLOBAL_ARGS
+    return _GLOBAL_ARGS.copy()
+
+
+def get_global_arg(key: str, default=None):
+    """Get a specific global argument for training."""
+    global _GLOBAL_ARGS
+    return _GLOBAL_ARGS.get(key, default)
+
+
+def set_global_arg(key: str, value) -> None:
+    """Set a specific global argument for training."""
+    global _GLOBAL_ARGS
+    _GLOBAL_ARGS[key] = value
+
+
+def clear_global_args() -> None:
+    """Clear all global arguments."""
+    global _GLOBAL_ARGS
+    _GLOBAL_ARGS.clear()

--- a/src/test/nn/moe/v2/ep_no_sync_1d_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_1d_test.py
@@ -1,0 +1,198 @@
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
+
+from olmo_core.config import DType
+from olmo_core.exceptions import OLMoConfigurationError
+from olmo_core.nn.attention import AttentionConfig, AttentionType
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlock
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.testing import requires_gpu, requires_multi_gpu, run_distributed_test
+
+
+def _build_ep_mesh() -> DeviceMesh:
+    world_size = dist.get_world_size()
+    mesh = torch.arange(world_size, dtype=torch.int).view(1, world_size)
+    return DeviceMesh(device_type="cuda", mesh=mesh, mesh_dim_names=("ep_dp", "ep_mp"))
+
+
+def _build_block(
+    *,
+    ep_no_sync: bool,
+    ep_no_sync_capacity_factor: float = 2.0,
+    d_model: int = 512,
+    hidden_size: int = 1024,
+    num_experts: int = 4,
+    top_k: int = 1,
+    uniform_expert_assignment: bool = True,
+    init_device: str = "cuda",
+    ep_no_sync_use_2d_all_to_all: bool = False,
+) -> MoEFusedV2TransformerBlock:
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=DType.float32)
+    return MoEFusedV2TransformerBlock(
+        d_model=d_model,
+        block_idx=0,
+        n_layers=1,
+        sequence_mixer=AttentionConfig(
+            name=AttentionType.default,
+            n_heads=2,
+            n_kv_heads=2,
+            bias=False,
+            use_flash=False,
+            dtype=DType.float32,
+        ),
+        attention_norm=layer_norm,
+        routed_experts_router=MoERouterConfigV2(
+            d_model=d_model,
+            num_experts=num_experts,
+            top_k=top_k,
+            gating_function=MoERouterGatingFunction.softmax,
+            uniform_expert_assignment=uniform_expert_assignment,
+            lb_loss_weight=None,
+            z_loss_weight=None,
+            dtype=DType.float32,
+        ),
+        shared_experts_router=None,
+        shared_experts=None,
+        routed_experts=RoutedExpertsConfig(
+            d_model=d_model,
+            hidden_size=hidden_size,
+            num_experts=num_experts,
+            bias=False,
+            dtype=DType.float32,
+        ),
+        feed_forward_norm=layer_norm,
+        ep_no_sync=ep_no_sync,
+        ep_no_sync_use_2d_all_to_all=ep_no_sync_use_2d_all_to_all,
+        ep_no_sync_capacity_factor=ep_no_sync_capacity_factor,
+        ep_no_sync_major_align=1,
+        init_device=init_device,
+    )
+
+
+def _init_block_params(block: MoEFusedV2TransformerBlock):
+    torch.manual_seed(1234)
+    with torch.no_grad():
+        for p in block.parameters():
+            if p.is_floating_point():
+                p.normal_(mean=0.0, std=0.02)
+
+
+def _install_forced_router(block: MoEFusedV2TransformerBlock):
+    """Force all tokens to expert 0 so dispatch/drop behavior is deterministic."""
+
+    def _make_forced_forward(router):
+        def _forced_forward(local_x, scores_only, loss_div_factor=None):
+            del loss_div_factor
+            B, S, _ = local_x.shape
+            if scores_only:
+                return (
+                    torch.ones(
+                        B, S, router.num_experts, device=local_x.device, dtype=local_x.dtype
+                    ),
+                    None,
+                    None,
+                    None,
+                )
+            expert_weights = torch.ones(
+                B, S, router.top_k, device=local_x.device, dtype=local_x.dtype
+            )
+            expert_indices = torch.zeros(
+                B, S, router.top_k, device=local_x.device, dtype=torch.long
+            )
+            batch_size_per_expert = torch.zeros(
+                router.num_experts, device=local_x.device, dtype=torch.long
+            )
+            batch_size_per_expert[0] = B * S * router.top_k
+            return expert_weights, expert_indices, batch_size_per_expert, None
+
+        return _forced_forward
+
+    assert block.routed_experts_router is not None
+    block.routed_experts_router.forward = _make_forced_forward(block.routed_experts_router)
+
+
+@requires_gpu
+def test_v2_ep_no_sync_2d_all_to_all_rejected():
+    # @requires_gpu (not CPU): block construction allocates CUDA events before the config check.
+    with pytest.raises(OLMoConfigurationError, match="2D all_to_all path was removed"):
+        _build_block(ep_no_sync=True, init_device="cpu", ep_no_sync_use_2d_all_to_all=True)
+
+
+def _run_ep_no_sync_drop_behavior():
+    block = _build_block(
+        ep_no_sync=True, ep_no_sync_capacity_factor=0.25, uniform_expert_assignment=False
+    )
+    block.apply_ep(_build_ep_mesh())
+    _init_block_params(block)
+    _install_forced_router(block)
+    block.train()
+
+    x = torch.randn(1, 8, block.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    y = block(x)
+    assert torch.isfinite(y).all()
+    y.sum().backward()
+    assert x.grad is not None
+
+    dbg = block._ep_no_sync_last_debug
+    assert dbg["num_dropped"].item() > 0
+    assert dbg["received_tokens_after_drop"].item() <= dbg["rank_capacity"].item()
+    assert dbg["allowed_splits"].sum().item() == dbg["local_kept_tokens"].item()
+    assert dbg["combined_tokens"].item() == dbg["local_kept_tokens"].item()
+    assert dbg["zero_rows_after_local_unpermute"].item() >= dbg["num_dropped"].item()
+
+
+def _run_ep_no_sync_quota_invariants():
+    block = _build_block(
+        ep_no_sync=True, ep_no_sync_capacity_factor=0.5, uniform_expert_assignment=False
+    )
+    block.apply_ep(_build_ep_mesh())
+    _init_block_params(block)
+    _install_forced_router(block)
+    block.train()
+
+    x = torch.randn(1, 8, block.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    y = block(x)
+    y.sum().backward()
+
+    dbg = block._ep_no_sync_last_debug
+    assert dbg["allowed_splits"].sum().item() == dbg["local_kept_tokens"].item()
+    assert dbg["received_tokens_after_drop"].item() <= dbg["rank_capacity"].item()
+    assert dbg["combined_tokens"].item() == dbg["local_kept_tokens"].item()
+
+
+def _run_ep_no_sync_hard_fail_setup():
+    import olmo_core.nn.moe.v2.block as block_module
+
+    ep_mesh = _build_ep_mesh()
+    old_symm = block_module._symm_mem
+    block_module._symm_mem = None
+    try:
+        block = _build_block(ep_no_sync=True)
+        try:
+            block.apply_ep(ep_mesh)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("Expected RuntimeError when symmetric memory is unavailable")
+    finally:
+        block_module._symm_mem = old_symm
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_drop_behavior():
+    run_distributed_test(_run_ep_no_sync_drop_behavior, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_quota_invariants():
+    run_distributed_test(_run_ep_no_sync_quota_invariants, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_hard_fail_setup():
+    run_distributed_test(_run_ep_no_sync_hard_fail_setup, backend="nccl", start_method="spawn")

--- a/src/test/nn/moe/v2/ep_no_sync_1d_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_1d_test.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import torch
 import torch.distributed as dist
@@ -124,6 +126,9 @@ def test_v2_ep_no_sync_2d_all_to_all_rejected():
 
 
 def _run_ep_no_sync_drop_behavior():
+    # The VDev-1d (non-rowwise) no-sync path runs on the legacy torch symmetric-memory backend;
+    # OLMo-owned symm-mem only supports the rowwise path.
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"
     block = _build_block(
         ep_no_sync=True, ep_no_sync_capacity_factor=0.25, uniform_expert_assignment=False
     )
@@ -147,6 +152,7 @@ def _run_ep_no_sync_drop_behavior():
 
 
 def _run_ep_no_sync_quota_invariants():
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # VDev-1d uses the legacy symm-mem backend
     block = _build_block(
         ep_no_sync=True, ep_no_sync_capacity_factor=0.5, uniform_expert_assignment=False
     )
@@ -168,6 +174,7 @@ def _run_ep_no_sync_quota_invariants():
 def _run_ep_no_sync_hard_fail_setup():
     import olmo_core.nn.moe.v2.block as block_module
 
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # VDev-1d uses the legacy symm-mem backend
     ep_mesh = _build_ep_mesh()
     old_symm = block_module._symm_mem
     block_module._symm_mem = None


### PR DESCRIPTION
Adds the 1D (VDev) no-sync expert-parallel forward.

## What's added
`nn/moe/v2/ep_no_sync_1d.py` — `combined_forward_ep_no_sync_1d`: dispatches each token to its expert-owning rank over the symmetric-memory variable-length all-to-all (`_DispatchVDevAutograd`), runs the routed experts on the received tokens, and combines the results back (`_CombineVDevAutograd`), using the buffer-lease pool for the symmetric buffers. Also shared by the 1D two-batch-overlap path.

Operates on a passed-in block; built on the comm transport, the no-sync common helpers, and the symmetric-memory buffer pool.

## Notes
- nvtx ranges use the shared `_nvtx.annotate(label, subsystem)` helper.

## Testing
This is a multi-rank symmetric-memory forward with no single-process surface (its only pure logic, rank-capacity, is already covered). It's validated end-to-end by the multi-GPU EP-vs-no-EP parity test that lands with the no-sync forward path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)