### PR TITLE
Make maybe_nvtx_annotate color-based instead of subsystem-based

### DIFF
--- a/src/olmo_core/_nvtx.py
+++ b/src/olmo_core/_nvtx.py
@@ -51,36 +51,24 @@ try:
 except ImportError:
     _active_nvtx = nvtx  # type: ignore[assignment]
 
-# Optional convention: map a subsystem to a consistent range color. Ranges without a subsystem get
-# no color (nvtx's default), so maybe_nvtx_annotate is a drop-in for a bare nvtx.annotate(label).
-_SUBSYSTEM_COLORS = {
-    "routing": "blue",  # token routing + per-block forward orchestration
-    "experts": "purple",  # expert compute and expert-weight preparation
-    "comm": "green",  # communication / token movement (permute, all-to-all, drop/restore)
-    "tbo": "orange",  # two-batch-overlap orchestration
-}
 
-
-def maybe_nvtx_annotate(label: str, subsystem: Optional[str] = None):
+def maybe_nvtx_annotate(label: str, color: Optional[str] = None):
     """
     Create an nvtx range (a no-op when nvtx isn't installed).
 
-    Usable as either a decorator (``@maybe_nvtx_annotate("MoERouter.forward", "routing")``) or a
-    context manager (``with maybe_nvtx_annotate("permute", "comm"): ...``).
+    Usable as either a decorator (``@maybe_nvtx_annotate("MoERouter.forward", ROUTING_COLOR)``) or a
+    context manager (``with maybe_nvtx_annotate("permute", COMM_COLOR): ...``).
+
+    This helper is subsystem-agnostic: it just forwards ``color`` to nvtx. The convention of mapping
+    a subsystem to a consistent color lives with the calling code — each domain declares its own
+    color constants (e.g. :mod:`olmo_core.nn.moe.v2._nvtx_colors`) and passes one in — so this
+    module needn't know about any particular subsystem.
 
     :param label: The range label — the qualified ``ClassName.method`` / ``module_function`` name
         for a whole callable, or a ``snake_case`` phase name for an inner block.
-    :param subsystem: One of ``"routing"``, ``"experts"``, ``"comm"``, ``"tbo"``; selects the range
-        color. Omit it for ranges that don't belong to a subsystem — they get no color.
-
-    :raises ValueError: If ``subsystem`` is given but not a known subsystem.
+    :param color: The nvtx range color (any color name nvtx accepts). Omit it for ranges that don't
+        need a color — they get nvtx's default.
     """
-    if subsystem is None:
+    if color is None:
         return _active_nvtx.annotate(label)
-    try:
-        color = _SUBSYSTEM_COLORS[subsystem]
-    except KeyError:
-        raise ValueError(
-            f"unknown nvtx subsystem {subsystem!r}; expected one of {sorted(_SUBSYSTEM_COLORS)}"
-        )
     return _active_nvtx.annotate(label, color=color)

--- a/src/olmo_core/nn/moe/v2/_nvtx_colors.py
+++ b/src/olmo_core/nn/moe/v2/_nvtx_colors.py
@@ -1,0 +1,12 @@
+"""
+nvtx range colors for the fused MoE modules.
+
+The shared :func:`olmo_core._nvtx.maybe_nvtx_annotate` helper is subsystem-agnostic — it just takes a
+color. This module holds the MoE domain's color convention so every MoE range is colored
+consistently: call sites pick the constant for their subsystem rather than a raw color string.
+"""
+
+ROUTING_COLOR = "blue"  # token routing + per-block forward orchestration
+EXPERTS_COLOR = "purple"  # expert compute and expert-weight preparation
+COMM_COLOR = "green"  # communication / token movement (permute, all-to-all, drop/restore)
+TBO_COLOR = "orange"  # two-batch-overlap orchestration

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional, cast
 import torch
 
 from olmo_core._nvtx import maybe_nvtx_annotate
+from olmo_core.nn.moe.v2._nvtx_colors import COMM_COLOR
 
 from ...moe.utils import wait_stream_no_compile
 from ..utils import (
@@ -109,7 +110,7 @@ def combined_forward_ep_no_sync_1d(
     num_out_tokens = local_x_global_routed_expert_indices.numel()
 
     with torch.no_grad():
-        with maybe_nvtx_annotate("config_capacity", "comm"):
+        with maybe_nvtx_annotate("config_capacity", COMM_COLOR):
             requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
             rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
             allowed_splits, recv_splits_by_src_local, _drop_token_cnt = cast(
@@ -184,7 +185,7 @@ def combined_forward_ep_no_sync_1d(
     assert packed_keep_mask is not None
     assert num_kept is not None
 
-    with maybe_nvtx_annotate("permute_local_tokens", "comm"):
+    with maybe_nvtx_annotate("permute_local_tokens", COMM_COLOR):
         (
             permutated_local_x,
             reversed_local_x_permutation_mapping,
@@ -229,7 +230,7 @@ def combined_forward_ep_no_sync_1d(
 
     dispatch_rank_major = dispatch_out
 
-    with maybe_nvtx_annotate("permute_global_tokens", "comm"):
+    with maybe_nvtx_annotate("permute_global_tokens", COMM_COLOR):
         if self.routed_experts.num_local_experts == 1:
             dispatch_rank_major = dispatch_rank_major.clone()
             global_chunk_row_id_map = None
@@ -251,7 +252,7 @@ def combined_forward_ep_no_sync_1d(
         padded_batch_size_per_local_expert,
     )
 
-    with maybe_nvtx_annotate("unpermute_global_tokens", "comm"):
+    with maybe_nvtx_annotate("unpermute_global_tokens", COMM_COLOR):
         if self.routed_experts.num_local_experts == 1:
             global_x_rank_major = dispatch_rank_major
         else:
@@ -279,7 +280,7 @@ def combined_forward_ep_no_sync_1d(
         self.ep_pg,
     )
 
-    with maybe_nvtx_annotate("unpermute_merge_local_tokens", "comm"):
+    with maybe_nvtx_annotate("unpermute_merge_local_tokens", COMM_COLOR):
         combine_out_for_unpermute = (
             combine_out.clone() if buffers.combine_out_is_shared else combine_out
         )

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_common.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_common.py
@@ -7,6 +7,7 @@ import torch.distributed as dist
 
 from olmo_core._nvtx import maybe_nvtx_annotate
 from olmo_core.distributed.utils import get_rank
+from olmo_core.nn.moe.v2._nvtx_colors import COMM_COLOR
 
 from ...moe.utils import (
     moe_unpermute_1d_fused_drop_no_compile,
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
     from .block import MoEFusedV2TransformerBlock
 
 
-@maybe_nvtx_annotate("build_keep_reorder", "comm")
+@maybe_nvtx_annotate("build_keep_reorder", COMM_COLOR)
 def build_keep_reorder(
     requested_splits: torch.Tensor,
     keep_splits: torch.Tensor,
@@ -71,7 +72,7 @@ def build_keep_reorder(
     return reorder_indices, inverse_reorder_indices, packed_keep_mask
 
 
-@maybe_nvtx_annotate("sync_tail_drop_allowed_splits_single_a2a", "comm")
+@maybe_nvtx_annotate("sync_tail_drop_allowed_splits_single_a2a", COMM_COLOR)
 def sync_tail_drop_allowed_splits_single_a2a(
     block: MoEFusedV2TransformerBlock,
     requested_splits: torch.Tensor,
@@ -159,7 +160,7 @@ def sync_tail_drop_allowed_splits_single_a2a(
     )
 
 
-@maybe_nvtx_annotate("restore_drop_unpermute_1d", "comm")
+@maybe_nvtx_annotate("restore_drop_unpermute_1d", COMM_COLOR)
 def restore_drop_unpermute_1d(
     block: MoEFusedV2TransformerBlock,
     *,
@@ -207,7 +208,7 @@ def restore_drop_unpermute_1d(
         if row_id_map_is_packed:
             restored_local_x = combine_out
         else:
-            with maybe_nvtx_annotate("restore_drop", "comm"):
+            with maybe_nvtx_annotate("restore_drop", COMM_COLOR):
                 restored_local_x = combine_out.index_select(
                     0,
                     local_inverse_reorder_indices,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_helpers.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_helpers.py
@@ -16,6 +16,7 @@ import torch
 
 from olmo_core._nvtx import maybe_nvtx_annotate
 from olmo_core.distributed.utils import get_rank
+from olmo_core.nn.moe.v2._nvtx_colors import COMM_COLOR
 
 if TYPE_CHECKING:
     from olmo_core.train.common import ReduceType
@@ -92,7 +93,7 @@ def accumulate_ep_no_sync_rowwise_metrics(
         )
 
 
-@maybe_nvtx_annotate("build_rowwise_route_maps", "comm")
+@maybe_nvtx_annotate("build_rowwise_route_maps", COMM_COLOR)
 def build_rowwise_route_maps(
     block: MoEFusedV2TransformerBlock,
     *,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
@@ -5,6 +5,12 @@ from typing import TYPE_CHECKING, Dict, Optional, cast
 import torch
 
 from olmo_core._nvtx import maybe_nvtx_annotate
+from olmo_core.nn.moe.v2._nvtx_colors import (
+    COMM_COLOR,
+    EXPERTS_COLOR,
+    ROUTING_COLOR,
+    TBO_COLOR,
+)
 from olmo_core.utils import get_or_init_stream
 
 from ...moe.utils import (
@@ -73,7 +79,7 @@ def ep_no_sync_stage_a(
     del x
 
     attn_kwargs = dict(kwargs)
-    with maybe_nvtx_annotate("a_attn_router", "routing"):
+    with maybe_nvtx_annotate("a_attn_router", ROUTING_COLOR):
         attn_res_out = self._checkpointed_res_norm_attn(block_inp, **attn_kwargs)
         moe_inp = self._prepare_moe_input(attn_res_out)
         (
@@ -136,7 +142,7 @@ def ep_no_sync_stage_a(
     num_out_tokens = local_x_global_routed_expert_indices.numel()
 
     with torch.no_grad():
-        with maybe_nvtx_annotate("a_config_capacity", "comm"):
+        with maybe_nvtx_annotate("a_config_capacity", COMM_COLOR):
             requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
             rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
             allowed_splits, recv_splits_by_src_local, _drop_token_cnt = cast(
@@ -175,7 +181,7 @@ def ep_no_sync_stage_a(
         slot_idx=slot_idx,
     )
 
-    with maybe_nvtx_annotate("a_permute_local", "comm"):
+    with maybe_nvtx_annotate("a_permute_local", COMM_COLOR):
         routing_map = local_x_global_routed_expert_indices.view(
             -1, self.routed_experts_router.top_k
         ).int()
@@ -274,7 +280,7 @@ def ep_no_sync_stage_e(
             dtype=torch.long,
         )
 
-    with maybe_nvtx_annotate("e_permute_global", "comm"):
+    with maybe_nvtx_annotate("e_permute_global", COMM_COLOR):
         if self.routed_experts.num_local_experts == 1:
             dispatch_rank_major = dispatch_rank_major.clone()
             global_chunk_row_id_map = None
@@ -291,13 +297,13 @@ def ep_no_sync_stage_e(
                 backward_grad_input_buffer=buffers.dispatch_out.detach(),
             )
 
-    with maybe_nvtx_annotate("e_routed_experts", "experts"):
+    with maybe_nvtx_annotate("e_routed_experts", EXPERTS_COLOR):
         dispatch_rank_major = self.routed_experts(
             dispatch_rank_major,
             padded_batch_size_per_local_expert,
         )
 
-    with maybe_nvtx_annotate("e_unpermute_global", "comm"):
+    with maybe_nvtx_annotate("e_unpermute_global", COMM_COLOR):
         if self.routed_experts.num_local_experts == 1:
             global_x_rank_major = dispatch_rank_major
         else:
@@ -362,7 +368,7 @@ def ep_no_sync_stage_tail(
     combine_out = (
         pending_ctx.combine_out if pending_ctx.combine_out is not None else buffers.combine_out
     )
-    with maybe_nvtx_annotate("tail_unpermute_merge", "comm"):
+    with maybe_nvtx_annotate("tail_unpermute_merge", COMM_COLOR):
         combine_out_for_unpermute = (
             combine_out.clone() if buffers.combine_out_is_shared else combine_out
         )
@@ -410,10 +416,10 @@ def combined_forward_ep_no_sync_tbo(
             )
         pending_prev = x1_ctx
 
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         if pending_prev is not None:
             pending_prev = ep_no_sync_stage_c_launch(pending_prev.block, pending_prev)
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         a0 = ep_no_sync_stage_a(
             self,
             x0,
@@ -422,7 +428,7 @@ def combined_forward_ep_no_sync_tbo(
             **kwargs,
         )
 
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         if x1_is_fresh:
             fresh_ctx = cast(Dict[str, torch.Tensor], x1_ctx)
             block_inp1 = fresh_ctx["x1"]
@@ -430,9 +436,9 @@ def combined_forward_ep_no_sync_tbo(
             assert pending_prev is not None
             block_inp1 = ep_no_sync_stage_tail(pending_prev.block, pending_prev)
 
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         d0 = ep_no_sync_stage_d_launch(self, a0)
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         a1 = ep_no_sync_stage_a(
             self,
             block_inp1,
@@ -441,17 +447,17 @@ def combined_forward_ep_no_sync_tbo(
             **kwargs,
         )
 
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         d1 = ep_no_sync_stage_d_launch(self, a1)
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         pending0_pre_c = ep_no_sync_stage_e(self, d0)
 
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         pending0_post_c = ep_no_sync_stage_c_launch(self, pending0_pre_c)
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         pending1_pre_c = ep_no_sync_stage_e(self, d1)
 
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         final_out = ep_no_sync_stage_tail(self, pending0_post_c)
 
     return final_out, pending1_pre_c

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Dict, Optional, cast
 import torch
 
 from olmo_core._nvtx import maybe_nvtx_annotate
+from olmo_core.nn.moe.v2._nvtx_colors import COMM_COLOR, ROUTING_COLOR, TBO_COLOR
 from olmo_core.utils import get_or_init_stream
 
 from ...moe.utils import (
@@ -129,7 +130,7 @@ def ep_no_sync_rowwise_tbo_stage_a(
     block_inp = x
     del x
 
-    with maybe_nvtx_annotate("rowwise_tbo_a_attn_router", "routing"):
+    with maybe_nvtx_annotate("rowwise_tbo_a_attn_router", ROUTING_COLOR):
         attn_res_out = self._checkpointed_res_norm_attn(block_inp, **kwargs)
         moe_inp_3d = self._prepare_moe_input(attn_res_out)
         (
@@ -163,7 +164,7 @@ def ep_no_sync_rowwise_tbo_stage_a(
     ) and use_ep_no_sync_rowwise_symm_combine_gather(self)
     lease_lifetime_buffers = torch.is_grad_enabled() and not activation_checkpointing
     with torch.no_grad():
-        with maybe_nvtx_annotate("rowwise_tbo_a_config_capacity", "comm"):
+        with maybe_nvtx_annotate("rowwise_tbo_a_config_capacity", COMM_COLOR):
             requested_splits = local_batch_size_per_global_routed_expert.to(dtype=torch.long)
             rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
             (
@@ -465,13 +466,13 @@ def combined_forward_ep_no_sync_tbo_rowwise(
             )
         pending_prev = x1_ctx
 
-    with maybe_nvtx_annotate("rowwise_tbo_1", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_1", TBO_COLOR):
         if pending_prev is not None:
             pending_prev = ep_no_sync_rowwise_tbo_stage_c_launch(
                 pending_prev.block,
                 pending_prev,
             )
-    with maybe_nvtx_annotate("rowwise_tbo_0", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_0", TBO_COLOR):
         a0 = ep_no_sync_rowwise_tbo_stage_a(
             self,
             x0,
@@ -480,7 +481,7 @@ def combined_forward_ep_no_sync_tbo_rowwise(
             **kwargs,
         )
 
-    with maybe_nvtx_annotate("rowwise_tbo_1", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_1", TBO_COLOR):
         if x1_is_fresh:
             fresh_ctx = cast(Dict[str, torch.Tensor], x1_ctx)
             block_inp1 = fresh_ctx["x1"]
@@ -491,9 +492,9 @@ def combined_forward_ep_no_sync_tbo_rowwise(
                 pending_prev,
             )
 
-    with maybe_nvtx_annotate("rowwise_tbo_0", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_0", TBO_COLOR):
         d0 = ep_no_sync_rowwise_tbo_stage_d_launch(self, a0)
-    with maybe_nvtx_annotate("rowwise_tbo_1", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_1", TBO_COLOR):
         a1 = ep_no_sync_rowwise_tbo_stage_a(
             self,
             block_inp1,
@@ -502,17 +503,17 @@ def combined_forward_ep_no_sync_tbo_rowwise(
             **kwargs,
         )
 
-    with maybe_nvtx_annotate("rowwise_tbo_1", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_1", TBO_COLOR):
         d1 = ep_no_sync_rowwise_tbo_stage_d_launch(self, a1)
-    with maybe_nvtx_annotate("rowwise_tbo_0", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_0", TBO_COLOR):
         pending0_pre_c = ep_no_sync_rowwise_tbo_stage_e(self, d0)
 
-    with maybe_nvtx_annotate("rowwise_tbo_0", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_0", TBO_COLOR):
         pending0_post_c = ep_no_sync_rowwise_tbo_stage_c_launch(self, pending0_pre_c)
-    with maybe_nvtx_annotate("rowwise_tbo_1", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_1", TBO_COLOR):
         pending1_pre_c = ep_no_sync_rowwise_tbo_stage_e(self, d1)
 
-    with maybe_nvtx_annotate("rowwise_tbo_0", "tbo"):
+    with maybe_nvtx_annotate("rowwise_tbo_0", TBO_COLOR):
         final_out = ep_no_sync_rowwise_tbo_stage_tail(self, pending0_post_c)
 
     return final_out, pending1_pre_c

--- a/src/olmo_core/nn/moe/v2/ep_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_sync_1d.py
@@ -18,6 +18,7 @@ from torch.utils.checkpoint import checkpoint
 
 from olmo_core._nvtx import maybe_nvtx_annotate
 from olmo_core.distributed.utils import get_rank
+from olmo_core.nn.moe.v2._nvtx_colors import COMM_COLOR, EXPERTS_COLOR
 from olmo_core.ops import moe as ops
 
 from ...moe.utils import async_copy_to_cpu, wait_stream_no_compile
@@ -45,7 +46,7 @@ def routed_experts_unpermute_1d(
 
     global_x = self.routed_experts(global_x, parallel_batch_size_per_local_expert_cpu)
 
-    with maybe_nvtx_annotate("unpermute_global_tokens", "comm"):
+    with maybe_nvtx_annotate("unpermute_global_tokens", COMM_COLOR):
         if self.routed_experts.num_local_experts == 1:
             return global_x
         return moe_unpermute_no_compile(
@@ -69,7 +70,7 @@ def checkpointed_permute_routed_experts_unpermute_1d(
 
     # The initial permute does not save input for backward, so only the
     # routed-expert/unpermute section is optionally checkpointed.
-    with maybe_nvtx_annotate("permute_global_tokens", "comm"):
+    with maybe_nvtx_annotate("permute_global_tokens", COMM_COLOR):
         routing_map2 = global_x_local_expert_indices.view(-1, 1).int()
         num_out_tokens2 = routing_map2.size(0)
         hidden_shape_before_permute2 = global_x.shape
@@ -145,7 +146,7 @@ def combined_forward_ep_1d(
         other_stream=torch.cuda.current_stream(),
     )
 
-    with maybe_nvtx_annotate("token_count_all_to_all", "comm"):
+    with maybe_nvtx_annotate("token_count_all_to_all", COMM_COLOR):
         with torch.no_grad():
             global_batch_size_per_local_expert = torch.empty_like(
                 local_batch_size_per_global_routed_expert,
@@ -177,7 +178,7 @@ def combined_forward_ep_1d(
 
     moe_inp = moe_inp.view(-1, in_shape[-1])
 
-    with maybe_nvtx_annotate("sync_token_count", "comm"):
+    with maybe_nvtx_annotate("sync_token_count", COMM_COLOR):
         with torch.no_grad():
             global_batch_size_handle.wait()
 
@@ -217,7 +218,7 @@ def combined_forward_ep_1d(
             self.num_local_routed_experts,
         )
 
-    with maybe_nvtx_annotate("permute_local_tokens", "comm"):
+    with maybe_nvtx_annotate("permute_local_tokens", COMM_COLOR):
         routing_map = local_x_global_routed_expert_indices.view(
             -1, self.routed_experts_router.top_k
         ).int()
@@ -261,7 +262,7 @@ def combined_forward_ep_1d(
             recv_counts,
         )
 
-    with maybe_nvtx_annotate("all2all", "comm"):
+    with maybe_nvtx_annotate("all2all", COMM_COLOR):
         permutated_local_x, global_x, global_x_handle = ops.all_to_all_async(
             permutated_local_x,
             recv_counts,
@@ -292,7 +293,7 @@ def combined_forward_ep_1d(
     before_rev_all2all_event = torch.cuda.current_stream().record_event(
         event=self._before_rev_all2all_event
     )
-    with maybe_nvtx_annotate("reverse_all_to_all", "comm"):
+    with maybe_nvtx_annotate("reverse_all_to_all", COMM_COLOR):
         global_x = cast(torch.Tensor, global_x)
 
         global_x, local_x, local_x_handle = ops.all_to_all_async(
@@ -307,7 +308,7 @@ def combined_forward_ep_1d(
         assert shared_out_gate is not None
 
         self.get_dense_stream().wait_event(before_rev_all2all_event)
-        with maybe_nvtx_annotate("merge_shared", "experts"):
+        with maybe_nvtx_annotate("merge_shared", EXPERTS_COLOR):
             with torch.cuda.stream(self.get_dense_stream()):
                 shared_out = self.shared_experts.forward2(
                     shared_out_up, shared_out_gate, attn_res_out.shape
@@ -332,7 +333,7 @@ def combined_forward_ep_1d(
 
     local_x = ops.all_to_all_wait(global_x, local_x, local_x_handle)
 
-    with maybe_nvtx_annotate("unpermute_merge_local_tokens", "comm"):
+    with maybe_nvtx_annotate("unpermute_merge_local_tokens", COMM_COLOR):
         if self.checkpoint_second_unpermute:
             local_x = checkpoint(
                 moe_unpermute_no_compile,

--- a/src/olmo_core/nn/moe/v2/ep_sync_tbo.py
+++ b/src/olmo_core/nn/moe/v2/ep_sync_tbo.py
@@ -17,6 +17,7 @@ import torch
 import torch.distributed as dist
 
 from olmo_core._nvtx import maybe_nvtx_annotate
+from olmo_core.nn.moe.v2._nvtx_colors import COMM_COLOR, EXPERTS_COLOR, TBO_COLOR
 from olmo_core.ops import moe as ops
 
 from ...moe.utils import async_copy_to_cpu
@@ -63,7 +64,7 @@ def combined_forward_ep_tbo(
             self.num_local_routed_experts,
         )  # e.g. [0, 1, 2, 3, 0, 1, 2, 3, ...] for 4 local experts
 
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         if x1_is_fresh:
             local_x1, local_x_handle1 = None, None
             last_block = None
@@ -79,7 +80,7 @@ def combined_forward_ep_tbo(
 
             assert last_block.routed_experts_router is not None
             # finish reverse all2all and other ops for x1
-            with maybe_nvtx_annotate("reverse_all_to_all", "comm"):
+            with maybe_nvtx_annotate("reverse_all_to_all", COMM_COLOR):
                 global_x1 = cast(torch.Tensor, global_x1)
                 global_x1, local_x1, local_x_handle1 = ops.all_to_all_async(
                     global_x1,
@@ -88,7 +89,7 @@ def combined_forward_ep_tbo(
                     group=last_block.ep_pg,
                 )
 
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         # attention
         # + attention norm
         # + residual connection
@@ -110,7 +111,7 @@ def combined_forward_ep_tbo(
         )
 
         # 1. Communicate the number of tokens that will be sent to each device
-        with maybe_nvtx_annotate("token_count_all_to_all", "comm"):
+        with maybe_nvtx_annotate("token_count_all_to_all", COMM_COLOR):
             with torch.no_grad():
                 # Pass token count information to the device on which the
                 # target expert resides.
@@ -144,7 +145,7 @@ def combined_forward_ep_tbo(
         # forward shared experts
         if self.shared_experts is not None:
             shared_out = self.shared_experts.forward(moe_inp)
-            with maybe_nvtx_annotate("merge_shared", "experts"):
+            with maybe_nvtx_annotate("merge_shared", EXPERTS_COLOR):
                 if self.shared_experts_router:
                     assert local_x_global_shared_expert_weights is not None
                     # weighted sum of the shared experts by router weights
@@ -176,7 +177,7 @@ def combined_forward_ep_tbo(
 
         # Compute the number of tokens that will be received from each
         # device and permute the input data across the devices.
-        with maybe_nvtx_annotate("sync_token_count", "comm"):
+        with maybe_nvtx_annotate("sync_token_count", COMM_COLOR):
             with torch.no_grad():
                 global_batch_size_handle.wait()
 
@@ -209,7 +210,7 @@ def combined_forward_ep_tbo(
 
         # 2. permute local tokens to be ready for all-to-all communication
 
-        with maybe_nvtx_annotate("permute_local_tokens", "comm"):
+        with maybe_nvtx_annotate("permute_local_tokens", COMM_COLOR):
             routing_map = local_x_global_routed_expert_indices.view(
                 -1, self.routed_experts_router.top_k
             ).int()
@@ -231,7 +232,7 @@ def combined_forward_ep_tbo(
             recv_counts = recv_counts_cpu.tolist()  # tensor to list
             tokens_received = sum(recv_counts)
 
-        with maybe_nvtx_annotate("all2all", "comm"):
+        with maybe_nvtx_annotate("all2all", COMM_COLOR):
             permutated_local_x, global_x, global_x_handle = ops.all_to_all_async(
                 permutated_local_x,
                 recv_counts,
@@ -247,7 +248,7 @@ def combined_forward_ep_tbo(
                 output_size=tokens_received,
             )  # e.g. [0, ...,  0, ... , 3, ..., 3, 0, ...] for 4 local experts
 
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         if x1_is_fresh:
             x1_ctx = cast(dict, x1_ctx)
             x1 = x1_ctx["x1"]
@@ -271,7 +272,7 @@ def combined_forward_ep_tbo(
             local_x1 = ops.all_to_all_wait(global_x1, local_x1, local_x_handle1)
 
             # 9. Unpermute the (local) tokens returned by all-to-all communication
-            with maybe_nvtx_annotate("unpermute_merge_local_tokens", "comm"):
+            with maybe_nvtx_annotate("unpermute_merge_local_tokens", COMM_COLOR):
                 local_x1 = moe_unpermute_no_compile(
                     inp=local_x1,
                     row_id_map=reversed_local_x_permutation_mapping1,
@@ -311,7 +312,7 @@ def combined_forward_ep_tbo(
             routed_expert_router_aux_loss_info1,
         )
 
-        with maybe_nvtx_annotate("token_count_all_to_all", "comm"):
+        with maybe_nvtx_annotate("token_count_all_to_all", COMM_COLOR):
             with torch.no_grad():
                 # Pass token count information to the device on which the
                 # target expert resides.
@@ -345,7 +346,7 @@ def combined_forward_ep_tbo(
         if self.shared_experts is not None:
             shared_out1 = self.shared_experts.forward(moe_inp1)
 
-            with maybe_nvtx_annotate("merge_shared", "experts"):
+            with maybe_nvtx_annotate("merge_shared", EXPERTS_COLOR):
                 if self.shared_experts_router:
                     assert local_x_global_shared_expert_weights1 is not None
                     # weighted sum of the shared experts by router weights
@@ -377,7 +378,7 @@ def combined_forward_ep_tbo(
 
         # Compute the number of tokens that will be received from each
         # device and permute the input data across the devices.
-        with maybe_nvtx_annotate("sync_token_count", "comm"):
+        with maybe_nvtx_annotate("sync_token_count", COMM_COLOR):
             with torch.no_grad():
                 global_batch_size_handle1.wait()
 
@@ -410,7 +411,7 @@ def combined_forward_ep_tbo(
 
         # 2. permute local tokens to be ready for all-to-all communication
 
-        with maybe_nvtx_annotate("permute_local_tokens", "comm"):
+        with maybe_nvtx_annotate("permute_local_tokens", COMM_COLOR):
             routing_map1 = local_x_global_routed_expert_indices1.view(
                 -1, self.routed_experts_router.top_k
             ).int()
@@ -432,11 +433,11 @@ def combined_forward_ep_tbo(
             recv_counts1 = recv_counts_cpu1.tolist()  # tensor to list
             tokens_received1 = sum(recv_counts1)
 
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         global_x = ops.all_to_all_wait(permutated_local_x, global_x, global_x_handle)
 
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
-        with maybe_nvtx_annotate("all2all", "comm"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
+        with maybe_nvtx_annotate("all2all", COMM_COLOR):
             permutated_local_x1, global_x1, global_x_handle1 = ops.all_to_all_async(
                 permutated_local_x1,
                 recv_counts1,
@@ -452,7 +453,7 @@ def combined_forward_ep_tbo(
                 output_size=tokens_received1,
             )  # e.g. [0, ...,  0, ... , 3, ..., 3, 0, ...] for 4 local experts
 
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         global_x = checkpointed_permute_routed_experts_unpermute_1d(
             self,
             global_x,
@@ -464,13 +465,13 @@ def combined_forward_ep_tbo(
             ),
         )
 
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         global_x1 = ops.all_to_all_wait(permutated_local_x1, global_x1, global_x_handle1)
 
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         # 8. reverse_all_to_all
 
-        with maybe_nvtx_annotate("reverse_all_to_all", "comm"):
+        with maybe_nvtx_annotate("reverse_all_to_all", COMM_COLOR):
             global_x = cast(torch.Tensor, global_x)
             global_x, local_x, local_x_handle = ops.all_to_all_async(
                 global_x,
@@ -479,7 +480,7 @@ def combined_forward_ep_tbo(
                 group=self.ep_pg,
             )
 
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         global_x1 = checkpointed_permute_routed_experts_unpermute_1d(
             self,
             global_x1,
@@ -491,11 +492,11 @@ def combined_forward_ep_tbo(
             ),
         )
 
-    with maybe_nvtx_annotate("tbo_0", "tbo"):
+    with maybe_nvtx_annotate("tbo_0", TBO_COLOR):
         local_x = ops.all_to_all_wait(global_x, local_x, local_x_handle)
 
         # 9. Unpermute the (local) tokens returned by all-to-all communication
-        with maybe_nvtx_annotate("unpermute_merge_local_tokens", "comm"):
+        with maybe_nvtx_annotate("unpermute_merge_local_tokens", COMM_COLOR):
             local_x = moe_unpermute_no_compile(
                 inp=local_x,
                 row_id_map=reversed_local_x_permutation_mapping,
@@ -512,7 +513,7 @@ def combined_forward_ep_tbo(
 
         final_out = self._res_norm_mlp(attn_res_out, mlp_out)
 
-    with maybe_nvtx_annotate("tbo_1", "tbo"):
+    with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
         x1_ctx = SyncedTboPendingContext(
             global_x=global_x1,
             send_counts=send_counts1,

--- a/src/olmo_core/nn/moe/v2/fp8.py
+++ b/src/olmo_core/nn/moe/v2/fp8.py
@@ -13,6 +13,7 @@ from olmo_core.kernels import (
     scaled_grouped_mm_q,
     scaled_grouped_mm_q_fp8_weight,
 )
+from olmo_core.nn.moe.v2._nvtx_colors import EXPERTS_COLOR
 
 if TYPE_CHECKING:
     from .block import MoEFusedV2TransformerBlock
@@ -143,7 +144,7 @@ def refresh_shared_rowwise_fp8_cache(block: MoEFusedV2TransformerBlock) -> None:
         reset_shared_rowwise_fp8_cache(block)
         return
 
-    with maybe_nvtx_annotate("moe_rowwise_fp8_param_refresh_shared_weight_prequant", "experts"):
+    with maybe_nvtx_annotate("moe_rowwise_fp8_param_refresh_shared_weight_prequant", EXPERTS_COLOR):
         if up_weight is not None and down_weight is not None:
             up_weight.refresh_from_logical_weight(
                 block.shared_experts.w_up_gate,
@@ -197,7 +198,7 @@ def refresh_rowwise_fp8_cache(block: MoEFusedV2TransformerBlock) -> None:
     if block.routed_experts is not None:
         if routed_enabled:
             with maybe_nvtx_annotate(
-                "moe_rowwise_fp8_param_refresh_routed_weight_prequant", "experts"
+                "moe_rowwise_fp8_param_refresh_routed_weight_prequant", EXPERTS_COLOR
             ):
                 block.routed_experts.refresh_rowwise_fp8_cache()
         else:

--- a/src/olmo_core/nn/moe/v2/model.py
+++ b/src/olmo_core/nn/moe/v2/model.py
@@ -29,6 +29,12 @@ from olmo_core.distributed.parallel import get_pp_mesh
 from olmo_core.distributed.utils import hide_from_torch, unhide_from_torch
 from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.kernels import olmo_symm_mem
+from olmo_core.nn.moe.v2._nvtx_colors import (
+    COMM_COLOR,
+    EXPERTS_COLOR,
+    ROUTING_COLOR,
+    TBO_COLOR,
+)
 from olmo_core.ops import moe as ops
 from olmo_core.utils import mark_dynamic
 
@@ -944,7 +950,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             # Mark sizes as dynamic for torch.compile().
             if self.compile_enabled:
                 mark_dynamic(h, (0, 1), strict=False)
-            with maybe_nvtx_annotate(f"fwd_block_{block_idx}", "routing"):
+            with maybe_nvtx_annotate(f"fwd_block_{block_idx}", ROUTING_COLOR):
                 # with self.offload_context:
                 one_block_kwargs = per_block_kwargs.get(int(block_key), {})
                 if self.checkpoint_tbo_dense_layers:
@@ -983,7 +989,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             if not block.is_moe:
                 continue
 
-            with maybe_nvtx_annotate(f"fwd_block_{block_idx}", "routing"):
+            with maybe_nvtx_annotate(f"fwd_block_{block_idx}", ROUTING_COLOR):
                 block = cast(MoEFusedV2TransformerBlock, block)
                 # with self.offload_context:
                 # x0, x1_ctx = block.checkpointed_combined_forward_ep_tbo(x0, x1_ctx, x1_is_fresh, **block_kwargs)
@@ -1035,18 +1041,18 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
                 stage_c_launch = ep_no_sync_stage_c_launch
                 stage_tail = ep_no_sync_stage_tail
 
-            with maybe_nvtx_annotate("tbo_1", "tbo"):
+            with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
                 pending_ctx = stage_c_launch(block, x1_ctx)
 
             h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
 
-            with maybe_nvtx_annotate("tbo_1", "tbo"):
+            with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
                 x1 = stage_tail(block, pending_ctx)
 
             h1 = self.maybe_forward_lm_head(x1, lm_head_kwargs, labels=labels1)
             return h0, h1
 
-        with maybe_nvtx_annotate("tbo_1", "tbo"):
+        with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
             global_x1 = x1_ctx.global_x
             send_counts1 = x1_ctx.send_counts
             recv_counts1 = x1_ctx.recv_counts
@@ -1054,7 +1060,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
 
             assert last_block.routed_experts_router is not None
             # finish reverse all2all and other ops for x1
-            with maybe_nvtx_annotate("reverse_all_to_all", "comm"):
+            with maybe_nvtx_annotate("reverse_all_to_all", COMM_COLOR):
                 global_x1 = cast(torch.Tensor, global_x1)
                 # Async all-to-all disabled; use the equivalent synchronous all-to-all.
                 # global_x1, local_x1, local_x_handle1 = ops.all_to_all_async(
@@ -1083,11 +1089,11 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
         # x0 lm head
         h0 = self.maybe_forward_lm_head(x0, lm_head_kwargs, labels=labels0)
 
-        with maybe_nvtx_annotate("tbo_1", "tbo"):
+        with maybe_nvtx_annotate("tbo_1", TBO_COLOR):
             # local_x1 = ops.all_to_all_wait(global_x1, local_x1, local_x_handle1)
 
             ## 9. Unpermute the (local) tokens returned by all-to-all communication ##
-            with maybe_nvtx_annotate("unpermute_merge_local_tokens", "comm"):
+            with maybe_nvtx_annotate("unpermute_merge_local_tokens", COMM_COLOR):
                 local_x1 = moe_unpermute_no_compile(
                     inp=local_x1,
                     row_id_map=reversed_local_x_permutation_mapping1,
@@ -1197,7 +1203,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             # Mark sizes as dynamic for torch.compile().
             if self.compile_enabled:
                 mark_dynamic(h, (0, 1), strict=False)
-            with maybe_nvtx_annotate(f"fwd_block_{block_key}", "routing"):
+            with maybe_nvtx_annotate(f"fwd_block_{block_key}", ROUTING_COLOR):
                 block_kwargs = per_block_kwargs.get(int(block_key), {})
                 combined_kwargs = {**all_block_kwargs, **block_kwargs}
                 do_not_recompute: List[int] = []  # HACK
@@ -1313,7 +1319,7 @@ class MoEFusedV2Transformer(olmo_core.nn.transformer.Transformer):
             if labels is not None:
                 lm_head_kwargs["labels"] = labels
 
-            with maybe_nvtx_annotate("lm_head", "experts"):
+            with maybe_nvtx_annotate("lm_head", EXPERTS_COLOR):
                 out = self.lm_head(h, **lm_head_kwargs)
 
             # check for nan

--- a/src/olmo_core/nn/moe/v2/no_ep.py
+++ b/src/olmo_core/nn/moe/v2/no_ep.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Optional, Union, cast
 import torch
 
 from olmo_core._nvtx import maybe_nvtx_annotate
+from olmo_core.nn.moe.v2._nvtx_colors import COMM_COLOR
 
 from ...moe.utils import async_copy_to_cpu, wait_stream_no_compile
 from ..utils import moe_permute_no_compile, moe_unpermute_no_compile
@@ -105,7 +106,7 @@ def combined_forward_no_ep(
     num_out_tokens = routing_map.size(0) * self.routed_experts_router.top_k
     hidden_shape_before_permute = moe_inp.shape
 
-    with maybe_nvtx_annotate("permute", "comm"):
+    with maybe_nvtx_annotate("permute", COMM_COLOR):
         permutated_input_tokens, reversed_input_permutation_mapping = moe_permute_no_compile(
             inp=moe_inp,
             routing_map=routing_map,
@@ -127,7 +128,7 @@ def combined_forward_no_ep(
             permutated_input_tokens, local_batch_size_per_global_routed_expert
         )
 
-    with maybe_nvtx_annotate("unpermute", "comm"):
+    with maybe_nvtx_annotate("unpermute", COMM_COLOR):
         unpermutated_x: torch.Tensor = moe_unpermute_no_compile(
             inp=mlp_x,
             row_id_map=reversed_input_permutation_mapping,

--- a/src/olmo_core/nn/moe/v2/routed_experts.py
+++ b/src/olmo_core/nn/moe/v2/routed_experts.py
@@ -55,6 +55,7 @@ from olmo_core.kernels.mxfp8_utils import (
     swiglu_quantize_rows_to_mxfp8,
 )
 from olmo_core.nn.fp8_weight import FP8WeightCacheSpec, FP8WeightStore
+from olmo_core.nn.moe.v2._nvtx_colors import EXPERTS_COLOR
 
 from .fp8 import MoERowwiseFP8Config, normalize_rowwise_fp8_config
 
@@ -717,7 +718,7 @@ class RoutedExperts(nn.Module):
         return cast(torch.Tensor, down)
 
     # @torch.compiler.disable(recursive=False)
-    @maybe_nvtx_annotate("RoutedExperts.forward", "experts")
+    @maybe_nvtx_annotate("RoutedExperts.forward", EXPERTS_COLOR)
     def forward(
         self,
         x: torch.Tensor,

--- a/src/olmo_core/nn/moe/v2/router.py
+++ b/src/olmo_core/nn/moe/v2/router.py
@@ -20,6 +20,7 @@ from olmo_core.distributed.utils import (
     is_distributed,
     unhide_from_torch,
 )
+from olmo_core.nn.moe.v2._nvtx_colors import ROUTING_COLOR
 
 from ...output_discard_checkpoint import OutputDiscardCheckpoint
 from ..loss import MoELoadBalancingLossGranularity, load_balancing_loss, router_z_loss
@@ -341,7 +342,7 @@ class MoERouterV2(nn.Module):
             noise = torch.rand_like(x)
             return x * (low + noise * (high - low))
 
-    @maybe_nvtx_annotate("MoERouter.get_top_k", "routing")
+    @maybe_nvtx_annotate("MoERouter.get_top_k", ROUTING_COLOR)
     def get_top_k(self, scores: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         expert_weights: torch.Tensor
         expert_indices: torch.Tensor
@@ -448,7 +449,7 @@ class MoERouterV2(nn.Module):
         logits = torch.round(logits.float() * q) / q
         return logits
 
-    @maybe_nvtx_annotate("MoERouter.forward", "routing")
+    @maybe_nvtx_annotate("MoERouter.forward", ROUTING_COLOR)
     def forward(
         self,
         x: torch.Tensor,
@@ -578,7 +579,7 @@ class MoERouterV2(nn.Module):
         )
         return expert_weights, expert_indices, batch_size_per_expert, aux_loss_info
 
-    @maybe_nvtx_annotate("MoERouter.compute_aux_loss", "routing")
+    @maybe_nvtx_annotate("MoERouter.compute_aux_loss", ROUTING_COLOR)
     def compute_aux_loss(
         self,
         scores,

--- a/src/olmo_core/nn/moe/v2/shared_experts.py
+++ b/src/olmo_core/nn/moe/v2/shared_experts.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 
 from olmo_core._nvtx import maybe_nvtx_annotate
 from olmo_core.config import Config, DType
+from olmo_core.nn.moe.v2._nvtx_colors import EXPERTS_COLOR
 
 
 # SwiGLU is intentionally SiLU-gated here, matching the fused fast paths (forward1/forward2)
@@ -116,7 +117,7 @@ class SharedExperts(nn.Module):
                 "SharedExperts bf16 fallback cannot run after fp8-only anchor storage has been released"
             )
 
-    @maybe_nvtx_annotate("SharedExperts.forward", "experts")
+    @maybe_nvtx_annotate("SharedExperts.forward", EXPERTS_COLOR)
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         x: (B, S, D) -> out: (E, B, S, D)
@@ -150,7 +151,7 @@ class SharedExperts(nn.Module):
 
         return out.view(E, B, S, D)
 
-    @maybe_nvtx_annotate("SharedExperts.forward1", "experts")
+    @maybe_nvtx_annotate("SharedExperts.forward1", EXPERTS_COLOR)
     def forward1(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Split the forward pass into two parts for better overlap in EP.
@@ -173,7 +174,7 @@ class SharedExperts(nn.Module):
 
         return up, gate
 
-    @maybe_nvtx_annotate("SharedExperts.forward2", "experts")
+    @maybe_nvtx_annotate("SharedExperts.forward2", EXPERTS_COLOR)
     def forward2(self, up: torch.Tensor, gate: torch.Tensor, xshape: torch.Size) -> torch.Tensor:
         """
         Split the forward pass into two parts for better overlap in EP.


### PR DESCRIPTION
`maybe_nvtx_annotate` previously owned a `_SUBSYSTEM_COLORS` map and took a `subsystem` argument, so the shared helper in `olmo_core/_nvtx.py` had to know about every domain's subsystems. This flips that around:

- The helper now takes a `color` and just forwards it to nvtx.
- Each domain declares its own color constants. For the MoE modules those move to `nn/moe/v2/_nvtx_colors.py` (`ROUTING_COLOR`, `EXPERTS_COLOR`, `COMM_COLOR`, `TBO_COLOR`).
- All 94 MoE call sites now pass a color constant instead of a subsystem string.

No behavior change — the same labels get the same colors as before.

This lets non-MoE callers (e.g. the custom pipeline-parallel layer) use the same helper with their own color vocabulary without teaching `_nvtx.py` about them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)