### PR TITLE
CI: raise GPU test task timeout from 10m to 15m

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -288,7 +288,7 @@ jobs:
             --priority low \
             --preemptible \
             --gpus ${{ matrix.task.gpus }} \
-            --task-timeout 10m \
+            --task-timeout 15m \
             --host-networking \
             --gpu-type h100 \
             --gpu-type a100 \


### PR DESCRIPTION
The GPU `Test` gantry job was hitting the 10-minute `--task-timeout` and getting killed. Bump it to 15m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)