### PR TITLE
Add MoEV2TransformerTrainModule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,64 +173,64 @@ jobs:
       fail-fast: false
       matrix:
         task:
-          # - name: Test (GPU)
-          #   image: &gpu_test_image tylerr/olmo-core-tch291cu128-2025-11-25
-          #   gpus: 2
-          #   run: |
-          #     pytest -v --color=yes --durations=3 -m gpu \
-          #       --ignore-glob='src/test/distributed/checkpoint*' \
-          #       --ignore-glob='src/test/nn/transformer*' \
-          #       --ignore-glob='src/test/nn/attention*' \
-          #       --ignore-glob='src/test/nn/moe*' \
-          #       --ignore-glob='src/test/optim*' \
-          #       --ignore-glob='src/test/kernels*' \
-          #       --ignore-glob='src/test/train/train_module/transformer/moe_train_module*' \
-          #       src/test/
+          - name: Test (GPU)
+            image: &gpu_test_image tylerr/olmo-core-tch291cu128-2025-11-25
+            gpus: 2
+            run: |
+              pytest -v --color=yes --durations=3 -m gpu \
+                --ignore-glob='src/test/distributed/checkpoint*' \
+                --ignore-glob='src/test/nn/transformer*' \
+                --ignore-glob='src/test/nn/attention*' \
+                --ignore-glob='src/test/nn/moe*' \
+                --ignore-glob='src/test/optim*' \
+                --ignore-glob='src/test/kernels*' \
+                --ignore-glob='src/test/train/train_module/transformer/moe_train_module*' \
+                src/test/
 
-          # - name: Test checkpoint (GPU)
-          #   image: *gpu_test_image
-          #   gpus: 2
-          #   run: |
-          #     pytest -v --color=yes --durations=3 -m gpu \
-          #       src/test/distributed/checkpoint*
+          - name: Test checkpoint (GPU)
+            image: *gpu_test_image
+            gpus: 2
+            run: |
+              pytest -v --color=yes --durations=3 -m gpu \
+                src/test/distributed/checkpoint*
 
-          # - name: Test transformer (GPU)
-          #   image: *gpu_test_image
-          #   gpus: 2
-          #   run: |
-          #     pytest -v --color=yes --durations=3 -m gpu \
-          #       src/test/nn/transformer*
+          - name: Test transformer (GPU)
+            image: *gpu_test_image
+            gpus: 2
+            run: |
+              pytest -v --color=yes --durations=3 -m gpu \
+                src/test/nn/transformer*
 
-          # - name: Test attention (GPU)
-          #   image: *gpu_test_image
-          #   gpus: 2
-          #   run: |
-          #     pytest -v --color=yes --durations=3 -m gpu \
-          #       src/test/nn/attention*
+          - name: Test attention (GPU)
+            image: *gpu_test_image
+            gpus: 2
+            run: |
+              pytest -v --color=yes --durations=3 -m gpu \
+                src/test/nn/attention*
 
-          # - name: Test MoE (GPU)
-          #   image: *gpu_test_image
-          #   gpus: 2
-          #   # The v2 MoE GPU tests need TransformerEngine + torch 2.10, which this image
-          #   # lacks, so they run in the "Test MoE kernels" job below; exclude them here.
-          #   run: |
-          #     pytest -v --color=yes --durations=3 -m gpu \
-          #       --ignore-glob='src/test/nn/moe/v2*' \
-          #       src/test/nn/moe*
+          - name: Test MoE (GPU)
+            image: *gpu_test_image
+            gpus: 2
+            # The v2 MoE GPU tests need TransformerEngine + torch 2.10, which this image
+            # lacks, so they run in the "Test MoE kernels" job below; exclude them here.
+            run: |
+              pytest -v --color=yes --durations=3 -m gpu \
+                --ignore-glob='src/test/nn/moe/v2*' \
+                src/test/nn/moe*
 
-          # - name: Test optim (GPU)
-          #   image: *gpu_test_image
-          #   gpus: 2
-          #   run: |
-          #     pytest -v --color=yes --durations=3 -m gpu \
-          #       src/test/optim*
+          - name: Test optim (GPU)
+            image: *gpu_test_image
+            gpus: 2
+            run: |
+              pytest -v --color=yes --durations=3 -m gpu \
+                src/test/optim*
 
-          # - name: Integration tests (GPU)
-          #   image: *gpu_test_image
-          #   gpus: 2
-          #   run: |
-          #     pytest -v --color=yes -m gpu \
-          #       src/integration_tests/
+          - name: Integration tests (GPU)
+            image: *gpu_test_image
+            gpus: 2
+            run: |
+              pytest -v --color=yes -m gpu \
+                src/integration_tests/
 
           # The MoE kernels require torch >= 2.10 (torch.nn.functional.grouped_mm,
           # F.ScalingType/F.SwizzleType) and JIT-build .cu extensions, so they need an

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,6 +184,7 @@ jobs:
                 --ignore-glob='src/test/nn/moe*' \
                 --ignore-glob='src/test/optim*' \
                 --ignore-glob='src/test/kernels*' \
+                --ignore-glob='src/test/train/train_module/transformer/moe_train_module*' \
                 src/test/
 
           - name: Test checkpoint (GPU)
@@ -241,7 +242,10 @@ jobs:
             image: akshitab/olmo-core-tch2100cu130-2026-07-03 #tianhuat/olmo-core-torch210-2404-cu128
             gpus: 2
             run: |
-              pytest -v --color=yes --durations=3 -m gpu src/test/kernels/ src/test/nn/moe/v2/
+              pytest -v --color=yes --durations=3 -m gpu \
+                src/test/kernels/ \
+                src/test/nn/moe/v2/ \
+                src/test/train/train_module/transformer/moe_train_module_test.py
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,7 @@ jobs:
           # (src/test/nn/moe/v2) also run here since they need TransformerEngine + the same
           # custom kernels, which the torch 2.9 image lacks.
           - name: Test MoE kernels (GPU, torch 2.10)
-            image: akshitab/olmo-core-tch2100cu130-2026-07-03 #tianhuat/olmo-core-torch210-2404-cu128
+            image: tianhuat/olmo-core-torch210-2404-cu128 #akshitab/olmo-core-tch2100cu130-2026-07-03
             gpus: 2
             run: |
               pytest -v --color=yes --durations=3 -m gpu \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,16 +241,11 @@ jobs:
           - name: Test MoE kernels (GPU, torch 2.10)
             image: akshitab/olmo-core-tch2100cu128-rma-2026-07-08 #akshitab/olmo-core-tch2100cu130-2026-07-03  #petew/olmo-core-tch2100cu128-2026-01-23
             gpus: 2
+            # Build the NVSHMEM symm_mem_vdev2d ext (compiled out-of-tree; needs an image with
+            # NVSHMEM + CUDA toolkit) before pytest, so the rowwise-EP tests that import the built
+            # module at collection time can run. One `bash -c` so both run inside the gantry container.
             run: |
-              # Build the NVSHMEM symm_mem_vdev2d extension ahead of pytest. It's a compiled
-              # out-of-tree ext (cmake + nvcc, links NVSHMEM), and `requires_symm_mem_vdev2d`
-              # imports the built module directly at collection time, so it must exist before
-              # the run or the rowwise-EP tests skip. Needs an image with NVSHMEM + CUDA toolkit.
-              python -m olmo_core.kernels.build_symm_mem_vdev2d_ext --inplace
-              pytest -v --color=yes --durations=3 -m gpu \
-                src/test/kernels/ \
-                src/test/nn/moe/v2/ \
-                src/test/train/train_module/transformer/moe_train_module_test.py
+              bash -c 'python -m olmo_core.kernels.build_symm_mem_vdev2d_ext --inplace && pytest -v --color=yes --durations=3 -m gpu src/test/kernels/ src/test/nn/moe/v2/ src/test/train/train_module/transformer/moe_train_module_test.py'
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,7 +239,16 @@ jobs:
           # (src/test/nn/moe/v2) also run here since they need TransformerEngine + the same
           # custom kernels, which the torch 2.9 image lacks.
           - name: Test MoE kernels (GPU, torch 2.10)
-            image: tianhuat/olmo-core-torch210-2404-cu128 #akshitab/olmo-core-tch2100cu130-2026-07-03
+            image: tianhuat/olmo-core-torch210-2404-cu128 #akshitab/olmo-core-tch2100cu130-2026-07-03  #petew/olmo-core-tch2100cu128-2026-01-23
+            gpus: 2
+            run: |
+              pytest -v --color=yes --durations=3 -m gpu \
+                src/test/kernels/ \
+                src/test/nn/moe/v2/ \
+                src/test/train/train_module/transformer/moe_train_module_test.py
+
+          - name: Test MoE kernels (GPU, torch 2.11)
+            image: akshitab/olmo-core-tch2100cu128-rma-2026-07-08 #tianhuat/olmo-core-torch210-2404-cu128 #akshitab/olmo-core-tch2100cu130-2026-07-03  #petew/olmo-core-tch2100cu128-2026-01-23
             gpus: 2
             run: |
               pytest -v --color=yes --durations=3 -m gpu \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,6 +242,11 @@ jobs:
             image: akshitab/olmo-core-tch2100cu128-rma-2026-07-08 #akshitab/olmo-core-tch2100cu130-2026-07-03  #petew/olmo-core-tch2100cu128-2026-01-23
             gpus: 2
             run: |
+              # Build the NVSHMEM symm_mem_vdev2d extension ahead of pytest. It's a compiled
+              # out-of-tree ext (cmake + nvcc, links NVSHMEM), and `requires_symm_mem_vdev2d`
+              # imports the built module directly at collection time, so it must exist before
+              # the run or the rowwise-EP tests skip. Needs an image with NVSHMEM + CUDA toolkit.
+              python -m olmo_core.kernels.build_symm_mem_vdev2d_ext --inplace
               pytest -v --color=yes --durations=3 -m gpu \
                 src/test/kernels/ \
                 src/test/nn/moe/v2/ \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,16 +239,7 @@ jobs:
           # (src/test/nn/moe/v2) also run here since they need TransformerEngine + the same
           # custom kernels, which the torch 2.9 image lacks.
           - name: Test MoE kernels (GPU, torch 2.10)
-            image: tianhuat/olmo-core-torch210-2404-cu128 #akshitab/olmo-core-tch2100cu130-2026-07-03  #petew/olmo-core-tch2100cu128-2026-01-23
-            gpus: 2
-            run: |
-              pytest -v --color=yes --durations=3 -m gpu \
-                src/test/kernels/ \
-                src/test/nn/moe/v2/ \
-                src/test/train/train_module/transformer/moe_train_module_test.py
-
-          - name: Test MoE kernels (GPU, torch 2.11)
-            image: akshitab/olmo-core-tch2100cu128-rma-2026-07-08 #tianhuat/olmo-core-torch210-2404-cu128 #akshitab/olmo-core-tch2100cu130-2026-07-03  #petew/olmo-core-tch2100cu128-2026-01-23
+            image: akshitab/olmo-core-tch2100cu128-rma-2026-07-08 #akshitab/olmo-core-tch2100cu130-2026-07-03  #petew/olmo-core-tch2100cu128-2026-01-23
             gpus: 2
             run: |
               pytest -v --color=yes --durations=3 -m gpu \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,64 +173,64 @@ jobs:
       fail-fast: false
       matrix:
         task:
-          - name: Test (GPU)
-            image: &gpu_test_image tylerr/olmo-core-tch291cu128-2025-11-25
-            gpus: 2
-            run: |
-              pytest -v --color=yes --durations=3 -m gpu \
-                --ignore-glob='src/test/distributed/checkpoint*' \
-                --ignore-glob='src/test/nn/transformer*' \
-                --ignore-glob='src/test/nn/attention*' \
-                --ignore-glob='src/test/nn/moe*' \
-                --ignore-glob='src/test/optim*' \
-                --ignore-glob='src/test/kernels*' \
-                --ignore-glob='src/test/train/train_module/transformer/moe_train_module*' \
-                src/test/
+          # - name: Test (GPU)
+          #   image: &gpu_test_image tylerr/olmo-core-tch291cu128-2025-11-25
+          #   gpus: 2
+          #   run: |
+          #     pytest -v --color=yes --durations=3 -m gpu \
+          #       --ignore-glob='src/test/distributed/checkpoint*' \
+          #       --ignore-glob='src/test/nn/transformer*' \
+          #       --ignore-glob='src/test/nn/attention*' \
+          #       --ignore-glob='src/test/nn/moe*' \
+          #       --ignore-glob='src/test/optim*' \
+          #       --ignore-glob='src/test/kernels*' \
+          #       --ignore-glob='src/test/train/train_module/transformer/moe_train_module*' \
+          #       src/test/
 
-          - name: Test checkpoint (GPU)
-            image: *gpu_test_image
-            gpus: 2
-            run: |
-              pytest -v --color=yes --durations=3 -m gpu \
-                src/test/distributed/checkpoint*
+          # - name: Test checkpoint (GPU)
+          #   image: *gpu_test_image
+          #   gpus: 2
+          #   run: |
+          #     pytest -v --color=yes --durations=3 -m gpu \
+          #       src/test/distributed/checkpoint*
 
-          - name: Test transformer (GPU)
-            image: *gpu_test_image
-            gpus: 2
-            run: |
-              pytest -v --color=yes --durations=3 -m gpu \
-                src/test/nn/transformer*
+          # - name: Test transformer (GPU)
+          #   image: *gpu_test_image
+          #   gpus: 2
+          #   run: |
+          #     pytest -v --color=yes --durations=3 -m gpu \
+          #       src/test/nn/transformer*
 
-          - name: Test attention (GPU)
-            image: *gpu_test_image
-            gpus: 2
-            run: |
-              pytest -v --color=yes --durations=3 -m gpu \
-                src/test/nn/attention*
+          # - name: Test attention (GPU)
+          #   image: *gpu_test_image
+          #   gpus: 2
+          #   run: |
+          #     pytest -v --color=yes --durations=3 -m gpu \
+          #       src/test/nn/attention*
 
-          - name: Test MoE (GPU)
-            image: *gpu_test_image
-            gpus: 2
-            # The v2 MoE GPU tests need TransformerEngine + torch 2.10, which this image
-            # lacks, so they run in the "Test MoE kernels" job below; exclude them here.
-            run: |
-              pytest -v --color=yes --durations=3 -m gpu \
-                --ignore-glob='src/test/nn/moe/v2*' \
-                src/test/nn/moe*
+          # - name: Test MoE (GPU)
+          #   image: *gpu_test_image
+          #   gpus: 2
+          #   # The v2 MoE GPU tests need TransformerEngine + torch 2.10, which this image
+          #   # lacks, so they run in the "Test MoE kernels" job below; exclude them here.
+          #   run: |
+          #     pytest -v --color=yes --durations=3 -m gpu \
+          #       --ignore-glob='src/test/nn/moe/v2*' \
+          #       src/test/nn/moe*
 
-          - name: Test optim (GPU)
-            image: *gpu_test_image
-            gpus: 2
-            run: |
-              pytest -v --color=yes --durations=3 -m gpu \
-                src/test/optim*
+          # - name: Test optim (GPU)
+          #   image: *gpu_test_image
+          #   gpus: 2
+          #   run: |
+          #     pytest -v --color=yes --durations=3 -m gpu \
+          #       src/test/optim*
 
-          - name: Integration tests (GPU)
-            image: *gpu_test_image
-            gpus: 2
-            run: |
-              pytest -v --color=yes -m gpu \
-                src/integration_tests/
+          # - name: Integration tests (GPU)
+          #   image: *gpu_test_image
+          #   gpus: 2
+          #   run: |
+          #     pytest -v --color=yes -m gpu \
+          #       src/integration_tests/
 
           # The MoE kernels require torch >= 2.10 (torch.nn.functional.grouped_mm,
           # F.ScalingType/F.SwizzleType) and JIT-build .cu extensions, so they need an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `MoEV2TransformerTrainModule` (and `MoEV2TransformerTrainModuleConfig`), the train module for the fused MoE-v2 transformer. It builds the fused MoE distributed optimizer (`MoEFusedV2OptimizerConfig`), wraps model parts in `MultiGroupDistributedDataParallel`, and supports DP/EP/TP/CP/PP parallelism.
 - Added a custom pipeline-parallel layer (`olmo_core.train.train_module.transformer.pipeline`) with `CustomPipelineStage` and the `CustomSchedule1F1BV` / `CustomScheduleInterleaved1F1B` schedules, which re-use point-to-point receive buffers across micro-batches over a NCCL-RMA transport. Enabled via `TransformerPipelineParallelConfig.use_custom_stage_implementation` and `PipelineP2PBackend`.
 - Added `MultiGroupDistributedDataParallel` (`olmo_core.nn.parallel`), a data-parallel wrapper that accumulates gradients into flat bucket views and supports per-parameter process groups (`param_process_group_fn`), overlapped bucketed all-reduce (finalized via `finalize_grad_reduce()`), and optional fp32 gradient accumulation/reduction.
 - Added `max_checkpoints` parameter to `CheckpointerCallback` (default: 3) to limit the number of permanent checkpoints retained. Oldest checkpoints are removed automatically when the limit is exceeded. Set to `None` to keep all (previous behavior).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,16 @@ environments = [
 include-package-data = true
 
 [tool.setuptools.package-data]
-olmo_core = ["py.typed", "*.txt", "nn/_csrc/*.cpp"]
+olmo_core = [
+    "py.typed",
+    "*.txt",
+    "nn/_csrc/*.cpp",
+    "kernels/cuda/*.cpp",
+    "kernels/cuda/*.cu",
+    "kernels/cuda/*.cuh",
+    "kernels/cuda/*.h",
+    "kernels/cuda/CMakeLists.txt",
+]
 
 [tool.setuptools.dynamic]
 version = { attr = "olmo_core.version.VERSION" }

--- a/src/olmo_core/distributed/parallel/__init__.py
+++ b/src/olmo_core/distributed/parallel/__init__.py
@@ -97,6 +97,10 @@ class MeshDimName(StrEnum):
     dp_ep = "dp_ep"
     dp_cp = "dp_cp"
 
+    # For MoEV2TransformerTrainModule.
+    ep_mp = "ep_mp"  # EP for model parallelism (sharding the model's experts).
+    ep_dp = "ep_dp"  # EP for data parallelism (gradient reduction).
+
 
 _WORLD_MESH: Optional[DeviceMesh] = None
 

--- a/src/olmo_core/train/train_module/__init__.py
+++ b/src/olmo_core/train/train_module/__init__.py
@@ -6,6 +6,8 @@ from .train_module import (
     TrainModule,
 )
 from .transformer import (
+    MoEV2TransformerTrainModule,
+    MoEV2TransformerTrainModuleConfig,
     TransformerActivationCheckpointingConfig,
     TransformerActivationCheckpointingMode,
     TransformerContextParallelConfig,
@@ -30,6 +32,8 @@ __all__ = [
     "TransformerTrainModuleConfig",
     "TransformerPipelineTrainModule",
     "TransformerPipelineTrainModuleConfig",
+    "MoEV2TransformerTrainModule",
+    "MoEV2TransformerTrainModuleConfig",
     "TransformerActivationCheckpointingConfig",
     "TransformerActivationCheckpointingMode",
     "TransformerDataParallelConfig",

--- a/src/olmo_core/train/train_module/transformer/__init__.py
+++ b/src/olmo_core/train/train_module/transformer/__init__.py
@@ -1,4 +1,5 @@
 from .config import (
+    MoEV2TransformerTrainModuleConfig,
     TransformerActivationCheckpointingConfig,
     TransformerActivationCheckpointingMode,
     TransformerContextParallelConfig,
@@ -10,6 +11,7 @@ from .config import (
     TransformerTensorParallelConfig,
     TransformerTrainModuleConfig,
 )
+from .moe_train_module import MoEV2TransformerTrainModule
 from .pipeline.pipeline_schedule import (
     CustomPipelineStage,
     CustomSchedule1F1BV,
@@ -23,6 +25,8 @@ __all__ = [
     "TransformerTrainModuleConfig",
     "TransformerPipelineTrainModule",
     "TransformerPipelineTrainModuleConfig",
+    "MoEV2TransformerTrainModule",
+    "MoEV2TransformerTrainModuleConfig",
     "TransformerActivationCheckpointingConfig",
     "TransformerActivationCheckpointingMode",
     "TransformerDataParallelConfig",

--- a/src/olmo_core/train/train_module/transformer/config.py
+++ b/src/olmo_core/train/train_module/transformer/config.py
@@ -33,12 +33,14 @@ from olmo_core.nn.transformer import (
     TransformerDataParallelWrappingStrategy,
 )
 from olmo_core.optim import OptimConfig
+from olmo_core.optim.moe_optimizer import MoEFusedV2OptimizerConfig
 from olmo_core.optim.scheduler import Scheduler
 from olmo_core.train.train_module.config import TrainModuleConfig
 
 from .pipeline.pipeline_schedule import CustomPipelineStage
 
 if TYPE_CHECKING:
+    from .moe_train_module import MoEV2TransformerTrainModule
     from .pipeline_train_module import TransformerPipelineTrainModule
     from .train_module import TransformerTrainModule
 
@@ -236,6 +238,22 @@ class TransformerDataParallelConfig(DataParallelConfig):
     """
 
     prefetch_factor: int = 0
+
+    only_allreduce_last_microbatch: bool = True
+    """
+    Only all-reduce gradients on the last micro-batch of a gradient-accumulation step (skip the
+    reduction on intermediate micro-batches). Used by :class:`MoEV2TransformerTrainModule` with
+    :class:`~olmo_core.nn.parallel.MultiGroupDistributedDataParallel`.
+    """
+
+    reduce_grads_in_fp32: bool = True
+    """Reduce gradients in fp32 (see :class:`~olmo_core.nn.parallel.MultiGroupDistributedDataParallel`)."""
+
+    accumulate_grads_in_fp32: bool = True
+    """Accumulate gradients in fp32 (see :class:`~olmo_core.nn.parallel.MultiGroupDistributedDataParallel`)."""
+
+    bucket_cap_mb: Optional[int] = None
+    """Gradient all-reduce bucket size cap in MiB (``None`` = backend default)."""
 
 
 @dataclass
@@ -445,3 +463,82 @@ class TransformerPipelineTrainModuleConfig(TransformerTrainModuleConfig):
     def __post_init__(self):
         if self.pp_config is None:
             raise OLMoConfigurationError("'pp_config' is required")
+
+
+@beta_feature
+@dataclass
+class MoEV2TransformerTrainModuleConfig(TrainModuleConfig):
+    """
+    Configuration for :class:`~olmo_core.train.train_module.transformer.moe_train_module.MoEV2TransformerTrainModule`,
+    the train module for the fused MoE-v2 transformer (built with the fused MoE distributed
+    optimizer, :class:`~olmo_core.optim.MoEFusedV2OptimizerConfig`).
+    """
+
+    rank_microbatch_size: int
+    max_sequence_length: int
+
+    # Optimizer settings.
+
+    optim: MoEFusedV2OptimizerConfig
+    max_grad_norm: Optional[float] = None
+    scheduler: Optional[Scheduler] = None
+
+    # Model settings.
+
+    compile_model: bool = False
+    float8_config: Optional[Float8Config] = None
+    pp_config: Optional[TransformerPipelineParallelConfig] = None
+    dp_config: Optional[TransformerDataParallelConfig] = None
+    tp_config: Optional[TransformerTensorParallelConfig] = None
+    cp_config: Optional[TransformerContextParallelConfig] = None
+    ep_config: Optional[TransformerExpertParallelConfig] = None
+    ac_config: Optional[TransformerActivationCheckpointingConfig] = None
+
+    grad_accum_in_fp32: Optional[bool] = None
+
+    # Loss function settings.
+
+    z_loss_multiplier: Optional[float] = None
+
+    # Checkpoint settings.
+
+    state_dict_save_opts: Optional[Dict[str, Any]] = None
+    state_dict_load_opts: Optional[Dict[str, Any]] = None
+    load_key_mapping: Optional[Dict[str, str]] = None
+    reset_optimizer_states_on_load: bool = False
+
+    # Other train settings.
+
+    label_ignore_index: int = -100
+
+    def build(
+        self,
+        model: Transformer,
+        device: Optional[torch.device] = None,
+        eval_only: bool = False,
+    ) -> "MoEV2TransformerTrainModule":
+        """
+        Build the corresponding :class:`MoEV2TransformerTrainModule`.
+
+        :param model: The :class:`~olmo_core.nn.transformer.Transformer` model to train.
+        :param device: The device to train on.
+        :param eval_only: If ``True``, build the train module without an optimizer (eval-only).
+        """
+        from .moe_train_module import MoEV2TransformerTrainModule
+
+        kwargs = self.as_dict(exclude_none=True, recurse=False)
+
+        if (state_dict_save_opts := kwargs.pop("state_dict_save_opts", None)) is not None:
+            kwargs["state_dict_save_opts"] = dist_cp_sd.StateDictOptions(**state_dict_save_opts)
+        if (state_dict_load_opts := kwargs.pop("state_dict_load_opts", None)) is not None:
+            kwargs["state_dict_load_opts"] = dist_cp_sd.StateDictOptions(**state_dict_load_opts)
+
+        # `grad_accum_in_fp32` is superseded by the DP config's `accumulate_grads_in_fp32`.
+        kwargs.pop("grad_accum_in_fp32", None)
+
+        return MoEV2TransformerTrainModule(
+            model=model,
+            device=device,
+            eval_only=eval_only,
+            **kwargs,
+        )

--- a/src/olmo_core/train/train_module/transformer/config.py
+++ b/src/olmo_core/train/train_module/transformer/config.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import torch
@@ -533,8 +533,11 @@ class MoEV2TransformerTrainModuleConfig(TrainModuleConfig):
         if (state_dict_load_opts := kwargs.pop("state_dict_load_opts", None)) is not None:
             kwargs["state_dict_load_opts"] = dist_cp_sd.StateDictOptions(**state_dict_load_opts)
 
-        # `grad_accum_in_fp32` is superseded by the DP config's `accumulate_grads_in_fp32`.
-        kwargs.pop("grad_accum_in_fp32", None)
+        # `grad_accum_in_fp32` is superseded by the DP config's `accumulate_grads_in_fp32`; map the
+        # legacy field onto the DP config so migrated configs that set it aren't silently ignored.
+        grad_accum_in_fp32 = kwargs.pop("grad_accum_in_fp32", None)
+        if grad_accum_in_fp32 is not None and (dp_config := kwargs.get("dp_config")) is not None:
+            kwargs["dp_config"] = replace(dp_config, accumulate_grads_in_fp32=grad_accum_in_fp32)
 
         return MoEV2TransformerTrainModule(
             model=model,

--- a/src/olmo_core/train/train_module/transformer/moe_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/moe_train_module.py
@@ -73,6 +73,7 @@ from ...common import MetricMergeStrategy, ReduceType
 from ..train_module import EvalBatchSpec, TrainModule
 from .config import (
     TransformerActivationCheckpointingConfig,
+    TransformerActivationCheckpointingMode,
     TransformerContextParallelConfig,
     TransformerDataParallelConfig,
     TransformerExpertParallelConfig,
@@ -205,8 +206,17 @@ class MoEV2TransformerTrainModule(TrainModule):
                 cp_config.degree > 1
             ), "Context parallelism requires a degree > 1, otherwise use None"
             raise NotImplementedError("Context parallelism is not implemented")
-        if float8_config is not None:
+        if float8_config is not None and float8_config.enabled:
             raise NotImplementedError("Float8 quantization is not implemented")
+
+        if (
+            ac_config is not None
+            and ac_config.mode == TransformerActivationCheckpointingMode.budget
+            and not compile_model
+        ):
+            raise OLMoConfigurationError(
+                "Activation checkpointing with 'budget' mode requires compilation to be enabled"
+            )
 
         assert (
             dp_config is not None
@@ -594,7 +604,13 @@ class MoEV2TransformerTrainModule(TrainModule):
             # TODO(moe-train-module-bsz-divisibility): this should raise when the global batch size
             # isn't divisible by rank_microbatch_size * dp_world_size, but the check was disabled
             # because it tripped on batch-size warmup + checkpoint load. Restore a correct check
-            # (accounting for warmup) instead of silently accepting it. Flagged for Tianhua.
+            # (accounting for warmup) instead of silently accepting it. A correct check should also
+            # reject the batch shapes the standard train modules reject, which currently only fail
+            # later at forward time (Codex): (a) with PP, batches not divisible by
+            # rank_microbatch_size * dp_ws (or < one microbatch) floor to uneven/0 microbatches that
+            # break the fixed-size P2P schedule; (b) with two_batch_overlap, odd microbatch counts
+            # (e.g. rank_microbatch_size == max_sequence_length) fail forward_tbo's even-batch
+            # requirement (model.py forward_tbo).
             pass
 
         if self.pp_enabled:
@@ -1345,15 +1361,17 @@ class MoEV2TransformerTrainModule(TrainModule):
 
         # Step optimizer.
         optim.step()
-        with maybe_nvtx_annotate(
-            "MoEV2TransformerTrainModule.refresh_rowwise_fp8_cache_after_optim", _BWD_COLOR
-        ):
-            for model in self.model_parts:
-                model.refresh_rowwise_fp8_cache()
-
-        # dist.barrier()
-
-        # self._copy_full_precision_to_low_precision_params()
+        # TODO(moe-train-module-rowwise-cache-refresh): this per-step refresh looks redundant —
+        # optim.step() already copies the updated main params back to the model params and refreshes
+        # the rowwise-FP8 caches via MoEFusedV2Optimizer._copy_main_params_to_model_params(), with no
+        # intervening weight change, so this rebuilds every cache a second time each step (Codex).
+        # Left commented pending confirmation on a real rowwise-FP8 run (incl. skip-step behavior)
+        # before removing outright.
+        # with maybe_nvtx_annotate(
+        #     "MoEV2TransformerTrainModule.refresh_rowwise_fp8_cache_after_optim", _BWD_COLOR
+        # ):
+        #     for model in self.model_parts:
+        #         model.refresh_rowwise_fp8_cache()
 
         total_grad_norm = optim.latest_grad_norm
 

--- a/src/olmo_core/train/train_module/transformer/moe_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/moe_train_module.py
@@ -64,7 +64,7 @@ from olmo_core.float8 import Float8Config
 from olmo_core.nn.lm_head import LMOutputWithLoss
 from olmo_core.nn.moe.v2.model import MoEFusedV2Transformer
 from olmo_core.nn.parallel.distributed import MultiGroupDistributedDataParallel
-from olmo_core.nn.transformer import MoEFusedV2TransformerConfig, Transformer
+from olmo_core.nn.transformer import Transformer
 from olmo_core.optim import MoEFusedV2OptimizerConfig
 from olmo_core.optim.scheduler import Scheduler
 from olmo_core.utils import get_default_device, log_once, move_to_device
@@ -138,12 +138,18 @@ class MoEV2TransformerTrainModule(TrainModule):
         assert isinstance(
             model, MoEFusedV2Transformer
         ), "MoEV2TransformerTrainModule only supports MoEFusedV2Transformer model"
-        if not isinstance(model.config, MoEFusedV2TransformerConfig):
-            raise OLMoConfigurationError(
-                "MoEV2TransformerTrainModule requires a global MoEFusedV2TransformerConfig "
-                "on model.config for FLOP accounting. Build the model from its config, or "
-                "attach the global config before constructing the train module."
-            )
+        # TODO(moe-train-module-model-config): this guard required a global config on `model.config`
+        # for the config-level FLOP accounting, but that was dropped in favor of model-level
+        # accounting (`model.num_flops_per_token`, captured below), and `model.config` isn't set by
+        # `MoEFusedV2TransformerConfig.build()` on core. Left commented out (not deleted) in case the
+        # config-level FLOP path is reinstated. To re-enable: re-add the MoEFusedV2TransformerConfig
+        # import and set `model.config`.
+        # if not isinstance(model.config, MoEFusedV2TransformerConfig):
+        #     raise OLMoConfigurationError(
+        #         "MoEV2TransformerTrainModule requires a global MoEFusedV2TransformerConfig "
+        #         "on model.config for FLOP accounting. Build the model from its config, or "
+        #         "attach the global config before constructing the train module."
+        #     )
 
         ######################### Validate arguments. [BEGIN] #########################
         if rank_microbatch_size % max_sequence_length != 0:

--- a/src/olmo_core/train/train_module/transformer/moe_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/moe_train_module.py
@@ -1430,6 +1430,13 @@ class MoEV2TransformerTrainModule(TrainModule):
             elif isinstance(self.model_parts[0], DDP):
                 raise OLMoConfigurationError("torch DDP not supported. Use replicate()")
             elif isinstance(self.model_parts[0], MultiGroupDistributedDataParallel):
+                # TODO(moe-train-module-ddp-per-microbatch-reduce): with only_allreduce_last_microbatch
+                # =False (non-default) this lets MultiGroupDDP launch a reduce on the first backward,
+                # but train_batch() only calls finalize_grad_reduce() after the whole loop, so later
+                # microbatches don't launch their own all-reduces and can accumulate into in-flight
+                # buckets — leaving grads unreduced/corrupted. Finalize after each synced microbatch
+                # (or keep no_sync() on all non-final microbatches). Only the default True path is
+                # exercised today. (Codex)
                 if not is_last_mb and self.dp_config.only_allreduce_last_microbatch:
                     stack.enter_context(self.model_parts[0].no_sync())
             elif self.dp_config.name == DataParallelType.ddp:  # temp fix

--- a/src/olmo_core/train/train_module/transformer/moe_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/moe_train_module.py
@@ -151,7 +151,7 @@ class MoEV2TransformerTrainModule(TrainModule):
         #         "attach the global config before constructing the train module."
         #     )
 
-        ######################### Validate arguments. [BEGIN] #########################
+        # Validate arguments.
         if rank_microbatch_size % max_sequence_length != 0:
             raise OLMoConfigurationError(
                 f"'rank_microbatch_size' ({rank_microbatch_size:,d} tokens) must be divisible by "
@@ -205,8 +205,6 @@ class MoEV2TransformerTrainModule(TrainModule):
                 cp_config.degree > 1
             ), "Context parallelism requires a degree > 1, otherwise use None"
             raise NotImplementedError("Context parallelism is not implemented")
-        # if ac_config is not None:
-        #     raise OLMoConfigurationError("In MoEV2TransformerTrainModule, activation checkpointing is controlled by the model, not the train module.")
         if float8_config is not None:
             raise NotImplementedError("Float8 quantization is not implemented")
 
@@ -214,8 +212,6 @@ class MoEV2TransformerTrainModule(TrainModule):
             dp_config is not None
         ), "Data parallel config is required for MoEV2TransformerTrainModule"
         assert dp_config.name == "ddp", "Data parallel config must be 'ddp'"
-
-        ########################## Validate arguments. [END] ##########################
 
         if is_distributed():
             self._build_world_mesh(
@@ -401,9 +397,6 @@ class MoEV2TransformerTrainModule(TrainModule):
         device_type = device_type or get_default_device().type
         dp_world_size = get_world_size()
 
-        # no config, Pure DP
-        # if pp is None and tp is None and cp is None and dp is None and ep is None:
-        #     self.world_mesh = init_device_mesh(device_type, (dp_world_size,), mesh_dim_names=(MeshDimName.dp,))
         #     return
 
         if dp is None:
@@ -473,7 +466,6 @@ class MoEV2TransformerTrainModule(TrainModule):
             mesh=mesh,
             mesh_dim_names=tuple(names),
         )
-        # self.dense_mesh = init_device_mesh(device_type, tuple(dims), mesh_dim_names=tuple(names))
         log.info(f"Built dense_mesh {get_device_mesh_info(self.dense_mesh)}")
 
         if ep is None:  # EP not used
@@ -527,7 +519,6 @@ class MoEV2TransformerTrainModule(TrainModule):
                 mesh_dim_names=tuple(names),
             )
             self.moe_mesh = device_mesh
-            # self.moe_mesh = init_device_mesh(device_type, tuple(dims), mesh_dim_names=tuple(names))
 
             log.info(f"Built moe_mesh{get_device_mesh_info(self.moe_mesh)}")
 
@@ -560,7 +551,6 @@ class MoEV2TransformerTrainModule(TrainModule):
             # max(self.rank_microbatch_size // 2, 1 * self.max_sequence_length),
             # 1 * self.max_sequence_length,
             max_sequence_length=self.max_sequence_length,
-            #  fixed_sequence_length=self.tp_enabled,
         )
 
     @property
@@ -601,11 +591,11 @@ class MoEV2TransformerTrainModule(TrainModule):
         # Validate batch size.
         dp_ws = get_world_size(self.trainer.dp_process_group)
         if self.trainer.global_batch_size % (self.rank_microbatch_size * dp_ws) != 0:
-            # raise OLMoConfigurationError(
-            #     f"global batch size ({self.trainer.global_batch_size:,d}) must be divisible by "
-            #     f"micro-batch size ({self.rank_microbatch_size:,d}) x DP world size ({dp_ws})"
-            # )
-            pass  # BUG: when batch size warmup + load checkpoint
+            # TODO(moe-train-module-bsz-divisibility): this should raise when the global batch size
+            # isn't divisible by rank_microbatch_size * dp_world_size, but the check was disabled
+            # because it tripped on batch-size warmup + checkpoint load. Restore a correct check
+            # (accounting for warmup) instead of silently accepting it. Flagged for Tianhua.
+            pass
 
         if self.pp_enabled:
             # Initialize pipeline schedule.
@@ -698,6 +688,16 @@ class MoEV2TransformerTrainModule(TrainModule):
         )
         return slots_by_part
 
+    # TODO(moe-train-module-checkpoint): this custom "direct" checkpoint path is incomplete and
+    # flagged for Tianhua (exercisable only in a real MoEV2 run with checkpointing, so deferred):
+    #   (a) it doesn't integrate with the standard Checkpointer — `Checkpointer.save()/load()` call
+    #       `state_dict_to_save()`/`state_dict_to_load()`/`state_dict()`, which raise here, so a run
+    #       using the normal checkpoint callback fails on the first save/resume. (Codex)
+    #   (b) `save_state_dict_direct` serializes only `optim.state_dict()`, so router `score_bias`
+    #       buffers (bias_gamma load-balancing) aren't saved → reset to zeros on resume. (Codex)
+    #   (c) `eval_only` loads don't refresh the rowwise-FP8 prequantized caches → stale FP8 on the
+    #       first forwards after load. (Codex)
+    #   (d) `eval_only` loads silently skip a missing param key despite `strict=True`. (Codex)
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         raise NotImplementedError("Use load_state_dict_direct instead")
 
@@ -726,11 +726,6 @@ class MoEV2TransformerTrainModule(TrainModule):
         for key, value in state_dict.items():
             if key.endswith(".main"):
                 main_param_sz += value.numel()
-
-        # this is the theretical model param size calculated from config before PP split
-        # model_param_sz = self.model_parts[0].num_params
-
-        # assert main_param_sz == model_param_sz, f"Main param size {main_param_sz} != model param size {model_param_sz}"
 
         dir = _prepare_env_for_save(dir, process_group=process_group, save_overwrite=save_overwrite)
         planner = FlatSavePlanner(dedup_save_to_lowest_rank=True)
@@ -819,7 +814,6 @@ class MoEV2TransformerTrainModule(TrainModule):
                 checkpoint_id=dir,
                 storage_reader=reader,
                 process_group=process_group,
-                # planner=FlatLoadPlanner(),
             )
 
             optim.load_state_dict(sd_to_load)
@@ -920,11 +914,11 @@ class MoEV2TransformerTrainModule(TrainModule):
             )
 
             if (~instance_mask).all():
-                print(
-                    f"[Warning] rank {dist.get_rank()} All instances ({instance_mask.shape}) in the micro-batch are masked out"
+                log.warning(
+                    "rank %s: all instances (%s) in the micro-batch are masked out",
+                    dist.get_rank(),
+                    instance_mask.shape,
                 )
-
-        #############################
 
         if not self.pp_enabled:
             # Calculate how many tokens are going to be used in the loss.
@@ -941,7 +935,7 @@ class MoEV2TransformerTrainModule(TrainModule):
                 )  # shifted labels does not count last token
 
             if batch_num_tokens_for_loss.item() == 0:
-                print(f"[Warning] rank {dist.get_rank()} batch_num_tokens_for_loss == 0")
+                log.warning("rank %s: batch_num_tokens_for_loss == 0", dist.get_rank())
 
             batch_num_tokens_for_loss = move_to_device(batch_num_tokens_for_loss, self.device)
 
@@ -1008,7 +1002,7 @@ class MoEV2TransformerTrainModule(TrainModule):
                 )  # shifted labels does not count last token
 
             if batch_num_tokens_for_loss == 0:
-                print(f"[Warning] rank {dist.get_rank()} batch_num_tokens_for_loss == 0")
+                log.warning("rank %s: batch_num_tokens_for_loss == 0", dist.get_rank())
 
             # Run pipeline schedule.
             input_ids, labels, model_kwargs = self._prepare_batch(batch, batch["labels"])
@@ -1052,8 +1046,6 @@ class MoEV2TransformerTrainModule(TrainModule):
             for idx, model in enumerate(self.model_parts):
                 model.finalize_grad_reduce()
 
-        #############################
-
         for model in self.model_parts:
             model.post_batch(dry_run=dry_run)
 
@@ -1072,8 +1064,6 @@ class MoEV2TransformerTrainModule(TrainModule):
         with maybe_nvtx_annotate("record_metrics"):
             if self.pp_enabled:
                 ce_batch_loss = self.reduce_send_recv(ce_batch_loss)
-                # if ce_batch_loss > 20 or ce_batch_loss < 0.05:
-                #     log.warning(f"Irregular CE loss detected: {ce_batch_loss.item()}")
                 self.record_ce_loss(ce_batch_loss)
                 optim.latest_loss = ce_batch_loss
             else:
@@ -1121,8 +1111,6 @@ class MoEV2TransformerTrainModule(TrainModule):
                     )
 
         # dist.barrier()
-        # if dist.get_rank() == 0:
-        #     print("-------train batch end--------")
 
     def eval_batch(
         self, batch: Dict[str, Any], labels: Optional[torch.Tensor] = None
@@ -1225,6 +1213,19 @@ class MoEV2TransformerTrainModule(TrainModule):
 
                 return final_lm_output
 
+    # TODO(moe-train-module-pp-eval): the pipeline-parallel eval path has several gaps, flagged for
+    # Tianhua (needs a real PP eval run to exercise, so deferred):
+    #   (a) non-final-stage ranks produce no last-stage output, so eval_batch() returns None there,
+    #       but EvaluatorCallback asserts an LMOutputWithLoss on every rank → fails off the last
+    #       stage instead of skipping / propagating the final-stage losses. (Codex)
+    #   (b) this reuses `train_pp_schedule`, whose `_n_microbatches` came from the training global
+    #       batch; PipelineSchedule.step() raises if the eval batch has fewer rows → use an
+    #       eval-specific microbatch count. (Codex)
+    #   (c) padding to the PP degree repeats the last example; slicing `schedule_outputs[stage]` (a
+    #       list of microbatch outputs) by original_batch_size doesn't trim the duplicated rows
+    #       inside each loss tensor → evaluators count padded samples as real. (Codex)
+    #   (d) intra-doc-masking kwargs (doc_lens/max_doc_lens) forwarded here are rejected by
+    #       PipelineSchedule._split_inputs (see TODO(pp-split-doc-lens) in pipeline_schedule.py). (Codex)
     def run_pipeline_eval(
         self,
         input_ids: torch.Tensor,
@@ -1258,7 +1259,6 @@ class MoEV2TransformerTrainModule(TrainModule):
                 target=padded_labels,
                 forward_only=True,  # <<<--- eval mode
                 # kwargs from now ---
-                # loss_div_factor=batch_num_tokens_for_loss,
                 labels=padded_labels,
                 **kwargs,
             )
@@ -1292,7 +1292,6 @@ class MoEV2TransformerTrainModule(TrainModule):
                     continue
                 _alloc_storage(param._mp_param, param.size())
                 with torch.no_grad():
-                    # assert param.data == param._fp_param, "param.data should point to param._fp_param before copy"
                     assert (
                         param.data.dtype == torch.float32
                     ), "param.data should be float32 before copy"
@@ -1327,8 +1326,6 @@ class MoEV2TransformerTrainModule(TrainModule):
         optim = self._require_optimizer()
 
         # dist.barrier()
-        # if dist.get_rank() == 0:
-        #     print("-------optim_step start--------")
 
         if self.reduce_scatter_grads:
             pass
@@ -1351,8 +1348,6 @@ class MoEV2TransformerTrainModule(TrainModule):
                 model.refresh_rowwise_fp8_cache()
 
         # dist.barrier()
-        # if dist.get_rank() == 0:
-        #     print("-------optim step done--------")
 
         # self._copy_full_precision_to_low_precision_params()
 
@@ -1665,7 +1660,6 @@ class MoEV2TransformerTrainModule(TrainModule):
             assert (
                 self.world_mesh["dense"] is not None
             ), "Dense mesh must be built before applying expert parallelism"
-            # param_dtype = dp_config.param_dtype.as_pt() if dp_config.param_dtype is not None else None
             dp_mesh = self.world_mesh["dense"]["dp"]
             ep_mesh = None
             # for m in model_parts:
@@ -1683,7 +1677,6 @@ class MoEV2TransformerTrainModule(TrainModule):
                 )
             log.info(f"Applied '{ac_config.mode}' activation checkpointing to the model")
 
-        # ac_budget = 0.05
         # torch._functorch.config.activation_memory_budget = ac_budget
 
         self.init_model_weights(
@@ -1750,7 +1743,6 @@ class MoEV2TransformerTrainModule(TrainModule):
                 model_part_idx=model_part_idx,
             )
             # for n, p in m.named_parameters():
-            #     print(f'{n} {p.shape}: mean={p.data.mean().item()}, std={p.data.std().item()}')
 
         self._prewarm_ep_no_sync_symm_buffers(
             model_parts=model_parts,
@@ -1830,24 +1822,6 @@ class MoEV2TransformerTrainModule(TrainModule):
             log.warning("Skipping model compilation since CUDA is not available")
 
     def reduce_send_recv(self, x: Optional[torch.Tensor] = None) -> torch.Tensor:
-        # assert self.pp_enabled and self._pp_config is not None
-
-        # if self.pp_group_rank == self.pp_final_stage_rank:
-        #     assert x is not None
-        #     # DP reduce (mean)
-        #     x = x / self._reduce_divide_factor
-        #     dist.all_reduce(x, group=self.dp_process_group)
-        #     x = x / self.dp_world_size * self._reduce_divide_factor
-        # else:
-        #     assert x is None
-        #     x = torch.empty([], device=self.device, dtype=torch.float32)
-
-        # # Broadcast from final stage to all PP ranks.
-        # handle = dist.broadcast(x, src=get_global_rank(self.pp_final_stage_rank, group=self.pp_group), group=self.pp_group, async_op=True)
-        # handle.wait()
-        # # print(f'{get_rank()} (pp group rank {self.pp_group_rank}) got {x.item()}')
-        # return x
-
         assert (
             self.pp_enabled and self._pp_config is not None
         ), "reduce_send_recv is only valid when PP is enabled"
@@ -1874,16 +1848,8 @@ class MoEV2TransformerTrainModule(TrainModule):
         send_ops: List[dist.P2POp] = []
         recv_ops: List[dist.P2POp] = []
         if src_rank is not None:
-            # print(
-            #     f"Rank {get_rank()} (pp group rank {self.pp_group_rank}) receiving from rank "
-            #     f"{get_global_rank(src_rank, group=self.pp_group)} (pp group rank {src_rank})"
-            # )
             recv_ops.append(dist.P2POp(dist.irecv, x, group=self.pp_group, group_peer=src_rank))
         if dst_rank is not None:
-            # print(
-            #     f"Rank {get_rank()} (pp group rank {self.pp_group_rank}) sending to rank "
-            #     f"{get_global_rank(dst_rank, group=self.pp_group)} (pp group rank {dst_rank})"
-            # )
             send_ops.append(dist.P2POp(dist.isend, x, group=self.pp_group, group_peer=dst_rank))
 
         if len(recv_ops) > 0:
@@ -1896,5 +1862,4 @@ class MoEV2TransformerTrainModule(TrainModule):
             for req in send_reqs:
                 req.wait()
 
-        # print(f'{get_rank()} (pp group rank {self.pp_group_rank}) got {x.item()}')
         return x

--- a/src/olmo_core/train/train_module/transformer/moe_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/moe_train_module.py
@@ -698,6 +698,10 @@ class MoEV2TransformerTrainModule(TrainModule):
     #   (c) `eval_only` loads don't refresh the rowwise-FP8 prequantized caches → stale FP8 on the
     #       first forwards after load. (Codex)
     #   (d) `eval_only` loads silently skip a missing param key despite `strict=True`. (Codex)
+    #   (e) `eval_only` loads ignore `config.load_key_mapping`: `_resolve_model_checkpoint_key` only
+    #       probes the current param name (and its `module.` prefix), so a checkpoint saved before a
+    #       parameter rename can't be loaded even though the standard transformer train modules honor
+    #       the mapping. (Codex)
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         raise NotImplementedError("Use load_state_dict_direct instead")
 
@@ -1674,6 +1678,7 @@ class MoEV2TransformerTrainModule(TrainModule):
                     block_interval=ac_config.block_interval,
                     modules=ac_config.modules,
                     activation_memory_budget=ac_config.activation_memory_budget,
+                    determinism_check=ac_config.determinism_check,
                 )
             log.info(f"Applied '{ac_config.mode}' activation checkpointing to the model")
 

--- a/src/olmo_core/train/train_module/transformer/moe_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/moe_train_module.py
@@ -434,7 +434,9 @@ class MoEV2TransformerTrainModule(TrainModule):
                 )
             dp_world_size //= tp.degree
         if ep is not None:
-            if ep.degree <= 1 or dp_world_size % ep.degree != 0:
+            # -1 is the "use all remaining ranks" shorthand also accepted by the EP mesh helpers.
+            ep_degree = dp_world_size if ep.degree == -1 else ep.degree
+            if ep_degree <= 1 or dp_world_size % ep_degree != 0:
                 raise OLMoConfigurationError(
                     f"{ep.__class__.__name__}.degree must be at least 1 and divide into the world size"
                 )
@@ -496,12 +498,12 @@ class MoEV2TransformerTrainModule(TrainModule):
                     dims.append(pp.degree)
 
             # Then EP data parallel.
-            ep_dp_world_size = dp_world_size // ep.degree
+            ep_dp_world_size = dp_world_size // ep_degree
             names.append(MeshDimName.ep_dp)
             dims.append(ep_dp_world_size)
 
             # Then EP model parallel.
-            ep_mp_world_size = ep.degree
+            ep_mp_world_size = ep_degree
             names.append(MeshDimName.ep_mp)
             dims.append(ep_mp_world_size)
 
@@ -718,6 +720,10 @@ class MoEV2TransformerTrainModule(TrainModule):
     #       probes the current param name (and its `module.` prefix), so a checkpoint saved before a
     #       parameter rename can't be loaded even though the standard transformer train modules honor
     #       the mapping. (Codex)
+    #   (f) with `freeze_params`, `save_state_dict_direct` serializes only `optim.state_dict()`, which
+    #       skips `requires_grad=False` params, so frozen embeddings/blocks are absent from the
+    #       checkpoint and left at fresh init on resume/eval. Serialize model state (or frozen params)
+    #       separately. (Codex)
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         raise NotImplementedError("Use load_state_dict_direct instead")
 

--- a/src/olmo_core/train/train_module/transformer/moe_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/moe_train_module.py
@@ -1,0 +1,1894 @@
+import contextlib
+import logging
+import math
+import os
+from functools import cached_property, lru_cache
+from typing import (
+    Any,
+    Collection,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
+
+import torch
+import torch.distributed as dist
+import torch.distributed.checkpoint as dist_cp
+import torch.distributed.checkpoint.state_dict as dist_cp_sd
+from torch.distributed import ProcessGroup
+from torch.distributed.checkpoint.default_planner import DefaultSavePlanner
+from torch.distributed.checkpoint.metadata import Metadata, TensorStorageMetadata
+from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.fsdp import FSDPModule
+from torch.distributed.pipelining import PipelineStage
+from torch.distributed.tensor import DTensor, Replicate, Shard
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from olmo_core._nvtx import maybe_nvtx_annotate
+from olmo_core.aliases import PathOrStr
+from olmo_core.data.utils import get_labels, split_batch
+from olmo_core.distributed.checkpoint import (
+    RemoteFileSystemReader,
+    RemoteFileSystemWriter,
+    _prepare_env_for_save,
+)
+from olmo_core.distributed.parallel import (
+    DataParallelType,
+    MeshDimName,
+    get_device_mesh_info,
+)
+from olmo_core.distributed.parallel.context_parallel import ContextParallelConfig
+from olmo_core.distributed.parallel.data_parallel import DataParallelConfig
+from olmo_core.distributed.parallel.expert_parallel import ExpertParallelConfig
+from olmo_core.distributed.parallel.pipeline_parallel import (
+    PipelineParallelConfig,
+    PipelineSchedule,
+)
+from olmo_core.distributed.parallel.tensor_parallel import TensorParallelConfig
+from olmo_core.distributed.utils import (
+    backend_supports_cuda,
+    get_local_tensor,
+    get_rank,
+    get_reduce_divide_factor,
+    get_world_size,
+    is_distributed,
+)
+from olmo_core.exceptions import OLMoConfigurationError
+from olmo_core.float8 import Float8Config
+from olmo_core.nn.lm_head import LMOutputWithLoss
+from olmo_core.nn.moe.v2.model import MoEFusedV2Transformer
+from olmo_core.nn.parallel.distributed import MultiGroupDistributedDataParallel
+from olmo_core.nn.transformer import MoEFusedV2TransformerConfig, Transformer
+from olmo_core.optim import MoEFusedV2OptimizerConfig
+from olmo_core.optim.scheduler import Scheduler
+from olmo_core.utils import get_default_device, log_once, move_to_device
+
+from ...common import MetricMergeStrategy, ReduceType
+from ..train_module import EvalBatchSpec, TrainModule
+from .config import (
+    TransformerActivationCheckpointingConfig,
+    TransformerContextParallelConfig,
+    TransformerDataParallelConfig,
+    TransformerExpertParallelConfig,
+    TransformerPipelineParallelConfig,
+    TransformerTensorParallelConfig,
+)
+
+log = logging.getLogger(__name__)
+
+# nvtx range colors (see olmo_core._nvtx.maybe_nvtx_annotate).
+_FWD_COLOR = "blue"  # micro-batch forward
+_BWD_COLOR = "red"  # micro-batch backward + rowwise-fp8 cache refresh
+
+
+M = TypeVar("M", bound=List[MoEFusedV2Transformer])
+
+
+def cpu_mesh_like(gpu_mesh: DeviceMesh) -> DeviceMesh:
+    # gpu_mesh.mesh is a CPU int tensor of ranks with the mesh's shape
+    ranks = gpu_mesh.mesh.clone()  # e.g., tensor([[0,1],[2,3]]) or nested shape
+    return DeviceMesh(
+        "cpu",
+        ranks,  # keep the exact shape
+        mesh_dim_names=gpu_mesh.mesh_dim_names,
+    )
+
+
+class FlatSavePlanner(DefaultSavePlanner):
+    pass
+
+
+class MoEV2TransformerTrainModule(TrainModule):
+    def __init__(
+        self,
+        model: Transformer,
+        optim: MoEFusedV2OptimizerConfig,
+        rank_microbatch_size: int,
+        max_sequence_length: int,
+        compile_model: bool = False,
+        float8_config: Optional[Float8Config] = None,
+        dp_config: Optional[TransformerDataParallelConfig] = None,
+        tp_config: Optional[TransformerTensorParallelConfig] = None,
+        pp_config: Optional[TransformerPipelineParallelConfig] = None,
+        cp_config: Optional[TransformerContextParallelConfig] = None,
+        ep_config: Optional[TransformerExpertParallelConfig] = None,
+        ac_config: Optional[TransformerActivationCheckpointingConfig] = None,
+        z_loss_multiplier: Optional[float] = None,
+        autocast_precision: Optional[torch.dtype] = None,
+        max_grad_norm: Optional[float] = None,
+        scheduler: Optional[Scheduler] = None,
+        device: Optional[torch.device] = None,
+        state_dict_save_opts: Optional[dist_cp_sd.StateDictOptions] = None,
+        state_dict_load_opts: Optional[dist_cp_sd.StateDictOptions] = None,
+        load_key_mapping: Optional[Dict[str, str]] = None,
+        reset_optimizer_states_on_load: bool = False,
+        label_ignore_index: int = -100,
+        reduce_scatter_grads: bool = False,
+        eval_only: bool = False,
+    ):
+        super().__init__()
+        from olmo_core.nn.moe.v2.model import MoEFusedV2Transformer
+
+        assert isinstance(
+            model, MoEFusedV2Transformer
+        ), "MoEV2TransformerTrainModule only supports MoEFusedV2Transformer model"
+        if not isinstance(model.config, MoEFusedV2TransformerConfig):
+            raise OLMoConfigurationError(
+                "MoEV2TransformerTrainModule requires a global MoEFusedV2TransformerConfig "
+                "on model.config for FLOP accounting. Build the model from its config, or "
+                "attach the global config before constructing the train module."
+            )
+
+        ######################### Validate arguments. [BEGIN] #########################
+        if rank_microbatch_size % max_sequence_length != 0:
+            raise OLMoConfigurationError(
+                f"'rank_microbatch_size' ({rank_microbatch_size:,d} tokens) must be divisible by "
+                f"'max_sequence_length' ({max_sequence_length:,d} tokens)"
+            )
+        self.max_sequence_length = max_sequence_length
+        self.rank_microbatch_size = rank_microbatch_size
+        self.eval_only = eval_only
+        # Build world mesh.
+        self.device = device or get_default_device()
+        self.world_mesh: Dict[str, Optional[DeviceMesh]] = {}
+        self.pp_group = None
+        self.dp_group = None
+        self.tp_group = None
+        self.ep_dp_group = None
+        self.ep_mp_group = None
+        self.ep_mp_high_priority_group = None
+        self.ep_mp_high_priority_groups = None
+
+        # compatibility
+        if autocast_precision is not None:
+            assert False, "Autocast precision is not supported in MoEV2TransformerTrainModule"
+        self.autocast_precision = None
+
+        # PP related state.
+        self._train_pp_schedule: Optional[PipelineSchedule] = None
+        self._pp_stages: Optional[List[PipelineStage]] = None
+        self.pp_group_rank = 0  # default 0
+        self.pp_group_size = 1  # default 1
+        self.pp_prev_rank = -1  # no previous stage
+        self.pp_next_rank = -1  # no next stage
+        self.pp_final_stage_rank = 0  # default 0
+
+        # If True, the DDP will not all-reduce grad for the last microbatch
+        # instead it will call optim.step() which will reduce_scatter
+        # directly into the owner main grad
+        self.reduce_scatter_grads = reduce_scatter_grads
+
+        if tp_config is not None:
+            assert (
+                tp_config.degree > 1
+            ), "Tensor parallelism requires a degree > 1, otherwise use None"
+            raise NotImplementedError("Tensor parallelism is not implemented")
+        if pp_config is not None:
+            assert (
+                pp_config.degree > 1
+            ), "Pipeline parallelism requires a degree > 1, otherwise use None"
+            # raise NotImplementedError("Pipeline parallelism is not implemented")
+        if cp_config is not None:
+            assert (
+                cp_config.degree > 1
+            ), "Context parallelism requires a degree > 1, otherwise use None"
+            raise NotImplementedError("Context parallelism is not implemented")
+        # if ac_config is not None:
+        #     raise OLMoConfigurationError("In MoEV2TransformerTrainModule, activation checkpointing is controlled by the model, not the train module.")
+        if float8_config is not None:
+            raise NotImplementedError("Float8 quantization is not implemented")
+
+        assert (
+            dp_config is not None
+        ), "Data parallel config is required for MoEV2TransformerTrainModule"
+        assert dp_config.name == "ddp", "Data parallel config must be 'ddp'"
+
+        ########################## Validate arguments. [END] ##########################
+
+        if is_distributed():
+            self._build_world_mesh(
+                dp=dp_config,
+                tp=tp_config,
+                cp=cp_config,
+                ep=ep_config,
+                pp=pp_config,
+                device_type=self.device.type,
+            )
+            self.dp_world_size = get_world_size(self.dp_process_group)
+            log.info(f"Data parallel world size = {self.dp_world_size:,d}")
+            assert self.world_mesh["dense"] is not None
+        else:
+            raise OLMoConfigurationError(
+                "Training parallelism is required for MoEV2TransformerTrainModule"
+            )
+
+        self._dp_config = dp_config
+        self._cp_config = cp_config
+        self._tp_config = tp_config
+        self._ep_config = ep_config
+        self._pp_config = pp_config
+
+        # Capture num_flops_per_token from the full unsplit model before parallelize_and_init_model
+        # shards/splits it. Under PP each rank only holds its stage's layers, so querying the
+        # (sharded) model parts would undercount. Uses the model-level accounting
+        # (Transformer.num_flops_per_token = Σ block + lm_head); the v2 block implements the MoE
+        # formula (routed + shared experts, top-k).
+        self._full_model_num_flops_per_token = model.num_flops_per_token
+
+        # Parallelize model.
+        self.model_parts = self.parallelize_and_init_model(
+            model,
+            compile_model=compile_model,
+            float8_config=float8_config,
+            dp_config=dp_config,
+            tp_config=tp_config,
+            cp_config=cp_config,
+            ep_config=ep_config,
+            ac_config=ac_config,
+            pp_config=pp_config,
+            eval_only=eval_only,
+        )
+
+        import torch._dynamo.config as dynamo_cfg
+
+        dynamo_cfg.recompile_limit = 64  # or any higher number you want
+
+        if compile_model:
+            self.compile_model()
+
+        self._dp_config = dp_config
+        self._cp_config = cp_config
+        self._tp_config = tp_config
+        self._ep_config = ep_config
+        self._pp_config = pp_config
+
+        self.label_ignore_index = label_ignore_index
+        self.z_loss_multiplier = z_loss_multiplier
+
+        self.max_grad_norm = max_grad_norm  # TODO: remove, use optim.max_grad_norm
+        self.scheduler = scheduler
+        self.state_dict_save_opts = state_dict_save_opts or dist_cp_sd.StateDictOptions(
+            flatten_optimizer_state_dict=True, cpu_offload=True
+        )
+        self.state_dict_load_opts = state_dict_load_opts or dist_cp_sd.StateDictOptions(
+            flatten_optimizer_state_dict=True, strict=True
+        )
+        self.load_key_mapping = load_key_mapping
+        self.reset_optimizer_states_on_load = reset_optimizer_states_on_load
+
+        self.optim = None
+        if not self.eval_only:
+            # Build optimizer(s).
+            log.info("Building optimizer...")
+
+            from olmo_core.optim.moe_optimizer import MoEFusedV2OptimizerConfig
+
+            assert isinstance(optim, MoEFusedV2OptimizerConfig)
+            optim = cast(MoEFusedV2OptimizerConfig, optim)
+            self.optim = optim.build(
+                self.model_parts,
+                self,
+                strict=False,  # group_overrides might only be matched in one group, strict=False allows it to not match in one group (could match in some other group),
+            )
+
+            if self.reduce_scatter_grads and isinstance(
+                self.model_parts[0], MultiGroupDistributedDataParallel
+            ):
+                raise NotImplementedError(
+                    "reduce_scatter_grads=True is incompatible with MultiGroupDistributedDataParallel. "
+                    "Disable DDP all-reduce path first or use reduce_scatter_grads=False."
+                )
+
+            self.optim.set_reduce_scatter_grads(self.reduce_scatter_grads)
+        else:
+            log.info("Skipping optimizer build because eval_only=True")
+
+    def _require_optimizer(self):
+        if self.optim is None:
+            raise RuntimeError(
+                f"{self.__class__.__name__} was built with eval_only=True and has no optimizer"
+            )
+        return self.optim
+
+    @property
+    def model(self) -> Transformer:
+        if self.pp_enabled or len(self.model_parts) != 1:
+            raise RuntimeError(
+                f"{type(self).__name__}.model is only valid without pipeline parallelism; "
+                f"got {len(self.model_parts)} model parts. Use model_parts instead."
+            )
+        return self.model_parts[0]
+
+    def _cast_to_fwd_bwd_precision(
+        self, model: Union[MoEFusedV2Transformer, List[MoEFusedV2Transformer]]
+    ) -> None:
+        """
+        Cast the model to the forward and backward precision.
+        """
+        if isinstance(model, list):
+            for m in model:
+                self._cast_to_fwd_bwd_precision(m)
+        else:
+            # if the model has implemented `cast_to_fwd_bwd_precision` method, call it.
+            if hasattr(model, "_cast_to_fwd_bwd_precision"):
+                assert callable(
+                    model._cast_to_fwd_bwd_precision
+                ), "model._cast_to_fwd_bwd_precision must be callable"
+                model._cast_to_fwd_bwd_precision()
+            else:
+                # if the model doesn't have `cast_to_fwd_bwd_precision`, we need to cast the parameters directly.
+                for p in model.parameters():
+                    p.data = p.data.to(torch.bfloat16)
+
+    def _build_world_mesh(
+        self,
+        *,
+        dp: Optional[DataParallelConfig] = None,
+        tp: Optional[TensorParallelConfig] = None,
+        cp: Optional[ContextParallelConfig] = None,
+        pp: Optional[PipelineParallelConfig] = None,
+        ep: Optional[ExpertParallelConfig] = None,
+        device_type: Optional[str] = None,
+    ) -> None:
+        """
+        Build a :class:`~torch.distributed.device_mesh.DeviceMesh` suitable for the given parallel strategies.
+
+        .. seealso::
+            Pass the mesh created by this function to any of the ``get_*_mesh()`` functions in
+            this module to get the right sub-mesh for a any given parallel strategy.
+
+            - :func:`get_dp_model_mesh()` gives you the 1 or 2D sub-mesh suitable for data parallel *model*
+            wrappers like FSDP(2) or DDP.
+            - :func:`get_dp_mesh()` gives you the 1D sub-mesh suitable for configuring *data loaders*.
+            - :func:`get_tp_mesh()` gives you the 1D sub-mesh for tensor parallelism.
+            - :func:`get_cp_mesh()` gives you the 1D sub-mesh for context parallelism.
+            - :func:`get_pp_mesh()` gives you the 1D sub-mesh for pipeline parallelism.
+            - :func:`get_ep_mesh()` gives you the 1D sub-mesh for expert parallelism.
+
+        .. important::
+            A data parallel config is required if any other parallel config is set.
+
+        .. important::
+            Not all parallel strategies are compatible with each other.
+
+        :param dp: Data parallel config.
+        :param tp: Tensor parallel config.
+        :param cp: Context parallel config.
+        :param pp: Pipeline parallel config.
+        :param ep: Expert parallel config.
+        :param device_type: The device type.
+
+        :returns: The world mesh with a shape compatible with the given parallel configs.
+        """
+
+        if len(self.world_mesh) > 0:
+            raise RuntimeError(
+                "world mesh already exists! You can only call 'build_world_mesh' once!"
+            )
+
+        device_type = device_type or get_default_device().type
+        dp_world_size = get_world_size()
+
+        # no config, Pure DP
+        # if pp is None and tp is None and cp is None and dp is None and ep is None:
+        #     self.world_mesh = init_device_mesh(device_type, (dp_world_size,), mesh_dim_names=(MeshDimName.dp,))
+        #     return
+
+        if dp is None:
+            raise OLMoConfigurationError(
+                "Data parallel config is required in addition to expert/tensor/context/pipeline parallel configs"
+            )
+
+        # Validate parallelism degrees while adjust the DP degree.
+        if pp is not None:
+            if pp.degree <= 1 or dp_world_size % pp.degree != 0:
+                raise OLMoConfigurationError(
+                    f"{pp.__class__.__name__}.degree must be at least 1 and divide into the world size"
+                )
+            dp_world_size //= pp.degree
+        if cp is not None:
+            if cp.degree <= 1 or dp_world_size % cp.degree != 0:
+                raise OLMoConfigurationError(
+                    f"{cp.__class__.__name__}.degree must be at least 1 and divide into the world size"
+                )
+            dp_world_size //= cp.degree
+        if tp is not None:
+            if tp.degree <= 1 or dp_world_size % tp.degree != 0:
+                raise OLMoConfigurationError(
+                    f"{tp.__class__.__name__}.degree must be at least 1 and divide into the world size"
+                )
+            dp_world_size //= tp.degree
+        if ep is not None:
+            if ep.degree <= 1 or dp_world_size % ep.degree != 0:
+                raise OLMoConfigurationError(
+                    f"{ep.__class__.__name__}.degree must be at least 1 and divide into the world size"
+                )
+
+        # Build up dense mesh dimensions. (PP , DP)
+        names: List[str] = []
+        dims: List[int] = []
+
+        # Pipeline parallel first.
+        use_paired_pp = False  # TODO: move to config
+        # TODO 2: implement paired pp properly
+        if pp is not None:
+            names.append(MeshDimName.pp)
+            if use_paired_pp:
+                dims.append(pp.degree // 2)
+            else:
+                dims.append(pp.degree)
+
+        # Then data parallel.
+        names.append(MeshDimName.dp)
+        dims.append(dp_world_size)
+
+        if pp is not None and use_paired_pp:
+            names.append("pp_paired")
+            dims.append(2)
+
+        with torch.device("cpu"):
+            mesh = torch.arange(math.prod(tuple(dims)), dtype=torch.int).view(tuple(dims))
+
+        if pp is not None and use_paired_pp:
+            r = mesh.permute(0, 2, 1).contiguous()
+            pp_dim, pp_paired, dp_dim = r.shape
+            r_merged = r.reshape(pp_dim * pp_paired, dp_dim)  # (pp*pp_paired, dp)
+            mesh = r_merged
+            names.remove("pp_paired")
+
+        self.dense_mesh = DeviceMesh(
+            device_type=device_type,
+            mesh=mesh,
+            mesh_dim_names=tuple(names),
+        )
+        # self.dense_mesh = init_device_mesh(device_type, tuple(dims), mesh_dim_names=tuple(names))
+        log.info(f"Built dense_mesh {get_device_mesh_info(self.dense_mesh)}")
+
+        if ep is None:  # EP not used
+            self.moe_mesh = None
+            log.info("Built moe_mesh None")
+
+        else:
+            # Build up moe mesh dimensions. (PP , EP_DP, EP_MP)
+            names = []
+            dims = []
+
+            # Pipeline parallel first.
+            if pp is not None:
+                names.append(MeshDimName.pp)
+                if use_paired_pp:
+                    dims.append(pp.degree // 2)
+                else:
+                    dims.append(pp.degree)
+
+            # Then EP data parallel.
+            ep_dp_world_size = dp_world_size // ep.degree
+            names.append(MeshDimName.ep_dp)
+            dims.append(ep_dp_world_size)
+
+            # Then EP model parallel.
+            ep_mp_world_size = ep.degree
+            names.append(MeshDimName.ep_mp)
+            dims.append(ep_mp_world_size)
+
+            if pp is not None and use_paired_pp:
+                names.append("pp_paired")
+                dims.append(2)
+
+            with torch.device("cpu"):
+                mesh = torch.arange(math.prod(tuple(dims)), dtype=torch.int).view(tuple(dims))
+
+            if pp is not None and use_paired_pp:
+                r = mesh.permute(
+                    0, 3, 1, 2
+                ).contiguous()  # (pp, ep_dp, ep_mp, pp_paired) -> (pp, pp_paired, ep_dp, ep_mp)
+                pp_dim, pp_paired, ep_dp_dim, ep_mp_dim = r.shape
+                r_merged = r.reshape(
+                    pp_dim * pp_paired, ep_dp_dim, ep_mp_dim
+                )  # (pp*pp_paired, ep_dp, ep_mp)
+                mesh = r_merged
+                names.remove("pp_paired")
+
+            device_mesh = DeviceMesh(
+                device_type=device_type,
+                mesh=mesh,
+                mesh_dim_names=tuple(names),
+            )
+            self.moe_mesh = device_mesh
+            # self.moe_mesh = init_device_mesh(device_type, tuple(dims), mesh_dim_names=tuple(names))
+
+            log.info(f"Built moe_mesh{get_device_mesh_info(self.moe_mesh)}")
+
+        # build process group
+
+        if pp is not None:
+            # self.dense_mesh['pp'] and self.moe_mesh['pp'] should be the same
+            self.pp_group = self.dense_mesh["pp"].get_group()  #
+
+        self.dp_group = self.dense_mesh["dp"].get_group()
+        if self.moe_mesh is not None:
+            self.ep_dp_group = self.moe_mesh["ep_dp"].get_group()
+            self.ep_mp_group = self.moe_mesh["ep_mp"].get_group()
+
+        self.world_mesh = {
+            "dense": self.dense_mesh,
+            "moe": self.moe_mesh,
+            "dense_cpu": cpu_mesh_like(self.dense_mesh),
+            "moe_cpu": None if self.moe_mesh is None else cpu_mesh_like(self.moe_mesh),
+        }
+
+    @property
+    def dp_process_group(self) -> Optional[dist.ProcessGroup]:
+        return self.dp_group
+
+    @property
+    def eval_batch_spec(self) -> EvalBatchSpec:
+        return EvalBatchSpec(
+            self.rank_microbatch_size,
+            # max(self.rank_microbatch_size // 2, 1 * self.max_sequence_length),
+            # 1 * self.max_sequence_length,
+            max_sequence_length=self.max_sequence_length,
+            #  fixed_sequence_length=self.tp_enabled,
+        )
+
+    @property
+    def dp_config(self) -> TransformerDataParallelConfig:
+        return self._dp_config
+
+    @property
+    def tp_enabled(self) -> bool:
+        return self._tp_config is not None
+
+    @property
+    def cp_enabled(self) -> bool:
+        return self._cp_config is not None
+
+    @property
+    def ep_enabled(self) -> bool:
+        return self._ep_config is not None
+
+    @property
+    def pp_enabled(self) -> bool:
+        return self._pp_config is not None
+
+    @property
+    def train_pp_schedule(self) -> PipelineSchedule:
+        self.trainer  # make sure trainer has been attached before trying to access this
+        assert self._train_pp_schedule is not None
+        return self._train_pp_schedule
+
+    @cached_property
+    def world_size(self) -> int:
+        return get_world_size()
+
+    @cached_property
+    def _reduce_divide_factor(self) -> float:
+        return get_reduce_divide_factor(self.world_size)
+
+    def on_attach(self):
+        # Validate batch size.
+        dp_ws = get_world_size(self.trainer.dp_process_group)
+        if self.trainer.global_batch_size % (self.rank_microbatch_size * dp_ws) != 0:
+            # raise OLMoConfigurationError(
+            #     f"global batch size ({self.trainer.global_batch_size:,d}) must be divisible by "
+            #     f"micro-batch size ({self.rank_microbatch_size:,d}) x DP world size ({dp_ws})"
+            # )
+            pass  # BUG: when batch size warmup + load checkpoint
+
+        if self.pp_enabled:
+            # Initialize pipeline schedule.
+            assert self._train_pp_schedule is None  # make sure we don't initialize this twice
+            assert self._pp_stages is not None
+            assert self._pp_config is not None
+            assert self.world_mesh["dense"] is not None
+            pp_mesh = self.world_mesh["dense"]["pp"]
+            assert pp_mesh is not None
+
+            # Determine the number of micro-batches.
+            rank_batch_size = self.trainer.global_batch_size // dp_ws
+            num_microbatches = rank_batch_size // self.rank_microbatch_size
+
+            self._train_pp_schedule = PipelineSchedule(
+                model_parts=self.model_parts,  # type: ignore[arg-type]
+                stages=self._pp_stages,
+                pp_mesh=pp_mesh,
+                schedule_name=self._pp_config.schedule,
+                forward_pull_ahead_extra_activations=self._pp_config.forward_pull_ahead_extra_activations,
+                num_microbatches=num_microbatches,
+            )
+            if not self._rowwise_lifetime_lease_slots_env_is_set():
+                self._prewarm_ep_no_sync_symm_buffers(
+                    model_parts=self.model_parts,
+                    rank_microbatch_size=self.rank_microbatch_size,
+                    rowwise_lifetime_lease_slots=self._estimate_pp_rowwise_lifetime_lease_slots_for_model_parts(),
+                )
+
+    @staticmethod
+    def _rowwise_lifetime_lease_slots_env_is_set() -> bool:
+        return any(
+            os.getenv(name) is not None
+            for name in (
+                "OLMO_MOE_ROWWISE_LIFETIME_LEASE_SLOTS",
+                "OLMO_MOE_ROWWISE_DISPATCH_OUT_LEASE_SLOTS",
+            )
+        )
+
+    def _estimate_pp_rowwise_lifetime_lease_slots_by_stage(self) -> Dict[int, int]:
+        if self._train_pp_schedule is None:
+            return {}
+        schedule_impl = getattr(self._train_pp_schedule, "schedule_impl", None)
+        pipeline_order = getattr(schedule_impl, "pipeline_order", None)
+        rank = getattr(schedule_impl, "rank", None)
+        if pipeline_order is None or rank is None or rank not in pipeline_order:
+            return {}
+
+        from olmo_core.train.train_module.transformer.pipeline.pipeline_schedule import (
+            PipelineActionType,
+        )
+
+        active_by_stage: Dict[int, int] = {}
+        high_water_by_stage: Dict[int, int] = {}
+        for action in pipeline_order[rank]:
+            if action is None:
+                continue
+            if action.computation_type == PipelineActionType.FORWARD:
+                stage_active = active_by_stage.get(action.stage_index, 0) + 1
+                active_by_stage[action.stage_index] = stage_active
+                high_water_by_stage[action.stage_index] = max(
+                    high_water_by_stage.get(action.stage_index, 0),
+                    stage_active,
+                )
+            elif action.computation_type == PipelineActionType.FULL_BACKWARD:
+                active_by_stage[action.stage_index] = max(
+                    0,
+                    active_by_stage.get(action.stage_index, 0) - 1,
+                )
+        return {stage_idx: max(1, slots) for stage_idx, slots in high_water_by_stage.items()}
+
+    def _estimate_pp_rowwise_lifetime_lease_slots_for_model_parts(self) -> List[int]:
+        if self._pp_stages is None:
+            return [1 for _ in self.model_parts]
+
+        high_water_by_stage = self._estimate_pp_rowwise_lifetime_lease_slots_by_stage()
+        fallback = max(1, int(getattr(self._train_pp_schedule, "num_microbatches", 1)))
+        slots_by_part = [
+            max(1, int(high_water_by_stage.get(stage.stage_index, fallback)))
+            for stage in self._pp_stages
+        ]
+        if len(slots_by_part) != len(self.model_parts):
+            raise RuntimeError(
+                "Could not size rowwise lifetime lease slots per PP model part: "
+                f"got {len(slots_by_part)} stages for {len(self.model_parts)} model parts"
+            )
+        log.info(
+            "Prewarming rowwise lifetime lease slots per local PP stage: %s",
+            {stage.stage_index: slots for stage, slots in zip(self._pp_stages, slots_by_part)},
+        )
+        return slots_by_part
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        raise NotImplementedError("Use load_state_dict_direct instead")
+
+    def state_dict_to_load(
+        self, metadata: Metadata, *, optim: Optional[bool] = True
+    ) -> Dict[str, Any]:
+        raise NotImplementedError("Use load_state_dict_direct instead")
+
+    def state_dict(self, *, optim: Optional[bool] = True) -> Dict[str, Any]:
+        raise NotImplementedError("Use save_state_dict_direct or load_state_dict_direct instead")
+
+    def save_state_dict_direct(
+        self,
+        dir: PathOrStr,
+        *,
+        process_group: Optional[dist.ProcessGroup] = None,
+        save_overwrite: bool = False,
+        thread_count: Optional[int] = None,
+        throttle_uploads: bool = False,
+    ):
+        optim = self._require_optimizer()
+        state_dict = optim.state_dict()  # this will free optim states, need to load back after save
+
+        # this is count the param size of the global dtensor, not the local shard
+        main_param_sz = 0
+        for key, value in state_dict.items():
+            if key.endswith(".main"):
+                main_param_sz += value.numel()
+
+        # this is the theretical model param size calculated from config before PP split
+        # model_param_sz = self.model_parts[0].num_params
+
+        # assert main_param_sz == model_param_sz, f"Main param size {main_param_sz} != model param size {model_param_sz}"
+
+        dir = _prepare_env_for_save(dir, process_group=process_group, save_overwrite=save_overwrite)
+        planner = FlatSavePlanner(dedup_save_to_lowest_rank=True)
+        dist_cp.state_dict_saver.save(
+            state_dict,
+            storage_writer=RemoteFileSystemWriter(
+                dir,
+                thread_count=thread_count,
+                process_group=process_group,
+                throttle_uploads=throttle_uploads,
+            ),
+            process_group=process_group,
+            planner=planner,
+        )
+
+        optim.load_state_dict(
+            state_dict,
+            reset_optimizer_moments_on_load=False,
+        )  # load back the optim state after save
+
+        torch.cuda.empty_cache()
+
+        return
+
+    def load_state_dict_direct(
+        self,
+        dir: PathOrStr,
+        *,
+        process_group: Optional[dist.ProcessGroup] = None,
+        pre_download: bool = False,
+        work_dir: Optional[PathOrStr] = None,
+        thread_count: Optional[int] = None,
+    ):
+        from olmo_core.io import normalize_path
+
+        dir = normalize_path(dir)
+        reader = RemoteFileSystemReader(
+            dir, thread_count=thread_count, pre_download=pre_download, work_dir=work_dir
+        )
+
+        metadata = reader.read_metadata()
+
+        if self.eval_only:
+            sd_to_load = self._get_model_state_dict_for_eval_load(metadata)
+            dist_cp.state_dict_loader.load(
+                sd_to_load,
+                checkpoint_id=dir,
+                storage_reader=reader,
+                process_group=process_group,
+            )
+        else:
+            optim = self._require_optimizer()
+            sd_to_load = optim.state_dict()
+            checkpoint_keys = set(metadata.state_dict_metadata.keys())
+            reset_optimizer_states_on_load = self.reset_optimizer_states_on_load
+            reset_optimizer_moments_on_load = getattr(
+                optim, "reset_optimizer_moments_on_load", False
+            )
+
+            if reset_optimizer_states_on_load:
+                log.info(
+                    "Resetting optimizer states during checkpoint load; loading only optimizer main params"
+                )
+                sd_to_load = {
+                    key: value for key, value in sd_to_load.items() if key.endswith(".main")
+                }
+            else:
+                # Backward compatibility: old checkpoints won't have rolling skip-step stats.
+                for optional_key in (
+                    optim.LOSSES_STATE_DICT_KEY,
+                    optim.GRAD_NORMS_STATE_DICT_KEY,
+                ):
+                    if optional_key not in checkpoint_keys:
+                        sd_to_load.pop(optional_key, None)
+
+                if reset_optimizer_moments_on_load:
+                    log.info(
+                        "Resetting optimizer exp_avg and exp_avg_sq buffers during checkpoint load"
+                    )
+                    for key in list(sd_to_load.keys()):
+                        if key.endswith(".exp_avg") or key.endswith(".exp_avg_sq"):
+                            sd_to_load.pop(key)
+
+            dist_cp.state_dict_loader.load(
+                sd_to_load,
+                checkpoint_id=dir,
+                storage_reader=reader,
+                process_group=process_group,
+                # planner=FlatLoadPlanner(),
+            )
+
+            optim.load_state_dict(sd_to_load)
+
+            # load into model params
+            optim._copy_main_params_to_model_params()
+
+        torch.cuda.empty_cache()
+
+        return
+
+    def _get_model_state_dict_for_eval_load(self, metadata: Metadata) -> Dict[str, Any]:
+        model_state: Dict[str, Any] = {}
+        checkpoint_keys = set(metadata.state_dict_metadata.keys())
+
+        for model_part in self.model_parts:
+            for name, param in model_part.named_parameters():
+                checkpoint_key = self._resolve_model_checkpoint_key(name, checkpoint_keys)
+                if checkpoint_key is None:
+                    continue
+
+                tensor_meta = metadata.state_dict_metadata[checkpoint_key]
+                assert isinstance(tensor_meta, TensorStorageMetadata)
+                global_numel = tensor_meta.size.numel()
+                local_flat = param.data.view(-1)
+                local_numel = local_flat.numel()
+
+                if local_numel == global_numel:
+                    model_state[checkpoint_key] = local_flat
+                else:
+                    moe_mesh = self.world_mesh["moe"]
+                    if moe_mesh is None:
+                        raise RuntimeError(
+                            f"Cannot load checkpoint tensor '{checkpoint_key}' for parameter "
+                            f"'{name}' in eval mode with expert parallelism disabled: checkpoint "
+                            f"has {global_numel:,d} elements but the model parameter has "
+                            f"{local_numel:,d} elements. EP=1 eval can load EP-trained "
+                            f"checkpoints when the checkpoint and model configs match; this "
+                            f"shape mismatch usually means the eval config does not match the "
+                            f"checkpoint."
+                        )
+
+                    ep_mp_size = moe_mesh["ep_mp"].size()
+                    expected_global_numel = local_numel * ep_mp_size
+                    if expected_global_numel != global_numel:
+                        raise RuntimeError(
+                            f"Cannot load checkpoint tensor '{checkpoint_key}' for sharded "
+                            f"parameter '{name}' in eval mode: checkpoint has "
+                            f"{global_numel:,d} elements, but the local parameter has "
+                            f"{local_numel:,d} elements across EP-MP size {ep_mp_size:,d} "
+                            f"({expected_global_numel:,d} total). This usually means the "
+                            f"eval config does not match the checkpoint."
+                        )
+
+                    model_state[checkpoint_key] = DTensor.from_local(
+                        local_flat,
+                        device_mesh=moe_mesh["ep_dp", "ep_mp"],
+                        placements=[Replicate(), Shard(0)],
+                        shape=(global_numel,),
+                        stride=(1,),
+                        run_check=False,
+                    )
+
+        if not model_state:
+            raise RuntimeError("Did not find any model weights to load in eval mode")
+
+        return model_state
+
+    def _resolve_model_checkpoint_key(
+        self, param_name: str, checkpoint_keys: Collection[str]
+    ) -> Optional[str]:
+        candidates = (
+            f"{param_name}.main",
+            f"module.{param_name}.main",
+        )
+        for key in candidates:
+            if key in checkpoint_keys:
+                return key
+        return None
+
+    @maybe_nvtx_annotate("train_batch")
+    def train_batch(self, batch: Dict[str, Any], dry_run: bool = False):
+        self._require_optimizer()
+
+        # Set model to train mode if it isn't already.
+        for m in self.model_parts:
+            m.train()
+
+        # Generate labels.
+        if "labels" not in batch:
+            batch["labels"] = get_labels(batch, label_ignore_index=self.label_ignore_index)
+
+        # Record how many instances are going to be skipped (masked out).
+        instance_mask = batch.get("instance_mask")
+        if (instance_mask) is not None and not dry_run:
+            self.record_metric(
+                "train/masked instances (%)", (~instance_mask).float().mean(), ReduceType.mean
+            )
+
+            if (~instance_mask).all():
+                print(
+                    f"[Warning] rank {dist.get_rank()} All instances ({instance_mask.shape}) in the micro-batch are masked out"
+                )
+
+        #############################
+
+        if not self.pp_enabled:
+            # Calculate how many tokens are going to be used in the loss.
+            batch_num_tokens_for_loss = (batch["labels"] != self.label_ignore_index).sum()
+
+            if instance_mask is not None:
+                # WARN: When we mask out instances with the instance filter, we count those tokens
+                # for the loss anyways. They will count as tokens with a zero loss. This means we
+                # get an artificially *low* loss for these batches. But it is really hard (and slow)
+                # to do this properly in a distributed setup. We add back in the full number of tokens
+                # for the loss so that each rank contributes to the loss calculation fairly.
+                batch_num_tokens_for_loss += (~instance_mask).sum() * (
+                    batch["labels"].shape[1] - 1
+                )  # shifted labels does not count last token
+
+            if batch_num_tokens_for_loss.item() == 0:
+                print(f"[Warning] rank {dist.get_rank()} batch_num_tokens_for_loss == 0")
+
+            batch_num_tokens_for_loss = move_to_device(batch_num_tokens_for_loss, self.device)
+
+            # Batch losses to record.
+            ce_batch_loss = move_to_device(torch.tensor(0.0), self.device)
+            z_batch_loss: Optional[torch.Tensor] = None
+            if self.z_loss_multiplier is not None:
+                z_batch_loss = move_to_device(torch.tensor(0.0), self.device)
+
+            # Split into micro-batches.
+            if self.rank_microbatch_size < (seq_len := batch["input_ids"].shape[1]):
+                raise RuntimeError(
+                    f"Microbatch size ({self.rank_microbatch_size}) is too small relative to sequence length ({seq_len})"
+                )
+            micro_batches = split_batch(batch, self.rank_microbatch_size // seq_len)
+            num_micro_batches = len(micro_batches)
+
+            # Train one micro-batch at a time.
+            for micro_batch_idx, micro_batch in enumerate(micro_batches):
+                with self._train_microbatch_context(micro_batch_idx, num_micro_batches):
+                    with maybe_nvtx_annotate(f"fwd_mb{micro_batch_idx}", _FWD_COLOR):
+                        input_ids, labels, model_kwargs = self._prepare_batch(micro_batch)
+                        # Run forward pass, get losses.
+                        _, loss, ce_loss, z_loss = self.model_forward_no_pipeline(
+                            input_ids,
+                            labels=labels,
+                            ignore_index=self.label_ignore_index,
+                            loss_reduction="sum",
+                            z_loss_multiplier=self.z_loss_multiplier,
+                            loss_div_factor=batch_num_tokens_for_loss,
+                            return_logits=False,
+                            **model_kwargs,
+                        )
+                        # Update total batch CE and Z loss.
+                        ce_batch_loss += get_local_tensor(ce_loss.detach())
+                        del ce_loss
+                        if z_batch_loss is not None:
+                            assert z_loss is not None
+                            z_batch_loss += get_local_tensor(z_loss.detach())
+                            del z_loss
+
+                    with maybe_nvtx_annotate(f"bwd_mb{micro_batch_idx}", _BWD_COLOR):
+                        # Run backward pass.
+                        loss.backward()
+
+            del batch  # In case this helps with memory utilization.
+
+            for idx, model in enumerate(self.model_parts):
+                model.finalize_grad_reduce()
+
+        else:
+            # pipeline parallel forward / backward
+            # Calculate how many tokens are going to be used in the loss.
+            batch_num_tokens_for_loss = (batch["labels"] != self.label_ignore_index).sum().item()
+
+            if instance_mask is not None:
+                # WARN: When we mask out instances with the instance filter, we count those tokens
+                # for the loss anyways. They will count as tokens with a zero loss. This means we
+                # get an artificially *low* loss for these batches. But it is really hard (and slow)
+                # to do this properly in a distributed setup. We add back in the full number of tokens
+                # for the loss so that each rank contributes to the loss calculation fairly.
+                batch_num_tokens_for_loss += (~instance_mask).sum() * (
+                    batch["labels"].shape[1] - 1
+                )  # shifted labels does not count last token
+
+            if batch_num_tokens_for_loss == 0:
+                print(f"[Warning] rank {dist.get_rank()} batch_num_tokens_for_loss == 0")
+
+            # Run pipeline schedule.
+            input_ids, labels, model_kwargs = self._prepare_batch(batch, batch["labels"])
+            assert labels is not None
+            pp_outputs = self.run_pipeline(
+                input_ids,
+                labels,
+                batch_num_tokens_for_loss,
+                ignore_index=self.label_ignore_index,
+                loss_reduction="sum",
+                z_loss_multiplier=self.z_loss_multiplier,
+                return_logits=False,
+                **model_kwargs,
+            )
+            # Collect losses from all micro-batches and all stages.
+            ce_batch_loss = None
+            z_batch_loss = None
+            for stage_outputs in pp_outputs:
+                for mb_output in stage_outputs:
+                    if mb_output is None:  # non-last stage
+                        continue
+                    else:
+                        assert isinstance(mb_output, LMOutputWithLoss)
+                        _, loss, ce_loss, z_loss = mb_output
+
+                        # ce_loss should always be not None
+                        ce_batch_loss = (
+                            (ce_batch_loss + ce_loss.detach())
+                            if ce_batch_loss is not None
+                            else ce_loss.detach()
+                        )
+
+                        # z loss is optional
+                        if z_loss is not None:
+                            z_batch_loss = (
+                                (z_batch_loss + z_loss.detach())
+                                if z_batch_loss is not None
+                                else z_loss.detach()
+                            )
+
+            for idx, model in enumerate(self.model_parts):
+                model.finalize_grad_reduce()
+
+        #############################
+
+        for model in self.model_parts:
+            model.post_batch(dry_run=dry_run)
+
+        if dry_run:
+            for model in self.model_parts:
+                model.reset_auxiliary_metrics()
+
+            torch.cuda.empty_cache()
+            from olmo_core.train.globals import set_global_arg
+
+            set_global_arg("dry_run_done", True)
+            return
+
+        # Record loss metrics.
+        optim = self._require_optimizer()
+        with maybe_nvtx_annotate("record_metrics"):
+            if self.pp_enabled:
+                ce_batch_loss = self.reduce_send_recv(ce_batch_loss)
+                # if ce_batch_loss > 20 or ce_batch_loss < 0.05:
+                #     log.warning(f"Irregular CE loss detected: {ce_batch_loss.item()}")
+                self.record_ce_loss(ce_batch_loss)
+                optim.latest_loss = ce_batch_loss
+            else:
+                assert ce_batch_loss is not None, "CE loss should not be None"
+                # Need to reduce the loss right away for the SkipStepOptimizer. NOTE: WHY?
+                if is_distributed():
+                    ce_batch_loss.div_(self._reduce_divide_factor)
+                    dist.all_reduce(ce_batch_loss)
+                    ce_batch_loss.div_(self.world_size)
+                    ce_batch_loss.mul_(self._reduce_divide_factor)
+                self.record_ce_loss(ce_batch_loss)
+                optim.latest_loss = ce_batch_loss
+
+            if z_batch_loss is not None:
+                assert self.z_loss_multiplier is not None
+                self.record_metric(
+                    "Z loss",
+                    z_batch_loss,
+                    ReduceType.mean,
+                    namespace="train",
+                )
+                self.record_metric(
+                    "Z loss unscaled",
+                    z_batch_loss / self.z_loss_multiplier,
+                    ReduceType.mean,
+                    namespace="train",
+                )
+
+            # And additional metrics.
+            for m in self.model_parts:
+                for metric_name, (metric_val, reduction) in m.compute_auxiliary_metrics(
+                    reset=True
+                ).items():
+                    merge_strategy = MetricMergeStrategy.warn
+                    if reduction in (ReduceType.sum, ReduceType.mean):
+                        merge_strategy = MetricMergeStrategy.sum
+                    elif reduction == ReduceType.max:
+                        merge_strategy = MetricMergeStrategy.max
+                    self.record_metric(
+                        metric_name,
+                        metric_val,
+                        reduction,
+                        namespace="train",
+                        merge_strategy=merge_strategy,
+                    )
+
+        # dist.barrier()
+        # if dist.get_rank() == 0:
+        #     print("-------train batch end--------")
+
+    def eval_batch(
+        self, batch: Dict[str, Any], labels: Optional[torch.Tensor] = None
+    ) -> Union[torch.Tensor, Optional[LMOutputWithLoss]]:
+        # TODO: (epwalsh) Currently all of our evaluators require the full logits locally,
+        # but when we're using CP/TP we usually can't materialize the full logits locally (due to OOMs).
+        # However we could at least support in-loop PPL evals with a little work in the evaluator
+        # code to handle the sharded logits.
+        if self.cp_enabled:
+            raise RuntimeError(
+                f"{self.__class__.__name__}.eval_batch() does not support context parallelism yet, "
+                "please disable in-loop evals"
+            )
+        if self.tp_enabled:
+            raise RuntimeError(
+                f"{self.__class__.__name__}.eval_batch() does not support tensor parallelism yet, "
+                "please disable in-loop evals"
+            )
+
+        input_ids, labels, model_kwargs = self._prepare_batch(batch, labels)
+
+        for m in self.model_parts:
+            m.eval()
+
+        with self._eval_batch_context():
+            if not self.pp_enabled:
+                lm_output = self.model_forward_no_pipeline(
+                    input_ids,
+                    labels=labels,
+                    ignore_index=self.label_ignore_index,
+                    loss_reduction="none",
+                    **model_kwargs,
+                )
+                assert isinstance(lm_output, LMOutputWithLoss), "Expected LMOutputWithLoss"
+                return lm_output
+
+            else:
+                assert labels is not None
+                lm_output = self.run_pipeline_eval(
+                    input_ids,
+                    labels,
+                    batch_num_tokens_for_loss=None,
+                    ignore_index=self.label_ignore_index,
+                    loss_reduction="none",
+                    **model_kwargs,
+                )
+                # merge lm_output from all stages and all micro-batches
+                # List[List[Optional[LMOutputWithLoss]]] --> Optional[LMOutputWithLoss]
+                final_lm_output: Optional[LMOutputWithLoss] = None
+                logits_list = []
+                loss_list = []
+                ce_loss_list = []
+                z_loss_list = []
+
+                # NOTE: here we combine the multiple stages assuming they are different stages
+                # with the same DP rank (e.g., stage 0 and stage 1 in X-stage PP, working on the same batch data).
+                # so at max one of the stage_outputs will have non-None output.
+                # TODO: this assumption might not hold in dualpipe and other schedules.
+                for stage_outputs in lm_output:
+                    for mb_output in stage_outputs:
+                        if mb_output is None:
+                            continue
+                        else:
+                            assert isinstance(mb_output, LMOutputWithLoss)
+                            (
+                                logits,  # [mb, seq_len, vocab_size]
+                                loss,  # [mb, seq_len] because loss_reduction="none"
+                                ce_loss,  # [mb, seq_len]
+                                z_loss,  # ??
+                            ) = mb_output
+
+                            # always not None
+                            loss_list.append(loss)
+                            ce_loss_list.append(ce_loss)
+
+                            # optional
+                            if logits is not None:
+                                logits_list.append(logits)
+                            if z_loss is not None:
+                                z_loss_list.append(z_loss)
+
+                # Concatenate all logits and losses
+                merged_logits = torch.cat(logits_list, dim=0) if len(logits_list) > 0 else None
+                merged_loss = torch.cat(loss_list, dim=0) if len(loss_list) > 0 else None
+                merged_ce_loss = torch.cat(ce_loss_list, dim=0) if len(ce_loss_list) > 0 else None
+                merged_z_loss = torch.cat(z_loss_list, dim=0) if len(z_loss_list) > 0 else None
+
+                if merged_loss is not None:
+                    # has last stage output
+                    assert merged_ce_loss is not None
+                    final_lm_output = LMOutputWithLoss(
+                        merged_logits,
+                        merged_loss,
+                        merged_ce_loss,
+                        merged_z_loss,
+                    )
+                else:
+                    # no last stage output
+                    final_lm_output = None
+
+                return final_lm_output
+
+    def run_pipeline_eval(
+        self,
+        input_ids: torch.Tensor,
+        labels: torch.Tensor,
+        **kwargs,
+    ) -> List[List[Optional[LMOutputWithLoss]]]:
+        # the micro-batch size should be a multiple of pp degree
+        def pad_dim_0_to_multiple_of(tensor: torch.Tensor, multiple: int) -> torch.Tensor:
+            bsz = tensor.size(0)
+            if bsz % multiple == 0:
+                return tensor
+            pad_size = multiple - (bsz % multiple)
+            padding_tensor = (
+                tensor[-1].unsqueeze(0).expand(pad_size, *tensor.size()[1:])
+            )  # repeat last element
+            padded_tensor = torch.cat([tensor, padding_tensor], dim=0).contiguous()
+            return padded_tensor
+
+        original_batch_size = input_ids.size(0)
+        padded_input_ids = pad_dim_0_to_multiple_of(
+            input_ids, self.train_pp_schedule.pp_mesh.size()
+        )
+        padded_labels = pad_dim_0_to_multiple_of(labels, self.train_pp_schedule.pp_mesh.size())
+        for k, v in kwargs.items():
+            if isinstance(v, torch.Tensor) and v.size(0) == original_batch_size:
+                kwargs[k] = pad_dim_0_to_multiple_of(v, self.train_pp_schedule.pp_mesh.size())
+
+        with self._model_forward_context():
+            schedule_outputs = self.train_pp_schedule.step(
+                padded_input_ids,
+                target=padded_labels,
+                forward_only=True,  # <<<--- eval mode
+                # kwargs from now ---
+                # loss_div_factor=batch_num_tokens_for_loss,
+                labels=padded_labels,
+                **kwargs,
+            )
+
+        # remove padding results from outputs
+        for stage_idx in range(len(schedule_outputs)):
+            schedule_outputs[stage_idx] = schedule_outputs[stage_idx][:original_batch_size]
+
+        return schedule_outputs
+
+    def _point_to_low_precision_params(self):
+        for model in self.model_parts:
+            for name, param in model.named_parameters():
+                if hasattr(param, "_ddp_ignored") and param._ddp_ignored:
+                    continue
+                param.data = param._mp_param
+
+    def _point_to_full_precision_params(self):
+        for model in self.model_parts:
+            for name, param in model.named_parameters():
+                if hasattr(param, "_ddp_ignored") and param._ddp_ignored:
+                    continue
+                param.data = param._mp_param
+
+    def _copy_full_precision_to_low_precision_params(self):
+        from torch.distributed.utils import _alloc_storage
+
+        for model in self.model_parts:
+            for name, param in model.named_parameters():
+                if hasattr(param, "_ddp_ignored") and param._ddp_ignored:
+                    continue
+                _alloc_storage(param._mp_param, param.size())
+                with torch.no_grad():
+                    # assert param.data == param._fp_param, "param.data should point to param._fp_param before copy"
+                    assert (
+                        param.data.dtype == torch.float32
+                    ), "param.data should be float32 before copy"
+                    param._mp_param.copy_(param.data)
+
+    def run_pipeline(
+        self,
+        input_ids: torch.Tensor,
+        labels: torch.Tensor,
+        batch_num_tokens_for_loss: Union[int, float],
+        **kwargs,
+    ) -> List[List[Optional[LMOutputWithLoss]]]:
+        """
+        Run the pipeline, returning the losses captured.
+        Returns:
+            ce_batch_loss: Cross-entropy loss for the batch.
+            z_batch_loss: Z loss for the batch (if applicable).
+        """
+        with self._model_forward_context():
+            schedule_outputs = self.train_pp_schedule.step(
+                input_ids,
+                target=labels,
+                loss_div_factor=batch_num_tokens_for_loss,
+                labels=labels,
+                **kwargs,
+            )
+        return schedule_outputs
+
+    def optim_step(self):
+        from olmo_core.optim.moe_optimizer import MoEFusedV2Optimizer
+
+        optim = self._require_optimizer()
+
+        # dist.barrier()
+        # if dist.get_rank() == 0:
+        #     print("-------optim_step start--------")
+
+        if self.reduce_scatter_grads:
+            pass
+        else:
+            pass
+            # raise RuntimeError("Deprecated code path, only reduce-scatter grads is supported now")
+
+        # Maybe adjust learning rate.
+        if self.scheduler is not None:
+            for group_idx, group in enumerate(optim.param_groups):
+                new_lr = self.scheduler.set_lr(group, self.trainer)
+                self.trainer.record_metric(f"LR (group {group_idx})", new_lr, namespace="optim")
+
+        # Step optimizer.
+        optim.step()
+        with maybe_nvtx_annotate(
+            "MoEV2TransformerTrainModule.refresh_rowwise_fp8_cache_after_optim", _BWD_COLOR
+        ):
+            for model in self.model_parts:
+                model.refresh_rowwise_fp8_cache()
+
+        # dist.barrier()
+        # if dist.get_rank() == 0:
+        #     print("-------optim step done--------")
+
+        # self._copy_full_precision_to_low_precision_params()
+
+        total_grad_norm = optim.latest_grad_norm
+
+        if total_grad_norm is not None:
+            self.trainer.record_metric(
+                "total grad norm", total_grad_norm, reduce_type=None, namespace="optim"
+            )
+
+        if isinstance(optim, MoEFusedV2Optimizer):
+            self.record_metric("step skipped", optim.step_skipped, namespace="optim")
+
+        for model in self.model_parts:
+            model.post_optim_step()
+
+    def zero_grads(self):
+        self._require_optimizer()
+        # Contract: optimizer consumes model grads but does not clear model grad buffers.
+        # Keep grad-buffer lifecycle in the model wrapper so bucket views stay stable.
+        for m in self.model_parts:
+            m.zero_grad(set_to_none=False)
+
+    def model_forward_no_pipeline(
+        self, input_ids: torch.Tensor, labels: Optional[torch.Tensor] = None, **kwargs
+    ) -> Union[torch.Tensor, LMOutputWithLoss]:
+        """
+        Run a forward pass on a micro-batch, returning the logits.
+        """
+        with self._model_forward_context():
+            return self.model_parts[0](input_ids, labels=labels, **kwargs)
+
+    @lru_cache  # type: ignore[override]
+    def num_flops_per_token(self, seq_len: int) -> int:
+        return int(self._full_model_num_flops_per_token(seq_len))
+
+    def global_num_flops_in_batch(self, batch: Dict[str, Any]) -> Optional[int]:
+        global_num_tokens = self.trainer.data_loader.global_num_tokens_in_batch(batch)
+        if global_num_tokens is None:
+            return None
+        flops_per_token = self.num_flops_per_token(seq_len=batch["input_ids"].shape[1])
+        return flops_per_token * global_num_tokens
+
+    @contextlib.contextmanager
+    def _train_microbatch_context(
+        self, micro_batch_idx: int, num_micro_batches: int
+    ) -> Generator[None, None, None]:
+        is_last_mb = micro_batch_idx == num_micro_batches - 1
+        with contextlib.ExitStack() as stack:
+            if isinstance(self.model_parts[0], FSDPModule):
+                raise OLMoConfigurationError("FSDP not supported. Use replicate()")
+            elif isinstance(self.model_parts[0], DDP):
+                raise OLMoConfigurationError("torch DDP not supported. Use replicate()")
+            elif isinstance(self.model_parts[0], MultiGroupDistributedDataParallel):
+                if not is_last_mb and self.dp_config.only_allreduce_last_microbatch:
+                    stack.enter_context(self.model_parts[0].no_sync())
+            elif self.dp_config.name == DataParallelType.ddp:  # temp fix
+                if (
+                    self.reduce_scatter_grads  # if use RS, always no sync
+                    or (  # if not, fall back to all-reduce
+                        # if specified, only AR at the last microbatch
+                        not is_last_mb
+                        and self.dp_config.only_allreduce_last_microbatch
+                    )
+                ):
+                    stack.enter_context(
+                        self.ddp_no_sync(self.model_parts)
+                    )  # only DDP has no_sync(), can only call set_requires_gradient_sync()
+            yield
+
+    @contextlib.contextmanager
+    def ddp_no_sync(self, model_parts: List[MoEFusedV2Transformer]):
+        for module in model_parts:
+            assert callable(getattr(module, "set_requires_gradient_sync", None)), (
+                f"{type(module).__name__} must implement set_requires_gradient_sync(flag: bool). "
+                "This is automatically managed if the model is returned by torch.distributed._composable.replicate"
+            )
+            # non-EP modules
+            module.set_requires_gradient_sync(False)  # type: ignore
+
+            # EP managed modules
+            ep_modules = [m for m in module.modules() if getattr(m, "_ep_sharded", False)]
+            for m in ep_modules:
+                m.set_requires_gradient_sync(False)  # type: ignore
+
+        try:
+            yield
+        finally:
+            for module in model_parts:
+                module.set_requires_gradient_sync(True)  # type: ignore
+                ep_modules = [m for m in module.modules() if getattr(m, "_ep_sharded", False)]
+                for m in ep_modules:
+                    m.set_requires_gradient_sync(True)  # type: ignore
+
+    @contextlib.contextmanager
+    def _eval_batch_context(self) -> Generator[None, None, None]:
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(torch.no_grad())
+            yield
+
+    @contextlib.contextmanager
+    def _model_forward_context(self) -> Generator[None, None, None]:
+        # NOTE: autocast_precision is deleted; ExitStack kept for future re-introduction.
+        with contextlib.ExitStack():
+            # if self.autocast_precision is not None:
+            #     stack.enter_context(torch.autocast(self.device.type, dtype=self.autocast_precision))
+            yield
+
+    def _clip_grad_norm(
+        self, max_grad_norm: float, norm_type: float = 2.0, foreach: Optional[bool] = None
+    ) -> torch.Tensor:
+        raise RuntimeError("Deprecated. Use optimizer's grad clipping instead.")
+
+    def _prepare_batch(
+        self, batch: Dict[str, Any], labels: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Dict[str, Any]]:
+        if self.pp_enabled:
+            input_ids = batch.pop("input_ids")
+            labels = labels if labels is not None else batch.pop("labels", None)
+            kwargs: Dict[str, Any] = {}
+            if "doc_lens" in batch and "max_doc_lens" in batch:
+                log_once(log, "intra-document masking enabled")
+                kwargs["doc_lens"] = batch["doc_lens"]
+                kwargs["max_doc_lens"] = batch["max_doc_lens"]
+            return input_ids, labels, kwargs
+        else:
+            input_ids = batch.pop("input_ids")
+            labels = labels if labels is not None else batch.pop("labels", None)
+            if "doc_lens" in batch and "max_doc_lens" in batch:
+                log_once(log, "intra-document masking enabled")
+            return input_ids, labels, batch
+
+    def parallelize_and_init_model(
+        self,
+        model: MoEFusedV2Transformer,  # the full model before sharding, the same on all models
+        *,
+        compile_model: bool = False,
+        float8_config: Optional[Float8Config] = None,
+        dp_config: Optional[TransformerDataParallelConfig] = None,
+        tp_config: Optional[TransformerTensorParallelConfig] = None,
+        cp_config: Optional[TransformerContextParallelConfig] = None,
+        ep_config: Optional[TransformerExpertParallelConfig] = None,
+        ac_config: Optional[TransformerActivationCheckpointingConfig] = None,
+        pp_config: Optional[TransformerPipelineParallelConfig] = None,
+        eval_only: bool = False,
+    ) -> List["MoEFusedV2Transformer"]:
+        from olmo_core.nn.moe.v2.model import MoEFusedV2Transformer
+
+        assert isinstance(model, MoEFusedV2Transformer), "model must be an instance of Transformer"
+
+        if tp_config is not None:
+            raise NotImplementedError("TP not supported yet")
+        if cp_config is not None:
+            raise NotImplementedError("CP not supported yet")
+
+        if pp_config is not None:
+            assert (
+                self.world_mesh["dense"] is not None
+            ), "Dense mesh must be built before applying pipeline parallelism"
+            self.pp_mesh = self.world_mesh["dense"]["pp"]
+            self.pp_group = self.pp_mesh.get_group()
+            self.pp_group_rank = get_rank(self.pp_group)
+            self.pp_group_size = get_world_size(self.pp_group)
+            self.pp_prev_rank = (self.pp_group_rank - 1) % self.pp_group_size
+            self.pp_next_rank = (self.pp_group_rank + 1) % self.pp_group_size
+            self.pp_final_stage_rank = pp_config.final_stage_rank()
+            pp_p2p_group = pp_config.build_p2p_process_group(self.world_mesh["dense"])
+
+            # Split model into pipeline stages.
+            model.purge_cuda_events()  # set event to None so that can be deepcopied
+
+            stages_and_model_parts = pp_config.split_model(
+                model,
+                pp_mesh=self.pp_mesh,
+                device=self.device,
+                use_ddp=self.world_mesh["dense"]["dp"].size() > 1,
+                p2p_group=pp_p2p_group,
+            )
+            stages = stages_and_model_parts[0]
+
+            model_parts: List[MoEFusedV2Transformer] = cast(
+                List[MoEFusedV2Transformer], stages_and_model_parts[1]
+            )
+
+            for model_part in model_parts:
+                assert isinstance(model_part, MoEFusedV2Transformer)
+                model_part.install_cuda_events()
+
+            self._pp_stages = stages
+            log.info(
+                f"Applied pipeline parallelism to the model with {get_device_mesh_info(self.pp_mesh)}"
+            )
+
+            # TODO: chunk layers into stages
+            assert (
+                self.world_mesh is not None
+            ), "World mesh must be built before applying expert parallelism"
+            assert (
+                self.world_mesh["dense"] is not None
+            ), "Dense mesh must be built before applying expert parallelism"
+
+            for m in model_parts:
+                m.apply_pp(self.pp_mesh)
+
+        else:
+            model_parts = cast(List[MoEFusedV2Transformer], [model])  # no PP, single part
+
+        # Maybe apply FP8 training.
+        if float8_config is not None and float8_config.enabled:
+            for m in model_parts:
+                m.apply_fp8(float8_config)
+                log.info("Swapped linear layers to Float8 linear layers\n%s", m)
+
+        assert dp_config is not None
+
+        if ep_config is not None:
+            # EP-DP combined
+            # for the dense part, replicate over DP pg
+            # for the moe part, replicate over EP-DP pg
+            assert (
+                self.world_mesh is not None
+            ), "World mesh must be built before applying expert parallelism"
+            assert (
+                self.world_mesh["moe"] is not None
+            ), "MoE mesh must be built before applying expert parallelism"
+            assert (
+                self.world_mesh["dense"] is not None
+            ), "Dense mesh must be built before applying expert parallelism"
+            ep_mesh = self.world_mesh["moe"]
+            dp_mesh = self.world_mesh["dense"]["dp"]
+            ep_mp_group_override: Optional[ProcessGroup] = None
+
+            if backend_supports_cuda():
+                ep_mp_dim = ep_mesh.mesh_dim_names.index(MeshDimName.ep_mp)
+                ep_rank_grid = ep_mesh.mesh
+                if ep_mp_dim != ep_rank_grid.ndim - 1:
+                    ep_rank_grid = torch.movedim(ep_rank_grid, ep_mp_dim, -1).contiguous()
+                ep_mp_rank_groups = ep_rank_grid.view(-1, ep_rank_grid.shape[-1]).tolist()
+                # Keep small synchronized-EP collectives on a high-priority stream.
+                # Shared experts can overlap the token-count exchange; if some EP
+                # ranks arrive earlier than others, this is meant to keep that
+                # overlap from delaying the collective start. Revalidate whether it
+                # still buys useful overlap on current NCCL/torch versions.
+                nccl_opts = dist.ProcessGroupNCCL.Options(is_high_priority_stream=True)
+                ep_mp_group, ep_mp_groups = dist.new_subgroups_by_enumeration(
+                    ranks_per_subgroup_list=ep_mp_rank_groups,
+                    backend="nccl",
+                    pg_options=nccl_opts,
+                    group_desc="ep_mp_high_priority",
+                )
+                if ep_mp_group == dist.GroupMember.NON_GROUP_MEMBER:
+                    raise RuntimeError("Current rank is not in any EP-MP high-priority subgroup")
+                ep_mp_group_override = cast(ProcessGroup, ep_mp_group)
+                self.ep_mp_high_priority_group = ep_mp_group_override
+                self.ep_mp_high_priority_groups = ep_mp_groups
+                log.info("Created high-priority NCCL EP-MP process groups")
+            else:
+                log.warning(
+                    "Skipping EP-MP high-priority group creation because backend is '%s'",
+                    dist.get_backend(),
+                )
+
+            share_ep_no_sync_scratch_pool = len(model_parts) > 1 and all(
+                (
+                    cast(MoEFusedV2Transformer, m).recompute_each_block
+                    or cast(MoEFusedV2Transformer, m).recompute_all_blocks_by_chunk
+                )
+                for m in model_parts
+            )
+            ep_no_sync_shared_pool: Optional[Any] = None
+            if share_ep_no_sync_scratch_pool:
+                log.info(
+                    "Sharing EP no-sync transient symmetric scratch pool across %d local PP model parts",
+                    len(model_parts),
+                )
+
+            ddp_model_parts: List[Any] = []
+            for m in model_parts:
+                if not m.is_moe:
+                    raise OLMoConfigurationError("Expert parallelism is only valid for MoE models")
+                returned_shared_pool = cast(MoEFusedV2Transformer, m).apply_ep(
+                    dp_mesh=dp_mesh,
+                    ep_mesh=ep_mesh,
+                    ep_mp_group=ep_mp_group_override,
+                    param_dtype=None,
+                    compile_enabled=compile_model,
+                    ep_no_sync_shared_pool=(
+                        ep_no_sync_shared_pool if share_ep_no_sync_scratch_pool else None
+                    ),
+                )
+                if share_ep_no_sync_scratch_pool and returned_shared_pool is not None:
+                    if ep_no_sync_shared_pool is None:
+                        ep_no_sync_shared_pool = returned_shared_pool
+                    elif returned_shared_pool is not ep_no_sync_shared_pool:
+                        raise RuntimeError(
+                            "Expected all local PP model parts to share the same EP no-sync "
+                            "symmetric scratch pool"
+                        )
+
+            log.info(
+                "Applied expert parallelism to the model with %s",
+                get_device_mesh_info(ep_mesh),
+            )
+        else:
+            # Pure DP (no EP)
+            pass
+            assert (
+                self.world_mesh is not None
+            ), "World mesh must be built before applying expert parallelism"
+            assert (
+                self.world_mesh["dense"] is not None
+            ), "Dense mesh must be built before applying expert parallelism"
+            # param_dtype = dp_config.param_dtype.as_pt() if dp_config.param_dtype is not None else None
+            dp_mesh = self.world_mesh["dense"]["dp"]
+            ep_mesh = None
+            # for m in model_parts:
+            #     cast(MoEFusedV2Transformer, m).apply_ddp(dp_mesh=dp_mesh, compile_enabled=compile_model, param_dtype=param_dtype)
+            # log.info(f"Applied DDP to the model with {get_device_mesh_info(dp_mesh)}")
+
+        # Maybe apply activation checkpointing.
+        if ac_config is not None:
+            for m in model_parts:
+                m.apply_activation_checkpointing(
+                    ac_config.mode,
+                    block_interval=ac_config.block_interval,
+                    modules=ac_config.modules,
+                    activation_memory_budget=ac_config.activation_memory_budget,
+                )
+            log.info(f"Applied '{ac_config.mode}' activation checkpointing to the model")
+
+        # ac_budget = 0.05
+        # torch._functorch.config.activation_memory_budget = ac_budget
+
+        self.init_model_weights(
+            model_parts=model_parts,
+            max_sequence_length=self.max_sequence_length,
+            rank_microbatch_size=self.rank_microbatch_size,
+        )
+
+        # now wrap with DDP (requires initialized params)
+        if eval_only:
+            # apply_dp() currently performs the bf16 cast used for MoE forward kernels.
+            # Keep that cast in eval-only mode even though we intentionally skip DDP wrapping.
+            self._cast_to_fwd_bwd_precision(model_parts)
+            for m in model_parts:
+                m.refresh_rowwise_fp8_cache()
+            log.info("Skipping DDP wrapping because eval_only=True")
+            return model_parts
+
+        ddp_model_parts = []
+        for idx, m in enumerate(model_parts):
+            ddp_m = m.apply_dp(
+                dp_mesh=dp_mesh,
+                ep_mesh=ep_mesh,
+                accumulate_grads_in_fp32=dp_config.accumulate_grads_in_fp32,
+                reduce_grads_in_fp32=dp_config.reduce_grads_in_fp32,
+                bucket_cap_mb=dp_config.bucket_cap_mb,
+            )
+            ddp_model_parts.append(ddp_m)
+
+            if pp_config is not None:
+                # update stage reference to point to the ddp wrapped model part
+                assert self._pp_stages is not None
+                assert self._pp_stages[idx].submod is m
+                self._pp_stages[idx].submod = ddp_m
+
+        with maybe_nvtx_annotate(
+            "MoEV2TransformerTrainModule.refresh_rowwise_fp8_cache_before_first_step", _BWD_COLOR
+        ):
+            for m in ddp_model_parts:
+                m.refresh_rowwise_fp8_cache()
+
+        return ddp_model_parts
+
+    def memory_usage_estimation(self):
+        pass
+
+    def init_model_weights(
+        self,
+        model_parts,
+        max_sequence_length: int,
+        rank_microbatch_size: int,
+    ):
+        from olmo_core.nn.moe.v2.model import MoEFusedV2Transformer
+
+        # Materialize and init parameters.
+        log.info("Initializing model weights...")
+        for model_part_idx, m in enumerate(model_parts):
+            m = cast(MoEFusedV2Transformer, m)
+            m.init_weights(
+                max_seq_len=max_sequence_length,
+                max_local_microbatch_size=rank_microbatch_size,
+                device=self.device,
+                world_mesh=self.world_mesh,  # only PP mesh is used, should be fine
+                model_part_idx=model_part_idx,
+            )
+            # for n, p in m.named_parameters():
+            #     print(f'{n} {p.shape}: mean={p.data.mean().item()}, std={p.data.std().item()}')
+
+        self._prewarm_ep_no_sync_symm_buffers(
+            model_parts=model_parts,
+            rank_microbatch_size=rank_microbatch_size,
+        )
+        for m in model_parts:
+            m.refresh_rowwise_fp8_cache()
+
+        return
+
+    def _prewarm_ep_no_sync_symm_buffers(
+        self,
+        *,
+        model_parts,
+        rank_microbatch_size: int,
+        rowwise_lifetime_lease_slots: Optional[Union[int, Sequence[int]]] = None,
+    ) -> None:
+        if self.world_mesh.get("moe") is None:
+            return
+        from olmo_core.kernels import olmo_symm_mem
+
+        typed_parts = [cast(MoEFusedV2Transformer, m) for m in model_parts]
+        local_counts = [m.count_ep_no_sync_blocks() for m in typed_parts]
+        if not any(local_counts):
+            return
+
+        use_olmo_symm = olmo_symm_mem.is_enabled()
+        if not use_olmo_symm and self.pp_enabled:
+            raise OLMoConfigurationError(
+                "EP no-sync with pipeline parallelism cannot use the legacy PyTorch symmetric-memory "
+                "backend. PyTorch's NVSHMEM symm_mem.empty() allocates through c10d group '0' before "
+                "the EP group is applied, which can hang when PP stages allocate unevenly. Use the "
+                "OLMo-owned symmetric-memory backend by setting OLMO_USE_OWN_SYMM_MEM=1, or disable "
+                "pipeline parallelism / EP no-sync."
+            )
+
+        if use_olmo_symm:
+            prewarm_olmo = os.getenv("OLMO_OWN_SYMM_PREWARM", "1").lower() not in (
+                "",
+                "0",
+                "false",
+                "no",
+                "off",
+            )
+            if not prewarm_olmo:
+                return
+
+        # Prewarm only the local model part's real blocks. The legacy PyTorch
+        # backend is only allowed here without PP, so there is no cross-stage
+        # allocation sequence to align with dummy padding.
+        max_counts = list(local_counts)
+
+        rowwise_slots_by_part: List[Optional[int]]
+        if isinstance(rowwise_lifetime_lease_slots, Sequence):
+            if len(rowwise_lifetime_lease_slots) != len(typed_parts):
+                raise RuntimeError(
+                    "rowwise_lifetime_lease_slots sequence length must match model_parts: "
+                    f"{len(rowwise_lifetime_lease_slots)} vs {len(typed_parts)}"
+                )
+            rowwise_slots_by_part = [int(slots) for slots in rowwise_lifetime_lease_slots]
+        else:
+            rowwise_slots_by_part = [rowwise_lifetime_lease_slots for _ in typed_parts]
+
+        for model_part_idx, (model_part, max_count) in enumerate(zip(typed_parts, max_counts)):
+            model_part.prewarm_ep_no_sync_symm_buffers(
+                max_local_microbatch_size=rank_microbatch_size,
+                pad_to_block_count=max_count,
+                rowwise_lifetime_lease_slots=rowwise_slots_by_part[model_part_idx],
+            )
+
+    def compile_model(self):
+        if torch.cuda.is_available():
+            for m in self.model_parts:
+                m.apply_compile()
+            log.info("Applied torch.compile() to the model")
+        else:
+            log.warning("Skipping model compilation since CUDA is not available")
+
+    def reduce_send_recv(self, x: Optional[torch.Tensor] = None) -> torch.Tensor:
+        # assert self.pp_enabled and self._pp_config is not None
+
+        # if self.pp_group_rank == self.pp_final_stage_rank:
+        #     assert x is not None
+        #     # DP reduce (mean)
+        #     x = x / self._reduce_divide_factor
+        #     dist.all_reduce(x, group=self.dp_process_group)
+        #     x = x / self.dp_world_size * self._reduce_divide_factor
+        # else:
+        #     assert x is None
+        #     x = torch.empty([], device=self.device, dtype=torch.float32)
+
+        # # Broadcast from final stage to all PP ranks.
+        # handle = dist.broadcast(x, src=get_global_rank(self.pp_final_stage_rank, group=self.pp_group), group=self.pp_group, async_op=True)
+        # handle.wait()
+        # # print(f'{get_rank()} (pp group rank {self.pp_group_rank}) got {x.item()}')
+        # return x
+
+        assert (
+            self.pp_enabled and self._pp_config is not None
+        ), "reduce_send_recv is only valid when PP is enabled"
+        if self.pp_group_rank == self.pp_final_stage_rank:
+            assert x is not None
+            # Reduce across DP process group.
+            dist.all_reduce(x, group=self.dp_process_group)
+            x.div_(self.dp_world_size)
+        else:
+            assert x is None
+            x = move_to_device(torch.empty([]), self.device)
+
+        # Propagate final-stage scalar metrics through PP ranks in completion
+        # order instead of broadcasting. This was inherited from older PP code;
+        # it likely avoids an ordering cycle with surrounding PP collectives, but
+        # the exact constraint should be revalidated before simplifying it.
+        ordered_ranks = list(self._pp_config.rank_completion_order())
+        local_index = ordered_ranks.index(self.pp_group_rank)
+        src_rank = None if local_index == 0 else ordered_ranks[local_index - 1]
+        dst_rank = (
+            None if local_index == (len(ordered_ranks) - 1) else ordered_ranks[local_index + 1]
+        )
+
+        send_ops: List[dist.P2POp] = []
+        recv_ops: List[dist.P2POp] = []
+        if src_rank is not None:
+            # print(
+            #     f"Rank {get_rank()} (pp group rank {self.pp_group_rank}) receiving from rank "
+            #     f"{get_global_rank(src_rank, group=self.pp_group)} (pp group rank {src_rank})"
+            # )
+            recv_ops.append(dist.P2POp(dist.irecv, x, group=self.pp_group, group_peer=src_rank))
+        if dst_rank is not None:
+            # print(
+            #     f"Rank {get_rank()} (pp group rank {self.pp_group_rank}) sending to rank "
+            #     f"{get_global_rank(dst_rank, group=self.pp_group)} (pp group rank {dst_rank})"
+            # )
+            send_ops.append(dist.P2POp(dist.isend, x, group=self.pp_group, group_peer=dst_rank))
+
+        if len(recv_ops) > 0:
+            recv_reqs = dist.batch_isend_irecv(recv_ops)
+            for req in recv_reqs:
+                req.wait()
+
+        if len(send_ops) > 0:
+            send_reqs = dist.batch_isend_irecv(send_ops)
+            for req in send_reqs:
+                req.wait()
+
+        # print(f'{get_rank()} (pp group rank {self.pp_group_rank}) got {x.item()}')
+        return x

--- a/src/test/kernels/nccl_rma_p2p_test.py
+++ b/src/test/kernels/nccl_rma_p2p_test.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import pytest
 import torch
 import torch.distributed as dist
 
 from olmo_core.distributed.utils import get_local_rank
 from olmo_core.kernels import nccl_rma_p2p
-from olmo_core.testing import requires_multi_gpu, run_distributed_test
+from olmo_core.testing import requires_nccl_rma, run_distributed_test
 
 
 def _broadcast_unique_id(rank: int) -> bytes:
@@ -86,14 +85,11 @@ def _run_put_signal_wait() -> None:
     dist.barrier()
 
 
-# NOTE: skipped until the CI image ships a new enough NCCL. The nccl_rma_p2p
-# extension uses NCCL's one-sided RMA "window" API (ncclPutSignal / ncclWaitSignal /
-# ncclWaitSignalDesc_t), which is only present in recent NCCL (~2.28+). The NCCL
-# bundled with the current torch build is older, so the extension fails to compile
-# ("'ncclPutSignal' was not declared"). Re-enable once the kernels CI image has a
-# new enough NCCL (e.g. via NCCL_HOME pointing at one with the RMA window API).
-@pytest.mark.skip(reason="Requires NCCL with the RMA window API (ncclPutSignal/ncclWaitSignal)")
-@requires_multi_gpu
+# The nccl_rma_p2p extension JIT-builds against NCCL's one-sided RMA "window" API
+# (ncclPutSignal / ncclWaitSignal / ncclWaitSignalDesc_t), present only in recent NCCL
+# (~2.28+). `requires_nccl_rma` detects that (dev headers + RMA symbols) and skips when
+# absent, so this runs only on images whose NCCL can actually compile the extension.
+@requires_nccl_rma
 def test_nccl_rma_p2p_put_signal_wait():
     # gloo is only the coordination PG (broadcast + barriers); the RMA path uses its
     # own NCCL comm. Force "spawn" though -- the gloo default is "fork", which can't

--- a/src/test/nn/moe/v2/activation_debug_test.py
+++ b/src/test/nn/moe/v2/activation_debug_test.py
@@ -1,0 +1,102 @@
+import torch
+from torch import nn
+
+from olmo_core.nn.moe.v2 import activation_debug
+
+
+class _DebugBlock(nn.Module):
+    def __init__(self, *, block_idx: int = 3):
+        super().__init__()
+        self.block_idx = block_idx
+        self.weight = nn.Parameter(torch.tensor(2.0))
+        self.calls = 0
+
+    def combined_forward_ep_no_sync_1d(self, x, *, loss_div_factor=None, **kwargs):
+        del loss_div_factor, kwargs
+        self.calls += 1
+        return x * self.weight
+
+
+def test_ep_no_sync_activation_debug_returns_none_when_gate_is_closed(monkeypatch):
+    block = _DebugBlock(block_idx=3)
+    x = torch.ones(8, 512, requires_grad=True)
+
+    monkeypatch.setattr(
+        activation_debug,
+        "_get_train_global_arg",
+        lambda key, default=None: False if key == "dry_run_done" else default,
+    )
+
+    out = activation_debug.maybe_dump_ep_no_sync_saved_activations(
+        block,
+        x,
+        loss_div_factor=None,
+        forward_kwargs={},
+        no_sync_forward=block.combined_forward_ep_no_sync_1d,
+    )
+
+    assert out is None
+    assert block.calls == 0
+
+
+def test_ep_no_sync_activation_debug_is_disabled_by_default(monkeypatch):
+    block = _DebugBlock(block_idx=3)
+    x = torch.ones(8, 512, requires_grad=True)
+    global_args = {
+        "dry_run_done": True,
+        "ep_no_sync_saved_activations_dumped_block_3": False,
+    }
+
+    monkeypatch.delenv(activation_debug.EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENV_VAR, raising=False)
+    monkeypatch.setattr(
+        activation_debug,
+        "_get_train_global_arg",
+        lambda key, default=None: global_args.get(key, default),
+    )
+
+    out = activation_debug.maybe_dump_ep_no_sync_saved_activations(
+        block,
+        x,
+        loss_div_factor=None,
+        forward_kwargs={},
+        no_sync_forward=block.combined_forward_ep_no_sync_1d,
+    )
+
+    assert out is None
+    assert block.calls == 0
+    assert global_args["ep_no_sync_saved_activations_dumped_block_3"] is False
+
+
+def test_ep_no_sync_activation_debug_runs_once_and_sets_global_flag(monkeypatch):
+    block = _DebugBlock(block_idx=3)
+    x = torch.ones(8, 512, requires_grad=True)
+    global_args = {
+        "dry_run_done": True,
+        "ep_no_sync_saved_activations_dumped_block_3": False,
+    }
+
+    monkeypatch.setenv(activation_debug.EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENV_VAR, "1")
+    monkeypatch.setattr(
+        activation_debug,
+        "_get_train_global_arg",
+        lambda key, default=None: global_args.get(key, default),
+    )
+    monkeypatch.setattr(
+        activation_debug,
+        "_set_train_global_arg",
+        lambda key, value: global_args.__setitem__(key, value),
+    )
+    monkeypatch.setattr(activation_debug, "get_rank", lambda: 0)
+    monkeypatch.setattr(activation_debug.torch.cuda, "memory_allocated", lambda: 0)
+
+    out = activation_debug.maybe_dump_ep_no_sync_saved_activations(
+        block,
+        x,
+        loss_div_factor=None,
+        forward_kwargs={"unused_kwarg": object()},
+        no_sync_forward=block.combined_forward_ep_no_sync_1d,
+    )
+
+    torch.testing.assert_close(out, x * 2)
+    assert block.calls == 1
+    assert global_args["ep_no_sync_saved_activations_dumped_block_3"] is True

--- a/src/test/nn/moe/v2/block_no_sync_test.py
+++ b/src/test/nn/moe/v2/block_no_sync_test.py
@@ -14,6 +14,7 @@ from olmo_core.testing import (
     requires_gpu,
     requires_grouped_gemm,
     requires_multi_gpu,
+    requires_symm_mem_vdev2d,
     run_distributed_test,
 )
 
@@ -489,6 +490,7 @@ def test_v2_ep_no_sync_hard_fail_setup():
 
 
 @requires_multi_gpu
+@requires_symm_mem_vdev2d
 def test_v2_ep_no_sync_rowwise_matches_synced():
     run_distributed_test(
         _run_ep_no_sync_rowwise_matches_synced, backend="nccl", start_method="spawn"
@@ -505,6 +507,7 @@ def test_v2_ep_no_sync_2d_all_to_all_rejected():
 
 
 @requires_multi_gpu
+@requires_symm_mem_vdev2d
 def test_v2_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
     run_distributed_test(
         _run_ep_no_sync_rowwise_drop_matches_independent_rowwise_block,

--- a/src/test/nn/moe/v2/block_no_sync_test.py
+++ b/src/test/nn/moe/v2/block_no_sync_test.py
@@ -1,0 +1,513 @@
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
+
+from olmo_core.config import DType
+from olmo_core.exceptions import OLMoConfigurationError
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlock
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.testing import (
+    requires_gpu,
+    requires_grouped_gemm,
+    requires_multi_gpu,
+    run_distributed_test,
+)
+
+
+def _build_ep_mesh() -> DeviceMesh:
+    world_size = dist.get_world_size()
+    mesh = torch.arange(world_size, dtype=torch.int).view(1, world_size)
+    return DeviceMesh(
+        device_type="cuda",
+        mesh=mesh,
+        mesh_dim_names=("ep_dp", "ep_mp"),
+    )
+
+
+def _build_block(
+    *,
+    ep_no_sync: bool,
+    ep_no_sync_capacity_factor: float = 2.0,
+    d_model: int = 512,
+    hidden_size: int = 1024,
+    num_experts: int = 4,
+    top_k: int = 1,
+    uniform_expert_assignment: bool = True,
+    init_device: str = "cuda",
+    ep_no_sync_use_2d_all_to_all: bool = False,
+) -> MoEFusedV2TransformerBlock:
+    layer_norm = LayerNormConfig(
+        name=LayerNormType.rms,
+        eps=1e-6,
+        bias=False,
+        dtype=DType.float32,
+    )
+    from olmo_core.nn.attention import AttentionConfig, AttentionType
+
+    return MoEFusedV2TransformerBlock(
+        d_model=d_model,
+        block_idx=0,
+        n_layers=1,
+        sequence_mixer=AttentionConfig(
+            name=AttentionType.default,
+            n_heads=2,
+            n_kv_heads=2,
+            bias=False,
+            use_flash=False,
+            dtype=DType.float32,
+        ),
+        attention_norm=layer_norm,
+        routed_experts_router=MoERouterConfigV2(
+            d_model=d_model,
+            num_experts=num_experts,
+            top_k=top_k,
+            gating_function=MoERouterGatingFunction.softmax,
+            uniform_expert_assignment=uniform_expert_assignment,
+            lb_loss_weight=None,
+            z_loss_weight=None,
+            dtype=DType.float32,
+        ),
+        shared_experts_router=None,
+        shared_experts=None,
+        routed_experts=RoutedExpertsConfig(
+            d_model=d_model,
+            hidden_size=hidden_size,
+            num_experts=num_experts,
+            bias=False,
+            dtype=DType.float32,
+        ),
+        feed_forward_norm=layer_norm,
+        ep_no_sync=ep_no_sync,
+        ep_no_sync_use_2d_all_to_all=ep_no_sync_use_2d_all_to_all,
+        ep_no_sync_capacity_factor=ep_no_sync_capacity_factor,
+        ep_no_sync_major_align=1,
+        init_device=init_device,
+    )
+
+
+def _init_block_params(block: MoEFusedV2TransformerBlock):
+    torch.manual_seed(1234)
+    with torch.no_grad():
+        for p in block.parameters():
+            if p.is_floating_point():
+                p.normal_(mean=0.0, std=0.02)
+
+
+def _install_forced_router(block: MoEFusedV2TransformerBlock):
+    def _make_forced_forward(router):
+        def _forced_forward(local_x, scores_only, loss_div_factor=None):
+            del loss_div_factor
+            B, S, _ = local_x.shape
+            if scores_only:
+                return (
+                    torch.ones(
+                        B,
+                        S,
+                        router.num_experts,
+                        device=local_x.device,
+                        dtype=local_x.dtype,
+                    ),
+                    None,
+                    None,
+                    None,
+                )
+
+            expert_weights = torch.ones(
+                B,
+                S,
+                router.top_k,
+                device=local_x.device,
+                dtype=local_x.dtype,
+            )
+            expert_indices = torch.zeros(
+                B,
+                S,
+                router.top_k,
+                device=local_x.device,
+                dtype=torch.long,
+            )
+            batch_size_per_expert = torch.zeros(
+                router.num_experts,
+                device=local_x.device,
+                dtype=torch.long,
+            )
+            batch_size_per_expert[0] = B * S * router.top_k
+            return expert_weights, expert_indices, batch_size_per_expert, None
+
+        return _forced_forward
+
+    assert block.routed_experts_router is not None
+    block.routed_experts_router.forward = _make_forced_forward(block.routed_experts_router)
+    if block.shared_experts_router is not None:
+        block.shared_experts_router.forward = _make_forced_forward(block.shared_experts_router)
+
+
+def _install_deterministic_topk_router(block: MoEFusedV2TransformerBlock):
+    def _make_deterministic_forward(router):
+        def _deterministic_forward(local_x, scores_only, loss_div_factor=None):
+            del loss_div_factor
+            B, S, _ = local_x.shape
+            if scores_only:
+                return (
+                    torch.ones(
+                        B,
+                        S,
+                        router.num_experts,
+                        device=local_x.device,
+                        dtype=local_x.dtype,
+                    ),
+                    None,
+                    None,
+                    None,
+                )
+
+            top_k = router.top_k
+            num_experts = router.num_experts
+            token_ids = torch.arange(B * S, device=local_x.device, dtype=torch.long).unsqueeze(1)
+            route_offsets = torch.arange(top_k, device=local_x.device, dtype=torch.long).unsqueeze(
+                0
+            )
+            expert_indices = (token_ids + route_offsets + dist.get_rank() * 3) % num_experts
+            expert_indices = expert_indices.view(B, S, top_k)
+
+            weights = torch.arange(1, top_k + 1, device=local_x.device, dtype=local_x.dtype)
+            weights = weights / weights.sum().clamp_min(1e-6)
+            expert_weights = weights.view(1, 1, top_k).expand(B, S, top_k).contiguous()
+
+            batch_size_per_expert = torch.bincount(
+                expert_indices.reshape(-1), minlength=num_experts
+            ).to(dtype=torch.long)
+            return expert_weights, expert_indices, batch_size_per_expert, None
+
+        return _deterministic_forward
+
+    assert block.routed_experts_router is not None
+    block.routed_experts_router.forward = _make_deterministic_forward(block.routed_experts_router)
+    if block.shared_experts_router is not None:
+        block.shared_experts_router.forward = _make_deterministic_forward(
+            block.shared_experts_router
+        )
+
+
+@requires_gpu
+@requires_grouped_gemm
+def test_v2_no_ep_forward_backward_smoke():
+    block = _build_block(ep_no_sync=False, init_device="cuda")
+    _init_block_params(block)
+    _install_forced_router(block)
+    block.train()
+
+    x = torch.randn(1, 8, block.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    y = block(x)
+
+    assert y.shape == x.shape
+    assert torch.isfinite(y).all()
+
+    y.square().mean().backward()
+
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+    for p in block.parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all()
+
+
+@requires_gpu
+@requires_grouped_gemm
+def test_v2_no_ep_apply_compile_forward_smoke():
+    block = _build_block(
+        ep_no_sync=False,
+        d_model=128,
+        hidden_size=256,
+        num_experts=4,
+        top_k=1,
+        init_device="cuda",
+    )
+    _init_block_params(block)
+    block.to(dtype=torch.bfloat16)
+    _install_forced_router(block)
+    block.train()
+    block.apply_compile()
+
+    x = torch.randn(1, 4, block.d_model, device="cuda", dtype=torch.bfloat16)
+    y = block(x)
+
+    assert y.shape == x.shape
+    assert torch.isfinite(y).all()
+
+
+def _run_ep_no_sync_matches_synced():
+    ep_mesh = _build_ep_mesh()
+
+    block_ep = _build_block(ep_no_sync=False, uniform_expert_assignment=True)
+    block_no_sync = _build_block(ep_no_sync=True, uniform_expert_assignment=True)
+    block_ep.apply_ep(ep_mesh)
+    block_no_sync.apply_ep(ep_mesh)
+
+    _init_block_params(block_ep)
+    block_no_sync.load_state_dict(block_ep.state_dict())
+    block_ep.train()
+    block_no_sync.train()
+
+    x = torch.randn(1, 8, block_ep.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_(True)
+
+    y_ep = block_ep(x)
+    y_no_sync = block_no_sync(x_ref)
+    torch.testing.assert_close(y_no_sync, y_ep, atol=2e-4, rtol=2e-4)
+
+    y_ep.sum().backward()
+    y_no_sync.sum().backward()
+    torch.testing.assert_close(x_ref.grad, x.grad, atol=3e-4, rtol=3e-4)
+
+    ep_params = dict(block_ep.named_parameters())
+    no_sync_params = dict(block_no_sync.named_parameters())
+    for name, p_ep in ep_params.items():
+        p_no_sync = no_sync_params[name]
+        if p_ep.grad is None or p_no_sync.grad is None:
+            continue
+        torch.testing.assert_close(p_no_sync.grad, p_ep.grad, atol=8e-4, rtol=8e-4)
+
+
+def _run_ep_no_sync_drop_behavior():
+    ep_mesh = _build_ep_mesh()
+
+    block_no_sync = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_capacity_factor=0.25,
+        uniform_expert_assignment=False,
+    )
+    block_no_sync.apply_ep(ep_mesh)
+    _init_block_params(block_no_sync)
+    _install_forced_router(block_no_sync)
+    block_no_sync.train()
+
+    x = torch.randn(
+        1, 8, block_no_sync.d_model, device="cuda", dtype=torch.float32, requires_grad=True
+    )
+    y = block_no_sync(x)
+    assert torch.isfinite(y).all()
+    y.sum().backward()
+    assert x.grad is not None
+
+    dbg = block_no_sync._ep_no_sync_last_debug
+    assert dbg["num_dropped"].item() > 0
+    assert dbg["received_tokens_after_drop"].item() <= dbg["rank_capacity"].item()
+    assert dbg["allowed_splits"].sum().item() == dbg["local_kept_tokens"].item()
+    assert dbg["combined_tokens"].item() == dbg["local_kept_tokens"].item()
+    assert dbg["zero_rows_after_local_unpermute"].item() >= dbg["num_dropped"].item()
+
+
+def _run_ep_no_sync_quota_invariants():
+    ep_mesh = _build_ep_mesh()
+
+    block_no_sync = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_capacity_factor=0.5,
+        uniform_expert_assignment=False,
+    )
+    block_no_sync.apply_ep(ep_mesh)
+    _init_block_params(block_no_sync)
+    _install_forced_router(block_no_sync)
+    block_no_sync.train()
+
+    x = torch.randn(
+        1, 8, block_no_sync.d_model, device="cuda", dtype=torch.float32, requires_grad=True
+    )
+    y = block_no_sync(x)
+    y.sum().backward()
+
+    dbg = block_no_sync._ep_no_sync_last_debug
+    assert dbg["allowed_splits"].sum().item() == dbg["local_kept_tokens"].item()
+    assert dbg["received_tokens_after_drop"].item() <= dbg["rank_capacity"].item()
+    assert dbg["combined_tokens"].item() == dbg["local_kept_tokens"].item()
+
+
+def _run_ep_no_sync_hard_fail_setup():
+    import olmo_core.nn.moe.v2.block as block_module
+
+    ep_mesh = _build_ep_mesh()
+    old_symm = block_module._symm_mem
+    block_module._symm_mem = None
+    try:
+        block = _build_block(ep_no_sync=True)
+        try:
+            block.apply_ep(ep_mesh)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("Expected RuntimeError when symmetric memory is unavailable")
+    finally:
+        block_module._symm_mem = old_symm
+
+
+def _run_ep_no_sync_rowwise_matches_synced():
+    ep_mesh = _build_ep_mesh()
+
+    block_ep = _build_block(
+        ep_no_sync=False,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=2,
+        uniform_expert_assignment=False,
+    )
+    block_rowwise = _build_block(
+        ep_no_sync=True,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=2,
+        uniform_expert_assignment=False,
+    )
+    block_ep.apply_ep(ep_mesh)
+    block_rowwise.apply_ep(ep_mesh)
+
+    _init_block_params(block_ep)
+    block_rowwise.load_state_dict(block_ep.state_dict())
+    _install_deterministic_topk_router(block_ep)
+    _install_deterministic_topk_router(block_rowwise)
+
+    block_rowwise.ep_no_sync_use_rowwise_all_to_all = True
+    block_rowwise.ep_no_sync_rowwise_nblocks = 128
+
+    block_ep.train()
+    block_rowwise.train()
+
+    x = torch.randn(1, 8, block_ep.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    x_rowwise = x.detach().clone().requires_grad_(True)
+
+    y_ep = block_ep(x)
+    y_rowwise = block_rowwise(x_rowwise)
+    torch.testing.assert_close(y_rowwise, y_ep, atol=5e-4, rtol=5e-4)
+
+    loss_ep = y_ep.square().mean() + (0.1 * y_ep.sum())
+    loss_rowwise = y_rowwise.square().mean() + (0.1 * y_rowwise.sum())
+    loss_ep.backward()
+    loss_rowwise.backward()
+
+    torch.testing.assert_close(x_rowwise.grad, x.grad, atol=5e-4, rtol=5e-4)
+
+    ep_params = dict(block_ep.named_parameters())
+    rowwise_params = dict(block_rowwise.named_parameters())
+    for name, p_ep in ep_params.items():
+        p_rowwise = rowwise_params[name]
+        if p_ep.grad is None or p_rowwise.grad is None:
+            continue
+        torch.testing.assert_close(p_rowwise.grad, p_ep.grad, atol=1e-3, rtol=1e-3)
+
+
+def _run_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
+    ep_mesh = _build_ep_mesh()
+
+    block_a = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_capacity_factor=0.5,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_b = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_capacity_factor=0.5,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_a.apply_ep(ep_mesh)
+    block_b.apply_ep(ep_mesh)
+
+    _init_block_params(block_a)
+    block_b.load_state_dict(block_a.state_dict())
+    _install_deterministic_topk_router(block_a)
+    _install_deterministic_topk_router(block_b)
+
+    block_a.ep_no_sync_use_rowwise_all_to_all = True
+    block_a.ep_no_sync_rowwise_nblocks = 128
+
+    block_b.ep_no_sync_use_rowwise_all_to_all = True
+    block_b.ep_no_sync_rowwise_nblocks = 128
+
+    block_a.train()
+    block_b.train()
+
+    x = torch.randn(2, 64, block_a.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    x_b = x.detach().clone().requires_grad_(True)
+
+    y_a = block_a(x)
+    y_b = block_b(x_b)
+    assert torch.isfinite(y_a).all()
+    assert torch.isfinite(y_b).all()
+    torch.testing.assert_close(y_b, y_a, atol=8e-4, rtol=8e-4)
+
+    loss_a = y_a.square().mean() + (0.1 * y_a.sum())
+    loss_b = y_b.square().mean() + (0.1 * y_b.sum())
+    loss_a.backward()
+    loss_b.backward()
+
+    assert torch.isfinite(x.grad).all()
+    assert torch.isfinite(x_b.grad).all()
+    torch.testing.assert_close(x_b.grad, x.grad, atol=2e-3, rtol=2e-3)
+
+    params_a = dict(block_a.named_parameters())
+    params_b = dict(block_b.named_parameters())
+    for name, p_a in params_a.items():
+        p_b = params_b[name]
+        if p_a.grad is None or p_b.grad is None:
+            continue
+        assert torch.isfinite(p_a.grad).all()
+        assert torch.isfinite(p_b.grad).all()
+        torch.testing.assert_close(p_b.grad, p_a.grad, atol=3e-3, rtol=3e-3)
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_matches_synced():
+    run_distributed_test(_run_ep_no_sync_matches_synced, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_drop_behavior():
+    run_distributed_test(_run_ep_no_sync_drop_behavior, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_quota_invariants():
+    run_distributed_test(_run_ep_no_sync_quota_invariants, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_hard_fail_setup():
+    run_distributed_test(_run_ep_no_sync_hard_fail_setup, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_rowwise_matches_synced():
+    run_distributed_test(
+        _run_ep_no_sync_rowwise_matches_synced, backend="nccl", start_method="spawn"
+    )
+
+
+def test_v2_ep_no_sync_2d_all_to_all_rejected():
+    with pytest.raises(OLMoConfigurationError, match="2D all_to_all path was removed"):
+        _build_block(
+            ep_no_sync=True,
+            init_device="cpu",
+            ep_no_sync_use_2d_all_to_all=True,
+        )
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
+    run_distributed_test(
+        _run_ep_no_sync_rowwise_drop_matches_independent_rowwise_block,
+        backend="nccl",
+        start_method="spawn",
+    )

--- a/src/test/nn/moe/v2/block_no_sync_test.py
+++ b/src/test/nn/moe/v2/block_no_sync_test.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import torch
 import torch.distributed as dist
@@ -242,6 +244,9 @@ def test_v2_no_ep_apply_compile_forward_smoke():
 
 
 def _run_ep_no_sync_matches_synced():
+    # VDev-1d no-sync EP uses the legacy torch symm-mem backend; OLMo-owned symm-mem
+    # (default on) supports only the rowwise no-sync path.
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"
     ep_mesh = _build_ep_mesh()
 
     block_ep = _build_block(ep_no_sync=False, uniform_expert_assignment=True)
@@ -275,6 +280,7 @@ def _run_ep_no_sync_matches_synced():
 
 
 def _run_ep_no_sync_drop_behavior():
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # non-rowwise EP → legacy symm-mem backend
     ep_mesh = _build_ep_mesh()
 
     block_no_sync = _build_block(
@@ -304,6 +310,7 @@ def _run_ep_no_sync_drop_behavior():
 
 
 def _run_ep_no_sync_quota_invariants():
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # non-rowwise EP → legacy symm-mem backend
     ep_mesh = _build_ep_mesh()
 
     block_no_sync = _build_block(
@@ -329,6 +336,7 @@ def _run_ep_no_sync_quota_invariants():
 
 
 def _run_ep_no_sync_hard_fail_setup():
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # non-rowwise EP → legacy symm-mem backend
     import olmo_core.nn.moe.v2.block as block_module
 
     ep_mesh = _build_ep_mesh()

--- a/src/test/nn/moe/v2/ep_no_sync_tbo_rowwise_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_tbo_rowwise_test.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any, List
+
+import pytest
+import torch
+
+from olmo_core.nn.moe.v2 import block as block_mod
+from olmo_core.nn.moe.v2 import ep_no_sync_tbo_1d as tbo_1d
+from olmo_core.nn.moe.v2 import ep_no_sync_tbo_rowwise as rowwise_tbo
+from olmo_core.nn.moe.v2 import model as model_mod
+
+
+def test_block_selects_rowwise_no_sync_tbo(monkeypatch):
+    calls: List[Any] = []
+
+    def fake_rowwise(block, x0, x1_ctx, x1_is_fresh, **kwargs):
+        calls.append(("rowwise", block, x0, x1_ctx, x1_is_fresh, kwargs))
+        return "rowwise-out", "rowwise-ctx"
+
+    def fake_1d(*args, **kwargs):
+        calls.append(("1d", args, kwargs))
+        return "1d-out", "1d-ctx"
+
+    monkeypatch.setattr(rowwise_tbo, "combined_forward_ep_no_sync_tbo_rowwise", fake_rowwise)
+    monkeypatch.setattr(tbo_1d, "combined_forward_ep_no_sync_tbo", fake_1d)
+
+    fake_block = SimpleNamespace(ep_no_sync_use_rowwise_all_to_all=True)
+    out, ctx = block_mod.MoEFusedV2TransformerBlock.combined_forward_ep_no_sync_tbo(
+        fake_block,  # type: ignore[arg-type]
+        "x0",
+        {"x1": "x1"},
+        True,
+        loss_div_factor=3.0,
+    )
+
+    assert (out, ctx) == ("rowwise-out", "rowwise-ctx")
+    assert calls == [
+        (
+            "rowwise",
+            fake_block,
+            "x0",
+            {"x1": "x1"},
+            True,
+            {"loss_div_factor": 3.0},
+        )
+    ]
+
+
+def test_block_keeps_existing_1d_tbo_when_rowwise_disabled(monkeypatch):
+    calls: List[Any] = []
+
+    monkeypatch.setattr(
+        rowwise_tbo,
+        "combined_forward_ep_no_sync_tbo_rowwise",
+        lambda *args, **kwargs: calls.append(("rowwise", args, kwargs)),
+    )
+
+    def fake_1d(block, x0, x1_ctx, x1_is_fresh, **kwargs):
+        calls.append(("1d", block, x0, x1_ctx, x1_is_fresh, kwargs))
+        return "1d-out", "1d-ctx"
+
+    monkeypatch.setattr(tbo_1d, "combined_forward_ep_no_sync_tbo", fake_1d)
+
+    fake_block = SimpleNamespace(ep_no_sync_use_rowwise_all_to_all=False)
+    out, ctx = block_mod.MoEFusedV2TransformerBlock.combined_forward_ep_no_sync_tbo(
+        fake_block,  # type: ignore[arg-type]
+        "x0",
+        {"x1": "x1"},
+        True,
+    )
+
+    assert (out, ctx) == ("1d-out", "1d-ctx")
+    assert calls[0][0] == "1d"
+
+
+def test_rowwise_tbo_fails_closed_for_fp8():
+    block = SimpleNamespace(
+        ep_no_sync_use_rowwise_all_to_all=True,
+        rowwise_fp8=SimpleNamespace(enabled=True),
+    )
+
+    with pytest.raises(NotImplementedError, match="Rowwise FP8"):
+        rowwise_tbo._check_rowwise_tbo_supported(block)  # type: ignore[arg-type]
+
+
+def test_model_finalizes_rowwise_pending_context(monkeypatch):
+    calls: List[Any] = []
+
+    def fake_stage_c(block, ctx):
+        calls.append(("stage_c", block, ctx))
+        return "combined-pending"
+
+    def fake_tail(block, ctx):
+        calls.append(("tail", block, ctx))
+        return "x1-final"
+
+    monkeypatch.setattr(rowwise_tbo, "ep_no_sync_rowwise_tbo_stage_c_launch", fake_stage_c)
+    monkeypatch.setattr(rowwise_tbo, "ep_no_sync_rowwise_tbo_stage_tail", fake_tail)
+
+    class FakeModel:
+        def maybe_forward_lm_head(self, x, lm_head_kwargs, labels=None):
+            calls.append(("lm_head", x, lm_head_kwargs, labels))
+            return f"head:{x}:{labels}"
+
+    fake_block = SimpleNamespace(ep_no_sync_use_rowwise_all_to_all=True)
+    pending = rowwise_tbo._NoSyncRowwiseTboPendingContext(
+        block=fake_block,  # type: ignore[arg-type]
+        lane_id=1,
+        a_state=SimpleNamespace(),  # type: ignore[arg-type]
+        global_x_rank_major=torch.ones(1, 2),
+    )
+
+    h0, h1 = model_mod.MoEFusedV2Transformer._tbo_last_step(
+        FakeModel(),  # type: ignore[arg-type]
+        "x0-final",
+        pending,
+        {"foo": "bar"},
+        "labels0",
+        "labels1",
+    )
+
+    assert h0 == "head:x0-final:labels0"
+    assert h1 == "head:x1-final:labels1"
+    assert calls == [
+        ("stage_c", fake_block, pending),
+        ("lm_head", "x0-final", {"foo": "bar"}, "labels0"),
+        ("tail", fake_block, "combined-pending"),
+        ("lm_head", "x1-final", {"foo": "bar"}, "labels1"),
+    ]
+
+
+def test_rowwise_tbo_combined_forward_fresh_schedule(monkeypatch):
+    calls: List[Any] = []
+    fake_block = SimpleNamespace()
+
+    def fake_stage_a(block, x, *, lane_id, loss_div_factor=None, **kwargs):
+        calls.append(("a", lane_id, x, loss_div_factor, kwargs))
+        return SimpleNamespace(lane_id=lane_id)
+
+    def fake_stage_d(block, a_state):
+        calls.append(("d", a_state.lane_id))
+        return SimpleNamespace(lane_id=a_state.lane_id)
+
+    def fake_stage_e(block, d_state):
+        calls.append(("e", d_state.lane_id))
+        return rowwise_tbo._NoSyncRowwiseTboPendingContext(
+            block=block,
+            lane_id=d_state.lane_id,
+            a_state=SimpleNamespace(lane_id=d_state.lane_id),  # type: ignore[arg-type]
+            global_x_rank_major=torch.tensor([[float(d_state.lane_id)]]),
+        )
+
+    def fake_stage_c(block, pending):
+        calls.append(("c", pending.lane_id))
+        pending.combine_out = torch.tensor([[10.0 + pending.lane_id]])
+        pending.combine_done_event = object()
+        return pending
+
+    def fake_tail(block, pending):
+        calls.append(("tail", pending.lane_id))
+        return f"final:{pending.lane_id}"
+
+    monkeypatch.setattr(rowwise_tbo, "ep_no_sync_rowwise_tbo_stage_a", fake_stage_a)
+    monkeypatch.setattr(rowwise_tbo, "ep_no_sync_rowwise_tbo_stage_d_launch", fake_stage_d)
+    monkeypatch.setattr(rowwise_tbo, "ep_no_sync_rowwise_tbo_stage_e", fake_stage_e)
+    monkeypatch.setattr(rowwise_tbo, "ep_no_sync_rowwise_tbo_stage_c_launch", fake_stage_c)
+    monkeypatch.setattr(rowwise_tbo, "ep_no_sync_rowwise_tbo_stage_tail", fake_tail)
+
+    out, pending = rowwise_tbo.combined_forward_ep_no_sync_tbo_rowwise(
+        fake_block,  # type: ignore[arg-type]
+        "x0",
+        {"x1": "x1"},
+        True,
+        loss_div_factor=7.0,
+        attention_mask="mask",
+    )
+
+    assert out == "final:0"
+    assert isinstance(pending, rowwise_tbo._NoSyncRowwiseTboPendingContext)
+    assert pending.lane_id == 1
+    assert calls == [
+        ("a", 0, "x0", 7.0, {"attention_mask": "mask"}),
+        ("d", 0),
+        ("a", 1, "x1", 7.0, {"attention_mask": "mask"}),
+        ("d", 1),
+        ("e", 0),
+        ("c", 0),
+        ("e", 1),
+        ("tail", 0),
+    ]
+
+
+def test_rowwise_stage_d_launch_uses_comm_stream_and_dispatch(monkeypatch):
+    calls: List[Any] = []
+    event = object()
+    comm_stream = object()
+
+    monkeypatch.setattr(rowwise_tbo, "get_or_init_stream", lambda **kwargs: comm_stream)
+    monkeypatch.setattr(
+        rowwise_tbo,
+        "wait_stream_no_compile",
+        lambda this_stream, other_stream: calls.append(("wait_stream", this_stream, other_stream)),
+    )
+    monkeypatch.setattr(
+        rowwise_tbo.torch.cuda,
+        "current_stream",
+        lambda: "current-stream",
+    )
+    monkeypatch.setattr(rowwise_tbo.torch.cuda, "stream", lambda stream: nullcontext())
+    monkeypatch.setattr(
+        rowwise_tbo,
+        "record_stream_event_no_compile",
+        lambda stream: calls.append(("record_event", stream)) or event,  # type: ignore[func-returns-value]
+    )
+
+    class FakeDispatch:
+        @staticmethod
+        def apply(*args):
+            calls.append(("dispatch", args))
+            return torch.full((2, 3), 5.0)
+
+    monkeypatch.setattr(rowwise_tbo, "_DispatchRowwiseAutograd", FakeDispatch)
+
+    buffers = SimpleNamespace(dispatch_out=torch.zeros(2, 3))
+    a_state = SimpleNamespace(
+        lane_id=1,
+        moe_inp=torch.ones(2, 3),
+        dst_ranks=torch.zeros(2, 1, dtype=torch.long),
+        dst_rows=torch.arange(2).view(2, 1),
+        buffers=buffers,
+        group_name="ep_group",
+        rowwise_nblocks=64,
+    )
+    block = SimpleNamespace(block_idx=4, ep_pg="pg")
+
+    d_state = rowwise_tbo.ep_no_sync_rowwise_tbo_stage_d_launch(block, a_state)  # type: ignore[arg-type]
+
+    assert d_state.lane_id == 1
+    assert d_state.a_state is a_state
+    assert torch.equal(d_state.dispatch_out, torch.full((2, 3), 5.0))
+    assert d_state.dispatch_done_event is event
+    assert calls[0] == ("wait_stream", comm_stream, "current-stream")
+    assert calls[1][0] == "dispatch"
+    assert calls[1][1] == (
+        a_state.moe_inp,
+        None,
+        a_state.dst_ranks,
+        a_state.dst_rows,
+        buffers.dispatch_out,
+        None,
+        "ep_group",
+        "pg",
+        64,
+        False,
+        True,
+        True,
+        True,
+    )
+    assert calls[2] == ("record_event", comm_stream)

--- a/src/test/nn/moe/v2/olmo_symm_mem_backend_test.py
+++ b/src/test/nn/moe/v2/olmo_symm_mem_backend_test.py
@@ -1,0 +1,233 @@
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from olmo_core.testing import requires_multi_gpu, run_distributed_test
+
+
+def _require_olmo_symm_extension() -> None:
+    try:
+        from olmo_core.kernels.symm_mem_vdev2d import _load_cuda_extension
+
+        ext = _load_cuda_extension()
+        ext.olmo_symm_get_unique_id()
+    except Exception as e:
+        pytest.skip(f"OLMo NVSHMEM symmetric-memory extension is unavailable: {e}")
+
+
+def _alloc_on_subgroup_only() -> None:
+    from olmo_core.kernels import olmo_symm_mem
+
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "1"
+    rank = dist.get_rank()
+    device = torch.device("cuda", torch.cuda.current_device())
+    group = dist.new_group(ranks=[0, 1])
+
+    if rank < 2:
+        tensor = olmo_symm_mem.empty(
+            (4, 4),
+            dtype=torch.float32,
+            device=device,
+            group=group,
+        )
+        olmo_symm_mem.rendezvous(tensor, group=group)
+        tensor.fill_(float(rank + 1))
+        torch.cuda.synchronize()
+
+    dist.barrier()
+
+
+def _alloc_two_independent_subgroups() -> None:
+    from olmo_core.kernels import olmo_symm_mem
+
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "1"
+    rank = dist.get_rank()
+    device = torch.device("cuda", torch.cuda.current_device())
+    group_a = dist.new_group(ranks=[0, 1])
+    group_b = dist.new_group(ranks=[2, 3])
+    group = group_a if rank < 2 else group_b
+    subgroup_rank = dist.get_rank(group)
+
+    tensor = olmo_symm_mem.empty(
+        (2, 3),
+        dtype=torch.float32,
+        device=device,
+        group=group,
+    )
+    olmo_symm_mem.rendezvous(tensor, group=group)
+    tensor.fill_(float(subgroup_rank + 1))
+    torch.cuda.synchronize()
+    dist.barrier()
+
+
+def _rowwise_dispatch_combine_roundtrip() -> None:
+    from olmo_core.kernels import olmo_symm_mem
+    from olmo_core.kernels.symm_mem_vdev2d import (
+        rowwise_combine_get,
+        rowwise_dispatch_put,
+    )
+
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "1"
+    group = dist.group.WORLD
+    rank = dist.get_rank(group)
+    world_size = dist.get_world_size(group)
+    if world_size != 2:
+        raise RuntimeError(f"Expected world_size=2, got {world_size}")
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    rows = 2
+    cols = 3
+    x = (
+        torch.arange(rows * cols, device=device, dtype=torch.float32)
+        .reshape(rows, cols)
+        .add_(rank * 100)
+    )
+
+    symm_out = olmo_symm_mem.empty(
+        (rows, cols),
+        dtype=torch.float32,
+        device=device,
+        group=group,
+    )
+    olmo_symm_mem.rendezvous(symm_out, group=group)
+    symm_out.zero_()
+
+    # Source row 0 goes to destination rank 0 at row=<source rank>.
+    # Source row 1 goes to destination rank 1 at row=<source rank>.
+    dst_ranks = torch.tensor([[0], [1]], device=device, dtype=torch.int64)
+    dst_rows = torch.full((rows, 1), rank, device=device, dtype=torch.int64)
+
+    rowwise_dispatch_put(
+        x,
+        symm_out,
+        dst_ranks,
+        dst_rows,
+        group.group_name,
+        nblocks=1,
+    )
+    torch.cuda.synchronize()
+
+    combine_out = torch.empty_like(x)
+    src_ranks = torch.tensor([[0], [1]], device=device, dtype=torch.int64)
+    src_rows = torch.full((rows, 1), rank, device=device, dtype=torch.int64)
+    rowwise_combine_get(
+        symm_out,
+        combine_out,
+        src_ranks,
+        src_rows,
+        group.group_name,
+        nblocks=1,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(combine_out, x)
+    dist.barrier()
+
+
+def _rowwise_dispatch_combine_subgroup_only() -> None:
+    from olmo_core.kernels import olmo_symm_mem
+    from olmo_core.kernels.symm_mem_vdev2d import (
+        rowwise_combine_get,
+        rowwise_dispatch_put,
+    )
+
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "1"
+    rank = dist.get_rank()
+    device = torch.device("cuda", torch.cuda.current_device())
+    group = dist.new_group(ranks=[0, 1])
+
+    if rank < 2:
+        subgroup_rank = dist.get_rank(group)
+        rows = 2
+        cols = 3
+        x = (
+            torch.arange(rows * cols, device=device, dtype=torch.float32)
+            .reshape(rows, cols)
+            .add_(subgroup_rank * 100)
+        )
+
+        symm_out = olmo_symm_mem.empty(
+            (rows, cols),
+            dtype=torch.float32,
+            device=device,
+            group=group,
+        )
+        olmo_symm_mem.rendezvous(symm_out, group=group)
+        symm_out.zero_()
+
+        dst_ranks = torch.tensor([[0], [1]], device=device, dtype=torch.int64)
+        dst_rows = torch.full((rows, 1), subgroup_rank, device=device, dtype=torch.int64)
+        rowwise_dispatch_put(
+            x,
+            symm_out,
+            dst_ranks,
+            dst_rows,
+            group.group_name,
+            nblocks=1,
+        )
+        torch.cuda.synchronize()
+
+        combine_out = torch.empty_like(x)
+        src_ranks = torch.tensor([[0], [1]], device=device, dtype=torch.int64)
+        src_rows = torch.full((rows, 1), subgroup_rank, device=device, dtype=torch.int64)
+        rowwise_combine_get(
+            symm_out,
+            combine_out,
+            src_ranks,
+            src_rows,
+            group.group_name,
+            nblocks=1,
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(combine_out, x)
+
+    dist.barrier()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="Requires 4 GPUs")
+@requires_multi_gpu
+def test_olmo_symm_alloc_subgroup_without_world_participation():
+    _require_olmo_symm_extension()
+    run_distributed_test(
+        _alloc_on_subgroup_only,
+        world_size=4,
+        backend="nccl",
+        start_method="spawn",
+    )
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="Requires 4 GPUs")
+@requires_multi_gpu
+def test_olmo_symm_alloc_two_independent_subgroups():
+    _require_olmo_symm_extension()
+    run_distributed_test(
+        _alloc_two_independent_subgroups,
+        world_size=4,
+        backend="nccl",
+        start_method="spawn",
+    )
+
+
+@requires_multi_gpu
+def test_olmo_symm_rowwise_dispatch_combine_roundtrip():
+    _require_olmo_symm_extension()
+    run_distributed_test(
+        _rowwise_dispatch_combine_roundtrip,
+        world_size=2,
+        backend="nccl",
+        start_method="spawn",
+    )
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 4, reason="Requires 4 GPUs")
+@requires_multi_gpu
+def test_olmo_symm_rowwise_subgroup_without_world_participation():
+    _require_olmo_symm_extension()
+    run_distributed_test(
+        _rowwise_dispatch_combine_subgroup_only,
+        world_size=4,
+        backend="nccl",
+        start_method="spawn",
+    )

--- a/src/test/nn/moe/v2/olmo_symm_mem_test.py
+++ b/src/test/nn/moe/v2/olmo_symm_mem_test.py
@@ -1,0 +1,50 @@
+import pytest
+
+import olmo_core.kernels.symm_mem_vdev2d as symm_mod
+from olmo_core.kernels import olmo_symm_mem
+
+
+def test_nvshmem_world_barrier_calls_extension(monkeypatch):
+    class _Ext:
+        called = False
+
+        def olmo_symm_world_barrier(self):
+            self.called = True
+
+    ext = _Ext()
+    monkeypatch.setattr(symm_mod, "_load_cuda_extension", lambda: ext)
+
+    symm_mod.nvshmem_world_barrier()
+
+    assert ext.called
+
+
+def test_bootstrap_world_barrier_calls_extension_for_bootstrap_group(monkeypatch):
+    class _Ext:
+        called = False
+
+        def olmo_symm_world_barrier(self):
+            self.called = True
+
+    ext = _Ext()
+    group = object()
+    monkeypatch.setattr(olmo_symm_mem, "_BOOTSTRAP_GLOBAL_RANKS", (0, 1))
+    monkeypatch.setattr(olmo_symm_mem, "_group_global_ranks", lambda current_group: (0, 1))
+    monkeypatch.setattr(olmo_symm_mem, "_load_cuda_extension", lambda: ext)
+
+    olmo_symm_mem.barrier(group)  # type: ignore[arg-type]
+
+    assert ext.called
+
+
+def test_bootstrap_world_barrier_rejects_inner_subgroup(monkeypatch):
+    def _raise_if_loaded():
+        raise AssertionError("subgroup barrier should fail before loading the extension")
+
+    group = object()
+    monkeypatch.setattr(olmo_symm_mem, "_BOOTSTRAP_GLOBAL_RANKS", (0, 1, 2, 3))
+    monkeypatch.setattr(olmo_symm_mem, "_group_global_ranks", lambda current_group: (0, 1))
+    monkeypatch.setattr(olmo_symm_mem, "_load_cuda_extension", _raise_if_loaded)
+
+    with pytest.raises(RuntimeError, match="bootstrap world"):
+        olmo_symm_mem.barrier(group)  # type: ignore[arg-type]

--- a/src/test/nn/moe/v2/permute_drop_fused_test.py
+++ b/src/test/nn/moe/v2/permute_drop_fused_test.py
@@ -1,10 +1,30 @@
+import pytest
 import torch
 
 from olmo_core.nn.moe.utils import (
     moe_permute_1d_fused_drop_no_compile,
     moe_permute_no_compile,
 )
+from olmo_core.nn.moe.v2.ep_no_sync_common import build_keep_reorder
 from olmo_core.testing import requires_gpu, requires_te
+
+
+def _build_random_keep_splits(
+    *,
+    num_rows: int,
+    keep_fraction: float,
+    seed: int,
+    device: torch.device,
+) -> torch.Tensor:
+    keep_count = int(round(keep_fraction * num_rows))
+    keep_count = max(0, min(keep_count, num_rows))
+    keep_splits = torch.zeros(num_rows, device=device, dtype=torch.long)
+    if keep_count > 0:
+        g = torch.Generator(device=device)
+        g.manual_seed(seed)
+        keep_rows = torch.randperm(num_rows, generator=g, device=device)[:keep_count]
+        keep_splits[keep_rows] = 1
+    return keep_splits
 
 
 @requires_gpu
@@ -94,3 +114,126 @@ def test_permute_drop_1d_one_shot_custom_cuda_matches_reference_kept_rows():
     assert x_reference.grad is not None
     assert x_fused.grad is not None
     torch.testing.assert_close(x_fused.grad, x_reference.grad, atol=5e-3, rtol=5e-3)
+
+
+@requires_gpu
+@requires_te
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("top_k", [1, 2, 4])
+@pytest.mark.parametrize("keep_fraction", [1.0, 0.7, 0.3])
+def test_permute_drop_1d_fused_matches_reference(
+    dtype: torch.dtype,
+    top_k: int,
+    keep_fraction: float,
+):
+    torch.manual_seed(13)
+    device = torch.device("cuda")
+    num_tokens = 128
+    d_model = 512
+    num_experts = 16
+    num_out_tokens = num_tokens * top_k
+
+    x = torch.randn(num_tokens, d_model, device=device, dtype=dtype)
+    routing_map = torch.randint(
+        low=0,
+        high=num_experts,
+        size=(num_tokens, top_k),
+        device=device,
+        dtype=torch.int32,
+    )
+
+    x_reference = x.detach().clone().requires_grad_(True)
+    permuted_reference, row_id_map_reference = moe_permute_no_compile(
+        inp=x_reference,
+        routing_map=routing_map,
+        num_out_tokens=num_out_tokens,
+        map_type="index",
+    )
+    requested_splits = torch.ones(permuted_reference.shape[0], device=device, dtype=torch.long)
+    keep_splits = _build_random_keep_splits(
+        num_rows=permuted_reference.shape[0],
+        keep_fraction=keep_fraction,
+        seed=19,
+        device=device,
+    )
+    reorder_indices, inverse_reorder_indices, _ = build_keep_reorder(
+        requested_splits,
+        keep_splits,
+        permuted_reference.shape[0],
+    )
+    dropped_reference = permuted_reference.index_select(0, reorder_indices)
+
+    x_fused = x.detach().clone().requires_grad_(True)
+    dropped_fused, row_id_map_fused = moe_permute_1d_fused_drop_no_compile(
+        inp=x_fused,
+        routing_map=routing_map,
+        num_out_tokens=num_out_tokens,
+        reorder_indices=reorder_indices,
+        inverse_reorder_indices=inverse_reorder_indices,
+        map_type="index",
+    )
+
+    torch.testing.assert_close(dropped_fused, dropped_reference, atol=5e-3, rtol=5e-3)
+    torch.testing.assert_close(row_id_map_fused, row_id_map_reference, atol=0, rtol=0)
+
+    grad_out = torch.randn_like(dropped_reference)
+    (dropped_reference * grad_out).sum().backward()
+    (dropped_fused * grad_out).sum().backward()
+
+    assert x_reference.grad is not None
+    assert x_fused.grad is not None
+    torch.testing.assert_close(x_fused.grad, x_reference.grad, atol=5e-3, rtol=5e-3)
+
+
+@requires_gpu
+@requires_te
+def test_permute_drop_1d_fused_out_buffer():
+    torch.manual_seed(17)
+    device = torch.device("cuda")
+    num_tokens = 64
+    top_k = 2
+    d_model = 512
+    num_experts = 8
+    num_out_tokens = num_tokens * top_k
+
+    x = torch.randn(num_tokens, d_model, device=device, dtype=torch.float16, requires_grad=True)
+    routing_map = torch.randint(
+        low=0,
+        high=num_experts,
+        size=(num_tokens, top_k),
+        device=device,
+        dtype=torch.int32,
+    )
+    permuted, _ = moe_permute_no_compile(
+        inp=x.detach(),
+        routing_map=routing_map,
+        num_out_tokens=num_out_tokens,
+        map_type="index",
+    )
+    requested_splits = torch.ones(permuted.shape[0], device=device, dtype=torch.long)
+    keep_splits = _build_random_keep_splits(
+        num_rows=permuted.shape[0],
+        keep_fraction=0.6,
+        seed=23,
+        device=device,
+    )
+    reorder_indices, inverse_reorder_indices, _ = build_keep_reorder(
+        requested_splits,
+        keep_splits,
+        permuted.shape[0],
+    )
+    out_buffer = torch.empty((num_out_tokens, d_model), device=device, dtype=x.dtype)
+
+    dropped, _ = moe_permute_1d_fused_drop_no_compile(
+        inp=x,
+        routing_map=routing_map,
+        num_out_tokens=num_out_tokens,
+        reorder_indices=reorder_indices,
+        inverse_reorder_indices=inverse_reorder_indices,
+        out=out_buffer,
+        map_type="index",
+    )
+    assert dropped.untyped_storage().data_ptr() == out_buffer.untyped_storage().data_ptr()
+
+    (dropped * dropped).sum().backward()
+    assert x.grad is not None

--- a/src/test/nn/moe/v2/permute_drop_fused_test.py
+++ b/src/test/nn/moe/v2/permute_drop_fused_test.py
@@ -118,9 +118,17 @@ def test_permute_drop_1d_one_shot_custom_cuda_matches_reference_kept_rows():
 
 @requires_gpu
 @requires_te
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
-@pytest.mark.parametrize("top_k", [1, 2, 4])
-@pytest.mark.parametrize("keep_fraction", [1.0, 0.7, 0.3])
+# Curated subset (not the full dtype x top_k x keep_fraction cross-product): each dtype, top_k, and
+# keep_fraction value appears at least once, covering the no-drop and heavy-drop paths.
+@pytest.mark.parametrize(
+    "dtype, top_k, keep_fraction",
+    [
+        (torch.bfloat16, 2, 1.0),
+        (torch.bfloat16, 2, 0.3),
+        (torch.float16, 1, 0.7),
+        (torch.float32, 4, 0.7),
+    ],
+)
 def test_permute_drop_1d_fused_matches_reference(
     dtype: torch.dtype,
     top_k: int,

--- a/src/test/nn/moe/v2/restore_unpermute_fused_test.py
+++ b/src/test/nn/moe/v2/restore_unpermute_fused_test.py
@@ -229,9 +229,17 @@ def _build_block(backend: str = "te_fused"):
 
 @requires_gpu
 @requires_te
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
-@pytest.mark.parametrize("top_k", [1, 2, 4])
-@pytest.mark.parametrize("keep_fraction", [1.0, 0.7, 0.3])
+# Curated subset (not the full dtype x top_k x keep_fraction cross-product): each dtype, top_k, and
+# keep_fraction value appears at least once, covering the no-drop and heavy-drop paths.
+@pytest.mark.parametrize(
+    "dtype, top_k, keep_fraction",
+    [
+        (torch.bfloat16, 2, 1.0),
+        (torch.bfloat16, 2, 0.3),
+        (torch.float16, 1, 0.7),
+        (torch.float32, 4, 0.7),
+    ],
+)
 def test_restore_unpermute_1d_te_fused_matches_reference(
     dtype: torch.dtype,
     top_k: int,

--- a/src/test/nn/moe/v2/restore_unpermute_fused_test.py
+++ b/src/test/nn/moe/v2/restore_unpermute_fused_test.py
@@ -1,6 +1,15 @@
+import pytest
 import torch
 
-from olmo_core.nn.moe.utils import moe_unpermute_1d_fused_drop_no_compile
+from olmo_core.nn.moe.utils import (
+    moe_permute_no_compile,
+    moe_unpermute_1d_fused_drop_no_compile,
+    moe_unpermute_no_compile,
+)
+from olmo_core.nn.moe.v2.ep_no_sync_common import (
+    build_keep_reorder,
+    restore_drop_unpermute_1d,
+)
 from olmo_core.testing import requires_gpu, requires_te
 
 
@@ -119,3 +128,269 @@ def test_restore_unpermute_1d_prob_grads_with_frozen_experts():
 
     assert probs.grad is not None
     torch.testing.assert_close(probs.grad, probs_ref.grad, atol=5e-3, rtol=5e-3)
+
+
+def _build_random_keep_splits(
+    *,
+    num_rows: int,
+    keep_fraction: float,
+    seed: int,
+    device: torch.device,
+) -> torch.Tensor:
+    keep_count = int(round(keep_fraction * num_rows))
+    keep_count = max(0, min(keep_count, num_rows))
+    keep_splits = torch.zeros(num_rows, device=device, dtype=torch.long)
+    if keep_count > 0:
+        g = torch.Generator(device=device)
+        g.manual_seed(seed)
+        keep_rows = torch.randperm(num_rows, generator=g, device=device)[:keep_count]
+        keep_splits[keep_rows] = 1
+    return keep_splits
+
+
+def _reference_restore_drop_unpermute(
+    *,
+    combine_out: torch.Tensor,
+    row_id_map: torch.Tensor,
+    local_inverse_reorder_indices: torch.Tensor,
+    packed_keep_mask: torch.Tensor,
+    merging_probs: torch.Tensor,
+    restore_shape: torch.Size,
+) -> torch.Tensor:
+    restored = combine_out.index_select(0, local_inverse_reorder_indices)
+    restored_keep_mask = packed_keep_mask.index_select(0, local_inverse_reorder_indices)
+    restored = torch.where(
+        restored_keep_mask.unsqueeze(-1),
+        restored,
+        torch.zeros_like(restored),
+    )
+    return moe_unpermute_no_compile(
+        inp=restored,
+        row_id_map=row_id_map,
+        merging_probs=merging_probs,
+        restore_shape=restore_shape,
+        map_type="index",
+    )
+
+
+def _build_block(backend: str = "te_fused"):
+    from olmo_core.config import DType
+    from olmo_core.nn.attention import AttentionConfig, AttentionType
+    from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+    from olmo_core.nn.moe import MoERouterGatingFunction
+    from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlock
+    from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+    from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+
+    layer_norm = LayerNormConfig(
+        name=LayerNormType.rms,
+        eps=1e-6,
+        bias=False,
+        dtype=DType.float32,
+    )
+    return MoEFusedV2TransformerBlock(
+        d_model=512,
+        block_idx=0,
+        n_layers=1,
+        sequence_mixer=AttentionConfig(
+            name=AttentionType.default,
+            n_heads=2,
+            n_kv_heads=2,
+            bias=False,
+            use_flash=False,
+            dtype=DType.float32,
+        ),
+        attention_norm=layer_norm,
+        routed_experts_router=MoERouterConfigV2(
+            d_model=512,
+            num_experts=4,
+            top_k=2,
+            gating_function=MoERouterGatingFunction.softmax,
+            uniform_expert_assignment=True,
+            lb_loss_weight=None,
+            z_loss_weight=None,
+            dtype=DType.float32,
+        ),
+        shared_experts_router=None,
+        shared_experts=None,
+        routed_experts=RoutedExpertsConfig(
+            d_model=512,
+            hidden_size=1024,
+            num_experts=4,
+            bias=False,
+            dtype=DType.float32,
+        ),
+        feed_forward_norm=layer_norm,
+        ep_no_sync=True,
+        ep_no_sync_restore_unpermute_backend=backend,
+        init_device="cuda",
+    )
+
+
+@requires_gpu
+@requires_te
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("top_k", [1, 2, 4])
+@pytest.mark.parametrize("keep_fraction", [1.0, 0.7, 0.3])
+def test_restore_unpermute_1d_te_fused_matches_reference(
+    dtype: torch.dtype,
+    top_k: int,
+    keep_fraction: float,
+):
+    torch.manual_seed(7)
+    device = torch.device("cuda")
+    num_tokens = 128
+    d_model = 512
+    num_experts = 16
+
+    x = torch.randn(num_tokens, d_model, device=device, dtype=dtype)
+    routing_map = torch.randint(
+        low=0,
+        high=num_experts,
+        size=(num_tokens, top_k),
+        device=device,
+        dtype=torch.int32,
+    )
+    permuted, row_id_map = moe_permute_no_compile(
+        inp=x,
+        routing_map=routing_map,
+        num_out_tokens=num_tokens * top_k,
+        map_type="index",
+    )
+    restore_shape = x.shape
+
+    requested_splits = torch.ones(permuted.shape[0], device=device, dtype=torch.long)
+    keep_splits = _build_random_keep_splits(
+        num_rows=permuted.shape[0],
+        keep_fraction=keep_fraction,
+        seed=11,
+        device=device,
+    )
+    reorder_indices, local_inverse_reorder_indices, packed_keep_mask = build_keep_reorder(
+        requested_splits,
+        keep_splits,
+        permuted.shape[0],
+    )
+    combine_out = permuted.index_select(0, reorder_indices)
+    merging_probs = torch.rand(num_tokens, top_k, device=device, dtype=torch.float32)
+
+    combine_out_reference = combine_out.detach().clone().requires_grad_(True)
+    combine_out_fused = combine_out.detach().clone().requires_grad_(True)
+    probs_reference = merging_probs.detach().clone().requires_grad_(True)
+    probs_fused = merging_probs.detach().clone().requires_grad_(True)
+
+    out_reference = _reference_restore_drop_unpermute(
+        combine_out=combine_out_reference,
+        row_id_map=row_id_map,
+        local_inverse_reorder_indices=local_inverse_reorder_indices,
+        packed_keep_mask=packed_keep_mask,
+        merging_probs=probs_reference,
+        restore_shape=restore_shape,
+    )
+    out_fused = moe_unpermute_1d_fused_drop_no_compile(
+        inp=combine_out_fused,
+        row_id_map=row_id_map,
+        local_inverse_reorder_indices=local_inverse_reorder_indices,
+        packed_keep_mask=packed_keep_mask,
+        merging_probs=probs_fused,
+        map_type="index",
+    )
+
+    torch.testing.assert_close(out_fused, out_reference, atol=5e-3, rtol=5e-3)
+
+    grad_out = torch.randn_like(out_reference)
+    (out_reference * grad_out).sum().backward()
+    (out_fused * grad_out).sum().backward()
+
+    assert combine_out_reference.grad is not None
+    assert combine_out_fused.grad is not None
+    assert probs_reference.grad is not None
+    assert probs_fused.grad is not None
+    torch.testing.assert_close(
+        combine_out_fused.grad, combine_out_reference.grad, atol=5e-3, rtol=5e-3
+    )
+    torch.testing.assert_close(probs_fused.grad, probs_reference.grad, atol=5e-3, rtol=5e-3)
+
+
+@requires_gpu
+@requires_te
+def test_restore_unpermute_backend_selector_behavior():
+    try:
+        block = _build_block()
+    except ImportError as exc:
+        pytest.skip(f"Skipping selector behavior test due import error: {exc}")
+    assert block.ep_no_sync_restore_unpermute_backend == "te_fused"
+
+    torch.manual_seed(23)
+    device = torch.device("cuda")
+    num_tokens = 64
+    top_k = 2
+    d_model = 512
+    num_experts = 8
+
+    x = torch.randn(num_tokens, d_model, device=device, dtype=torch.float16)
+    routing_map = torch.randint(
+        low=0,
+        high=num_experts,
+        size=(num_tokens, top_k),
+        device=device,
+        dtype=torch.int32,
+    )
+    permuted, row_id_map = moe_permute_no_compile(
+        inp=x,
+        routing_map=routing_map,
+        num_out_tokens=num_tokens * top_k,
+        map_type="index",
+    )
+    requested_splits = torch.ones(permuted.shape[0], device=device, dtype=torch.long)
+    keep_splits = _build_random_keep_splits(
+        num_rows=permuted.shape[0],
+        keep_fraction=0.7,
+        seed=5,
+        device=device,
+    )
+    reorder_indices, local_inverse_reorder_indices, packed_keep_mask = build_keep_reorder(
+        requested_splits,
+        keep_splits,
+        permuted.shape[0],
+    )
+    combine_out = permuted.index_select(0, reorder_indices)
+    probs = torch.rand(num_tokens, top_k, device=device, dtype=torch.float32)
+    num_kept = packed_keep_mask.to(dtype=torch.long).sum(dtype=torch.long)
+
+    block.ep_no_sync_restore_unpermute_backend = "te_unfused"
+    out_reference = restore_drop_unpermute_1d(
+        block,
+        combine_out=combine_out,
+        local_inverse_reorder_indices=local_inverse_reorder_indices,
+        packed_keep_mask=packed_keep_mask,
+        num_kept=num_kept,
+        reversed_local_x_permutation_mapping=row_id_map,
+        local_x_global_routed_expert_weights=probs,
+        hidden_shape_before_permute=torch.Size([num_tokens, d_model]),
+    )
+    block.ep_no_sync_restore_unpermute_backend = "te_fused"
+    out_fused = restore_drop_unpermute_1d(
+        block,
+        combine_out=combine_out,
+        local_inverse_reorder_indices=local_inverse_reorder_indices,
+        packed_keep_mask=packed_keep_mask,
+        num_kept=num_kept,
+        reversed_local_x_permutation_mapping=row_id_map,
+        local_x_global_routed_expert_weights=probs,
+        hidden_shape_before_permute=torch.Size([num_tokens, d_model]),
+    )
+    torch.testing.assert_close(out_fused, out_reference, atol=5e-3, rtol=5e-3)
+
+    block.ep_no_sync_restore_unpermute_backend = "cuda"
+    with pytest.raises(RuntimeError, match="not implemented yet"):
+        _ = restore_drop_unpermute_1d(
+            block,
+            combine_out=combine_out,
+            local_inverse_reorder_indices=local_inverse_reorder_indices,
+            packed_keep_mask=packed_keep_mask,
+            num_kept=num_kept,
+            reversed_local_x_permutation_mapping=row_id_map,
+            local_x_global_routed_expert_weights=probs,
+            hidden_shape_before_permute=torch.Size([num_tokens, d_model]),
+        )

--- a/src/test/nn/moe/v2/rowwise_fp8_config_test.py
+++ b/src/test/nn/moe/v2/rowwise_fp8_config_test.py
@@ -1,15 +1,22 @@
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from olmo_core.config import DType
 from olmo_core.kernels.scaled_grouped_mm import ScaledGroupedMMPrequantizedRHS
 from olmo_core.nn.fp8_weight import FP8WeightCacheSpec, FP8WeightStore
-from olmo_core.nn.moe.v2.fp8 import MoERowwiseFP8Config, normalize_rowwise_fp8_config
+from olmo_core.nn.moe.v2.fp8 import (
+    MoERowwiseFP8Config,
+    normalize_rowwise_fp8_config,
+    refresh_rowwise_fp8_cache,
+)
 from olmo_core.nn.moe.v2.routed_experts import (
     RoutedExperts,
     _swiglu_backward_grad_up_gate_impl,
     swiglu_backward_grad_up_gate,
 )
+from olmo_core.nn.parallel.distributed import MultiGroupDistributedDataParallel
 from olmo_core.testing import requires_gpu
 
 
@@ -499,3 +506,119 @@ def test_swiglu_backward_grad_up_gate_compiled_helper_matches_eager(monkeypatch)
     expected = _swiglu_backward_grad_up_gate_impl(up_gate, grad_h)
 
     torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+def test_multigroup_ddp_zeroes_module_logical_grads():
+    calls = []
+
+    class _FakeModule(torch.nn.Module):
+        def zero_mxfp8_expert_weight_grads(self, *, set_to_none: bool) -> None:
+            calls.append(set_to_none)
+
+    ddp = MultiGroupDistributedDataParallel.__new__(MultiGroupDistributedDataParallel)
+    torch.nn.Module.__init__(ddp)
+    ddp.module = _FakeModule()
+
+    ddp._zero_module_logical_grads(set_to_none=False)
+    ddp._zero_module_logical_grads(set_to_none=True)
+
+    assert calls == [False, True]
+
+
+def test_multigroup_ddp_syncs_module_logical_grads():
+    calls = []
+
+    class _FakeModule(torch.nn.Module):
+        def sync_mxfp8_expert_weight_grads_from_anchor(self) -> None:
+            calls.append("sync")
+
+    ddp = MultiGroupDistributedDataParallel.__new__(MultiGroupDistributedDataParallel)
+    torch.nn.Module.__init__(ddp)
+    ddp.module = _FakeModule()
+
+    ddp._sync_module_logical_grads_from_anchor()
+
+    assert calls == ["sync"]
+
+
+def test_block_refresh_rowwise_fp8_cache_honors_routed_config_without_block_config():
+    seen = {"refresh": 0, "invalidate": 0}
+
+    class _FakeRoutedExperts:
+        rowwise_fp8 = MoERowwiseFP8Config(enabled=True)
+
+        def refresh_rowwise_fp8_cache(self) -> None:
+            seen["refresh"] += 1
+
+        def invalidate_rowwise_fp8_cache(self) -> None:
+            seen["invalidate"] += 1
+
+    block = SimpleNamespace(
+        rowwise_fp8=None,
+        routed_experts=_FakeRoutedExperts(),
+        shared_experts=None,
+    )
+
+    refresh_rowwise_fp8_cache(block)
+
+    assert seen == {"refresh": 1, "invalidate": 0}
+    assert block._shared_rowwise_fp8_up_prequant is None
+    assert block._shared_rowwise_fp8_down_prequant is None
+
+
+def test_block_refresh_rowwise_fp8_cache_disabled_invalidates_without_refresh():
+    seen = {"refresh": 0, "invalidate": 0}
+
+    class _FakeRoutedExperts:
+        rowwise_fp8 = MoERowwiseFP8Config(enabled=False)
+
+        def refresh_rowwise_fp8_cache(self) -> None:
+            seen["refresh"] += 1
+
+        def invalidate_rowwise_fp8_cache(self) -> None:
+            seen["invalidate"] += 1
+
+    block = SimpleNamespace(
+        rowwise_fp8=MoERowwiseFP8Config(enabled=False),
+        routed_experts=_FakeRoutedExperts(),
+        shared_experts=None,
+        _shared_rowwise_fp8_up_prequant=object(),
+        _shared_rowwise_fp8_down_prequant=object(),
+        _shared_rowwise_fp8_up_prequant_t=object(),
+        _shared_rowwise_fp8_down_prequant_t=object(),
+        _shared_rowwise_fp8_weight_versions=(1, 2),
+    )
+
+    refresh_rowwise_fp8_cache(block)
+
+    assert seen == {"refresh": 0, "invalidate": 1}
+    assert block._shared_rowwise_fp8_up_prequant is None
+    assert block._shared_rowwise_fp8_down_prequant is None
+    assert block._shared_rowwise_fp8_up_prequant_t is None
+    assert block._shared_rowwise_fp8_down_prequant_t is None
+    assert block._shared_rowwise_fp8_weight_versions is None
+
+
+def test_block_refresh_rowwise_fp8_cache_shared_only_does_not_refresh_routed():
+    seen = {"refresh": 0, "invalidate": 0}
+
+    class _FakeRoutedExperts:
+        rowwise_fp8 = MoERowwiseFP8Config(enabled=False)
+
+        def refresh_rowwise_fp8_cache(self) -> None:
+            seen["refresh"] += 1
+
+        def invalidate_rowwise_fp8_cache(self) -> None:
+            seen["invalidate"] += 1
+
+    block = SimpleNamespace(
+        rowwise_fp8=MoERowwiseFP8Config(enabled=True),
+        routed_experts=_FakeRoutedExperts(),
+        shared_experts=None,
+    )
+
+    refresh_rowwise_fp8_cache(block)
+
+    assert seen == {"refresh": 0, "invalidate": 1}
+    assert block._shared_rowwise_fp8_up_prequant is None
+    assert block._shared_rowwise_fp8_down_prequant is None

--- a/src/test/nn/moe/v2/shared_experts_rowwise_fp8_test.py
+++ b/src/test/nn/moe/v2/shared_experts_rowwise_fp8_test.py
@@ -1,0 +1,269 @@
+import types
+
+import torch
+import torch.nn.functional as F
+
+from olmo_core.config import DType
+from olmo_core.nn.fp8_weight import FP8WeightStore
+from olmo_core.nn.moe.v2.fp8 import (
+    MoERowwiseFP8Config,
+    shared_experts_forward1_rowwise_fp8,
+    shared_experts_forward2_rowwise_fp8,
+)
+from olmo_core.nn.moe.v2.shared_experts import SharedExperts
+
+
+def _stub_scaled_grouped_mm_q(
+    mat_a: torch.Tensor,
+    mat_b: torch.Tensor,
+    *,
+    offs: torch.Tensor,
+    input_grad_out: torch.Tensor | None = None,
+    use_fast_accum: bool = True,
+    prequantized_lhs=None,
+    prequantized_rhs=None,
+    prequantized_rhs_for_dgrad=None,
+) -> torch.Tensor:
+    del (
+        input_grad_out,
+        use_fast_accum,
+        prequantized_lhs,
+        prequantized_rhs,
+        prequantized_rhs_for_dgrad,
+    )
+    return F.grouped_mm(mat_a, mat_b, offs=offs)
+
+
+def _forbid_forward_time_prequant(*args, **kwargs):
+    del args, kwargs
+    raise AssertionError("shared rowwise FP8 forward must not refresh/prequantize weights")
+
+
+def test_fp8_weight_store_can_accumulate_wgrad_in_fp32():
+    store = FP8WeightStore(
+        logical_name="w",
+        logical_shape=(2, 3),
+    )
+    store.accumulate_wgrad_in_fp32 = True
+
+    store.accumulate_wgrad(torch.ones(2, 3, dtype=torch.bfloat16))
+    store.accumulate_wgrad(torch.ones(2, 3, dtype=torch.bfloat16))
+
+    assert store.grad_bf16 is None
+    assert store.main_grad_fp32 is not None
+    assert store.main_grad_fp32.dtype == torch.float32
+    torch.testing.assert_close(store.main_grad_fp32, torch.full((2, 3), 2.0))
+
+
+def test_shared_experts_rowwise_fp8_helpers_match_bf16_reference(monkeypatch):
+    monkeypatch.setattr(
+        "olmo_core.nn.moe.v2.fp8.scaled_grouped_mm_q",
+        _stub_scaled_grouped_mm_q,
+    )
+    monkeypatch.setattr(
+        "olmo_core.nn.moe.v2.fp8.prequantize_scaled_grouped_mm_rhs",
+        _forbid_forward_time_prequant,
+    )
+
+    torch.manual_seed(123)
+    shared = SharedExperts(
+        d_model=512,
+        hidden_size=1024,
+        num_experts=3,
+        bias=False,
+        dtype=DType.float32,
+        init_device="cpu",
+    )
+    with torch.no_grad():
+        shared.w_up_gate.normal_(mean=0.0, std=0.02)
+        shared.w_down.normal_(mean=0.0, std=0.02)
+
+    fake_self = types.SimpleNamespace(
+        shared_experts=shared,
+        _shared_rowwise_fp8_up_prequant=object(),
+        _shared_rowwise_fp8_down_prequant=object(),
+        _shared_rowwise_fp8_up_prequant_t=object(),
+        _shared_rowwise_fp8_down_prequant_t=object(),
+        _shared_rowwise_fp8_weight_versions=None,
+        rowwise_fp8=None,
+    )
+
+    x = torch.randn(1, 8, 512, dtype=torch.float32)
+    up, gate = shared_experts_forward1_rowwise_fp8(
+        fake_self,  # type: ignore[arg-type]
+        x,
+        use_fast_accum=True,
+    )
+    out_fp8 = shared_experts_forward2_rowwise_fp8(
+        fake_self,  # type: ignore[arg-type]
+        up,
+        gate,
+        x.shape,
+        use_fast_accum=True,
+    )
+
+    with torch.no_grad():
+        out_ref = shared.forward(x)
+
+    torch.testing.assert_close(out_fp8, out_ref)
+
+
+def test_shared_experts_rowwise_fp8_forward1_accepts_flattened_input(monkeypatch):
+    monkeypatch.setattr(
+        "olmo_core.nn.moe.v2.fp8.scaled_grouped_mm_q",
+        _stub_scaled_grouped_mm_q,
+    )
+    monkeypatch.setattr(
+        "olmo_core.nn.moe.v2.fp8.prequantize_scaled_grouped_mm_rhs",
+        _forbid_forward_time_prequant,
+    )
+
+    torch.manual_seed(123)
+    shared = SharedExperts(
+        d_model=512,
+        hidden_size=1024,
+        num_experts=3,
+        bias=False,
+        dtype=DType.float32,
+        init_device="cpu",
+    )
+    with torch.no_grad():
+        shared.w_up_gate.normal_(mean=0.0, std=0.02)
+        shared.w_down.normal_(mean=0.0, std=0.02)
+
+    fake_self = types.SimpleNamespace(
+        shared_experts=shared,
+        _shared_rowwise_fp8_up_prequant=object(),
+        _shared_rowwise_fp8_down_prequant=object(),
+        _shared_rowwise_fp8_up_prequant_t=object(),
+        _shared_rowwise_fp8_down_prequant_t=object(),
+        _shared_rowwise_fp8_weight_versions=None,
+        rowwise_fp8=None,
+    )
+
+    x = torch.randn(1, 8, 512, dtype=torch.float32)
+    x_flat = x.view(-1, x.shape[-1])
+    up, gate = shared_experts_forward1_rowwise_fp8(
+        fake_self,  # type: ignore[arg-type]
+        x_flat,
+        use_fast_accum=True,
+    )
+    out_fp8 = shared_experts_forward2_rowwise_fp8(
+        fake_self,  # type: ignore[arg-type]
+        up,
+        gate,
+        x.shape,
+        use_fast_accum=True,
+    )
+
+    with torch.no_grad():
+        out_ref = shared.forward(x)
+
+    torch.testing.assert_close(out_fp8, out_ref)
+
+
+def test_shared_experts_fp8_only_path_uses_generic_weight_stores(monkeypatch):
+    seen = []
+
+    def _stub_scaled_grouped_mm_q_fp8_weight(
+        mat_a: torch.Tensor,
+        grad_anchor: torch.Tensor,
+        *,
+        offs: torch.Tensor,
+        input_grad_out: torch.Tensor | None = None,
+        use_fast_accum: bool = True,
+        prequantized_lhs=None,
+        prequantized_rhs=None,
+        prequantized_rhs_for_dgrad=None,
+        wgrad_sink=None,
+        wgrad_sink_transpose_last2: bool = False,
+        wgrad_sink_squeeze_first_dim: bool = False,
+    ) -> torch.Tensor:
+        del (
+            input_grad_out,
+            use_fast_accum,
+            prequantized_lhs,
+            prequantized_rhs,
+            prequantized_rhs_for_dgrad,
+        )
+        seen.append(
+            {
+                "anchor_shape": tuple(grad_anchor.shape),
+                "anchor_requires_grad": grad_anchor.requires_grad,
+                "sink": wgrad_sink,
+                "transpose": wgrad_sink_transpose_last2,
+                "squeeze": wgrad_sink_squeeze_first_dim,
+            }
+        )
+        return F.grouped_mm(mat_a, grad_anchor, offs=offs)
+
+    monkeypatch.setattr(
+        "olmo_core.nn.moe.v2.fp8.scaled_grouped_mm_q_fp8_weight",
+        _stub_scaled_grouped_mm_q_fp8_weight,
+    )
+    monkeypatch.setattr(
+        "olmo_core.nn.moe.v2.fp8.prequantize_scaled_grouped_mm_rhs",
+        _forbid_forward_time_prequant,
+    )
+
+    torch.manual_seed(123)
+    shared = SharedExperts(
+        d_model=512,
+        hidden_size=1024,
+        num_experts=3,
+        bias=False,
+        dtype=DType.float32,
+        init_device="cpu",
+    )
+    with torch.no_grad():
+        shared.w_up_gate.normal_(mean=0.0, std=0.02)
+        shared.w_down.normal_(mean=0.0, std=0.02)
+
+    up_store = object()
+    down_store = object()
+    fake_self = types.SimpleNamespace(
+        shared_experts=shared,
+        _shared_rowwise_fp8_up_prequant=object(),
+        _shared_rowwise_fp8_down_prequant=object(),
+        _shared_rowwise_fp8_up_prequant_t=object(),
+        _shared_rowwise_fp8_down_prequant_t=object(),
+        _shared_rowwise_fp8_weight_versions=None,
+        _shared_rowwise_fp8_up_gate_weight=up_store,
+        _shared_rowwise_fp8_down_weight=down_store,
+        rowwise_fp8=MoERowwiseFP8Config(enabled=True, fp8_only_params=True),
+    )
+
+    x = torch.randn(1, 8, 512, dtype=torch.float32)
+    up, gate = shared_experts_forward1_rowwise_fp8(
+        fake_self,  # type: ignore[arg-type]
+        x,
+        use_fast_accum=True,
+    )
+    out_fp8 = shared_experts_forward2_rowwise_fp8(
+        fake_self,  # type: ignore[arg-type]
+        up,
+        gate,
+        x.shape,
+        use_fast_accum=True,
+    )
+
+    with torch.no_grad():
+        out_ref = shared.forward(x)
+
+    torch.testing.assert_close(out_fp8, out_ref)
+    assert seen == [
+        {
+            "anchor_shape": (1, 512, 3 * 2 * 1024),
+            "anchor_requires_grad": False,
+            "sink": up_store,
+            "transpose": False,
+            "squeeze": True,
+        },
+        {
+            "anchor_shape": (3, 1024, 512),
+            "anchor_requires_grad": False,
+            "sink": down_store,
+            "transpose": False,
+            "squeeze": False,
+        },
+    ]

--- a/src/test/nn/moe/v2/shared_experts_rowwise_fp8_test.py
+++ b/src/test/nn/moe/v2/shared_experts_rowwise_fp8_test.py
@@ -1,5 +1,6 @@
 import types
 
+import pytest
 import torch
 import torch.nn.functional as F
 
@@ -11,6 +12,13 @@ from olmo_core.nn.moe.v2.fp8 import (
     shared_experts_forward2_rowwise_fp8,
 )
 from olmo_core.nn.moe.v2.shared_experts import SharedExperts
+from olmo_core.testing import has_torch_grouped_mm
+
+# The stubs below drive the real torch.nn.functional.grouped_mm (torch >= 2.10); skip on older
+# torch so CPU-only runs don't error instead of skipping.
+pytestmark = pytest.mark.skipif(
+    not has_torch_grouped_mm, reason="requires torch.nn.functional.grouped_mm (torch>=2.10)"
+)
 
 
 def _stub_scaled_grouped_mm_q(

--- a/src/test/nn/moe/v2/symm_mem_vdev2d_scaled_test.py
+++ b/src/test/nn/moe/v2/symm_mem_vdev2d_scaled_test.py
@@ -1,0 +1,302 @@
+import torch
+
+import olmo_core.kernels.symm_mem_vdev2d as symm_mod
+
+
+def _patch_reduce_identity(monkeypatch):
+    def _reduce_identity(
+        gathered_q,
+        gathered_scales,
+        out,
+        *,
+        probs=None,
+        valid_mask=None,
+        block_size=32,
+        gathered_out=None,
+    ):
+        del gathered_scales, block_size
+        gathered = gathered_q.to(torch.float32)
+        if valid_mask is not None:
+            gathered = gathered * valid_mask.to(torch.float32).unsqueeze(-1)
+        if gathered_out is not None:
+            gathered_out.copy_(gathered.to(gathered_out.dtype))
+        if probs is not None:
+            gathered = gathered * probs.to(torch.float32).unsqueeze(-1)
+        out.copy_(gathered.sum(dim=1).to(out.dtype))
+
+    monkeypatch.setattr(symm_mod, "reduce_gathered_rows_from_mxfp8", _reduce_identity)
+
+
+def test_rowwise_combine_get_scaled_masks_invalid_routes(monkeypatch):
+    _patch_reduce_identity(monkeypatch)
+
+    def _fake_gather(
+        expert_out,
+        out,
+        src_ranks,
+        src_rows,
+        group_name,
+        *,
+        nblocks=0,
+        pre_barrier=True,
+        post_barrier=False,
+    ):
+        del expert_out, group_name, nblocks, pre_barrier, post_barrier
+        if out.shape[1] == 16:
+            out.fill_(1.0)
+            invalid = (src_ranks.reshape(-1) < 0) | (src_rows.reshape(-1) < 0)
+            out[invalid] = 0.0
+        else:
+            for i in range(out.shape[0]):
+                if src_ranks[i, 0] < 0 or src_rows[i, 0] < 0:
+                    out[i].zero_()
+                else:
+                    out[i].fill_(float(i + 1))
+
+    monkeypatch.setattr(symm_mod, "rowwise_gather_get", _fake_gather)
+
+    # N=2, K=2. Route (0,1) is dropped.
+    src_ranks = torch.tensor([[0, -1], [1, 0]], dtype=torch.long)
+    src_rows = torch.tensor([[0, -1], [2, 3]], dtype=torch.long)
+
+    out = torch.empty((2, 512), dtype=torch.float32)
+    expert_out_q = torch.empty((8, 512), dtype=torch.float32)
+    expert_out_scales = torch.empty((8, 16), dtype=torch.float32)
+
+    symm_mod.rowwise_combine_get_scaled(
+        expert_out_q,
+        expert_out_scales,
+        out,
+        src_ranks,
+        src_rows,
+        "dummy_group",
+        block_size=32,
+    )
+
+    # Flat gathered rows are [1,2,3,4], but row 2 is invalid and must be zeroed.
+    expected = torch.stack(
+        [
+            torch.full((512,), 1.0, dtype=torch.float32),  # 1 + 0
+            torch.full((512,), 7.0, dtype=torch.float32),  # 3 + 4
+        ],
+    )
+    torch.testing.assert_close(out, expected)
+
+
+def test_rowwise_combine_get_scaled_weighted(monkeypatch):
+    _patch_reduce_identity(monkeypatch)
+
+    def _fake_gather(
+        expert_out,
+        out,
+        src_ranks,
+        src_rows,
+        group_name,
+        *,
+        nblocks=0,
+        pre_barrier=True,
+        post_barrier=False,
+    ):
+        del expert_out, src_ranks, src_rows, group_name, nblocks, pre_barrier, post_barrier
+        if out.shape[1] == 16:
+            out.fill_(1.0)
+        else:
+            vals = torch.stack(
+                [
+                    torch.full((512,), 2.0, dtype=out.dtype),
+                    torch.full((512,), 6.0, dtype=out.dtype),
+                ],
+            )
+            out.copy_(vals)
+
+    monkeypatch.setattr(symm_mod, "rowwise_gather_get", _fake_gather)
+
+    src_ranks = torch.tensor([[0, 1]], dtype=torch.long)
+    src_rows = torch.tensor([[0, 1]], dtype=torch.long)
+    probs = torch.tensor([[0.25, 0.75]], dtype=torch.float32)
+
+    out = torch.empty((1, 512), dtype=torch.float32)
+    gathered_out = torch.empty((1, 2, 512), dtype=torch.float32)
+    expert_out_q = torch.empty((4, 512), dtype=torch.float32)
+    expert_out_scales = torch.ones((4, 16), dtype=torch.float32)
+
+    symm_mod.rowwise_combine_get_scaled(
+        expert_out_q,
+        expert_out_scales,
+        out,
+        src_ranks,
+        src_rows,
+        "dummy_group",
+        probs=probs,
+        block_size=32,
+        gathered_out=gathered_out,
+    )
+
+    expected_gather = torch.stack(
+        [
+            torch.stack(
+                [
+                    torch.full((512,), 2.0, dtype=torch.float32),
+                    torch.full((512,), 6.0, dtype=torch.float32),
+                ],
+            )
+        ],
+    )
+    expected = torch.full((1, 512), 5.0, dtype=torch.float32)
+    torch.testing.assert_close(gathered_out, expected_gather)
+    torch.testing.assert_close(out, expected)
+
+
+def test_rowwise_combine_get_scaled_reuses_gather_output_buffers(monkeypatch):
+    _patch_reduce_identity(monkeypatch)
+
+    observed_ptrs = {}
+
+    def _fake_gather(
+        expert_out,
+        out,
+        src_ranks,
+        src_rows,
+        group_name,
+        *,
+        nblocks=0,
+        pre_barrier=True,
+        post_barrier=False,
+    ):
+        del expert_out, src_ranks, src_rows, group_name, nblocks, pre_barrier, post_barrier
+        if out.shape[1] == 512:
+            observed_ptrs["q"] = out.data_ptr()
+            out.copy_(
+                torch.stack(
+                    [
+                        torch.full((512,), 1.0, dtype=out.dtype),
+                        torch.full((512,), 3.0, dtype=out.dtype),
+                    ],
+                )
+            )
+        else:
+            observed_ptrs["s"] = out.data_ptr()
+            out.fill_(1.0)
+
+    monkeypatch.setattr(symm_mod, "rowwise_gather_get", _fake_gather)
+
+    src_ranks = torch.tensor([[0, 1]], dtype=torch.long)
+    src_rows = torch.tensor([[0, 1]], dtype=torch.long)
+    out = torch.empty((1, 512), dtype=torch.float32)
+    expert_out_q = torch.empty((4, 512), dtype=torch.float32)
+    expert_out_scales = torch.ones((4, 16), dtype=torch.float32)
+    gathered_q_out = torch.empty((1, 2, 512), dtype=torch.float32)
+    gathered_scales_out = torch.empty((1, 2, 16), dtype=torch.float32)
+
+    symm_mod.rowwise_combine_get_scaled(
+        expert_out_q,
+        expert_out_scales,
+        out,
+        src_ranks,
+        src_rows,
+        "dummy_group",
+        block_size=32,
+        gathered_q_out=gathered_q_out,
+        gathered_scales_out=gathered_scales_out,
+    )
+
+    assert observed_ptrs["q"] == gathered_q_out.view(-1, 512).data_ptr()
+    assert observed_ptrs["s"] == gathered_scales_out.view(-1, 16).data_ptr()
+    torch.testing.assert_close(
+        gathered_q_out,
+        torch.stack(
+            [
+                torch.stack(
+                    [
+                        torch.full((512,), 1.0, dtype=torch.float32),
+                        torch.full((512,), 3.0, dtype=torch.float32),
+                    ],
+                )
+            ],
+        ),
+    )
+    torch.testing.assert_close(gathered_scales_out, torch.ones_like(gathered_scales_out))
+    torch.testing.assert_close(out, torch.full((1, 512), 4.0, dtype=torch.float32))
+
+
+def test_rowwise_combine_get_scaled_applies_outer_barriers_once(monkeypatch):
+    _patch_reduce_identity(monkeypatch)
+    calls = []
+
+    def _fake_gather(
+        expert_out,
+        out,
+        src_ranks,
+        src_rows,
+        group_name,
+        *,
+        nblocks=0,
+        pre_barrier=True,
+        post_barrier=False,
+    ):
+        del expert_out, src_ranks, src_rows, group_name, nblocks
+        calls.append((out.shape[1], pre_barrier, post_barrier))
+        out.fill_(1.0)
+
+    monkeypatch.setattr(symm_mod, "rowwise_gather_get", _fake_gather)
+
+    src_ranks = torch.tensor([[0, 1]], dtype=torch.long)
+    src_rows = torch.tensor([[0, 1]], dtype=torch.long)
+    out = torch.empty((1, 512), dtype=torch.float32)
+    expert_out_q = torch.empty((4, 512), dtype=torch.float32)
+    expert_out_scales = torch.ones((4, 16), dtype=torch.float32)
+
+    symm_mod.rowwise_combine_get_scaled(
+        expert_out_q,
+        expert_out_scales,
+        out,
+        src_ranks,
+        src_rows,
+        "dummy_group",
+        pre_barrier=True,
+        post_barrier=True,
+    )
+
+    assert calls == [(512, True, False), (16, False, True)]
+
+
+def test_rowwise_dispatch_put_scaled_applies_outer_barriers_once(monkeypatch):
+    qdata = torch.empty((1, 512), dtype=torch.float32)
+    scales = torch.empty((1, 16), dtype=torch.float32)
+
+    def _fake_quantize(input_hp, *, block_size=32):
+        del input_hp, block_size
+        return qdata, scales
+
+    calls = []
+
+    def _fake_put(
+        input,
+        out,
+        dst_ranks,
+        dst_rows,
+        group_name,
+        *,
+        probs=None,
+        nblocks=0,
+        pre_barrier=False,
+        post_barrier=True,
+    ):
+        del out, dst_ranks, dst_rows, group_name, probs, nblocks
+        calls.append((input.shape[1], pre_barrier, post_barrier))
+
+    monkeypatch.setattr(symm_mod, "quantize_rows_to_mxfp8", _fake_quantize)
+    monkeypatch.setattr(symm_mod, "rowwise_dispatch_put", _fake_put)
+
+    symm_mod.rowwise_dispatch_put_scaled(
+        torch.empty((1, 512), dtype=torch.float32),
+        torch.empty((1, 512), dtype=torch.float32),
+        torch.empty((1, 16), dtype=torch.float32),
+        torch.tensor([[0]], dtype=torch.long),
+        torch.tensor([[0]], dtype=torch.long),
+        "dummy_group",
+        pre_barrier=True,
+        post_barrier=True,
+    )
+
+    assert calls == [(512, True, False), (16, False, True)]

--- a/src/test/nn/moe/v2/tbo_test.py
+++ b/src/test/nn/moe/v2/tbo_test.py
@@ -1,3 +1,5 @@
+import os
+
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
@@ -155,6 +157,9 @@ def _run_synced_ep_tbo_matches_standard_forward():
 
 
 def _run_no_sync_ep_tbo_matches_standard_forward():
+    # VDev-1d no-sync EP uses the legacy torch symm-mem backend; OLMo-owned symm-mem
+    # (default on) supports only the rowwise no-sync path.
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"
     ref_model = _build_tbo_model(two_batch_overlap=False, ep_no_sync=True)
     tbo_model = _build_tbo_model(two_batch_overlap=True, ep_no_sync=True)
     _apply_synced_ep(ref_model)

--- a/src/test/nn/moe/v2/tbo_test.py
+++ b/src/test/nn/moe/v2/tbo_test.py
@@ -1,0 +1,209 @@
+import torch
+import torch.distributed as dist
+from torch.distributed.device_mesh import DeviceMesh
+
+from olmo_core.config import DType
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.testing import requires_multi_gpu, run_distributed_test
+
+
+def _build_ep_mesh() -> DeviceMesh:
+    world_size = dist.get_world_size()
+    mesh = torch.arange(world_size, dtype=torch.int).view(1, world_size)
+    return DeviceMesh(
+        device_type="cuda",
+        mesh=mesh,
+        mesh_dim_names=("ep_dp", "ep_mp"),
+    )
+
+
+def _build_tbo_model(*, two_batch_overlap: bool, ep_no_sync: bool = False):
+    from olmo_core.nn.attention import AttentionConfig, AttentionType
+    from olmo_core.nn.lm_head import LMHeadConfig
+    from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlockConfig
+    from olmo_core.nn.transformer import (
+        MoEFusedV2TransformerConfig,
+        TransformerBlockType,
+        TransformerType,
+    )
+
+    layer_norm = LayerNormConfig(
+        name=LayerNormType.rms,
+        eps=1e-6,
+        bias=False,
+        dtype=DType.float32,
+    )
+    config = MoEFusedV2TransformerConfig(
+        name=TransformerType.moe_fused_v2,
+        d_model=512,
+        vocab_size=128,
+        n_layers=2,
+        two_batch_overlap=two_batch_overlap,
+        recompute_each_block=False,
+        recompute_all_blocks_by_chunk=False,
+        lm_head=LMHeadConfig(bias=False, dtype=DType.float32),
+        block=MoEFusedV2TransformerBlockConfig(
+            name=TransformerBlockType.moe_fused_v2,
+            sequence_mixer=AttentionConfig(
+                name=AttentionType.default,
+                n_heads=2,
+                n_kv_heads=2,
+                bias=False,
+                use_flash=False,
+                dtype=DType.float32,
+            ),
+            attention_norm=layer_norm,
+            routed_experts_router=MoERouterConfigV2(
+                d_model=512,
+                num_experts=8,
+                top_k=2,
+                gating_function=MoERouterGatingFunction.softmax,
+                uniform_expert_assignment=False,
+                lb_loss_weight=None,
+                z_loss_weight=None,
+                dtype=DType.float32,
+            ),
+            shared_experts_router=None,
+            shared_experts=None,
+            routed_experts=RoutedExpertsConfig(
+                d_model=512,
+                hidden_size=1024,
+                num_experts=8,
+                bias=False,
+                dtype=DType.float32,
+            ),
+            feed_forward_norm=layer_norm,
+            ep_no_sync=ep_no_sync,
+            ep_no_sync_capacity_factor=8.0,
+            ep_no_sync_major_align=1,
+            ep_no_sync_shared_slots=2 if two_batch_overlap and ep_no_sync else 1,
+        ),
+    )
+    return config.build(init_device="cuda")
+
+
+def _init_model_params(model):
+    torch.manual_seed(2718)
+    with torch.no_grad():
+        for param in model.parameters():
+            if param.is_floating_point():
+                param.normal_(mean=0.0, std=0.02)
+
+
+def _apply_synced_ep(model) -> None:
+    ep_mesh = _build_ep_mesh()
+    model.apply_ep(
+        dp_mesh=ep_mesh["ep_dp"],
+        ep_mesh=ep_mesh,
+        ep_mp_group=ep_mesh["ep_mp"].get_group(),
+    )
+
+
+def _assert_matching_grads(ref_model, tbo_model) -> None:
+    ref_params = dict(ref_model.named_parameters())
+    tbo_params = dict(tbo_model.named_parameters())
+    for name, ref_param in ref_params.items():
+        tbo_param = tbo_params[name]
+        if ref_param.grad is None:
+            assert tbo_param.grad is None, name
+            continue
+        assert tbo_param.grad is not None, name
+        torch.testing.assert_close(tbo_param.grad, ref_param.grad, atol=1e-3, rtol=1e-3)
+
+
+def _run_synced_ep_tbo_matches_standard_forward():
+    ref_model = _build_tbo_model(two_batch_overlap=False)
+    tbo_model = _build_tbo_model(two_batch_overlap=True)
+    _apply_synced_ep(ref_model)
+    _apply_synced_ep(tbo_model)
+    _init_model_params(ref_model)
+    tbo_model.load_state_dict(ref_model.state_dict())
+    # routing uses the model's real (seeded) router; TBO must match the standard forward for identical weights
+    ref_model.train()
+    tbo_model.train()
+
+    input_ids = torch.randint(0, ref_model.vocab_size, (4, 8), device="cuda", dtype=torch.long)
+    labels = torch.randint(0, ref_model.vocab_size, (4, 8), device="cuda", dtype=torch.long)
+
+    logits_ref = ref_model(input_ids, return_logits=True)
+    logits_tbo = tbo_model(input_ids, return_logits=True)
+    torch.testing.assert_close(logits_tbo, logits_ref, atol=5e-4, rtol=5e-4)
+
+    out_ref = ref_model(
+        input_ids,
+        labels=labels,
+        loss_reduction="sum",
+        return_logits=True,
+    )
+    out_tbo = tbo_model(
+        input_ids,
+        labels=labels,
+        loss_reduction="sum",
+        return_logits=True,
+    )
+    assert out_ref.logits is not None
+    assert out_tbo.logits is not None
+    torch.testing.assert_close(out_tbo.logits, out_ref.logits, atol=5e-4, rtol=5e-4)
+    torch.testing.assert_close(out_tbo.loss, out_ref.loss, atol=5e-4, rtol=5e-4)
+    torch.testing.assert_close(out_tbo.ce_loss, out_ref.ce_loss, atol=5e-4, rtol=5e-4)
+
+    out_ref.loss.backward()
+    out_tbo.loss.backward()
+    _assert_matching_grads(ref_model, tbo_model)
+
+
+def _run_no_sync_ep_tbo_matches_standard_forward():
+    ref_model = _build_tbo_model(two_batch_overlap=False, ep_no_sync=True)
+    tbo_model = _build_tbo_model(two_batch_overlap=True, ep_no_sync=True)
+    _apply_synced_ep(ref_model)
+    _apply_synced_ep(tbo_model)
+    _init_model_params(ref_model)
+    tbo_model.load_state_dict(ref_model.state_dict())
+    # routing uses the model's real (seeded) router; TBO must match the standard forward for identical weights
+    ref_model.train()
+    tbo_model.train()
+
+    input_ids = torch.randint(0, ref_model.vocab_size, (4, 8), device="cuda", dtype=torch.long)
+    labels = torch.randint(0, ref_model.vocab_size, (4, 8), device="cuda", dtype=torch.long)
+
+    out_ref = ref_model(
+        input_ids,
+        labels=labels,
+        loss_reduction="sum",
+        return_logits=False,
+    )
+    out_tbo = tbo_model(
+        input_ids,
+        labels=labels,
+        loss_reduction="sum",
+        return_logits=False,
+    )
+    assert out_ref.logits is None
+    assert out_tbo.logits is None
+    torch.testing.assert_close(out_tbo.loss, out_ref.loss, atol=5e-4, rtol=5e-4)
+    torch.testing.assert_close(out_tbo.ce_loss, out_ref.ce_loss, atol=5e-4, rtol=5e-4)
+
+    out_ref.loss.backward()
+    out_tbo.loss.backward()
+    _assert_matching_grads(ref_model, tbo_model)
+
+
+@requires_multi_gpu
+def test_synced_ep_tbo_matches_standard_forward():
+    run_distributed_test(
+        _run_synced_ep_tbo_matches_standard_forward,
+        backend="nccl",
+        start_method="spawn",
+    )
+
+
+@requires_multi_gpu
+def test_no_sync_ep_tbo_matches_standard_forward():
+    run_distributed_test(
+        _run_no_sync_ep_tbo_matches_standard_forward,
+        backend="nccl",
+        start_method="spawn",
+    )

--- a/src/test/nn/moe/v2/tbo_test.py
+++ b/src/test/nn/moe/v2/tbo_test.py
@@ -55,7 +55,7 @@ def _build_tbo_model(*, two_batch_overlap: bool, ep_no_sync: bool = False):
                 use_flash=False,
                 dtype=DType.float32,
             ),
-            attention_norm=layer_norm,
+            layer_norm=layer_norm,
             routed_experts_router=MoERouterConfigV2(
                 d_model=512,
                 num_experts=8,
@@ -75,7 +75,6 @@ def _build_tbo_model(*, two_batch_overlap: bool, ep_no_sync: bool = False):
                 bias=False,
                 dtype=DType.float32,
             ),
-            feed_forward_norm=layer_norm,
             ep_no_sync=ep_no_sync,
             ep_no_sync_capacity_factor=8.0,
             ep_no_sync_major_align=1,

--- a/src/test/train/train_module/transformer/moe_train_module_test.py
+++ b/src/test/train/train_module/transformer/moe_train_module_test.py
@@ -1,0 +1,42 @@
+"""
+Tests for :class:`MoEV2TransformerTrainModule`.
+
+The fused MoE-v2 model is GPU-only by construction (its blocks allocate CUDA events for the
+EP/TBO comm paths), so end-to-end training coverage lives in the GPU test job. What's CPU-testable
+here is the config surface: construction and serialization round-trip.
+"""
+
+from olmo_core.distributed.parallel import DataParallelType
+from olmo_core.optim import MoEFusedV2OptimizerConfig
+from olmo_core.train.train_module import MoEV2TransformerTrainModuleConfig
+from olmo_core.train.train_module.transformer import (
+    TransformerDataParallelConfig,
+    TransformerPipelineParallelConfig,
+)
+
+
+def test_moe_v2_train_module_config_roundtrips():
+    config = MoEV2TransformerTrainModuleConfig(
+        rank_microbatch_size=1024,
+        max_sequence_length=512,
+        optim=MoEFusedV2OptimizerConfig(lr=1e-3),
+    )
+    restored = MoEV2TransformerTrainModuleConfig.from_dict(config.as_dict())
+    assert restored == config
+    assert restored.optim.lr == 1e-3
+
+
+def test_moe_v2_train_module_config_roundtrips_with_parallelism():
+    config = MoEV2TransformerTrainModuleConfig(
+        rank_microbatch_size=1024,
+        max_sequence_length=512,
+        optim=MoEFusedV2OptimizerConfig(lr=1e-3),
+        dp_config=TransformerDataParallelConfig(
+            name=DataParallelType.hsdp, reduce_grads_in_fp32=False
+        ),
+        pp_config=TransformerPipelineParallelConfig(degree=2),
+    )
+    restored = MoEV2TransformerTrainModuleConfig.from_dict(config.as_dict())
+    assert restored == config
+    assert restored.dp_config is not None and restored.dp_config.reduce_grads_in_fp32 is False
+    assert restored.pp_config is not None and restored.pp_config.degree == 2

--- a/src/test/train/train_module/transformer/moe_train_module_test.py
+++ b/src/test/train/train_module/transformer/moe_train_module_test.py
@@ -52,8 +52,9 @@ def test_moe_v2_train_module_config_roundtrips_with_parallelism():
     assert restored.pp_config is not None and restored.pp_config.degree == 2
 
 
-def _tiny_model_config(*, d_model: int = 64, n_layers: int = 2) -> MoEFusedV2TransformerConfig:
-    dtype = DType.float32
+def _tiny_model_config(
+    *, d_model: int = 64, n_layers: int = 2, dtype: DType = DType.float32
+) -> MoEFusedV2TransformerConfig:
     layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=dtype)
     return MoEFusedV2TransformerConfig(
         init_seed=0,
@@ -108,7 +109,9 @@ def test_moe_v2_train_module_construction_no_ep():
 
 
 def _run_construct_ep():
-    model = _tiny_model_config().build(init_device="cuda")
+    # bf16 params → the fused optimizer maintains fp32 master params (its realistic config); a pure
+    # fp32 model instead takes the optimizer's "expect fp32 param" branch.
+    model = _tiny_model_config(dtype=DType.bfloat16).build(init_device="cuda")
     config = MoEV2TransformerTrainModuleConfig(
         rank_microbatch_size=512,
         max_sequence_length=512,
@@ -116,13 +119,14 @@ def _run_construct_ep():
         dp_config=TransformerDataParallelConfig(name=DataParallelType.ddp),
         ep_config=TransformerExpertParallelConfig(degree=2),
     )
-    # eval_only=True skips the optimizer build; this covers wiring expert parallelism through the
-    # train module (moe mesh + apply_ep sharding the experts across the two ranks + DP wrapping).
-    train_module = config.build(model, device=torch.device("cuda"), eval_only=True)
+    # Full build (eval_only=False): wires expert parallelism through the train module (moe mesh +
+    # apply_ep sharding the experts across the two ranks + DP wrapping) and builds the optimizer.
+    train_module = config.build(model, device=torch.device("cuda"), eval_only=False)
 
     assert len(train_module.model_parts) == 1  # no pipeline parallelism
     assert train_module.moe_mesh is not None
     assert train_module.ep_mp_group is not None
+    assert train_module.optim is not None
     assert train_module.num_flops_per_token(seq_len=512) > 0
 
 

--- a/src/test/train/train_module/transformer/moe_train_module_test.py
+++ b/src/test/train/train_module/transformer/moe_train_module_test.py
@@ -16,10 +16,11 @@ from olmo_core.nn.transformer import (
     TransformerType,
 )
 from olmo_core.optim import MoEFusedV2OptimizerConfig
-from olmo_core.testing import run_distributed_test
+from olmo_core.testing import requires_multi_gpu, run_distributed_test
 from olmo_core.train.train_module import MoEV2TransformerTrainModuleConfig
 from olmo_core.train.train_module.transformer import (
     TransformerDataParallelConfig,
+    TransformerExpertParallelConfig,
     TransformerPipelineParallelConfig,
 )
 
@@ -102,5 +103,34 @@ def test_moe_v2_train_module_construction_no_ep():
         _run_construct_no_ep,
         world_size=2,
         backend="gloo",
+        start_method="spawn",
+    )
+
+
+def _run_construct_ep():
+    model = _tiny_model_config().build(init_device="cuda")
+    config = MoEV2TransformerTrainModuleConfig(
+        rank_microbatch_size=512,
+        max_sequence_length=512,
+        optim=MoEFusedV2OptimizerConfig(lr=1e-3),
+        dp_config=TransformerDataParallelConfig(name=DataParallelType.ddp),
+        ep_config=TransformerExpertParallelConfig(degree=2),
+    )
+    # eval_only=True skips the optimizer build; this covers wiring expert parallelism through the
+    # train module (moe mesh + apply_ep sharding the experts across the two ranks + DP wrapping).
+    train_module = config.build(model, device=torch.device("cuda"), eval_only=True)
+
+    assert len(train_module.model_parts) == 1  # no pipeline parallelism
+    assert train_module.moe_mesh is not None
+    assert train_module.ep_mp_group is not None
+    assert train_module.num_flops_per_token(seq_len=512) > 0
+
+
+@requires_multi_gpu
+def test_moe_v2_train_module_construction_ep():
+    run_distributed_test(
+        _run_construct_ep,
+        world_size=2,
+        backend="nccl",
         start_method="spawn",
     )

--- a/src/test/train/train_module/transformer/moe_train_module_test.py
+++ b/src/test/train/train_module/transformer/moe_train_module_test.py
@@ -1,13 +1,22 @@
-"""
-Tests for :class:`MoEV2TransformerTrainModule`.
+"""Tests for :class:`MoEV2TransformerTrainModule` config and construction."""
 
-The fused MoE-v2 model is GPU-only by construction (its blocks allocate CUDA events for the
-EP/TBO comm paths), so end-to-end training coverage lives in the GPU test job. What's CPU-testable
-here is the config surface: construction and serialization round-trip.
-"""
+import torch
 
+from olmo_core.config import DType
 from olmo_core.distributed.parallel import DataParallelType
+from olmo_core.nn.attention import AttentionConfig, AttentionType
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.lm_head import LMHeadConfig
+from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlockConfig
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.nn.transformer import (
+    MoEFusedV2TransformerConfig,
+    TransformerBlockType,
+    TransformerType,
+)
 from olmo_core.optim import MoEFusedV2OptimizerConfig
+from olmo_core.testing import run_distributed_test
 from olmo_core.train.train_module import MoEV2TransformerTrainModuleConfig
 from olmo_core.train.train_module.transformer import (
     TransformerDataParallelConfig,
@@ -40,3 +49,58 @@ def test_moe_v2_train_module_config_roundtrips_with_parallelism():
     assert restored == config
     assert restored.dp_config is not None and restored.dp_config.reduce_grads_in_fp32 is False
     assert restored.pp_config is not None and restored.pp_config.degree == 2
+
+
+def _tiny_model_config(*, d_model: int = 64, n_layers: int = 2) -> MoEFusedV2TransformerConfig:
+    dtype = DType.float32
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=dtype)
+    return MoEFusedV2TransformerConfig(
+        init_seed=0,
+        d_model=d_model,
+        recompute_each_block=False,
+        vocab_size=128,
+        n_layers=n_layers,
+        name=TransformerType.moe_fused_v2,
+        block=MoEFusedV2TransformerBlockConfig(
+            name=TransformerBlockType.moe_fused_v2,
+            attention=AttentionConfig(
+                name=AttentionType.default, n_heads=4, bias=False, use_flash=False, dtype=dtype
+            ),
+            routed_experts=RoutedExpertsConfig(
+                d_model=d_model, hidden_size=128, num_experts=4, bias=False, dtype=dtype
+            ),
+            routed_experts_router=MoERouterConfigV2(
+                d_model=d_model, num_experts=4, top_k=2, dtype=dtype
+            ),
+            shared_experts=None,
+            layer_norm=layer_norm,
+        ),
+        lm_head=LMHeadConfig(layer_norm=layer_norm, bias=False, dtype=dtype),
+    )
+
+
+def _run_construct_no_ep():
+    model = _tiny_model_config().build(init_device="cpu")
+    config = MoEV2TransformerTrainModuleConfig(
+        rank_microbatch_size=512,
+        max_sequence_length=512,
+        optim=MoEFusedV2OptimizerConfig(lr=1e-3),
+        dp_config=TransformerDataParallelConfig(name=DataParallelType.ddp),
+    )
+    # eval_only=True skips the optimizer build (its fp32-master-param setup is exercised on GPU);
+    # this covers the world-mesh build + data-parallel wrapping with no expert parallelism.
+    train_module = config.build(model, device=torch.device("cpu"), eval_only=True)
+
+    assert len(train_module.model_parts) == 1  # no pipeline parallelism
+    assert train_module.dp_world_size == 2
+    assert train_module.world_mesh["dense"] is not None
+    assert train_module.moe_mesh is None  # no expert parallelism
+
+
+def test_moe_v2_train_module_construction_no_ep():
+    run_distributed_test(
+        _run_construct_no_ep,
+        world_size=2,
+        backend="gloo",
+        start_method="spawn",
+    )


### PR DESCRIPTION
The train module for the fused MoE-v2 transformer — the piece that makes the already-landed MoE model, fused distributed optimizer, `MultiGroupDistributedDataParallel`, and custom PP layer exercisable end-to-end.

## What's added

- **`moe_train_module.py`**: `MoEV2TransformerTrainModule(TrainModule)` + `FlatSavePlanner`. Builds the fused MoE distributed optimizer (`MoEFusedV2OptimizerConfig`), wraps model parts in `MultiGroupDistributedDataParallel`, and drives DP/EP/TP/CP/PP. nvtx converted to `maybe_nvtx_annotate` (color-based).
- **`config.py`**: `MoEV2TransformerTrainModuleConfig` (`@beta_feature`) + the DP-config fields it consumes on `TransformerDataParallelConfig` (`only_allreduce_last_microbatch`, `reduce_grads_in_fp32`, `accumulate_grads_in_fp32`, `bucket_cap_mb`).
- **`distributed/parallel/__init__.py`**: `MeshDimName.ep_mp` / `ep_dp`.
- Exports wired through the `transformer` and `train_module` `__init__`s.

## FLOPs

Uses **model-level** accounting captured before the model is sharded/split (`Transformer.num_flops_per_token`; the v2 block implements the MoE routed+shared/top-k formula), matching the PP train module. The dev branch's config-level `num_flops_per_token` was dropped earlier as a non-upstreamable duplicate of the module-level system.

## Tests

- `moe_train_module_test.py` (CPU): config construction + serialization round-trip (incl. DP/PP parallelism fields).
- ⚠️ **The MoE-v2 model is GPU-only by construction** (blocks allocate CUDA events), so end-to-end training coverage needs the GPU test job (TE + torch 2.10, like "Test MoE kernels") — to be added as a follow-up. This is also where the deferred Codex findings on the optimizer/PP layers become exercisable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)