### PR TITLE
Add synchronous expert-parallel forward (1D and two-batch-overlap)

### DIFF
--- a/src/olmo_core/nn/moe/v2/_nvtx.py
+++ b/src/olmo_core/nn/moe/v2/_nvtx.py
@@ -24,12 +24,12 @@ _SUBSYSTEM_COLORS = {
 _DEFAULT_COLOR = "gray"
 
 
-def annotate(label: str, subsystem: str | None = None):
+def maybe_annotate(label: str, subsystem: str | None = None):
     """
     Create an nvtx range following the shared annotation convention.
 
-    Usable as either a decorator (``@annotate("MoERouter.forward", "routing")``) or a context
-    manager (``with annotate("permute", "comm"): ...``), and a no-op when nvtx isn't installed.
+    Usable as either a decorator (``@maybe_annotate("MoERouter.forward", "routing")``) or a context
+    manager (``with maybe_annotate("permute", "comm"): ...``), and a no-op when nvtx isn't installed.
 
     :param label: The range label — the qualified ``ClassName.method`` / ``module_function`` name
         for a whole callable, or a ``snake_case`` phase name for an inner block.

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
@@ -10,7 +10,7 @@ from ..utils import (
     moe_chunk_reorder_no_compile,
     moe_permute_1d_fused_drop_no_compile,
 )
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 from .comm import _CombineVDevAutograd, _DispatchVDevAutograd
 from .ep_no_sync_buffers import (
     compute_ep_no_sync_rank_capacity,
@@ -108,7 +108,7 @@ def combined_forward_ep_no_sync_1d(
     num_out_tokens = local_x_global_routed_expert_indices.numel()
 
     with torch.no_grad():
-        with annotate("config_capacity", "comm"):
+        with maybe_annotate("config_capacity", "comm"):
             requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
             rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
             allowed_splits, recv_splits_by_src_local, _drop_token_cnt = cast(
@@ -183,7 +183,7 @@ def combined_forward_ep_no_sync_1d(
     assert packed_keep_mask is not None
     assert num_kept is not None
 
-    with annotate("permute_local_tokens", "comm"):
+    with maybe_annotate("permute_local_tokens", "comm"):
         (
             permutated_local_x,
             reversed_local_x_permutation_mapping,
@@ -228,7 +228,7 @@ def combined_forward_ep_no_sync_1d(
 
     dispatch_rank_major = dispatch_out
 
-    with annotate("permute_global_tokens", "comm"):
+    with maybe_annotate("permute_global_tokens", "comm"):
         if self.routed_experts.num_local_experts == 1:
             dispatch_rank_major = dispatch_rank_major.clone()
             global_chunk_row_id_map = None
@@ -250,7 +250,7 @@ def combined_forward_ep_no_sync_1d(
         padded_batch_size_per_local_expert,
     )
 
-    with annotate("unpermute_global_tokens", "comm"):
+    with maybe_annotate("unpermute_global_tokens", "comm"):
         if self.routed_experts.num_local_experts == 1:
             global_x_rank_major = dispatch_rank_major
         else:
@@ -278,7 +278,7 @@ def combined_forward_ep_no_sync_1d(
         self.ep_pg,
     )
 
-    with annotate("unpermute_merge_local_tokens", "comm"):
+    with maybe_annotate("unpermute_merge_local_tokens", "comm"):
         combine_out_for_unpermute = (
             combine_out.clone() if buffers.combine_out_is_shared else combine_out
         )

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_common.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_common.py
@@ -11,13 +11,13 @@ from ...moe.utils import (
     moe_unpermute_1d_fused_drop_no_compile,
     moe_unpermute_no_compile,
 )
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 
 if TYPE_CHECKING:
     from .block import MoEFusedV2TransformerBlock
 
 
-@annotate("build_keep_reorder", "comm")
+@maybe_annotate("build_keep_reorder", "comm")
 def build_keep_reorder(
     requested_splits: torch.Tensor,
     keep_splits: torch.Tensor,
@@ -71,7 +71,7 @@ def build_keep_reorder(
     return reorder_indices, inverse_reorder_indices, packed_keep_mask
 
 
-@annotate("sync_tail_drop_allowed_splits_single_a2a", "comm")
+@maybe_annotate("sync_tail_drop_allowed_splits_single_a2a", "comm")
 def sync_tail_drop_allowed_splits_single_a2a(
     block: MoEFusedV2TransformerBlock,
     requested_splits: torch.Tensor,
@@ -159,7 +159,7 @@ def sync_tail_drop_allowed_splits_single_a2a(
     )
 
 
-@annotate("restore_drop_unpermute_1d", "comm")
+@maybe_annotate("restore_drop_unpermute_1d", "comm")
 def restore_drop_unpermute_1d(
     block: MoEFusedV2TransformerBlock,
     *,
@@ -207,7 +207,7 @@ def restore_drop_unpermute_1d(
         if row_id_map_is_packed:
             restored_local_x = combine_out
         else:
-            with annotate("restore_drop", "comm"):
+            with maybe_annotate("restore_drop", "comm"):
                 restored_local_x = combine_out.index_select(
                     0,
                     local_inverse_reorder_indices,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_helpers.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_helpers.py
@@ -16,7 +16,7 @@ import torch
 
 from olmo_core.distributed.utils import get_rank
 
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 
 if TYPE_CHECKING:
     from olmo_core.train.common import ReduceType
@@ -93,7 +93,7 @@ def accumulate_ep_no_sync_rowwise_metrics(
         )
 
 
-@annotate("build_rowwise_route_maps", "comm")
+@maybe_annotate("build_rowwise_route_maps", "comm")
 def build_rowwise_route_maps(
     block: MoEFusedV2TransformerBlock,
     *,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
@@ -16,7 +16,7 @@ from ..utils import (
     moe_chunk_reorder_no_compile,
     moe_permute_1d_fused_drop_no_compile,
 )
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 from .comm import _CombineVDevAutograd, _DispatchVDevAutograd
 from .ep_no_sync_buffers import (
     _NoSyncStageAState,
@@ -73,7 +73,7 @@ def ep_no_sync_stage_a(
     del x
 
     attn_kwargs = dict(kwargs)
-    with annotate("a_attn_router", "routing"):
+    with maybe_annotate("a_attn_router", "routing"):
         attn_res_out = self._checkpointed_res_norm_attn(block_inp, **attn_kwargs)
         moe_inp = self._prepare_moe_input(attn_res_out)
         (
@@ -136,7 +136,7 @@ def ep_no_sync_stage_a(
     num_out_tokens = local_x_global_routed_expert_indices.numel()
 
     with torch.no_grad():
-        with annotate("a_config_capacity", "comm"):
+        with maybe_annotate("a_config_capacity", "comm"):
             requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
             rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
             allowed_splits, recv_splits_by_src_local, _drop_token_cnt = cast(
@@ -175,7 +175,7 @@ def ep_no_sync_stage_a(
         slot_idx=slot_idx,
     )
 
-    with annotate("a_permute_local", "comm"):
+    with maybe_annotate("a_permute_local", "comm"):
         routing_map = local_x_global_routed_expert_indices.view(
             -1, self.routed_experts_router.top_k
         ).int()
@@ -274,7 +274,7 @@ def ep_no_sync_stage_e(
             dtype=torch.long,
         )
 
-    with annotate("e_permute_global", "comm"):
+    with maybe_annotate("e_permute_global", "comm"):
         if self.routed_experts.num_local_experts == 1:
             dispatch_rank_major = dispatch_rank_major.clone()
             global_chunk_row_id_map = None
@@ -291,13 +291,13 @@ def ep_no_sync_stage_e(
                 backward_grad_input_buffer=buffers.dispatch_out.detach(),
             )
 
-    with annotate("e_routed_experts", "experts"):
+    with maybe_annotate("e_routed_experts", "experts"):
         dispatch_rank_major = self.routed_experts(
             dispatch_rank_major,
             padded_batch_size_per_local_expert,
         )
 
-    with annotate("e_unpermute_global", "comm"):
+    with maybe_annotate("e_unpermute_global", "comm"):
         if self.routed_experts.num_local_experts == 1:
             global_x_rank_major = dispatch_rank_major
         else:
@@ -362,7 +362,7 @@ def ep_no_sync_stage_tail(
     combine_out = (
         pending_ctx.combine_out if pending_ctx.combine_out is not None else buffers.combine_out
     )
-    with annotate("tail_unpermute_merge", "comm"):
+    with maybe_annotate("tail_unpermute_merge", "comm"):
         combine_out_for_unpermute = (
             combine_out.clone() if buffers.combine_out_is_shared else combine_out
         )
@@ -410,10 +410,10 @@ def combined_forward_ep_no_sync_tbo(
             )
         pending_prev = x1_ctx
 
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         if pending_prev is not None:
             pending_prev = ep_no_sync_stage_c_launch(pending_prev.block, pending_prev)
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         a0 = ep_no_sync_stage_a(
             self,
             x0,
@@ -422,7 +422,7 @@ def combined_forward_ep_no_sync_tbo(
             **kwargs,
         )
 
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         if x1_is_fresh:
             fresh_ctx = cast(Dict[str, torch.Tensor], x1_ctx)
             block_inp1 = fresh_ctx["x1"]
@@ -430,9 +430,9 @@ def combined_forward_ep_no_sync_tbo(
             assert pending_prev is not None
             block_inp1 = ep_no_sync_stage_tail(pending_prev.block, pending_prev)
 
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         d0 = ep_no_sync_stage_d_launch(self, a0)
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         a1 = ep_no_sync_stage_a(
             self,
             block_inp1,
@@ -441,17 +441,17 @@ def combined_forward_ep_no_sync_tbo(
             **kwargs,
         )
 
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         d1 = ep_no_sync_stage_d_launch(self, a1)
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         pending0_pre_c = ep_no_sync_stage_e(self, d0)
 
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         pending0_post_c = ep_no_sync_stage_c_launch(self, pending0_pre_c)
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         pending1_pre_c = ep_no_sync_stage_e(self, d1)
 
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         final_out = ep_no_sync_stage_tail(self, pending0_post_c)
 
     return final_out, pending1_pre_c

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
@@ -20,7 +20,7 @@ from ...moe.utils import (
     wait_event_no_compile,
     wait_stream_no_compile,
 )
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 from .checkpointing import is_activation_checkpointing
 from .comm import _DispatchRowwiseAutograd, _RowwiseCombineWeightedAutograd
 from .ep_no_sync_buffers import (
@@ -129,7 +129,7 @@ def ep_no_sync_rowwise_tbo_stage_a(
     block_inp = x
     del x
 
-    with annotate("rowwise_tbo_a_attn_router", "routing"):
+    with maybe_annotate("rowwise_tbo_a_attn_router", "routing"):
         attn_res_out = self._checkpointed_res_norm_attn(block_inp, **kwargs)
         moe_inp_3d = self._prepare_moe_input(attn_res_out)
         (
@@ -163,7 +163,7 @@ def ep_no_sync_rowwise_tbo_stage_a(
     ) and use_ep_no_sync_rowwise_symm_combine_gather(self)
     lease_lifetime_buffers = torch.is_grad_enabled() and not activation_checkpointing
     with torch.no_grad():
-        with annotate("rowwise_tbo_a_config_capacity", "comm"):
+        with maybe_annotate("rowwise_tbo_a_config_capacity", "comm"):
             requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
             rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
             (
@@ -465,13 +465,13 @@ def combined_forward_ep_no_sync_tbo_rowwise(
             )
         pending_prev = x1_ctx
 
-    with annotate("rowwise_tbo_1", "tbo"):
+    with maybe_annotate("rowwise_tbo_1", "tbo"):
         if pending_prev is not None:
             pending_prev = ep_no_sync_rowwise_tbo_stage_c_launch(
                 pending_prev.block,
                 pending_prev,
             )
-    with annotate("rowwise_tbo_0", "tbo"):
+    with maybe_annotate("rowwise_tbo_0", "tbo"):
         a0 = ep_no_sync_rowwise_tbo_stage_a(
             self,
             x0,
@@ -480,7 +480,7 @@ def combined_forward_ep_no_sync_tbo_rowwise(
             **kwargs,
         )
 
-    with annotate("rowwise_tbo_1", "tbo"):
+    with maybe_annotate("rowwise_tbo_1", "tbo"):
         if x1_is_fresh:
             fresh_ctx = cast(Dict[str, torch.Tensor], x1_ctx)
             block_inp1 = fresh_ctx["x1"]
@@ -491,9 +491,9 @@ def combined_forward_ep_no_sync_tbo_rowwise(
                 pending_prev,
             )
 
-    with annotate("rowwise_tbo_0", "tbo"):
+    with maybe_annotate("rowwise_tbo_0", "tbo"):
         d0 = ep_no_sync_rowwise_tbo_stage_d_launch(self, a0)
-    with annotate("rowwise_tbo_1", "tbo"):
+    with maybe_annotate("rowwise_tbo_1", "tbo"):
         a1 = ep_no_sync_rowwise_tbo_stage_a(
             self,
             block_inp1,
@@ -502,17 +502,17 @@ def combined_forward_ep_no_sync_tbo_rowwise(
             **kwargs,
         )
 
-    with annotate("rowwise_tbo_1", "tbo"):
+    with maybe_annotate("rowwise_tbo_1", "tbo"):
         d1 = ep_no_sync_rowwise_tbo_stage_d_launch(self, a1)
-    with annotate("rowwise_tbo_0", "tbo"):
+    with maybe_annotate("rowwise_tbo_0", "tbo"):
         pending0_pre_c = ep_no_sync_rowwise_tbo_stage_e(self, d0)
 
-    with annotate("rowwise_tbo_0", "tbo"):
+    with maybe_annotate("rowwise_tbo_0", "tbo"):
         pending0_post_c = ep_no_sync_rowwise_tbo_stage_c_launch(self, pending0_pre_c)
-    with annotate("rowwise_tbo_1", "tbo"):
+    with maybe_annotate("rowwise_tbo_1", "tbo"):
         pending1_pre_c = ep_no_sync_rowwise_tbo_stage_e(self, d1)
 
-    with annotate("rowwise_tbo_0", "tbo"):
+    with maybe_annotate("rowwise_tbo_0", "tbo"):
         final_out = ep_no_sync_rowwise_tbo_stage_tail(self, pending0_post_c)
 
     return final_out, pending1_pre_c

--- a/src/olmo_core/nn/moe/v2/ep_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_sync_1d.py
@@ -1,0 +1,372 @@
+"""
+Synchronous (count-synchronized) expert-parallel forward (single batch, no two-batch overlap).
+
+``combined_forward_ep_1d`` exchanges per-expert token counts with a blocking all-to-all, then
+dispatches and combines tokens with an async all-to-all over the expert-parallel group, runs the
+routed experts, and overlaps the shared experts on a side stream. "Sync" refers to the token-count
+synchronization (the no-sync paths instead use a fixed per-rank capacity and never block on counts).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional, cast
+
+import torch
+import torch.distributed as dist
+from torch.utils.checkpoint import checkpoint
+
+from olmo_core.distributed.utils import get_rank
+from olmo_core.ops import moe as ops
+
+from ...moe.utils import async_copy_to_cpu, wait_stream_no_compile
+from ..utils import moe_permute_no_compile, moe_unpermute_no_compile
+from ._nvtx import annotate
+from .routed_experts import requires_host_side_split_sizes
+
+if TYPE_CHECKING:
+    from .block import MoEFusedV2TransformerBlock
+
+log = logging.getLogger(__name__)
+
+
+def routed_experts_unpermute_1d(
+    block: MoEFusedV2TransformerBlock,
+    global_x: torch.Tensor,
+    global_x_local_expert_indices: torch.Tensor,
+    parallel_batch_size_per_local_expert_cpu,
+    hidden_shape_before_permute2: torch.Size,
+    reversed_global_x_permutation_mapping: Optional[torch.Tensor],
+) -> torch.Tensor:
+    """Run the routed experts on the gathered global tokens and unpermute them back."""
+    del global_x_local_expert_indices
+    self = block
+    assert self.routed_experts is not None
+
+    global_x = self.routed_experts(global_x, parallel_batch_size_per_local_expert_cpu)
+
+    with annotate("unpermute_global_tokens", "comm"):
+        if self.routed_experts.num_local_experts == 1:
+            return global_x
+        return moe_unpermute_no_compile(
+            inp=global_x,
+            row_id_map=reversed_global_x_permutation_mapping,
+            merging_probs=None,
+            restore_shape=hidden_shape_before_permute2,
+            map_type="index",
+        )
+
+
+def checkpointed_permute_routed_experts_unpermute_1d(
+    block: MoEFusedV2TransformerBlock,
+    global_x: torch.Tensor,
+    global_x_local_expert_indices: torch.Tensor,
+    parallel_batch_size_per_local_expert_cpu,
+) -> torch.Tensor:
+    """Permute gathered tokens by local expert, then run + unpermute (optionally checkpointed)."""
+    self = block
+    assert self.routed_experts is not None
+
+    # The initial permute does not save input for backward, so only the
+    # routed-expert/unpermute section is optionally checkpointed.
+    with annotate("permute_global_tokens", "comm"):
+        routing_map2 = global_x_local_expert_indices.view(-1, 1).int()
+        num_out_tokens2 = routing_map2.size(0)
+        hidden_shape_before_permute2 = global_x.shape
+        if self.routed_experts.num_local_experts == 1:
+            reversed_global_x_permutation_mapping = None
+        else:
+            global_x, reversed_global_x_permutation_mapping = moe_permute_no_compile(
+                inp=global_x,
+                routing_map=routing_map2,
+                num_out_tokens=num_out_tokens2,
+                map_type="index",
+            )
+
+    if self.checkpoint_permute_moe_unpermute:
+        out = checkpoint(
+            routed_experts_unpermute_1d,
+            self,
+            global_x,
+            global_x_local_expert_indices,
+            parallel_batch_size_per_local_expert_cpu,
+            hidden_shape_before_permute2,
+            reversed_global_x_permutation_mapping,
+            use_reentrant=False,
+        )
+        return cast(torch.Tensor, out)
+    return routed_experts_unpermute_1d(
+        self,
+        global_x,
+        global_x_local_expert_indices,
+        parallel_batch_size_per_local_expert_cpu,
+        hidden_shape_before_permute2,
+        reversed_global_x_permutation_mapping,
+    )
+
+
+def combined_forward_ep_1d(
+    block: MoEFusedV2TransformerBlock,
+    x: torch.Tensor,
+    *,
+    loss_div_factor: Optional[torch.Tensor | float] = None,
+    **kwargs,
+) -> torch.Tensor:
+    """Forward function with synced expert parallelism."""
+    self = block
+    assert self.routed_experts_router is not None
+    assert self.ep_enabled
+    assert self.num_local_routed_experts is not None
+
+    B, S, D = x.shape
+
+    block_inp = x
+    del x
+
+    attn_res_out = self._checkpointed_res_norm_attn(block_inp, **kwargs)
+
+    kwargs.pop("max_doc_len", None)
+    kwargs.pop("cu_doc_lens", None)
+    moe_inp = self._prepare_moe_input(attn_res_out)
+
+    (
+        local_x_global_routed_expert_weights,
+        local_x_global_routed_expert_indices,
+        local_batch_size_per_global_routed_expert,
+        routed_expert_router_aux_loss_info,
+    ) = self.routed_experts_router(
+        moe_inp,
+        False,
+        loss_div_factor=loss_div_factor,
+    )
+
+    wait_stream_no_compile(
+        this_stream=self.get_dense_stream(),
+        other_stream=torch.cuda.current_stream(),
+    )
+
+    with annotate("token_count_all_to_all", "comm"):
+        with torch.no_grad():
+            global_batch_size_per_local_expert = torch.empty_like(
+                local_batch_size_per_global_routed_expert,
+            )
+            global_batch_size_handle = dist.all_to_all_single(
+                global_batch_size_per_local_expert,
+                local_batch_size_per_global_routed_expert,
+                group=self.ep_pg,
+                async_op=True,
+            )
+            assert global_batch_size_handle is not None
+
+    with torch.cuda.stream(self.get_dense_stream()):
+        if self.shared_experts_router:
+            (
+                local_x_global_shared_expert_weights,
+                _,
+                _,
+                _,
+            ) = self.shared_experts_router(
+                moe_inp,
+                True,
+                loss_div_factor=loss_div_factor,
+            )
+        else:
+            local_x_global_shared_expert_weights = None
+
+    in_shape = moe_inp.size()
+
+    moe_inp = moe_inp.view(-1, in_shape[-1])
+
+    with annotate("sync_token_count", "comm"):
+        with torch.no_grad():
+            global_batch_size_handle.wait()
+
+            local_batch_size_per_global_routed_expert = (
+                local_batch_size_per_global_routed_expert.view(
+                    self.ep_world_size, self.num_local_routed_experts
+                )
+            )
+            global_batch_size_per_local_expert = global_batch_size_per_local_expert.view(
+                self.ep_world_size, self.num_local_routed_experts
+            )
+            parallel_batch_size_per_local_expert = global_batch_size_per_local_expert.sum(
+                dim=0,
+                dtype=torch.long,
+            )
+
+            send_counts_gpu = local_batch_size_per_global_routed_expert.sum(dim=-1)
+            recv_counts_gpu = global_batch_size_per_local_expert.sum(dim=-1)
+            send_counts_cpu, copy_stream, dtoh_event_send = async_copy_to_cpu(
+                send_counts_gpu, event=self._dtoh_event_send
+            )
+            recv_counts_cpu, copy_stream, dtoh_event_recv = async_copy_to_cpu(
+                recv_counts_gpu, event=self._dtoh_event_recv
+            )
+            parallel_batch_size_per_local_expert_cpu, copy_stream, dtoh_event = async_copy_to_cpu(
+                parallel_batch_size_per_local_expert,
+                event=self._dtoh_event,
+            )
+
+    with torch.no_grad():
+        global_x_local_expert_indices = torch.remainder(
+            torch.arange(
+                self.routed_experts_router.num_experts,
+                dtype=torch.int32,
+                device=moe_inp.device,
+            ),
+            self.num_local_routed_experts,
+        )
+
+    with annotate("permute_local_tokens", "comm"):
+        routing_map = local_x_global_routed_expert_indices.view(
+            -1, self.routed_experts_router.top_k
+        ).int()
+        num_out_tokens = routing_map.size(0) * self.routed_experts_router.top_k
+        hidden_shape_before_permute = moe_inp.shape
+        permutated_local_x, reversed_local_x_permutation_mapping = moe_permute_no_compile(
+            inp=moe_inp,
+            routing_map=routing_map,
+            num_out_tokens=num_out_tokens,
+            map_type="index",
+        )
+
+    if self.shared_experts is not None:
+        wait_stream_no_compile(
+            this_stream=self.get_dense_stream(),
+            other_stream=torch.cuda.current_stream(),
+        )
+        with torch.cuda.stream(self.get_dense_stream()):
+            shared_out_up, shared_out_gate = self.shared_experts.forward1(moe_inp.view(B, S, D))
+    else:
+        shared_out_up, shared_out_gate = None, None
+
+    with torch.no_grad():
+        assert dtoh_event_send
+        assert dtoh_event_recv
+        assert dtoh_event
+
+        dtoh_event.synchronize()
+        send_counts = send_counts_cpu.tolist()
+        recv_counts = recv_counts_cpu.tolist()
+        tokens_received = sum(recv_counts)
+
+    if tokens_received == 0:
+        log.warning(
+            "(grad=%s) block %s EP rank %s has 0 tokens received in all2all: "
+            "send_counts=%s recv_counts=%s",
+            torch.is_grad_enabled(),
+            self.block_idx,
+            get_rank(self.ep_pg),
+            send_counts,
+            recv_counts,
+        )
+
+    with annotate("all2all", "comm"):
+        permutated_local_x, global_x, global_x_handle = ops.all_to_all_async(
+            permutated_local_x,
+            recv_counts,
+            send_counts,
+            group=self.ep_pg,
+        )
+
+    with torch.no_grad():
+        global_x_local_expert_indices = torch.repeat_interleave(
+            global_x_local_expert_indices,
+            global_batch_size_per_local_expert.flatten(),
+            output_size=tokens_received,
+        )
+
+    global_x = ops.all_to_all_wait(permutated_local_x, global_x, global_x_handle)
+
+    global_x = checkpointed_permute_routed_experts_unpermute_1d(
+        self,
+        global_x,
+        global_x_local_expert_indices,
+        (
+            parallel_batch_size_per_local_expert_cpu
+            if requires_host_side_split_sizes()
+            else parallel_batch_size_per_local_expert
+        ),
+    )
+
+    before_rev_all2all_event = torch.cuda.current_stream().record_event(
+        event=self._before_rev_all2all_event
+    )
+    with annotate("reverse_all_to_all", "comm"):
+        global_x = cast(torch.Tensor, global_x)
+
+        global_x, local_x, local_x_handle = ops.all_to_all_async(
+            global_x,
+            send_counts,
+            recv_counts,
+            group=self.ep_pg,
+        )
+
+    if self.shared_experts is not None:
+        assert shared_out_up is not None
+        assert shared_out_gate is not None
+
+        self.get_dense_stream().wait_event(before_rev_all2all_event)
+        with annotate("merge_shared", "experts"):
+            with torch.cuda.stream(self.get_dense_stream()):
+                shared_out = self.shared_experts.forward2(
+                    shared_out_up, shared_out_gate, attn_res_out.shape
+                )
+                if self.shared_experts_router:
+                    assert local_x_global_shared_expert_weights is not None
+                    _, _, E_s = local_x_global_shared_expert_weights.shape
+                    mixed_shared_out = (
+                        torch.bmm(
+                            local_x_global_shared_expert_weights.to(shared_out.dtype).reshape(
+                                B * S, 1, E_s
+                            ),
+                            shared_out.permute(1, 2, 0, 3).contiguous().view(B * S, E_s, D),
+                        )
+                        .squeeze(1)
+                        .view(B, S, D)
+                    )
+                else:
+                    mixed_shared_out = shared_out.squeeze(0)
+    else:
+        mixed_shared_out = None
+
+    local_x = ops.all_to_all_wait(global_x, local_x, local_x_handle)
+
+    with annotate("unpermute_merge_local_tokens", "comm"):
+        if self.checkpoint_second_unpermute:
+            local_x = checkpoint(
+                moe_unpermute_no_compile,
+                inp=local_x,
+                row_id_map=reversed_local_x_permutation_mapping,
+                merging_probs=local_x_global_routed_expert_weights.view(
+                    -1, self.routed_experts_router.top_k
+                ),
+                restore_shape=hidden_shape_before_permute,
+                map_type="index",
+                use_reentrant=False,
+            )
+            local_x = cast(torch.Tensor, local_x)
+        else:
+            local_x = moe_unpermute_no_compile(
+                inp=local_x,
+                row_id_map=reversed_local_x_permutation_mapping,
+                merging_probs=local_x_global_routed_expert_weights.view(
+                    -1, self.routed_experts_router.top_k
+                ),
+                restore_shape=hidden_shape_before_permute,
+                map_type="index",
+            )
+            local_x = cast(torch.Tensor, local_x)
+
+    local_x = local_x.view(in_shape)
+
+    wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
+
+    mlp_out = self._merge_routed_and_shared(local_x, mixed_shared_out)
+
+    final_out = self._res_norm_mlp(attn_res_out, mlp_out)
+
+    return self._attach_routed_aux_loss(
+        final_out,
+        routed_expert_router_aux_loss_info,
+    )

--- a/src/olmo_core/nn/moe/v2/ep_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_sync_1d.py
@@ -21,7 +21,7 @@ from olmo_core.ops import moe as ops
 
 from ...moe.utils import async_copy_to_cpu, wait_stream_no_compile
 from ..utils import moe_permute_no_compile, moe_unpermute_no_compile
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 from .routed_experts import requires_host_side_split_sizes
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ def routed_experts_unpermute_1d(
 
     global_x = self.routed_experts(global_x, parallel_batch_size_per_local_expert_cpu)
 
-    with annotate("unpermute_global_tokens", "comm"):
+    with maybe_annotate("unpermute_global_tokens", "comm"):
         if self.routed_experts.num_local_experts == 1:
             return global_x
         return moe_unpermute_no_compile(
@@ -69,7 +69,7 @@ def checkpointed_permute_routed_experts_unpermute_1d(
 
     # The initial permute does not save input for backward, so only the
     # routed-expert/unpermute section is optionally checkpointed.
-    with annotate("permute_global_tokens", "comm"):
+    with maybe_annotate("permute_global_tokens", "comm"):
         routing_map2 = global_x_local_expert_indices.view(-1, 1).int()
         num_out_tokens2 = routing_map2.size(0)
         hidden_shape_before_permute2 = global_x.shape
@@ -145,7 +145,7 @@ def combined_forward_ep_1d(
         other_stream=torch.cuda.current_stream(),
     )
 
-    with annotate("token_count_all_to_all", "comm"):
+    with maybe_annotate("token_count_all_to_all", "comm"):
         with torch.no_grad():
             global_batch_size_per_local_expert = torch.empty_like(
                 local_batch_size_per_global_routed_expert,
@@ -177,7 +177,7 @@ def combined_forward_ep_1d(
 
     moe_inp = moe_inp.view(-1, in_shape[-1])
 
-    with annotate("sync_token_count", "comm"):
+    with maybe_annotate("sync_token_count", "comm"):
         with torch.no_grad():
             global_batch_size_handle.wait()
 
@@ -217,7 +217,7 @@ def combined_forward_ep_1d(
             self.num_local_routed_experts,
         )
 
-    with annotate("permute_local_tokens", "comm"):
+    with maybe_annotate("permute_local_tokens", "comm"):
         routing_map = local_x_global_routed_expert_indices.view(
             -1, self.routed_experts_router.top_k
         ).int()
@@ -261,7 +261,7 @@ def combined_forward_ep_1d(
             recv_counts,
         )
 
-    with annotate("all2all", "comm"):
+    with maybe_annotate("all2all", "comm"):
         permutated_local_x, global_x, global_x_handle = ops.all_to_all_async(
             permutated_local_x,
             recv_counts,
@@ -292,7 +292,7 @@ def combined_forward_ep_1d(
     before_rev_all2all_event = torch.cuda.current_stream().record_event(
         event=self._before_rev_all2all_event
     )
-    with annotate("reverse_all_to_all", "comm"):
+    with maybe_annotate("reverse_all_to_all", "comm"):
         global_x = cast(torch.Tensor, global_x)
 
         global_x, local_x, local_x_handle = ops.all_to_all_async(
@@ -307,7 +307,7 @@ def combined_forward_ep_1d(
         assert shared_out_gate is not None
 
         self.get_dense_stream().wait_event(before_rev_all2all_event)
-        with annotate("merge_shared", "experts"):
+        with maybe_annotate("merge_shared", "experts"):
             with torch.cuda.stream(self.get_dense_stream()):
                 shared_out = self.shared_experts.forward2(
                     shared_out_up, shared_out_gate, attn_res_out.shape
@@ -332,7 +332,7 @@ def combined_forward_ep_1d(
 
     local_x = ops.all_to_all_wait(global_x, local_x, local_x_handle)
 
-    with annotate("unpermute_merge_local_tokens", "comm"):
+    with maybe_annotate("unpermute_merge_local_tokens", "comm"):
         if self.checkpoint_second_unpermute:
             local_x = checkpoint(
                 moe_unpermute_no_compile,

--- a/src/olmo_core/nn/moe/v2/ep_sync_tbo.py
+++ b/src/olmo_core/nn/moe/v2/ep_sync_tbo.py
@@ -20,7 +20,7 @@ from olmo_core.ops import moe as ops
 
 from ...moe.utils import async_copy_to_cpu
 from ..utils import moe_permute_no_compile, moe_unpermute_no_compile
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 from .ep_sync_1d import checkpointed_permute_routed_experts_unpermute_1d
 from .routed_experts import requires_host_side_split_sizes
 from .tbo_state import SyncedTboPendingContext
@@ -63,7 +63,7 @@ def combined_forward_ep_tbo(
             self.num_local_routed_experts,
         )  # e.g. [0, 1, 2, 3, 0, 1, 2, 3, ...] for 4 local experts
 
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         if x1_is_fresh:
             local_x1, local_x_handle1 = None, None
             last_block = None
@@ -79,7 +79,7 @@ def combined_forward_ep_tbo(
 
             assert last_block.routed_experts_router is not None
             # finish reverse all2all and other ops for x1
-            with annotate("reverse_all_to_all", "comm"):
+            with maybe_annotate("reverse_all_to_all", "comm"):
                 global_x1 = cast(torch.Tensor, global_x1)
                 global_x1, local_x1, local_x_handle1 = ops.all_to_all_async(
                     global_x1,
@@ -88,7 +88,7 @@ def combined_forward_ep_tbo(
                     group=last_block.ep_pg,
                 )
 
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         # attention
         # + attention norm
         # + residual connection
@@ -110,7 +110,7 @@ def combined_forward_ep_tbo(
         )
 
         # 1. Communicate the number of tokens that will be sent to each device
-        with annotate("token_count_all_to_all", "comm"):
+        with maybe_annotate("token_count_all_to_all", "comm"):
             with torch.no_grad():
                 # Pass token count information to the device on which the
                 # target expert resides.
@@ -144,7 +144,7 @@ def combined_forward_ep_tbo(
         # forward shared experts
         if self.shared_experts is not None:
             shared_out = self.shared_experts.forward(moe_inp)
-            with annotate("merge_shared", "experts"):
+            with maybe_annotate("merge_shared", "experts"):
                 if self.shared_experts_router:
                     assert local_x_global_shared_expert_weights is not None
                     # weighted sum of the shared experts by router weights
@@ -176,7 +176,7 @@ def combined_forward_ep_tbo(
 
         # Compute the number of tokens that will be received from each
         # device and permute the input data across the devices.
-        with annotate("sync_token_count", "comm"):
+        with maybe_annotate("sync_token_count", "comm"):
             with torch.no_grad():
                 global_batch_size_handle.wait()
 
@@ -209,7 +209,7 @@ def combined_forward_ep_tbo(
 
         # 2. permute local tokens to be ready for all-to-all communication
 
-        with annotate("permute_local_tokens", "comm"):
+        with maybe_annotate("permute_local_tokens", "comm"):
             routing_map = local_x_global_routed_expert_indices.view(
                 -1, self.routed_experts_router.top_k
             ).int()
@@ -231,7 +231,7 @@ def combined_forward_ep_tbo(
             recv_counts = recv_counts_cpu.tolist()  # tensor to list
             tokens_received = sum(recv_counts)
 
-        with annotate("all2all", "comm"):
+        with maybe_annotate("all2all", "comm"):
             permutated_local_x, global_x, global_x_handle = ops.all_to_all_async(
                 permutated_local_x,
                 recv_counts,
@@ -247,7 +247,7 @@ def combined_forward_ep_tbo(
                 output_size=tokens_received,
             )  # e.g. [0, ...,  0, ... , 3, ..., 3, 0, ...] for 4 local experts
 
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         if x1_is_fresh:
             x1_ctx = cast(dict, x1_ctx)
             x1 = x1_ctx["x1"]
@@ -271,7 +271,7 @@ def combined_forward_ep_tbo(
             local_x1 = ops.all_to_all_wait(global_x1, local_x1, local_x_handle1)
 
             # 9. Unpermute the (local) tokens returned by all-to-all communication
-            with annotate("unpermute_merge_local_tokens", "comm"):
+            with maybe_annotate("unpermute_merge_local_tokens", "comm"):
                 local_x1 = moe_unpermute_no_compile(
                     inp=local_x1,
                     row_id_map=reversed_local_x_permutation_mapping1,
@@ -311,7 +311,7 @@ def combined_forward_ep_tbo(
             routed_expert_router_aux_loss_info1,
         )
 
-        with annotate("token_count_all_to_all", "comm"):
+        with maybe_annotate("token_count_all_to_all", "comm"):
             with torch.no_grad():
                 # Pass token count information to the device on which the
                 # target expert resides.
@@ -345,7 +345,7 @@ def combined_forward_ep_tbo(
         if self.shared_experts is not None:
             shared_out1 = self.shared_experts.forward(moe_inp1)
 
-            with annotate("merge_shared", "experts"):
+            with maybe_annotate("merge_shared", "experts"):
                 if self.shared_experts_router:
                     assert local_x_global_shared_expert_weights1 is not None
                     # weighted sum of the shared experts by router weights
@@ -377,7 +377,7 @@ def combined_forward_ep_tbo(
 
         # Compute the number of tokens that will be received from each
         # device and permute the input data across the devices.
-        with annotate("sync_token_count", "comm"):
+        with maybe_annotate("sync_token_count", "comm"):
             with torch.no_grad():
                 global_batch_size_handle1.wait()
 
@@ -410,7 +410,7 @@ def combined_forward_ep_tbo(
 
         # 2. permute local tokens to be ready for all-to-all communication
 
-        with annotate("permute_local_tokens", "comm"):
+        with maybe_annotate("permute_local_tokens", "comm"):
             routing_map1 = local_x_global_routed_expert_indices1.view(
                 -1, self.routed_experts_router.top_k
             ).int()
@@ -432,11 +432,11 @@ def combined_forward_ep_tbo(
             recv_counts1 = recv_counts_cpu1.tolist()  # tensor to list
             tokens_received1 = sum(recv_counts1)
 
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         global_x = ops.all_to_all_wait(permutated_local_x, global_x, global_x_handle)
 
-    with annotate("tbo_1", "tbo"):
-        with annotate("all2all", "comm"):
+    with maybe_annotate("tbo_1", "tbo"):
+        with maybe_annotate("all2all", "comm"):
             permutated_local_x1, global_x1, global_x_handle1 = ops.all_to_all_async(
                 permutated_local_x1,
                 recv_counts1,
@@ -452,7 +452,7 @@ def combined_forward_ep_tbo(
                 output_size=tokens_received1,
             )  # e.g. [0, ...,  0, ... , 3, ..., 3, 0, ...] for 4 local experts
 
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         global_x = checkpointed_permute_routed_experts_unpermute_1d(
             self,
             global_x,
@@ -464,13 +464,13 @@ def combined_forward_ep_tbo(
             ),
         )
 
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         global_x1 = ops.all_to_all_wait(permutated_local_x1, global_x1, global_x_handle1)
 
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         # 8. reverse_all_to_all
 
-        with annotate("reverse_all_to_all", "comm"):
+        with maybe_annotate("reverse_all_to_all", "comm"):
             global_x = cast(torch.Tensor, global_x)
             global_x, local_x, local_x_handle = ops.all_to_all_async(
                 global_x,
@@ -479,7 +479,7 @@ def combined_forward_ep_tbo(
                 group=self.ep_pg,
             )
 
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         global_x1 = checkpointed_permute_routed_experts_unpermute_1d(
             self,
             global_x1,
@@ -491,11 +491,11 @@ def combined_forward_ep_tbo(
             ),
         )
 
-    with annotate("tbo_0", "tbo"):
+    with maybe_annotate("tbo_0", "tbo"):
         local_x = ops.all_to_all_wait(global_x, local_x, local_x_handle)
 
         # 9. Unpermute the (local) tokens returned by all-to-all communication
-        with annotate("unpermute_merge_local_tokens", "comm"):
+        with maybe_annotate("unpermute_merge_local_tokens", "comm"):
             local_x = moe_unpermute_no_compile(
                 inp=local_x,
                 row_id_map=reversed_local_x_permutation_mapping,
@@ -512,7 +512,7 @@ def combined_forward_ep_tbo(
 
         final_out = self._res_norm_mlp(attn_res_out, mlp_out)
 
-    with annotate("tbo_1", "tbo"):
+    with maybe_annotate("tbo_1", "tbo"):
         x1_ctx = SyncedTboPendingContext(
             global_x=global_x1,
             send_counts=send_counts1,

--- a/src/olmo_core/nn/moe/v2/ep_sync_tbo.py
+++ b/src/olmo_core/nn/moe/v2/ep_sync_tbo.py
@@ -1,0 +1,532 @@
+"""
+Synchronous (count-synchronized) expert-parallel forward with two-batch overlap (TBO).
+
+``combined_forward_ep_tbo`` runs two micro-batches through the synchronous expert-parallel pipeline
+with their stages interleaved so one batch's expert-parallel all-to-all overlaps the other's
+attention/router compute. It shares the per-batch permute/dispatch/combine machinery with
+:mod:`~olmo_core.nn.moe.v2.ep_sync_1d`. Batch 0 ("TBO-0") is finished within the call; batch 1
+("TBO-1") is left mid-flight and returned in a :class:`SyncedTboPendingContext` for the next block
+(or the model's final TBO step) to complete.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, cast
+
+import torch
+import torch.distributed as dist
+
+from olmo_core.ops import moe as ops
+
+from ...moe.utils import async_copy_to_cpu
+from ..utils import moe_permute_no_compile, moe_unpermute_no_compile
+from ._nvtx import annotate
+from .ep_sync_1d import checkpointed_permute_routed_experts_unpermute_1d
+from .routed_experts import requires_host_side_split_sizes
+from .tbo_state import SyncedTboPendingContext
+
+if TYPE_CHECKING:
+    from .block import MoEFusedV2TransformerBlock
+
+
+def combined_forward_ep_tbo(
+    block: MoEFusedV2TransformerBlock,
+    x0: torch.Tensor,
+    x1_ctx: object,
+    x1_is_fresh: bool,
+    *,
+    loss_div_factor: Optional[torch.Tensor | float] = None,
+    **kwargs,
+) -> tuple[torch.Tensor, object]:
+    """Synchronous expert-parallel forward with two-batch overlap (see module docstring)."""
+    self = block
+
+    assert self.routed_experts is not None
+    assert self.routed_experts_router is not None
+    assert self.ep_enabled
+    assert self.num_local_routed_experts is not None
+
+    B, S, D = x0.shape
+
+    # rename "x" to avoid confusion
+    block_inp = x0
+    del x0
+
+    with torch.no_grad():
+        # Construct the expert indices for the permuted tokens.
+        global_x_local_expert_indices_0 = torch.remainder(
+            torch.arange(
+                self.routed_experts.num_experts,
+                dtype=torch.int32,
+                device=block_inp.device,
+            ),
+            self.num_local_routed_experts,
+        )  # e.g. [0, 1, 2, 3, 0, 1, 2, 3, ...] for 4 local experts
+
+    with annotate("tbo_1", "tbo"):
+        if x1_is_fresh:
+            local_x1, local_x_handle1 = None, None
+            last_block = None
+        else:
+            if not isinstance(x1_ctx, SyncedTboPendingContext):
+                raise RuntimeError(
+                    "Expected synced TBO context from previous block, " f"got type={type(x1_ctx)}"
+                )
+            global_x1 = x1_ctx.global_x
+            send_counts1 = x1_ctx.send_counts
+            recv_counts1 = x1_ctx.recv_counts
+            last_block = x1_ctx.last_block
+
+            assert last_block.routed_experts_router is not None
+            # finish reverse all2all and other ops for x1
+            with annotate("reverse_all_to_all", "comm"):
+                global_x1 = cast(torch.Tensor, global_x1)
+                global_x1, local_x1, local_x_handle1 = ops.all_to_all_async(
+                    global_x1,
+                    send_counts1,
+                    recv_counts1,
+                    group=last_block.ep_pg,
+                )
+
+    with annotate("tbo_0", "tbo"):
+        # attention
+        # + attention norm
+        # + residual connection
+        attn_res_out = self._checkpointed_res_norm_attn(block_inp, **kwargs)
+        moe_inp = self._prepare_moe_input(attn_res_out)
+        # routed expert router
+        (
+            local_x_global_routed_expert_weights,  # (B, S, top_k)
+            local_x_global_routed_expert_indices,  # (B, S, top_k)
+            local_batch_size_per_global_routed_expert,  # (num_experts, )
+            routed_expert_router_aux_loss_info,
+        ) = self.routed_experts_router(
+            moe_inp, False, loss_div_factor=loss_div_factor  # scalar
+        )
+
+        attn_res_out = self._attach_routed_aux_loss(
+            attn_res_out,
+            routed_expert_router_aux_loss_info,
+        )
+
+        # 1. Communicate the number of tokens that will be sent to each device
+        with annotate("token_count_all_to_all", "comm"):
+            with torch.no_grad():
+                # Pass token count information to the device on which the
+                # target expert resides.
+                global_batch_size_per_local_expert = torch.empty_like(
+                    local_batch_size_per_global_routed_expert,
+                )
+                global_batch_size_handle = dist.all_to_all_single(
+                    global_batch_size_per_local_expert,  # Gathered concatenated output tensor.
+                    local_batch_size_per_global_routed_expert,  # Input tensor to scatter.
+                    group=self.ep_pg,
+                    async_op=True,
+                )
+
+                assert global_batch_size_handle is not None  # because of async
+
+        if self.shared_experts_router:
+            # shared expert router
+            (
+                local_x_global_shared_expert_weights,  # (B, S, E_shared)
+                _,
+                _,
+                _,
+            ) = self.shared_experts_router(
+                moe_inp,
+                True,  # only need scores for shared experts
+                loss_div_factor=loss_div_factor,  # scalar
+            )
+        else:
+            local_x_global_shared_expert_weights = None
+
+        # forward shared experts
+        if self.shared_experts is not None:
+            shared_out = self.shared_experts.forward(moe_inp)
+            with annotate("merge_shared", "experts"):
+                if self.shared_experts_router:
+                    assert local_x_global_shared_expert_weights is not None
+                    # weighted sum of the shared experts by router weights
+                    # local_x_global_shared_expert_weights -> (B, S, E_shared)
+                    # shared_out -> (E_shared, B, S, D)
+                    _, _, E_s = local_x_global_shared_expert_weights.shape
+                    mixed_shared_out = (
+                        torch.bmm(
+                            local_x_global_shared_expert_weights.to(shared_out.dtype).reshape(
+                                B * S, 1, E_s
+                            ),  # (BS, 1, E),
+                            shared_out.permute(1, 2, 0, 3)
+                            .contiguous()
+                            .view(B * S, E_s, D),  # (BS, E, D)
+                        )
+                        .squeeze(1)
+                        .view(B, S, D)
+                    )
+                else:
+                    mixed_shared_out = shared_out.squeeze(0)
+        else:
+            mixed_shared_out = None
+
+        in_shape = moe_inp.size()
+
+        moe_inp = moe_inp.view(-1, in_shape[-1])  # (B*S, D)
+
+        # 3. Configure the sizes for grouped GEMM
+
+        # Compute the number of tokens that will be received from each
+        # device and permute the input data across the devices.
+        with annotate("sync_token_count", "comm"):
+            with torch.no_grad():
+                global_batch_size_handle.wait()
+
+                # Reshape to (ep_world_size, num_local_routed_experts).
+                local_batch_size_per_global_routed_expert = (
+                    local_batch_size_per_global_routed_expert.view(
+                        self.ep_world_size, self.num_local_routed_experts
+                    )
+                )
+                global_batch_size_per_local_expert = global_batch_size_per_local_expert.view(
+                    self.ep_world_size, self.num_local_routed_experts
+                )
+                # Calculate the bins boundaries from the token counts. # [EP, num_local_routed_experts] -> [num_local_routed_experts,]
+                parallel_batch_size_per_local_expert = global_batch_size_per_local_expert.sum(
+                    dim=0,
+                    dtype=torch.long,
+                )
+
+                send_counts_gpu = local_batch_size_per_global_routed_expert.sum(dim=-1)
+                recv_counts_gpu = global_batch_size_per_local_expert.sum(dim=-1)
+                send_counts_cpu, _, dtoh_event_send = async_copy_to_cpu(
+                    send_counts_gpu, event=self._dtoh_event_send
+                )
+                recv_counts_cpu, _, dtoh_event_recv = async_copy_to_cpu(
+                    recv_counts_gpu, event=self._dtoh_event_recv
+                )
+                parallel_batch_size_per_local_expert_cpu, _, dtoh_event = async_copy_to_cpu(
+                    parallel_batch_size_per_local_expert, event=self._dtoh_event
+                )
+
+        # 2. permute local tokens to be ready for all-to-all communication
+
+        with annotate("permute_local_tokens", "comm"):
+            routing_map = local_x_global_routed_expert_indices.view(
+                -1, self.routed_experts_router.top_k
+            ).int()
+            num_out_tokens = routing_map.size(0) * self.routed_experts_router.top_k  # dropless
+            hidden_shape_before_permute = moe_inp.shape
+            permutated_local_x, reversed_local_x_permutation_mapping = moe_permute_no_compile(
+                inp=moe_inp,
+                routing_map=routing_map,
+                num_out_tokens=num_out_tokens,
+                map_type="index",
+            )
+
+        with torch.no_grad():
+            assert dtoh_event_send
+            assert dtoh_event_recv
+            assert dtoh_event
+            dtoh_event.synchronize()
+            send_counts = send_counts_cpu.tolist()  # tensor to list
+            recv_counts = recv_counts_cpu.tolist()  # tensor to list
+            tokens_received = sum(recv_counts)
+
+        with annotate("all2all", "comm"):
+            permutated_local_x, global_x, global_x_handle = ops.all_to_all_async(
+                permutated_local_x,
+                recv_counts,
+                send_counts,
+                group=self.ep_pg,
+            )
+
+        with torch.no_grad():
+            # this specifiyes for the received global tokens, which local expert they belong to
+            global_x_local_expert_indices = torch.repeat_interleave(
+                global_x_local_expert_indices_0,
+                global_batch_size_per_local_expert.flatten(),
+                output_size=tokens_received,
+            )  # e.g. [0, ...,  0, ... , 3, ..., 3, 0, ...] for 4 local experts
+
+    with annotate("tbo_1", "tbo"):
+        if x1_is_fresh:
+            x1_ctx = cast(dict, x1_ctx)
+            x1 = x1_ctx["x1"]
+            assert x1.shape == (B, S, D)
+            block_inp1 = x1
+            del x1
+        else:
+            assert isinstance(x1_ctx, SyncedTboPendingContext)
+            reversed_local_x_permutation_mapping1 = x1_ctx.reversed_local_x_permutation_mapping
+            local_x_global_routed_expert_weights1 = x1_ctx.local_x_global_routed_expert_weights
+            hidden_shape_before_permute1 = x1_ctx.hidden_shape_before_permute
+            in_shape1 = x1_ctx.in_shape
+            mixed_shared_out1 = x1_ctx.mixed_shared_out
+            attn_res_out1 = x1_ctx.attn_res_out
+
+            assert last_block is not None
+            assert local_x_handle1 is not None
+            assert local_x1 is not None
+            assert last_block.routed_experts_router is not None
+
+            local_x1 = ops.all_to_all_wait(global_x1, local_x1, local_x_handle1)
+
+            # 9. Unpermute the (local) tokens returned by all-to-all communication
+            with annotate("unpermute_merge_local_tokens", "comm"):
+                local_x1 = moe_unpermute_no_compile(
+                    inp=local_x1,
+                    row_id_map=reversed_local_x_permutation_mapping1,
+                    merging_probs=local_x_global_routed_expert_weights1.view(
+                        -1, last_block.routed_experts_router.top_k
+                    ),
+                    restore_shape=hidden_shape_before_permute1,
+                    map_type="index",
+                )
+
+            local_x1 = local_x1.view(in_shape1)
+
+            mlp_out1 = last_block._merge_routed_and_shared(local_x1, mixed_shared_out1)
+
+            block_inp1 = last_block._res_norm_mlp(attn_res_out1, mlp_out1)
+
+        # x1 last step done
+
+        # attention
+        # + attention norm
+        # + residual connection
+        attn_res_out1 = self._checkpointed_res_norm_attn(block_inp1, **kwargs)
+        moe_inp1 = self._prepare_moe_input(attn_res_out1)
+
+        # routed expert router
+        (
+            local_x_global_routed_expert_weights1,  # (B, S, top_k)
+            local_x_global_routed_expert_indices1,  # (B, S, top_k)
+            local_batch_size_per_global_routed_expert1,  # (num_experts, )
+            routed_expert_router_aux_loss_info1,
+        ) = self.routed_experts_router(
+            moe_inp1, False, loss_div_factor=loss_div_factor  # scalar
+        )
+
+        attn_res_out1 = self._attach_routed_aux_loss(
+            attn_res_out1,
+            routed_expert_router_aux_loss_info1,
+        )
+
+        with annotate("token_count_all_to_all", "comm"):
+            with torch.no_grad():
+                # Pass token count information to the device on which the
+                # target expert resides.
+                global_batch_size_per_local_expert1 = torch.empty_like(
+                    local_batch_size_per_global_routed_expert1,
+                )
+                global_batch_size_handle1 = dist.all_to_all_single(
+                    global_batch_size_per_local_expert1,  # Gathered concatenated output tensor.
+                    local_batch_size_per_global_routed_expert1,  # Input tensor to scatter.
+                    group=self.ep_pg,
+                    async_op=True,
+                )
+
+                assert global_batch_size_handle1 is not None  # because of async
+
+        if self.shared_experts_router:
+            # shared expert router
+            (
+                local_x_global_shared_expert_weights1,  # (B, S, E_shared)
+                _,
+                _,
+                _,
+            ) = self.shared_experts_router(
+                moe_inp1,
+                True,  # only need scores for shared experts
+                loss_div_factor=loss_div_factor,  # scalar
+            )
+        else:
+            local_x_global_shared_expert_weights1 = None
+
+        if self.shared_experts is not None:
+            shared_out1 = self.shared_experts.forward(moe_inp1)
+
+            with annotate("merge_shared", "experts"):
+                if self.shared_experts_router:
+                    assert local_x_global_shared_expert_weights1 is not None
+                    # weighted sum of the shared experts by router weights
+                    # local_x_global_shared_expert_weights -> (B, S, E_shared)
+                    # shared_out -> (E_shared, B, S, D)
+                    _, _, E_s1 = local_x_global_shared_expert_weights1.shape
+                    mixed_shared_out1 = (
+                        torch.bmm(
+                            local_x_global_shared_expert_weights1.to(shared_out1.dtype).reshape(
+                                B * S, 1, E_s1
+                            ),  # (BS, 1, E),
+                            shared_out1.permute(1, 2, 0, 3)
+                            .contiguous()
+                            .view(B * S, E_s1, D),  # (BS, E, D)
+                        )
+                        .squeeze(1)
+                        .view(B, S, D)
+                    )
+                else:
+                    mixed_shared_out1 = shared_out1.squeeze(0)
+        else:
+            mixed_shared_out1 = None
+
+        in_shape1 = moe_inp1.size()
+
+        moe_inp1 = moe_inp1.view(-1, in_shape1[-1])  # (B*S, D)
+
+        # 3. Configure the sizes for grouped GEMM
+
+        # Compute the number of tokens that will be received from each
+        # device and permute the input data across the devices.
+        with annotate("sync_token_count", "comm"):
+            with torch.no_grad():
+                global_batch_size_handle1.wait()
+
+                # Reshape to (ep_world_size, num_local_routed_experts).
+                local_batch_size_per_global_routed_expert1 = (
+                    local_batch_size_per_global_routed_expert1.view(
+                        self.ep_world_size, self.num_local_routed_experts
+                    )
+                )
+                global_batch_size_per_local_expert1 = global_batch_size_per_local_expert1.view(
+                    self.ep_world_size, self.num_local_routed_experts
+                )
+                # Calculate the bins boundaries from the token counts. # [EP, num_local_routed_experts] -> [num_local_routed_experts,]
+                parallel_batch_size_per_local_expert1 = global_batch_size_per_local_expert1.sum(
+                    dim=0,
+                    dtype=torch.long,
+                )
+
+                send_counts_gpu1 = local_batch_size_per_global_routed_expert1.sum(dim=-1)
+                recv_counts_gpu1 = global_batch_size_per_local_expert1.sum(dim=-1)
+                send_counts_cpu1, _, dtoh_event_send1 = async_copy_to_cpu(
+                    send_counts_gpu1, event=self._dtoh_event_send1
+                )
+                recv_counts_cpu1, _, dtoh_event_recv1 = async_copy_to_cpu(
+                    recv_counts_gpu1, event=self._dtoh_event_recv1
+                )
+                parallel_batch_size_per_local_expert_cpu1, _, dtoh_event1 = async_copy_to_cpu(
+                    parallel_batch_size_per_local_expert1, event=self._dtoh_event1
+                )
+
+        # 2. permute local tokens to be ready for all-to-all communication
+
+        with annotate("permute_local_tokens", "comm"):
+            routing_map1 = local_x_global_routed_expert_indices1.view(
+                -1, self.routed_experts_router.top_k
+            ).int()
+            num_out_tokens1 = routing_map1.size(0) * self.routed_experts_router.top_k  # dropless
+            hidden_shape_before_permute1 = moe_inp1.shape
+            permutated_local_x1, reversed_local_x_permutation_mapping1 = moe_permute_no_compile(
+                inp=moe_inp1,
+                routing_map=routing_map1,
+                num_out_tokens=num_out_tokens1,
+                map_type="index",
+            )
+
+        with torch.no_grad():
+            # assert dtoh_event_send1
+            # assert dtoh_event_recv1
+            assert dtoh_event1
+            dtoh_event1.synchronize()
+            send_counts1 = send_counts_cpu1.tolist()  # tensor to list
+            recv_counts1 = recv_counts_cpu1.tolist()  # tensor to list
+            tokens_received1 = sum(recv_counts1)
+
+    with annotate("tbo_0", "tbo"):
+        global_x = ops.all_to_all_wait(permutated_local_x, global_x, global_x_handle)
+
+    with annotate("tbo_1", "tbo"):
+        with annotate("all2all", "comm"):
+            permutated_local_x1, global_x1, global_x_handle1 = ops.all_to_all_async(
+                permutated_local_x1,
+                recv_counts1,
+                send_counts1,
+                group=self.ep_pg,
+            )
+
+        with torch.no_grad():
+            # this specifiyes for the received global tokens, which local expert they belong to
+            global_x_local_expert_indices1 = torch.repeat_interleave(
+                global_x_local_expert_indices_0,
+                global_batch_size_per_local_expert1.flatten(),
+                output_size=tokens_received1,
+            )  # e.g. [0, ...,  0, ... , 3, ..., 3, 0, ...] for 4 local experts
+
+    with annotate("tbo_0", "tbo"):
+        global_x = checkpointed_permute_routed_experts_unpermute_1d(
+            self,
+            global_x,
+            global_x_local_expert_indices,
+            (
+                parallel_batch_size_per_local_expert_cpu
+                if requires_host_side_split_sizes()
+                else parallel_batch_size_per_local_expert
+            ),
+        )
+
+    with annotate("tbo_1", "tbo"):
+        global_x1 = ops.all_to_all_wait(permutated_local_x1, global_x1, global_x_handle1)
+
+    with annotate("tbo_0", "tbo"):
+        # 8. reverse_all_to_all
+
+        with annotate("reverse_all_to_all", "comm"):
+            global_x = cast(torch.Tensor, global_x)
+            global_x, local_x, local_x_handle = ops.all_to_all_async(
+                global_x,
+                send_counts,
+                recv_counts,
+                group=self.ep_pg,
+            )
+
+    with annotate("tbo_1", "tbo"):
+        global_x1 = checkpointed_permute_routed_experts_unpermute_1d(
+            self,
+            global_x1,
+            global_x_local_expert_indices1,
+            (
+                parallel_batch_size_per_local_expert_cpu1
+                if requires_host_side_split_sizes()
+                else parallel_batch_size_per_local_expert1
+            ),
+        )
+
+    with annotate("tbo_0", "tbo"):
+        local_x = ops.all_to_all_wait(global_x, local_x, local_x_handle)
+
+        # 9. Unpermute the (local) tokens returned by all-to-all communication
+        with annotate("unpermute_merge_local_tokens", "comm"):
+            local_x = moe_unpermute_no_compile(
+                inp=local_x,
+                row_id_map=reversed_local_x_permutation_mapping,
+                merging_probs=local_x_global_routed_expert_weights.view(
+                    -1, self.routed_experts_router.top_k
+                ),
+                restore_shape=hidden_shape_before_permute,
+                map_type="index",
+            )
+
+        local_x = local_x.view(in_shape)
+
+        mlp_out = self._merge_routed_and_shared(local_x, mixed_shared_out)
+
+        final_out = self._res_norm_mlp(attn_res_out, mlp_out)
+
+    with annotate("tbo_1", "tbo"):
+        x1_ctx = SyncedTboPendingContext(
+            global_x=global_x1,
+            send_counts=send_counts1,
+            recv_counts=recv_counts1,
+            reversed_local_x_permutation_mapping=reversed_local_x_permutation_mapping1,
+            local_x_global_routed_expert_weights=local_x_global_routed_expert_weights1,
+            hidden_shape_before_permute=hidden_shape_before_permute1,
+            in_shape=in_shape1,
+            mixed_shared_out=mixed_shared_out1,
+            attn_res_out=attn_res_out1,
+            last_block=self,
+        )
+
+    return (
+        final_out,
+        x1_ctx,
+    )

--- a/src/olmo_core/nn/moe/v2/fp8.py
+++ b/src/olmo_core/nn/moe/v2/fp8.py
@@ -13,7 +13,7 @@ from olmo_core.kernels import (
     scaled_grouped_mm_q_fp8_weight,
 )
 
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 
 if TYPE_CHECKING:
     from .block import MoEFusedV2TransformerBlock
@@ -144,7 +144,7 @@ def refresh_shared_rowwise_fp8_cache(block: MoEFusedV2TransformerBlock) -> None:
         reset_shared_rowwise_fp8_cache(block)
         return
 
-    with annotate("moe_rowwise_fp8_param_refresh_shared_weight_prequant", "experts"):
+    with maybe_annotate("moe_rowwise_fp8_param_refresh_shared_weight_prequant", "experts"):
         if up_weight is not None and down_weight is not None:
             up_weight.refresh_from_logical_weight(
                 block.shared_experts.w_up_gate,
@@ -197,7 +197,7 @@ def refresh_rowwise_fp8_cache(block: MoEFusedV2TransformerBlock) -> None:
 
     if block.routed_experts is not None:
         if routed_enabled:
-            with annotate("moe_rowwise_fp8_param_refresh_routed_weight_prequant", "experts"):
+            with maybe_annotate("moe_rowwise_fp8_param_refresh_routed_weight_prequant", "experts"):
                 block.routed_experts.refresh_rowwise_fp8_cache()
         else:
             block.routed_experts.invalidate_rowwise_fp8_cache()

--- a/src/olmo_core/nn/moe/v2/model.py
+++ b/src/olmo_core/nn/moe/v2/model.py
@@ -33,7 +33,7 @@ from olmo_core.utils import mark_dynamic
 
 from ...lm_head import LMOutputWithLoss
 from ..utils import moe_unpermute_no_compile
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 from .block import MoEFusedV2TransformerBlock
 from .checkpointing import checkpoint_recompute_context_fn
 
@@ -944,7 +944,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             # Mark sizes as dynamic for torch.compile().
             if self.compile_enabled:
                 mark_dynamic(h, (0, 1), strict=False)
-            with annotate(f"fwd_block_{block_idx}", "routing"):
+            with maybe_annotate(f"fwd_block_{block_idx}", "routing"):
                 # with self.offload_context:
                 one_block_kwargs = per_block_kwargs.get(int(block_key), {})
                 if self.checkpoint_tbo_dense_layers:
@@ -983,7 +983,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             if not block.is_moe:
                 continue
 
-            with annotate(f"fwd_block_{block_idx}", "routing"):
+            with maybe_annotate(f"fwd_block_{block_idx}", "routing"):
                 block = cast(MoEFusedV2TransformerBlock, block)
                 # with self.offload_context:
                 # x0, x1_ctx = block.checkpointed_combined_forward_ep_tbo(x0, x1_ctx, x1_is_fresh, **block_kwargs)
@@ -1035,18 +1035,18 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
                 stage_c_launch = ep_no_sync_stage_c_launch
                 stage_tail = ep_no_sync_stage_tail
 
-            with annotate("tbo_1", "tbo"):
+            with maybe_annotate("tbo_1", "tbo"):
                 pending_ctx = stage_c_launch(block, x1_ctx)
 
             h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
 
-            with annotate("tbo_1", "tbo"):
+            with maybe_annotate("tbo_1", "tbo"):
                 x1 = stage_tail(block, pending_ctx)
 
             h1 = self.maybe_forward_lm_head(x1, lm_head_kwargs, labels=labels1)
             return h0, h1
 
-        with annotate("tbo_1", "tbo"):
+        with maybe_annotate("tbo_1", "tbo"):
             global_x1 = x1_ctx.global_x
             send_counts1 = x1_ctx.send_counts
             recv_counts1 = x1_ctx.recv_counts
@@ -1054,7 +1054,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
 
             assert last_block.routed_experts_router is not None
             # finish reverse all2all and other ops for x1
-            with annotate("reverse_all_to_all", "comm"):
+            with maybe_annotate("reverse_all_to_all", "comm"):
                 global_x1 = cast(torch.Tensor, global_x1)
                 # Async all-to-all disabled; use the equivalent synchronous all-to-all.
                 # global_x1, local_x1, local_x_handle1 = ops.all_to_all_async(
@@ -1083,11 +1083,11 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
         # x0 lm head
         h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
 
-        with annotate("tbo_1", "tbo"):
+        with maybe_annotate("tbo_1", "tbo"):
             # local_x1 = ops.all_to_all_wait(global_x1, local_x1, local_x_handle1)
 
             ## 9. Unpermute the (local) tokens returned by all-to-all communication ##
-            with annotate("unpermute_merge_local_tokens", "comm"):
+            with maybe_annotate("unpermute_merge_local_tokens", "comm"):
                 local_x1 = moe_unpermute_no_compile(
                     inp=local_x1,
                     row_id_map=reversed_local_x_permutation_mapping1,
@@ -1197,7 +1197,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             # Mark sizes as dynamic for torch.compile().
             if self.compile_enabled:
                 mark_dynamic(h, (0, 1), strict=False)
-            with annotate(f"fwd_block_{block_key}", "routing"):
+            with maybe_annotate(f"fwd_block_{block_key}", "routing"):
                 block_kwargs = per_block_kwargs.get(int(block_key), {})
                 combined_kwargs = {**all_block_kwargs, **block_kwargs}
                 do_not_recompute: List[int] = []  # HACK
@@ -1313,7 +1313,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             if labels is not None:
                 lm_head_kwargs["labels"] = labels
 
-            with annotate("lm_head", "experts"):
+            with maybe_annotate("lm_head", "experts"):
                 out = self.lm_head(h, **lm_head_kwargs)
 
             # check for nan

--- a/src/olmo_core/nn/moe/v2/no_ep.py
+++ b/src/olmo_core/nn/moe/v2/no_ep.py
@@ -6,7 +6,7 @@ import torch
 
 from ...moe.utils import async_copy_to_cpu, wait_stream_no_compile
 from ..utils import moe_permute_no_compile, moe_unpermute_no_compile
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 from .routed_experts import requires_host_side_split_sizes
 
 if TYPE_CHECKING:
@@ -104,7 +104,7 @@ def combined_forward_no_ep(
     num_out_tokens = routing_map.size(0) * self.routed_experts_router.top_k
     hidden_shape_before_permute = moe_inp.shape
 
-    with annotate("permute", "comm"):
+    with maybe_annotate("permute", "comm"):
         permutated_input_tokens, reversed_input_permutation_mapping = moe_permute_no_compile(
             inp=moe_inp,
             routing_map=routing_map,
@@ -126,7 +126,7 @@ def combined_forward_no_ep(
             permutated_input_tokens, local_batch_size_per_global_routed_expert
         )
 
-    with annotate("unpermute", "comm"):
+    with maybe_annotate("unpermute", "comm"):
         unpermutated_x: torch.Tensor = moe_unpermute_no_compile(
             inp=mlp_x,
             row_id_map=reversed_input_permutation_mapping,

--- a/src/olmo_core/nn/moe/v2/routed_experts.py
+++ b/src/olmo_core/nn/moe/v2/routed_experts.py
@@ -55,7 +55,7 @@ from olmo_core.kernels.mxfp8_utils import (
 )
 from olmo_core.nn.fp8_weight import FP8WeightCacheSpec, FP8WeightStore
 
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 from .fp8 import MoERowwiseFP8Config, normalize_rowwise_fp8_config
 
 
@@ -717,7 +717,7 @@ class RoutedExperts(nn.Module):
         return cast(torch.Tensor, down)
 
     # @torch.compiler.disable(recursive=False)
-    @annotate("RoutedExperts.forward", "experts")
+    @maybe_annotate("RoutedExperts.forward", "experts")
     def forward(
         self,
         x: torch.Tensor,

--- a/src/olmo_core/nn/moe/v2/router.py
+++ b/src/olmo_core/nn/moe/v2/router.py
@@ -23,7 +23,7 @@ from olmo_core.distributed.utils import (
 from ...output_discard_checkpoint import OutputDiscardCheckpoint
 from ..loss import MoELoadBalancingLossGranularity, load_balancing_loss, router_z_loss
 from ..router import MoERouterGatingFunction, _uniform_expert_assignment
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 
 if TYPE_CHECKING:
     from olmo_core.train.common import ReduceType
@@ -341,7 +341,7 @@ class MoERouterV2(nn.Module):
             noise = torch.rand_like(x)
             return x * (low + noise * (high - low))
 
-    @annotate("MoERouter.get_top_k", "routing")
+    @maybe_annotate("MoERouter.get_top_k", "routing")
     def get_top_k(self, scores: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         expert_weights: torch.Tensor
         expert_indices: torch.Tensor
@@ -448,7 +448,7 @@ class MoERouterV2(nn.Module):
         logits = torch.round(logits.float() * q) / q
         return logits
 
-    @annotate("MoERouter.forward", "routing")
+    @maybe_annotate("MoERouter.forward", "routing")
     def forward(
         self,
         x: torch.Tensor,
@@ -578,7 +578,7 @@ class MoERouterV2(nn.Module):
         )
         return expert_weights, expert_indices, batch_size_per_expert, aux_loss_info
 
-    @annotate("MoERouter.compute_aux_loss", "routing")
+    @maybe_annotate("MoERouter.compute_aux_loss", "routing")
     def compute_aux_loss(
         self,
         scores,

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 from olmo_core.config import Config, DType
 
-from ._nvtx import annotate
+from ._nvtx import maybe_annotate
 
 
 # SwiGLU is intentionally SiLU-gated here, matching the fused fast paths (forward1/forward2)
@@ -117,7 +117,7 @@ class SharedExperts(nn.Module):
                 "SharedExperts bf16 fallback cannot run after fp8-only anchor storage has been released"
             )
 
-    @annotate("SharedExperts.forward", "experts")
+    @maybe_annotate("SharedExperts.forward", "experts")
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         x: (B, S, D) -> out: (E, B, S, D)
@@ -151,7 +151,7 @@ class SharedExperts(nn.Module):
 
         return out.view(E, B, S, D)
 
-    @annotate("SharedExperts.forward1", "experts")
+    @maybe_annotate("SharedExperts.forward1", "experts")
     def forward1(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Split the forward pass into two parts for better overlap in EP.
@@ -174,7 +174,7 @@ class SharedExperts(nn.Module):
 
         return up, gate
 
-    @annotate("SharedExperts.forward2", "experts")
+    @maybe_annotate("SharedExperts.forward2", "experts")
     def forward2(self, up: torch.Tensor, gate: torch.Tensor, xshape: torch.Size) -> torch.Tensor:
         """
         Split the forward pass into two parts for better overlap in EP.

--- a/src/olmo_core/ops/moe.py
+++ b/src/olmo_core/ops/moe.py
@@ -289,6 +289,30 @@ class AllToAllAsyncOp(torch.autograd.Function):
     later blocks on the handle. The work handle and the metadata needed by the wait /
     backward passes are stashed as attributes on the output tensor (``_a2a_*``) so they
     travel through autograd without extra ``ctx`` plumbing across the two ops.
+
+    The backward mirrors the forward, so the gradient all-to-all overlaps too:
+    ``AllToAllWaitOp.backward`` launches the reverse all-to-all and ``AllToAllAsyncOp.backward``
+    waits on it. The in-flight handle is handed between them by stashing it on the gradient of
+    the passthrough ``x``.
+
+    That handoff only works if ``x`` has a single consumer (the matching
+    :func:`all_to_all_wait`), because Python attributes don't survive tensor arithmetic.
+    Tracing the gradient of ``x``:
+
+    - One consumer (correct)::
+
+        WaitOp.backward -> x_grad (._a2a_handle attached)
+                        -> AsyncOp.backward gets that same tensor -> handle found, waited
+
+    - Two consumers / fan-out (wrong)::
+
+        WaitOp.backward -> grad_A (._a2a_handle attached)
+        the other op    -> grad_B (no attribute)
+        autograd sums   -> grad_A + grad_B = a NEW tensor (handle lost)
+                        -> AsyncOp.backward gets the new tensor -> handle missing -> raises
+
+    The guard in ``AllToAllAsyncOp.backward`` turns the fan-out case into a clear error instead
+    of a silent desync. The single-consumer contract is not otherwise enforced.
     """
 
     @staticmethod
@@ -322,8 +346,18 @@ class AllToAllAsyncOp(torch.autograd.Function):
     @staticmethod
     def backward(ctx, *grad_outputs):
         x_grad = grad_outputs[0]
-        x_grad_handle = x_grad._a2a_handle
-        x_grad_handle.wait()
+        # The reverse all-to-all handle was stashed on this gradient by AllToAllWaitOp.backward.
+        # If it's missing, the passthrough was fanned out to more than one consumer: autograd
+        # summed the gradients into a fresh tensor, which dropped the attribute (see class doc).
+        handle = getattr(x_grad, "_a2a_handle", None)
+        if handle is None:
+            raise RuntimeError(
+                "all_to_all_async backward could not find its in-flight gradient handle. The "
+                "passthrough tensor returned by all_to_all_async must feed ONLY the matching "
+                "all_to_all_wait; fanning it out to other ops makes autograd accumulate "
+                "gradients into a new tensor that drops the stashed handle."
+            )
+        handle.wait()
         del x_grad._a2a_handle
         return x_grad, None, None, None, None
 

--- a/src/olmo_core/ops/moe.py
+++ b/src/olmo_core/ops/moe.py
@@ -280,6 +280,141 @@ def all_to_all(
     )
 
 
+class AllToAllAsyncOp(torch.autograd.Function):
+    """
+    Autograd function backing :func:`all_to_all_async` / :func:`all_to_all_wait`.
+
+    :func:`all_to_all_async` launches the all-to-all and returns immediately so the
+    caller can overlap unrelated compute with the communication; :func:`all_to_all_wait`
+    later blocks on the handle. The work handle and the metadata needed by the wait /
+    backward passes are stashed as attributes on the output tensor (``_a2a_*``) so they
+    travel through autograd without extra ``ctx`` plumbing across the two ops.
+    """
+
+    @staticmethod
+    def forward(ctx, x, output_split_sizes, input_split_sizes, group):
+        if output_split_sizes is not None:
+            y = torch.empty(
+                (sum(output_split_sizes),) + x.shape[1:], device=x.device, dtype=x.dtype
+            )
+        else:
+            y = torch.empty_like(x)
+
+        ctx.output_split_sizes = output_split_sizes
+        ctx.input_split_sizes = input_split_sizes
+        ctx.group = group
+        y_handle = dist.all_to_all_single(
+            y,
+            x.contiguous(),
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=group,
+            async_op=True,
+        )
+        # Carry the metadata the matching AllToAllWaitOp needs on the output tensor.
+        setattr(y, "_a2a_input_shape", x.shape)
+        setattr(y, "_a2a_output_split_sizes", output_split_sizes)
+        setattr(y, "_a2a_input_split_sizes", input_split_sizes)
+        setattr(y, "_a2a_group", group)
+
+        return x, y, y_handle
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        x_grad = grad_outputs[0]
+        x_grad_handle = x_grad._a2a_handle
+        x_grad_handle.wait()
+        del x_grad._a2a_handle
+        return x_grad, None, None, None, None
+
+
+class AllToAllWaitOp(torch.autograd.Function):
+    """Completion half of :class:`AllToAllAsyncOp` (see :func:`all_to_all_wait`)."""
+
+    @staticmethod
+    def forward(ctx, x, y, y_handle):
+        # y is the output tensor from AllToAllAsyncOp; read the stashed input shape
+        # rather than y.shape (which is the post-all-to-all shape).
+        ctx.input_shape = y._a2a_input_shape
+        ctx.output_split_sizes = y._a2a_output_split_sizes
+        ctx.input_split_sizes = y._a2a_input_split_sizes
+        ctx.group = y._a2a_group
+        del y._a2a_output_split_sizes
+        del y._a2a_input_split_sizes
+        del y._a2a_group
+        del y._a2a_input_shape
+
+        y_handle.wait()
+        return y
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        y_grad = grad_outputs[0]
+        x_grad = torch.empty(
+            ctx.input_shape,
+            device=y_grad.device,
+            dtype=y_grad.dtype,
+        )
+        x_grad_handle = dist.all_to_all_single(
+            x_grad,
+            y_grad.contiguous(),
+            output_split_sizes=ctx.input_split_sizes,
+            input_split_sizes=ctx.output_split_sizes,
+            group=ctx.group,
+            async_op=True,
+        )
+        # Stash the in-flight handle on the gradient; AllToAllAsyncOp.backward waits on it.
+        setattr(x_grad, "_a2a_handle", x_grad_handle)
+        return x_grad, y_grad, None
+
+
+@torch._dynamo.disable()
+def all_to_all_async(
+    x: torch.Tensor,
+    output_split_sizes: Optional[List[int]] = None,
+    input_split_sizes: Optional[List[int]] = None,
+    group: Optional[dist.ProcessGroup] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, dist.Work]:
+    """
+    Launch a non-blocking all-to-all and return without waiting on it.
+
+    Pairs with :func:`all_to_all_wait` to overlap communication with compute::
+
+        x, y, handle = all_to_all_async(x, ...)
+        z = some_independent_compute(x)   # overlaps with the all-to-all
+        y = all_to_all_wait(x, y, handle) # blocks until the transfer is done
+
+    :param x: The local input tensor (sharded along dim 0).
+    :param output_split_sizes: Per-rank receive counts; ``None`` for an even split.
+    :param input_split_sizes: Per-rank send counts; ``None`` for an even split.
+    :param group: The process group to communicate over.
+
+    :returns: ``(x, y, handle)`` — the (unchanged) input ``x``, the output buffer ``y``
+        (not yet valid until waited on), and the in-flight work ``handle``.
+    """
+    return AllToAllAsyncOp.apply(  # type: ignore
+        x,
+        output_split_sizes,
+        input_split_sizes,
+        group,
+    )
+
+
+@torch._dynamo.disable()
+def all_to_all_wait(x: torch.Tensor, y: torch.Tensor, y_handle: dist.Work) -> torch.Tensor:
+    """
+    Block until the all-to-all launched by :func:`all_to_all_async` completes.
+
+    :param x: The original input tensor returned by :func:`all_to_all_async` (kept in the
+        autograd graph so the backward all-to-all is wired correctly).
+    :param y: The output buffer returned by :func:`all_to_all_async`.
+    :param y_handle: The work handle returned by :func:`all_to_all_async`.
+
+    :returns: The completed output tensor ``y``.
+    """
+    return AllToAllWaitOp.apply(x, y, y_handle)  # type: ignore
+
+
 def sum_tensor(x: torch.Tensor, dim: int = 0) -> torch.Tensor:
     if x.shape[dim] == 1:
         return x.squeeze(dim=dim)

--- a/src/olmo_core/ops/moe.py
+++ b/src/olmo_core/ops/moe.py
@@ -391,6 +391,14 @@ def all_to_all_async(
 
     :returns: ``(x, y, handle)`` — the (unchanged) input ``x``, the output buffer ``y``
         (not yet valid until waited on), and the in-flight work ``handle``.
+
+    .. warning::
+        The returned passthrough ``x`` must feed **only** the matching
+        :func:`all_to_all_wait` — do not fan it out to other ops. The backward all-to-all
+        handle is stashed as an attribute on ``x``'s gradient and carried along that single
+        autograd edge from :class:`AllToAllWaitOp` to :class:`AllToAllAsyncOp`. If ``x`` has
+        more than one consumer, autograd sums the incoming gradients into a fresh tensor that
+        drops the stashed handle, breaking the backward pass. This contract is not enforced.
     """
     return AllToAllAsyncOp.apply(  # type: ignore
         x,

--- a/src/olmo_core/ops/moe.py
+++ b/src/olmo_core/ops/moe.py
@@ -415,7 +415,7 @@ def all_to_all_async(
     Pairs with :func:`all_to_all_wait` to overlap communication with compute::
 
         x, y, handle = all_to_all_async(x, ...)
-        z = some_independent_compute(x)   # overlaps with the all-to-all
+        z = some_independent_compute(w)   # overlaps; note: NOT on x (see warning)
         y = all_to_all_wait(x, y, handle) # blocks until the transfer is done
 
     :param x: The local input tensor (sharded along dim 0).
@@ -433,6 +433,22 @@ def all_to_all_async(
         autograd edge from :class:`AllToAllWaitOp` to :class:`AllToAllAsyncOp`. If ``x`` has
         more than one consumer, autograd sums the incoming gradients into a fresh tensor that
         drops the stashed handle, breaking the backward pass. This contract is not enforced.
+
+    .. note::
+        The *only* thing this op adds over the existing ``all_to_all(..., async_op=True)``
+        (which already returns a work handle, giving forward comm/compute overlap) is
+        overlap of the **backward** gradient all-to-all, via the paired-``Function`` design.
+        So it pays off only when ``backward()`` runs. The synchronous EP strategies that use
+        it are, in practice, mostly the **eval/inference** path (no-sync configs fall back to
+        them at eval because no-sync can hang on uneven per-rank token counts) — and eval runs
+        no backward, so there this is equivalent to a plain async ``all_to_all`` but with the
+        passthrough footgun above. Production *training* uses the no-sync (symmetric-memory)
+        path, which doesn't use this op at all; only a few sync-training debug/ablation runs
+        actually exercise the backward overlap.
+
+        TODO: revisit whether this op earns its keep. If the sync EP path can use
+        ``all_to_all(..., async_op=True)`` for its forward overlap, consider dropping
+        ``all_to_all_async`` / ``all_to_all_wait`` (and their passthrough footgun) entirely.
     """
     return AllToAllAsyncOp.apply(  # type: ignore
         x,

--- a/src/test/nn/moe/v2/ep_sync_1d_test.py
+++ b/src/test/nn/moe/v2/ep_sync_1d_test.py
@@ -1,0 +1,168 @@
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
+
+from olmo_core.config import DType
+from olmo_core.nn.attention import AttentionConfig, AttentionType
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlock
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.testing import requires_multi_gpu, run_distributed_test
+
+
+def _build_ep_mesh() -> DeviceMesh:
+    world_size = dist.get_world_size()
+    mesh = torch.arange(world_size, dtype=torch.int).view(1, world_size)
+    return DeviceMesh(device_type="cuda", mesh=mesh, mesh_dim_names=("ep_dp", "ep_mp"))
+
+
+def _build_block() -> MoEFusedV2TransformerBlock:
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=DType.float32)
+    return MoEFusedV2TransformerBlock(
+        d_model=512,
+        block_idx=0,
+        n_layers=1,
+        sequence_mixer=AttentionConfig(
+            name=AttentionType.default,
+            n_heads=2,
+            n_kv_heads=2,
+            bias=False,
+            use_flash=False,
+            dtype=DType.float32,
+        ),
+        attention_norm=layer_norm,
+        routed_experts_router=MoERouterConfigV2(
+            d_model=512,
+            num_experts=8,
+            top_k=2,
+            gating_function=MoERouterGatingFunction.softmax,
+            uniform_expert_assignment=False,
+            lb_loss_weight=None,
+            z_loss_weight=None,
+            dtype=DType.float32,
+        ),
+        shared_experts_router=None,
+        shared_experts=None,
+        routed_experts=RoutedExpertsConfig(
+            d_model=512, hidden_size=1024, num_experts=8, bias=False, dtype=DType.float32
+        ),
+        feed_forward_norm=layer_norm,
+        # Synchronous (count-synchronized) EP: ep_no_sync=False. The sync path is dropless,
+        # so it should match the no-EP reference exactly (no capacity / no symmetric memory).
+        ep_no_sync=False,
+        init_device="cuda",
+    )
+
+
+def _init_block_params(block: MoEFusedV2TransformerBlock):
+    torch.manual_seed(1234)
+    with torch.no_grad():
+        for p in block.parameters():
+            if p.is_floating_point():
+                p.normal_(mean=0.0, std=0.02)
+
+
+def _install_deterministic_topk_router(block: MoEFusedV2TransformerBlock):
+    def _make(router):
+        def _forward(local_x, scores_only, loss_div_factor=None):
+            del loss_div_factor
+            B, S, _ = local_x.shape
+            if scores_only:
+                return (
+                    torch.ones(
+                        B, S, router.num_experts, device=local_x.device, dtype=local_x.dtype
+                    ),
+                    None,
+                    None,
+                    None,
+                )
+            top_k, num_experts = router.top_k, router.num_experts
+            token_ids = torch.arange(B * S, device=local_x.device, dtype=torch.long).unsqueeze(1)
+            route_offsets = torch.arange(top_k, device=local_x.device, dtype=torch.long).unsqueeze(
+                0
+            )
+            expert_indices = ((token_ids + route_offsets + dist.get_rank() * 3) % num_experts).view(
+                B, S, top_k
+            )
+            weights = torch.arange(1, top_k + 1, device=local_x.device, dtype=local_x.dtype)
+            weights = weights / weights.sum().clamp_min(1e-6)
+            expert_weights = weights.view(1, 1, top_k).expand(B, S, top_k).contiguous()
+            batch_size_per_expert = torch.bincount(
+                expert_indices.reshape(-1), minlength=num_experts
+            ).to(dtype=torch.long)
+            return expert_weights, expert_indices, batch_size_per_expert, None
+
+        return _forward
+
+    assert block.routed_experts_router is not None
+    block.routed_experts_router.forward = _make(block.routed_experts_router)
+
+
+def _copy_no_ep_weights_to_ep_shard(no_ep_block, ep_block):
+    no_ep_params = dict(no_ep_block.named_parameters())
+    local_experts = ep_block.routed_experts.num_local_experts
+    start = ep_block.routed_experts.ep_rank * local_experts
+    end = start + local_experts
+    with torch.no_grad():
+        for name, param in ep_block.named_parameters():
+            if name == "routed_experts.w_up_gate":
+                param.copy_(no_ep_block.routed_experts.w_up_gate[start:end])
+            elif name == "routed_experts.w_down":
+                param.copy_(no_ep_block.routed_experts.w_down[start:end])
+            else:
+                param.copy_(no_ep_params[name])
+
+
+def _assert_expert_grad_matches_no_ep_global_sum(no_ep_block, ep_block, *, atol, rtol):
+    local_experts = ep_block.routed_experts.num_local_experts
+    start = ep_block.routed_experts.ep_rank * local_experts
+    end = start + local_experts
+    for name in ("w_up_gate", "w_down"):
+        no_ep_grad = getattr(no_ep_block.routed_experts, name).grad
+        ep_grad = getattr(ep_block.routed_experts, name).grad
+        assert no_ep_grad is not None and ep_grad is not None
+        no_ep_grad_global = no_ep_grad.detach().clone()
+        dist.all_reduce(no_ep_grad_global, op=dist.ReduceOp.SUM)
+        torch.testing.assert_close(ep_grad, no_ep_grad_global[start:end], atol=atol, rtol=rtol)
+
+
+def _run_sync_ep_matches_no_ep():
+    ep_mesh = _build_ep_mesh()
+    no_ep_block = _build_block()
+    ep_block = _build_block()
+    # apply_ep with ep_no_sync=False selects the synchronous all-to-all path
+    # (combined_forward_ep_1d). The no-EP block never calls apply_ep, so it runs
+    # combined_forward_no_ep as the reference.
+    ep_block.apply_ep(ep_mesh)
+
+    _init_block_params(no_ep_block)
+    _copy_no_ep_weights_to_ep_shard(no_ep_block, ep_block)
+    _install_deterministic_topk_router(no_ep_block)
+    _install_deterministic_topk_router(ep_block)
+    no_ep_block.train()
+    ep_block.train()
+
+    x = torch.randn(
+        1, 8, no_ep_block.d_model, device="cuda", dtype=torch.float32, requires_grad=True
+    )
+    x_ep = x.detach().clone().requires_grad_(True)
+
+    y_no_ep = no_ep_block(x)
+    y_ep = ep_block(x_ep)
+    torch.testing.assert_close(y_ep, y_no_ep, atol=5e-4, rtol=5e-4)
+
+    (y_no_ep.square().mean() + 0.1 * y_no_ep.sum()).backward()
+    (y_ep.square().mean() + 0.1 * y_ep.sum()).backward()
+    torch.testing.assert_close(x_ep.grad, x.grad, atol=5e-4, rtol=5e-4)
+    _assert_expert_grad_matches_no_ep_global_sum(no_ep_block, ep_block, atol=1e-3, rtol=1e-3)
+
+
+@requires_multi_gpu
+def test_v2_sync_ep_matches_no_ep():
+    run_distributed_test(
+        _run_sync_ep_matches_no_ep,
+        backend="nccl",
+        start_method="spawn",
+    )

--- a/src/test/nn/moe/v2/ep_sync_tbo_test.py
+++ b/src/test/nn/moe/v2/ep_sync_tbo_test.py
@@ -1,0 +1,177 @@
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
+
+from olmo_core.config import DType
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlock
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.testing import requires_multi_gpu, run_distributed_test
+
+
+def _build_ep_mesh() -> DeviceMesh:
+    world_size = dist.get_world_size()
+    mesh = torch.arange(world_size, dtype=torch.int).view(1, world_size)
+    return DeviceMesh(device_type="cuda", mesh=mesh, mesh_dim_names=("ep_dp", "ep_mp"))
+
+
+def _build_tbo_model(*, two_batch_overlap: bool):
+    from olmo_core.nn.attention import AttentionConfig, AttentionType
+    from olmo_core.nn.lm_head import LMHeadConfig
+    from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlockConfig
+    from olmo_core.nn.transformer import (
+        MoEFusedV2TransformerConfig,
+        TransformerBlockType,
+        TransformerType,
+    )
+
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=DType.float32)
+    config = MoEFusedV2TransformerConfig(
+        name=TransformerType.moe_fused_v2,
+        d_model=512,
+        vocab_size=128,
+        n_layers=2,
+        two_batch_overlap=two_batch_overlap,
+        recompute_each_block=False,
+        recompute_all_blocks_by_chunk=False,
+        lm_head=LMHeadConfig(bias=False, dtype=DType.float32),
+        block=MoEFusedV2TransformerBlockConfig(
+            name=TransformerBlockType.moe_fused_v2,
+            sequence_mixer=AttentionConfig(
+                name=AttentionType.default,
+                n_heads=2,
+                n_kv_heads=2,
+                bias=False,
+                use_flash=False,
+                dtype=DType.float32,
+            ),
+            routed_experts_router=MoERouterConfigV2(
+                d_model=512,
+                num_experts=8,
+                top_k=2,
+                gating_function=MoERouterGatingFunction.softmax,
+                uniform_expert_assignment=False,
+                lb_loss_weight=None,
+                z_loss_weight=None,
+                dtype=DType.float32,
+            ),
+            shared_experts_router=None,
+            shared_experts=None,
+            routed_experts=RoutedExpertsConfig(
+                d_model=512, hidden_size=1024, num_experts=8, bias=False, dtype=DType.float32
+            ),
+            layer_norm=layer_norm,
+            # Synchronous EP (ep_no_sync=False): the count-synchronized dispatch is dropless,
+            # so TBO and non-TBO must agree exactly.
+            ep_no_sync=False,
+        ),
+    )
+    return config.build(init_device="cuda")
+
+
+def _init_model_params(model):
+    torch.manual_seed(2718)
+    with torch.no_grad():
+        for param in model.parameters():
+            if param.is_floating_point():
+                param.normal_(mean=0.0, std=0.02)
+
+
+def _install_deterministic_topk_router(block: MoEFusedV2TransformerBlock):
+    """Force a deterministic, drop-free top-k routing so the TBO/non-TBO outputs are comparable."""
+
+    def _make(router):
+        def _forward(local_x, scores_only, loss_div_factor=None):
+            del loss_div_factor
+            B, S, _ = local_x.shape
+            if scores_only:
+                return (
+                    torch.ones(
+                        B, S, router.num_experts, device=local_x.device, dtype=local_x.dtype
+                    ),
+                    None,
+                    None,
+                    None,
+                )
+            top_k, num_experts = router.top_k, router.num_experts
+            token_ids = torch.arange(B * S, device=local_x.device, dtype=torch.long).unsqueeze(1)
+            route_offsets = torch.arange(top_k, device=local_x.device, dtype=torch.long).unsqueeze(
+                0
+            )
+            expert_indices = ((token_ids + route_offsets + dist.get_rank() * 3) % num_experts).view(
+                B, S, top_k
+            )
+            weights = torch.arange(1, top_k + 1, device=local_x.device, dtype=local_x.dtype)
+            weights = weights / weights.sum().clamp_min(1e-6)
+            expert_weights = weights.view(1, 1, top_k).expand(B, S, top_k).contiguous()
+            batch_size_per_expert = torch.bincount(
+                expert_indices.reshape(-1), minlength=num_experts
+            ).to(dtype=torch.long)
+            return expert_weights, expert_indices, batch_size_per_expert, None
+
+        return _forward
+
+    assert block.routed_experts_router is not None
+    block.routed_experts_router.forward = _make(block.routed_experts_router)
+
+
+def _install_model_routers(model) -> None:
+    for block in model.blocks.values():
+        assert isinstance(block, MoEFusedV2TransformerBlock)
+        _install_deterministic_topk_router(block)
+
+
+def _apply_ep(model) -> None:
+    ep_mesh = _build_ep_mesh()
+    model.apply_ep(
+        dp_mesh=ep_mesh["ep_dp"],
+        ep_mesh=ep_mesh,
+        ep_mp_group=ep_mesh["ep_mp"].get_group(),
+    )
+
+
+def _assert_matching_grads(ref_model, tbo_model) -> None:
+    ref_params = dict(ref_model.named_parameters())
+    for name, ref_param in ref_params.items():
+        tbo_param = dict(tbo_model.named_parameters())[name]
+        if ref_param.grad is None:
+            assert tbo_param.grad is None, name
+            continue
+        assert tbo_param.grad is not None, name
+        torch.testing.assert_close(tbo_param.grad, ref_param.grad, atol=1e-3, rtol=1e-3)
+
+
+def _run_sync_ep_tbo_matches_standard_forward():
+    ref_model = _build_tbo_model(two_batch_overlap=False)
+    tbo_model = _build_tbo_model(two_batch_overlap=True)
+    _apply_ep(ref_model)
+    _apply_ep(tbo_model)
+    _init_model_params(ref_model)
+    tbo_model.load_state_dict(ref_model.state_dict())
+    _install_model_routers(ref_model)
+    _install_model_routers(tbo_model)
+    ref_model.train()
+    tbo_model.train()
+
+    input_ids = torch.randint(0, ref_model.vocab_size, (4, 8), device="cuda", dtype=torch.long)
+    labels = torch.randint(0, ref_model.vocab_size, (4, 8), device="cuda", dtype=torch.long)
+
+    out_ref = ref_model(input_ids, labels=labels, loss_reduction="sum", return_logits=False)
+    out_tbo = tbo_model(input_ids, labels=labels, loss_reduction="sum", return_logits=False)
+    torch.testing.assert_close(out_tbo.loss, out_ref.loss, atol=5e-4, rtol=5e-4)
+    torch.testing.assert_close(out_tbo.ce_loss, out_ref.ce_loss, atol=5e-4, rtol=5e-4)
+
+    out_ref.loss.backward()
+    out_tbo.loss.backward()
+    _assert_matching_grads(ref_model, tbo_model)
+
+
+@requires_multi_gpu
+def test_sync_ep_tbo_matches_standard_forward():
+    run_distributed_test(
+        _run_sync_ep_tbo_matches_standard_forward,
+        backend="nccl",
+        start_method="spawn",
+    )

--- a/src/test/ops/moe_test.py
+++ b/src/test/ops/moe_test.py
@@ -3,7 +3,12 @@ import pytest
 import torch
 
 from olmo_core.ops import moe as ops
-from olmo_core.testing import DEVICES, requires_gpu, requires_multi_gpu, run_distributed_test
+from olmo_core.testing import (
+    DEVICES,
+    requires_gpu,
+    requires_multi_gpu,
+    run_distributed_test,
+)
 
 
 @requires_gpu

--- a/src/test/ops/moe_test.py
+++ b/src/test/ops/moe_test.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 
 from olmo_core.ops import moe as ops
-from olmo_core.testing import DEVICES, requires_gpu
+from olmo_core.testing import DEVICES, requires_gpu, requires_multi_gpu, run_distributed_test
 
 
 @requires_gpu
@@ -162,3 +162,41 @@ def test_batched_histc(device: torch.device):
     torch.testing.assert_close(
         hist, torch.tensor([[1, 2, 0, 0, 0], [2, 0, 1, 0, 0]], device=device)
     )
+
+
+def _run_all_to_all_async_matches_sync():
+    import torch.distributed as dist
+
+    from olmo_core.distributed.utils import get_local_rank
+
+    rank = dist.get_rank()
+    local_rank = get_local_rank()
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+
+    # Distinct input per rank; the async path and the synchronous reference run on the
+    # same values, so output + gradient must match exactly.
+    torch.manual_seed(42 + rank)
+    x = torch.randn(8, 16, device=device, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_(True)
+
+    # Async path: launch, (a real caller overlaps compute here), then wait. The passthrough
+    # tensor returned first must feed only the wait, so the backward handle survives.
+    x_passthrough, y, handle = ops.all_to_all_async(x)
+    y = ops.all_to_all_wait(x_passthrough, y, handle)
+
+    # Synchronous reference.
+    out_ref, _ = ops.all_to_all(x_ref, async_op=False)
+    torch.testing.assert_close(y, out_ref)
+
+    # Backward parity (the custom autograd does the reverse all-to-all).
+    grad = torch.randn_like(y)
+    y.backward(grad)
+    out_ref.backward(grad)
+    assert x.grad is not None and x_ref.grad is not None
+    torch.testing.assert_close(x.grad, x_ref.grad)
+
+
+@requires_multi_gpu
+def test_all_to_all_async_matches_sync():
+    run_distributed_test(_run_all_to_all_async_matches_sync, world_size=2, backend="nccl")


### PR DESCRIPTION
Adds the synchronous (count-synchronized) expert-parallel forward paths for the fused MoE block:

- `ep_sync_1d.py` — single-batch forward. Exchanges per-expert token counts with a blocking
  all-to-all, then dispatches and combines tokens with an async all-to-all over the expert-parallel
  group, runs the routed experts, and overlaps the shared experts on a side stream.
- `ep_sync_tbo.py` — the same pipeline with two-batch overlap: two micro-batches are interleaved so
  one batch's expert-parallel all-to-all overlaps the other's attention/router compute. Batch 0 is
  finished within the call; batch 1 is returned mid-flight in a `SyncedTboPendingContext` for the
  next block (or the model's final TBO step) to complete.

`MoEFusedV2TransformerBlock.combined_forward_ep_tbo` dispatches the no-sync case before importing
this module, so the sync TBO entry point here is sync-only.

These forwards rely on the async all-to-all primitives (`all_to_all_async` / `all_to_all_wait`) in
`olmo_core.ops.moe`, which are included here so the paths type-check and run.
