### PR TITLE
Add the 1D no-sync two-batch-overlap forward

### DIFF
--- a/src/olmo_core/nn/moe/v2/block.py
+++ b/src/olmo_core/nn/moe/v2/block.py
@@ -1276,6 +1276,15 @@ class MoEFusedV2TransformerBlock(olmo_core.nn.transformer.block.TransformerBlock
         loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, object]:
+        # Dispatch no-sync here so the no-sync TBO path never imports the sync module.
+        if self.ep_no_sync:
+            return self.combined_forward_ep_no_sync_tbo(
+                x0,
+                x1_ctx,
+                x1_is_fresh,
+                loss_div_factor=loss_div_factor,
+                **kwargs,
+            )
         from .ep_sync_tbo import combined_forward_ep_tbo as _combined_forward_ep_tbo
 
         return _combined_forward_ep_tbo(

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Dict, Optional, cast
 
-import nvtx
 import torch
 
 from olmo_core.utils import get_or_init_stream
@@ -17,6 +16,7 @@ from ..utils import (
     moe_chunk_reorder_no_compile,
     moe_permute_1d_fused_drop_no_compile,
 )
+from ._nvtx import annotate
 from .comm import _CombineVDevAutograd, _DispatchVDevAutograd
 from .ep_no_sync_buffers import (
     _NoSyncStageAState,
@@ -43,7 +43,7 @@ def ep_no_sync_stage_a(
     x: torch.Tensor,
     *,
     lane_id: int,
-    loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+    loss_div_factor: Optional[torch.Tensor | float] = None,
     **kwargs,
 ) -> _NoSyncStageAState:
     self = block
@@ -73,7 +73,7 @@ def ep_no_sync_stage_a(
     del x
 
     attn_kwargs = dict(kwargs)
-    with nvtx.annotate("A-AttnRouter", color="purple"):
+    with annotate("a_attn_router", "routing"):
         attn_res_out = self._checkpointed_res_norm_attn(block_inp, **attn_kwargs)
         moe_inp = self._prepare_moe_input(attn_res_out)
         (
@@ -136,11 +136,11 @@ def ep_no_sync_stage_a(
     num_out_tokens = local_x_global_routed_expert_indices.numel()
 
     with torch.no_grad():
-        with nvtx.annotate("A-ConfigCapacity", color="green"):
+        with annotate("a_config_capacity", "comm"):
             requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
             rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
             allowed_splits, recv_splits_by_src_local, _drop_token_cnt = cast(
-                Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+                tuple[torch.Tensor, torch.Tensor, torch.Tensor],
                 sync_tail_drop_allowed_splits_single_a2a(
                     self,
                     requested_splits,
@@ -175,7 +175,7 @@ def ep_no_sync_stage_a(
         slot_idx=slot_idx,
     )
 
-    with nvtx.annotate("A-PermuteLocal", color="green"):
+    with annotate("a_permute_local", "comm"):
         routing_map = local_x_global_routed_expert_indices.view(
             -1, self.routed_experts_router.top_k
         ).int()
@@ -274,7 +274,7 @@ def ep_no_sync_stage_e(
             dtype=torch.long,
         )
 
-    with nvtx.annotate("E-PermuteGlobal", color="green"):
+    with annotate("e_permute_global", "comm"):
         if self.routed_experts.num_local_experts == 1:
             dispatch_rank_major = dispatch_rank_major.clone()
             global_chunk_row_id_map = None
@@ -291,13 +291,13 @@ def ep_no_sync_stage_e(
                 backward_grad_input_buffer=buffers.dispatch_out.detach(),
             )
 
-    with nvtx.annotate("E-RoutedExperts", color="green"):
+    with annotate("e_routed_experts", "experts"):
         dispatch_rank_major = self.routed_experts(
             dispatch_rank_major,
             padded_batch_size_per_local_expert,
         )
 
-    with nvtx.annotate("E-UnpermuteGlobal", color="green"):
+    with annotate("e_unpermute_global", "comm"):
         if self.routed_experts.num_local_experts == 1:
             global_x_rank_major = dispatch_rank_major
         else:
@@ -362,7 +362,7 @@ def ep_no_sync_stage_tail(
     combine_out = (
         pending_ctx.combine_out if pending_ctx.combine_out is not None else buffers.combine_out
     )
-    with nvtx.annotate("Tail-UnpermuteMerge", color="green"):
+    with annotate("tail_unpermute_merge", "comm"):
         combine_out_for_unpermute = (
             combine_out.clone() if buffers.combine_out_is_shared else combine_out
         )
@@ -397,9 +397,9 @@ def combined_forward_ep_no_sync_tbo(
     x1_ctx: object,
     x1_is_fresh: bool,
     *,
-    loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+    loss_div_factor: Optional[torch.Tensor | float] = None,
     **kwargs,
-) -> Tuple[torch.Tensor, _NoSyncTboPendingContext]:
+) -> tuple[torch.Tensor, _NoSyncTboPendingContext]:
     self = block
     if x1_is_fresh:
         pending_prev = None
@@ -410,10 +410,10 @@ def combined_forward_ep_no_sync_tbo(
             )
         pending_prev = x1_ctx
 
-    with nvtx.annotate("TBO-1", color="orange"):
+    with annotate("tbo_1", "tbo"):
         if pending_prev is not None:
             pending_prev = ep_no_sync_stage_c_launch(pending_prev.block, pending_prev)
-    with nvtx.annotate("TBO-0", color="purple"):
+    with annotate("tbo_0", "tbo"):
         a0 = ep_no_sync_stage_a(
             self,
             x0,
@@ -422,7 +422,7 @@ def combined_forward_ep_no_sync_tbo(
             **kwargs,
         )
 
-    with nvtx.annotate("TBO-1", color="orange"):
+    with annotate("tbo_1", "tbo"):
         if x1_is_fresh:
             fresh_ctx = cast(Dict[str, torch.Tensor], x1_ctx)
             block_inp1 = fresh_ctx["x1"]
@@ -430,9 +430,9 @@ def combined_forward_ep_no_sync_tbo(
             assert pending_prev is not None
             block_inp1 = ep_no_sync_stage_tail(pending_prev.block, pending_prev)
 
-    with nvtx.annotate("TBO-0", color="purple"):
+    with annotate("tbo_0", "tbo"):
         d0 = ep_no_sync_stage_d_launch(self, a0)
-    with nvtx.annotate("TBO-1", color="orange"):
+    with annotate("tbo_1", "tbo"):
         a1 = ep_no_sync_stage_a(
             self,
             block_inp1,
@@ -441,17 +441,17 @@ def combined_forward_ep_no_sync_tbo(
             **kwargs,
         )
 
-    with nvtx.annotate("TBO-1", color="orange"):
+    with annotate("tbo_1", "tbo"):
         d1 = ep_no_sync_stage_d_launch(self, a1)
-    with nvtx.annotate("TBO-0", color="purple"):
+    with annotate("tbo_0", "tbo"):
         pending0_pre_c = ep_no_sync_stage_e(self, d0)
 
-    with nvtx.annotate("TBO-0", color="purple"):
+    with annotate("tbo_0", "tbo"):
         pending0_post_c = ep_no_sync_stage_c_launch(self, pending0_pre_c)
-    with nvtx.annotate("TBO-1", color="orange"):
+    with annotate("tbo_1", "tbo"):
         pending1_pre_c = ep_no_sync_stage_e(self, d1)
 
-    with nvtx.annotate("TBO-0", color="purple"):
+    with annotate("tbo_0", "tbo"):
         final_out = ep_no_sync_stage_tail(self, pending0_post_c)
 
     return final_out, pending1_pre_c

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union, cast
+
+import nvtx
+import torch
+
+from olmo_core.utils import get_or_init_stream
+
+from ...moe.utils import (
+    record_stream_event_no_compile,
+    wait_event_no_compile,
+    wait_stream_no_compile,
+)
+from ..utils import (
+    build_chunk_te_routing_map,
+    moe_chunk_reorder_no_compile,
+    moe_permute_1d_fused_drop_no_compile,
+)
+from .comm import _CombineVDevAutograd, _DispatchVDevAutograd
+from .ep_no_sync_buffers import (
+    _NoSyncStageAState,
+    _NoSyncStageDState,
+    _NoSyncTboPendingContext,
+    compute_ep_no_sync_rank_capacity,
+    ep_no_sync_slot_for_lane,
+    get_ep_no_sync_buffers,
+    get_ep_no_sync_group_name,
+)
+from .ep_no_sync_common import (
+    build_keep_reorder,
+    restore_drop_unpermute_1d,
+    sync_tail_drop_allowed_splits_single_a2a,
+)
+from .routed_experts import requires_host_side_split_sizes, use_torch_grouped_mm
+
+if TYPE_CHECKING:
+    from .block import MoEFusedV2TransformerBlock
+
+
+def ep_no_sync_stage_a(
+    block: MoEFusedV2TransformerBlock,
+    x: torch.Tensor,
+    *,
+    lane_id: int,
+    loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+    **kwargs,
+) -> _NoSyncStageAState:
+    self = block
+    assert self.routed_experts is not None
+    assert self.routed_experts_router is not None
+    assert self.ep_enabled
+    assert self.num_local_routed_experts is not None
+    assert use_torch_grouped_mm(), "EP no-sync implementation requires torch.grouped_mm support"
+    assert (
+        not requires_host_side_split_sizes()
+    ), "EP no-sync implementation does not support host-side split size communication"
+    if self.ep_no_sync_use_2d_all_to_all:
+        raise RuntimeError(
+            "ep_no_sync_use_2d_all_to_all=True is no longer supported: "
+            "the 2D all_to_all path was removed due to correctness/performance issues."
+        )
+    if self.ep_no_sync_use_rowwise_all_to_all:
+        raise RuntimeError(
+            "ep_no_sync_use_rowwise_all_to_all=True is only implemented for "
+            "combined_forward_ep_no_sync_rowwise() (non-TBO path) right now."
+        )
+
+    group_name = get_ep_no_sync_group_name(self)
+    slot_idx = ep_no_sync_slot_for_lane(self, lane_id)
+    B, S, D = x.shape
+    block_inp = x
+    del x
+
+    attn_kwargs = dict(kwargs)
+    with nvtx.annotate("A-AttnRouter", color="purple"):
+        attn_res_out = self._checkpointed_res_norm_attn(block_inp, **attn_kwargs)
+        moe_inp = self._prepare_moe_input(attn_res_out)
+        (
+            local_x_global_routed_expert_weights,
+            local_x_global_routed_expert_indices,
+            local_batch_size_per_global_routed_expert,
+            routed_expert_router_aux_loss_info,
+        ) = self.routed_experts_router(
+            moe_inp,
+            False,
+            loss_div_factor=loss_div_factor,
+        )
+
+    mixed_shared_out: Optional[torch.Tensor]
+    shared_done_event: Optional[torch.cuda.Event] = None
+    wait_stream_no_compile(
+        this_stream=self.get_dense_stream(),
+        other_stream=torch.cuda.current_stream(),
+    )
+    dense_stream = self.get_dense_stream()
+    with torch.cuda.stream(dense_stream):
+        if self.shared_experts_router:
+            (
+                local_x_global_shared_expert_weights,
+                _,
+                _,
+                _,
+            ) = self.shared_experts_router(
+                moe_inp,
+                True,
+                loss_div_factor=loss_div_factor,
+            )
+        else:
+            local_x_global_shared_expert_weights = None
+
+        if self.shared_experts is not None:
+            shared_out = self.shared_experts(moe_inp)
+            if self.shared_experts_router:
+                assert local_x_global_shared_expert_weights is not None
+                _, _, E_s = local_x_global_shared_expert_weights.shape
+                mixed_shared_out = (
+                    torch.bmm(
+                        local_x_global_shared_expert_weights.to(shared_out.dtype).reshape(
+                            B * S, 1, E_s
+                        ),
+                        shared_out.permute(1, 2, 0, 3).contiguous().view(B * S, E_s, D),
+                    )
+                    .squeeze(1)
+                    .view(B, S, D)
+                )
+            else:
+                mixed_shared_out = shared_out.squeeze(0)
+            shared_done_event = record_stream_event_no_compile(dense_stream)
+        else:
+            mixed_shared_out = None
+
+    in_shape = moe_inp.size()
+    moe_inp = moe_inp.view(-1, in_shape[-1])
+    hidden_shape_before_permute = moe_inp.shape
+    num_out_tokens = local_x_global_routed_expert_indices.numel()
+
+    with torch.no_grad():
+        with nvtx.annotate("A-ConfigCapacity", color="green"):
+            requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
+            rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
+            allowed_splits, recv_splits_by_src_local, _drop_token_cnt = cast(
+                Tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+                sync_tail_drop_allowed_splits_single_a2a(
+                    self,
+                    requested_splits,
+                    rank_capacity=rank_capacity,
+                ),
+            )
+            (
+                local_reorder_indices,
+                local_inverse_reorder_indices,
+                packed_keep_mask,
+            ) = build_keep_reorder(
+                requested_splits=requested_splits,
+                keep_splits=allowed_splits,
+                num_out_tokens=num_out_tokens,
+            )
+            num_kept = allowed_splits.sum(dtype=torch.long)
+
+            dispatch_in_cap = num_out_tokens
+            dispatch_out_cap = rank_capacity
+            combine_in_cap = rank_capacity
+            combine_out_cap = num_out_tokens
+
+    buffers = get_ep_no_sync_buffers(
+        self,
+        dispatch_in_cap=dispatch_in_cap,
+        dispatch_out_cap=dispatch_out_cap,
+        combine_in_cap=combine_in_cap,
+        combine_out_cap=combine_out_cap,
+        d_model=moe_inp.shape[-1],
+        dtype=moe_inp.dtype,
+        device=moe_inp.device,
+        slot_idx=slot_idx,
+    )
+
+    with nvtx.annotate("A-PermuteLocal", color="green"):
+        routing_map = local_x_global_routed_expert_indices.view(
+            -1, self.routed_experts_router.top_k
+        ).int()
+        (
+            permutated_local_x,
+            reversed_local_x_permutation_mapping,
+        ) = moe_permute_1d_fused_drop_no_compile(
+            inp=moe_inp,
+            routing_map=routing_map,
+            num_out_tokens=num_out_tokens,
+            reorder_indices=local_reorder_indices,
+            inverse_reorder_indices=local_inverse_reorder_indices,
+            requested_splits=requested_splits,
+            keep_splits=allowed_splits,
+            out=buffers.dispatch_in.detach(),
+            map_type="index",
+        )
+
+    with torch.no_grad():
+        send_rank_splits = allowed_splits.view(
+            self.ep_world_size, self.num_local_routed_experts
+        ).sum(dim=-1, dtype=torch.long)
+
+    return _NoSyncStageAState(
+        lane_id=lane_id,
+        slot_idx=slot_idx,
+        group_name=group_name,
+        in_shape=in_shape,
+        hidden_shape_before_permute=hidden_shape_before_permute,
+        B=B,
+        S=S,
+        D=D,
+        attn_res_out=attn_res_out,
+        mixed_shared_out=mixed_shared_out,
+        shared_done_event=shared_done_event,
+        local_x_global_routed_expert_weights=local_x_global_routed_expert_weights,
+        routed_expert_router_aux_loss_info=routed_expert_router_aux_loss_info,
+        requested_splits=requested_splits,
+        allowed_splits=allowed_splits,
+        recv_splits_by_src_local=recv_splits_by_src_local,
+        local_inverse_reorder_indices=local_inverse_reorder_indices,
+        packed_keep_mask=packed_keep_mask,
+        num_kept=num_kept,
+        num_out_tokens=num_out_tokens,
+        send_rank_splits=send_rank_splits,
+        buffers=buffers,
+        permutated_local_x=permutated_local_x,
+        reversed_local_x_permutation_mapping=reversed_local_x_permutation_mapping,
+    )
+
+
+def ep_no_sync_stage_d_launch(
+    block: MoEFusedV2TransformerBlock, a_state: _NoSyncStageAState
+) -> _NoSyncStageDState:
+    self = block
+    comm_stream = get_or_init_stream(id=f"ep_no_sync_comm_block_{self.block_idx}", priority=0)
+    wait_stream_no_compile(this_stream=comm_stream, other_stream=torch.cuda.current_stream())
+
+    with torch.cuda.stream(comm_stream):
+        dispatch_out, dispatch_rank_splits_offsets = _DispatchVDevAutograd.apply(
+            a_state.permutated_local_x,
+            a_state.send_rank_splits,
+            a_state.buffers.dispatch_in,
+            a_state.buffers.dispatch_in_rank_splits,
+            a_state.buffers.dispatch_out,
+            a_state.buffers.dispatch_rank_splits_offsets,
+            a_state.buffers.dispatch_tmp_rank_splits_offsets,
+            a_state.group_name,
+            self.ep_pg,
+        )
+        dispatch_done_event = record_stream_event_no_compile(comm_stream)
+
+    return _NoSyncStageDState(
+        lane_id=a_state.lane_id,
+        a_state=a_state,
+        dispatch_out=dispatch_out,
+        dispatch_rank_splits_offsets=dispatch_rank_splits_offsets,
+        dispatch_done_event=dispatch_done_event,
+    )
+
+
+def ep_no_sync_stage_e(
+    block: MoEFusedV2TransformerBlock, d_state: _NoSyncStageDState
+) -> _NoSyncTboPendingContext:
+    self = block
+    assert self.routed_experts is not None
+    wait_event_no_compile(torch.cuda.current_stream(), d_state.dispatch_done_event)
+
+    a_state = d_state.a_state
+    buffers = a_state.buffers
+    dispatch_rank_major = d_state.dispatch_out
+
+    with torch.no_grad():
+        padded_batch_size_per_local_expert = a_state.recv_splits_by_src_local.sum(
+            dim=0,
+            dtype=torch.long,
+        )
+
+    with nvtx.annotate("E-PermuteGlobal", color="green"):
+        if self.routed_experts.num_local_experts == 1:
+            dispatch_rank_major = dispatch_rank_major.clone()
+            global_chunk_row_id_map = None
+        else:
+            with torch.no_grad():
+                global_chunk_routing_map = build_chunk_te_routing_map(
+                    a_state.recv_splits_by_src_local,
+                    rows=dispatch_rank_major.shape[0],
+                )
+            dispatch_rank_major, global_chunk_row_id_map = moe_chunk_reorder_no_compile(
+                inp=dispatch_rank_major,
+                routing_map=global_chunk_routing_map,
+                num_out_tokens=dispatch_rank_major.shape[0],
+                backward_grad_input_buffer=buffers.dispatch_out.detach(),
+            )
+
+    with nvtx.annotate("E-RoutedExperts", color="green"):
+        dispatch_rank_major = self.routed_experts(
+            dispatch_rank_major,
+            padded_batch_size_per_local_expert,
+        )
+
+    with nvtx.annotate("E-UnpermuteGlobal", color="green"):
+        if self.routed_experts.num_local_experts == 1:
+            global_x_rank_major = dispatch_rank_major
+        else:
+            assert global_chunk_row_id_map is not None
+            global_x_rank_major = moe_chunk_reorder_no_compile(
+                inp=dispatch_rank_major,
+                row_id_map=global_chunk_row_id_map,
+                out=buffers.combine_in.detach(),
+            )
+
+    return _NoSyncTboPendingContext(
+        block=self,
+        lane_id=d_state.lane_id,
+        a_state=a_state,
+        dispatch_rank_splits_offsets=d_state.dispatch_rank_splits_offsets,
+        global_x_rank_major=global_x_rank_major,
+    )
+
+
+def ep_no_sync_stage_c_launch(
+    block: MoEFusedV2TransformerBlock,
+    pending_ctx: _NoSyncTboPendingContext,
+) -> _NoSyncTboPendingContext:
+    del block
+    block = pending_ctx.block
+    a_state = pending_ctx.a_state
+    buffers = a_state.buffers
+    comm_stream = get_or_init_stream(id=f"ep_no_sync_comm_block_{block.block_idx}", priority=0)
+    wait_stream_no_compile(this_stream=comm_stream, other_stream=torch.cuda.current_stream())
+
+    with torch.cuda.stream(comm_stream):
+        combine_out, _combine_rank_splits_offsets = _CombineVDevAutograd.apply(
+            pending_ctx.global_x_rank_major,
+            pending_ctx.dispatch_rank_splits_offsets[0],
+            buffers.combine_in,
+            buffers.combine_in_rank_splits,
+            buffers.combine_out,
+            buffers.combine_rank_splits_offsets,
+            buffers.combine_tmp_rank_splits_offsets,
+            a_state.group_name,
+            block.ep_pg,
+        )
+        combine_done_event = record_stream_event_no_compile(comm_stream)
+
+    pending_ctx.combine_out = combine_out
+    pending_ctx.combine_done_event = combine_done_event
+    return pending_ctx
+
+
+def ep_no_sync_stage_tail(
+    block: MoEFusedV2TransformerBlock, pending_ctx: _NoSyncTboPendingContext
+) -> torch.Tensor:
+    self = block
+    if pending_ctx.combine_done_event is not None:
+        wait_event_no_compile(torch.cuda.current_stream(), pending_ctx.combine_done_event)
+
+    a_state = pending_ctx.a_state
+    buffers = a_state.buffers
+    if a_state.shared_done_event is not None:
+        wait_event_no_compile(torch.cuda.current_stream(), a_state.shared_done_event)
+
+    combine_out = (
+        pending_ctx.combine_out if pending_ctx.combine_out is not None else buffers.combine_out
+    )
+    with nvtx.annotate("Tail-UnpermuteMerge", color="green"):
+        combine_out_for_unpermute = (
+            combine_out.clone() if buffers.combine_out_is_shared else combine_out
+        )
+        local_x = restore_drop_unpermute_1d(
+            self,
+            combine_out=combine_out_for_unpermute,
+            local_inverse_reorder_indices=a_state.local_inverse_reorder_indices,
+            packed_keep_mask=a_state.packed_keep_mask,
+            num_kept=a_state.num_kept,
+            reversed_local_x_permutation_mapping=a_state.reversed_local_x_permutation_mapping,
+            local_x_global_routed_expert_weights=a_state.local_x_global_routed_expert_weights,
+            hidden_shape_before_permute=a_state.hidden_shape_before_permute,
+            row_id_map_is_packed=True,
+            backward_grad_input_buffer=buffers.combine_out.detach(),
+        )
+
+    local_x = local_x.view(a_state.in_shape)
+    wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
+
+    mlp_out = self._merge_routed_and_shared(local_x, a_state.mixed_shared_out)
+
+    final_out = self._res_norm_mlp(a_state.attn_res_out, mlp_out)
+    return self._attach_routed_aux_loss(
+        final_out,
+        a_state.routed_expert_router_aux_loss_info,
+    )
+
+
+def combined_forward_ep_no_sync_tbo(
+    block: MoEFusedV2TransformerBlock,
+    x0: torch.Tensor,
+    x1_ctx: object,
+    x1_is_fresh: bool,
+    *,
+    loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, _NoSyncTboPendingContext]:
+    self = block
+    if x1_is_fresh:
+        pending_prev = None
+    else:
+        if not isinstance(x1_ctx, _NoSyncTboPendingContext):
+            raise RuntimeError(
+                "Expected no-sync TBO context from previous block, " f"got type={type(x1_ctx)}"
+            )
+        pending_prev = x1_ctx
+
+    with nvtx.annotate("TBO-1", color="orange"):
+        if pending_prev is not None:
+            pending_prev = ep_no_sync_stage_c_launch(pending_prev.block, pending_prev)
+    with nvtx.annotate("TBO-0", color="purple"):
+        a0 = ep_no_sync_stage_a(
+            self,
+            x0,
+            lane_id=0,
+            loss_div_factor=loss_div_factor,
+            **kwargs,
+        )
+
+    with nvtx.annotate("TBO-1", color="orange"):
+        if x1_is_fresh:
+            fresh_ctx = cast(Dict[str, torch.Tensor], x1_ctx)
+            block_inp1 = fresh_ctx["x1"]
+        else:
+            assert pending_prev is not None
+            block_inp1 = ep_no_sync_stage_tail(pending_prev.block, pending_prev)
+
+    with nvtx.annotate("TBO-0", color="purple"):
+        d0 = ep_no_sync_stage_d_launch(self, a0)
+    with nvtx.annotate("TBO-1", color="orange"):
+        a1 = ep_no_sync_stage_a(
+            self,
+            block_inp1,
+            lane_id=1,
+            loss_div_factor=loss_div_factor,
+            **kwargs,
+        )
+
+    with nvtx.annotate("TBO-1", color="orange"):
+        d1 = ep_no_sync_stage_d_launch(self, a1)
+    with nvtx.annotate("TBO-0", color="purple"):
+        pending0_pre_c = ep_no_sync_stage_e(self, d0)
+
+    with nvtx.annotate("TBO-0", color="purple"):
+        pending0_post_c = ep_no_sync_stage_c_launch(self, pending0_pre_c)
+    with nvtx.annotate("TBO-1", color="orange"):
+        pending1_pre_c = ep_no_sync_stage_e(self, d1)
+
+    with nvtx.annotate("TBO-0", color="purple"):
+        final_out = ep_no_sync_stage_tail(self, pending0_post_c)
+
+    return final_out, pending1_pre_c

--- a/src/olmo_core/nn/moe/v2/model.py
+++ b/src/olmo_core/nn/moe/v2/model.py
@@ -1010,45 +1010,34 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
         labels0: Optional[torch.Tensor],
         labels1: Optional[torch.Tensor],
     ):
-        from .ep_no_sync_tbo_1d import (
-            _NoSyncTboPendingContext,
-            ep_no_sync_stage_c_launch,
-            ep_no_sync_stage_tail,
-        )
-        from .ep_no_sync_tbo_rowwise import (
-            _NoSyncRowwiseTboPendingContext,
-            ep_no_sync_rowwise_tbo_stage_c_launch,
-            ep_no_sync_rowwise_tbo_stage_tail,
-        )
-
-        if isinstance(x1_ctx, _NoSyncRowwiseTboPendingContext):
-            with annotate("tbo_1", "tbo"):
-                pending_ctx = ep_no_sync_rowwise_tbo_stage_c_launch(x1_ctx.block, x1_ctx)
-
-            h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
-
-            with annotate("tbo_1", "tbo"):
-                x1 = ep_no_sync_rowwise_tbo_stage_tail(x1_ctx.block, pending_ctx)
-
-            h1 = self.maybe_forward_lm_head(x1, lm_head_kwargs, labels=labels1)
-            return h0, h1
-
-        if isinstance(x1_ctx, _NoSyncTboPendingContext):
-            with annotate("tbo_1", "tbo"):
-                pending_ctx_1d = ep_no_sync_stage_c_launch(x1_ctx.block, x1_ctx)
-
-            h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
-
-            with annotate("tbo_1", "tbo"):
-                x1 = ep_no_sync_stage_tail(x1_ctx.block, pending_ctx_1d)
-
-            h1 = self.maybe_forward_lm_head(x1, lm_head_kwargs, labels=labels1)
-            return h0, h1
-
         if not isinstance(x1_ctx, SyncedTboPendingContext):
-            raise RuntimeError(
-                "Expected synced TBO context for the final TBO step, " f"got type={type(x1_ctx)}"
-            )
+            # No-sync TBO: the pending context carries its producing block, whose config
+            # selects the family, so only the family in use is imported here.
+            block = cast(MoEFusedV2TransformerBlock, getattr(x1_ctx, "block"))
+            if block.ep_no_sync_use_rowwise_all_to_all:
+                from .ep_no_sync_tbo_rowwise import (
+                    ep_no_sync_rowwise_tbo_stage_c_launch as _stage_c_launch,
+                )
+                from .ep_no_sync_tbo_rowwise import (
+                    ep_no_sync_rowwise_tbo_stage_tail as _stage_tail,
+                )
+            else:
+                from .ep_no_sync_tbo_1d import (
+                    ep_no_sync_stage_c_launch as _stage_c_launch,
+                )
+                from .ep_no_sync_tbo_1d import ep_no_sync_stage_tail as _stage_tail
+
+            with annotate("tbo_1", "tbo"):
+                pending_ctx = _stage_c_launch(block, x1_ctx)
+
+            h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
+
+            with annotate("tbo_1", "tbo"):
+                x1 = _stage_tail(block, pending_ctx)
+
+            h1 = self.maybe_forward_lm_head(x1, lm_head_kwargs, labels=labels1)
+            return h0, h1
+
         with annotate("tbo_1", "tbo"):
             global_x1 = x1_ctx.global_x
             send_counts1 = x1_ctx.send_counts

--- a/src/test/nn/moe/v2/ep_no_sync_tbo_1d_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_tbo_1d_test.py
@@ -1,0 +1,185 @@
+import os
+
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
+
+from olmo_core.config import DType
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlock
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.testing import requires_multi_gpu, run_distributed_test
+
+
+def _build_ep_mesh() -> DeviceMesh:
+    world_size = dist.get_world_size()
+    mesh = torch.arange(world_size, dtype=torch.int).view(1, world_size)
+    return DeviceMesh(device_type="cuda", mesh=mesh, mesh_dim_names=("ep_dp", "ep_mp"))
+
+
+def _build_tbo_model(*, two_batch_overlap: bool, ep_no_sync: bool):
+    from olmo_core.nn.attention import AttentionConfig, AttentionType
+    from olmo_core.nn.lm_head import LMHeadConfig
+    from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlockConfig
+    from olmo_core.nn.transformer import (
+        MoEFusedV2TransformerConfig,
+        TransformerBlockType,
+        TransformerType,
+    )
+
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=DType.float32)
+    config = MoEFusedV2TransformerConfig(
+        name=TransformerType.moe_fused_v2,
+        d_model=512,
+        vocab_size=128,
+        n_layers=2,
+        two_batch_overlap=two_batch_overlap,
+        recompute_each_block=False,
+        recompute_all_blocks_by_chunk=False,
+        lm_head=LMHeadConfig(bias=False, dtype=DType.float32),
+        block=MoEFusedV2TransformerBlockConfig(
+            name=TransformerBlockType.moe_fused_v2,
+            sequence_mixer=AttentionConfig(
+                name=AttentionType.default,
+                n_heads=2,
+                n_kv_heads=2,
+                bias=False,
+                use_flash=False,
+                dtype=DType.float32,
+            ),
+            attention_norm=layer_norm,
+            routed_experts_router=MoERouterConfigV2(
+                d_model=512,
+                num_experts=8,
+                top_k=2,
+                gating_function=MoERouterGatingFunction.softmax,
+                uniform_expert_assignment=False,
+                lb_loss_weight=None,
+                z_loss_weight=None,
+                dtype=DType.float32,
+            ),
+            shared_experts_router=None,
+            shared_experts=None,
+            routed_experts=RoutedExpertsConfig(
+                d_model=512, hidden_size=1024, num_experts=8, bias=False, dtype=DType.float32
+            ),
+            feed_forward_norm=layer_norm,
+            ep_no_sync=ep_no_sync,
+            ep_no_sync_capacity_factor=8.0,
+            ep_no_sync_major_align=1,
+            ep_no_sync_shared_slots=2 if two_batch_overlap and ep_no_sync else 1,
+        ),
+    )
+    return config.build(init_device="cuda")
+
+
+def _init_model_params(model):
+    torch.manual_seed(2718)
+    with torch.no_grad():
+        for param in model.parameters():
+            if param.is_floating_point():
+                param.normal_(mean=0.0, std=0.02)
+
+
+def _install_deterministic_topk_router(block: MoEFusedV2TransformerBlock):
+    """Force a deterministic, drop-free top-k routing so the TBO/non-TBO outputs are comparable."""
+
+    def _make(router):
+        def _forward(local_x, scores_only, loss_div_factor=None):
+            del loss_div_factor
+            B, S, _ = local_x.shape
+            if scores_only:
+                return (
+                    torch.ones(
+                        B, S, router.num_experts, device=local_x.device, dtype=local_x.dtype
+                    ),
+                    None,
+                    None,
+                    None,
+                )
+            top_k, num_experts = router.top_k, router.num_experts
+            token_ids = torch.arange(B * S, device=local_x.device, dtype=torch.long).unsqueeze(1)
+            route_offsets = torch.arange(top_k, device=local_x.device, dtype=torch.long).unsqueeze(
+                0
+            )
+            expert_indices = ((token_ids + route_offsets + dist.get_rank() * 3) % num_experts).view(
+                B, S, top_k
+            )
+            weights = torch.arange(1, top_k + 1, device=local_x.device, dtype=local_x.dtype)
+            weights = weights / weights.sum().clamp_min(1e-6)
+            expert_weights = weights.view(1, 1, top_k).expand(B, S, top_k).contiguous()
+            batch_size_per_expert = torch.bincount(
+                expert_indices.reshape(-1), minlength=num_experts
+            ).to(dtype=torch.long)
+            return expert_weights, expert_indices, batch_size_per_expert, None
+
+        return _forward
+
+    assert block.routed_experts_router is not None
+    block.routed_experts_router.forward = _make(block.routed_experts_router)
+
+
+def _install_model_routers(model) -> None:
+    for block in model.blocks.values():
+        assert isinstance(block, MoEFusedV2TransformerBlock)
+        _install_deterministic_topk_router(block)
+
+
+def _apply_ep(model) -> None:
+    ep_mesh = _build_ep_mesh()
+    model.apply_ep(
+        dp_mesh=ep_mesh["ep_dp"],
+        ep_mesh=ep_mesh,
+        ep_mp_group=ep_mesh["ep_mp"].get_group(),
+    )
+
+
+def _assert_matching_grads(ref_model, tbo_model) -> None:
+    ref_params = dict(ref_model.named_parameters())
+    for name, ref_param in ref_params.items():
+        tbo_param = dict(tbo_model.named_parameters())[name]
+        if ref_param.grad is None:
+            assert tbo_param.grad is None, name
+            continue
+        assert tbo_param.grad is not None, name
+        torch.testing.assert_close(tbo_param.grad, ref_param.grad, atol=1e-3, rtol=1e-3)
+
+
+def _run_no_sync_ep_tbo_matches_standard_forward():
+    # The VDev-1d no-sync machinery (shared by this TBO path) runs on the legacy torch
+    # symmetric-memory backend; OLMo-owned symm-mem supports only the rowwise path.
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"
+
+    ref_model = _build_tbo_model(two_batch_overlap=False, ep_no_sync=True)
+    tbo_model = _build_tbo_model(two_batch_overlap=True, ep_no_sync=True)
+    _apply_ep(ref_model)
+    _apply_ep(tbo_model)
+    _init_model_params(ref_model)
+    tbo_model.load_state_dict(ref_model.state_dict())
+    _install_model_routers(ref_model)
+    _install_model_routers(tbo_model)
+    ref_model.train()
+    tbo_model.train()
+
+    input_ids = torch.randint(0, ref_model.vocab_size, (4, 8), device="cuda", dtype=torch.long)
+    labels = torch.randint(0, ref_model.vocab_size, (4, 8), device="cuda", dtype=torch.long)
+
+    out_ref = ref_model(input_ids, labels=labels, loss_reduction="sum", return_logits=False)
+    out_tbo = tbo_model(input_ids, labels=labels, loss_reduction="sum", return_logits=False)
+    torch.testing.assert_close(out_tbo.loss, out_ref.loss, atol=5e-4, rtol=5e-4)
+    torch.testing.assert_close(out_tbo.ce_loss, out_ref.ce_loss, atol=5e-4, rtol=5e-4)
+
+    out_ref.loss.backward()
+    out_tbo.loss.backward()
+    _assert_matching_grads(ref_model, tbo_model)
+
+
+@requires_multi_gpu
+def test_no_sync_ep_tbo_matches_standard_forward():
+    run_distributed_test(
+        _run_no_sync_ep_tbo_matches_standard_forward,
+        backend="nccl",
+        start_method="spawn",
+    )

--- a/src/test/nn/moe/v2/ep_no_sync_tbo_1d_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_tbo_1d_test.py
@@ -49,7 +49,6 @@ def _build_tbo_model(*, two_batch_overlap: bool, ep_no_sync: bool):
                 use_flash=False,
                 dtype=DType.float32,
             ),
-            attention_norm=layer_norm,
             routed_experts_router=MoERouterConfigV2(
                 d_model=512,
                 num_experts=8,
@@ -65,7 +64,7 @@ def _build_tbo_model(*, two_batch_overlap: bool, ep_no_sync: bool):
             routed_experts=RoutedExpertsConfig(
                 d_model=512, hidden_size=1024, num_experts=8, bias=False, dtype=DType.float32
             ),
-            feed_forward_norm=layer_norm,
+            layer_norm=layer_norm,
             ep_no_sync=ep_no_sync,
             ep_no_sync_capacity_factor=8.0,
             ep_no_sync_major_align=1,


### PR DESCRIPTION
Adds the two-batch-overlap (TBO) variant of the 1D no-sync expert-parallel forward.

## What's added
`nn/moe/v2/ep_no_sync_tbo_1d.py` — `combined_forward_ep_no_sync_tbo` and its stage pipeline (`ep_no_sync_stage_a` / `stage_c_launch` / `stage_d_launch` / `stage_e` / `stage_tail`, plus the `_NoSyncTboPendingContext` carried between stages). It splits a micro-batch into two halves and overlaps one half's symmetric-memory all-to-all with the other half's compute. Driven by the model's `forward_tbo` / `_tbo_last_step` (which lazy-import it).

Depends only on the comm transport, the no-sync common helpers, and the symmetric-memory buffer pool (all on `moe-v2-core`).

## Notes
- nvtx ranges use the shared `_nvtx.annotate(label, subsystem)` helper.

## Testing
The applicable dev test (`v2_tbo_test.py`, no-sync variant — TBO output must match the non-TBO no-sync forward) compares against the non-TBO `combined_forward_ep_no_sync_1d`, so it lands once that forward (`ep_no_sync_1d`) is on the branch. The sync-TBO variant needs the sync EP family. Both are multi-GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)