### PR TITLE
Add entry for B300 in SpeedMonitorCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OLMO_RICH_LOGGING` can now explicitly enable *or* disable rich console logging (`0`/`false`/`no`/`off` disables it); previously setting it to any value only force-enabled rich logging.
 - `init_distributed()` now bootstraps a minimal single-process environment (`RANK=0`, `WORLD_SIZE=1`, `MASTER_ADDR`/`MASTER_PORT`) when launch env vars are absent, so scripts can be run directly (without `torchrun`) for single-process debugging.
 - Added a configurable `determinism_check` option to activation checkpointing (default `"default"`); set it to `"none"` to skip torch's recompute metadata check for opaque linear-attention kernels under `torch.compile`.
+- Added B300 GPU recognition to `SpeedMonitorCallback`, using the same peak FLOP/s as B200 for MFU/throughput reporting.
 
 
 ### Fixed

--- a/src/olmo_core/train/callbacks/speed_monitor.py
+++ b/src/olmo_core/train/callbacks/speed_monitor.py
@@ -105,7 +105,7 @@ class SpeedMonitorCallback(Callback):
                         self.device_peak_flops_per_second = int(1513e12 * dense_correction)
                     else:  # for SXM and other variants
                         self.device_peak_flops_per_second = int(1979e12 * dense_correction)
-                elif "B200" in device_name:
+                elif "B200" in device_name or "B300" in device_name:
                     # data from https://www.nvidia.com/en-us/data-center/hgx/
                     self.device_peak_flops_per_second = int(4.5e15 * dense_correction)
                 else:  # for other GPU types, assume A100


### PR DESCRIPTION
Reuses the B200 entry for B300s as they have equivalent bf16 TC performance.