### PR TITLE
Let EvaluatorCallback and BatchSizeSchedulerCallback recognize the MoE-v2 train module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `EvaluatorCallback` and `BatchSizeSchedulerCallback` now recognize `MoEV2TransformerTrainModule` (previously they only accepted `TransformerTrainModule`/`TransformerPipelineTrainModule`, so in-loop eval and batch-size scheduling aborted with a MoE-v2 run). `BatchSizeSchedulerCallback` also accepts the `MoEFusedV2Optimizer` for its learning-rate adjustment.
 - The CPU `Test` CI job now caches `HF_HOME` across runs so the HuggingFace roundtrip tests (Qwen3-0.6B, Gemma-3-270m) don't re-download their checkpoints every run.
 - Excluded `mark_dynamic` from `torch.compile` tracing (`@torch.compiler.disable`).
 - Clearer error messages (now include the offending values) when a rank batch size isn't divisible by the sequence length, or `max_target_sequence_length` isn't a multiple of `sequence_length`.

--- a/src/olmo_core/train/callbacks/batch_size_scheduler.py
+++ b/src/olmo_core/train/callbacks/batch_size_scheduler.py
@@ -2,16 +2,25 @@ import dataclasses
 import logging
 import math
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import torch
 
 from olmo_core.exceptions import OLMoConfigurationError
-from olmo_core.optim import INITIAL_LR_FIELD, LR_FIELD, SkipStepAdamW
+from olmo_core.optim import (
+    INITIAL_LR_FIELD,
+    LR_FIELD,
+    MoEFusedV2Optimizer,
+    SkipStepAdamW,
+)
 from olmo_core.optim.scheduler import WSD, ConstantScheduler, Scheduler
 
 from ..common import Duration
-from ..train_module import TransformerPipelineTrainModule, TransformerTrainModule
+from ..train_module import (
+    MoEV2TransformerTrainModule,
+    TransformerPipelineTrainModule,
+    TransformerTrainModule,
+)
 from .callback import Callback
 from .speed_monitor import SpeedMonitorCallback
 
@@ -93,6 +102,8 @@ class BatchSizeSchedulerCallback(Callback):
             scheduler = self.trainer.train_module.scheduler
         elif isinstance(self.trainer.train_module, TransformerPipelineTrainModule):
             scheduler = self.trainer.train_module.scheduler
+        elif isinstance(self.trainer.train_module, MoEV2TransformerTrainModule):
+            scheduler = self.trainer.train_module.scheduler
 
         # If we have an LR scheduler, we need to make sure that the value it uses for `t_max`
         # (the end point of the schedule) won't be changed by this callback, since that would
@@ -156,13 +167,18 @@ class BatchSizeSchedulerCallback(Callback):
         lr_adjustment_factor = math.sqrt(ratio)
         self.trainer.data_loader.global_batch_size = batch_size
 
-        optimizers: Optional[List[torch.optim.Optimizer]] = None
+        # Heterogeneous: MoEFusedV2Optimizer isn't a torch.optim.Optimizer subclass (it exposes the
+        # same `param_groups` surface the LR adjustment below relies on).
+        optimizers: Optional[List[Any]] = None
         scheduler: Optional[Scheduler] = None
         if isinstance(self.trainer.train_module, TransformerTrainModule):
             optimizers = [self.trainer.train_module.optim]
             scheduler = self.trainer.train_module.scheduler
         elif isinstance(self.trainer.train_module, TransformerPipelineTrainModule):
             optimizers = self.trainer.train_module.optimizers
+            scheduler = self.trainer.train_module.scheduler
+        elif isinstance(self.trainer.train_module, MoEV2TransformerTrainModule):
+            optimizers = [self.trainer.train_module.optim]
             scheduler = self.trainer.train_module.scheduler
 
         if not optimizers:
@@ -171,7 +187,9 @@ class BatchSizeSchedulerCallback(Callback):
             )
 
         for optim in optimizers:
-            if not isinstance(optim, (torch.optim.Adam, torch.optim.AdamW, SkipStepAdamW)):
+            if not isinstance(
+                optim, (torch.optim.Adam, torch.optim.AdamW, SkipStepAdamW, MoEFusedV2Optimizer)
+            ):
                 raise NotImplementedError(
                     f"Unable to adjust learning rate for {optim.__class__.__name__} optimizer"
                 )

--- a/src/olmo_core/train/callbacks/evaluator_callback.py
+++ b/src/olmo_core/train/callbacks/evaluator_callback.py
@@ -30,7 +30,12 @@ from olmo_core.utils import (
 )
 
 from ..common import Duration, MetricMergeStrategy
-from ..train_module import EvalBatchSizeUnit, EvalBatchSpec, TransformerTrainModule
+from ..train_module import (
+    EvalBatchSizeUnit,
+    EvalBatchSpec,
+    MoEV2TransformerTrainModule,
+    TransformerTrainModule,
+)
 from .callback import Callback, CallbackConfig
 
 if TYPE_CHECKING:
@@ -91,9 +96,12 @@ class EvaluatorCallback(Callback):
     """
 
     def post_attach(self):
-        if not isinstance(self.trainer.train_module, TransformerTrainModule):
+        if not isinstance(
+            self.trainer.train_module, (TransformerTrainModule, MoEV2TransformerTrainModule)
+        ):
             raise OLMoConfigurationError(
-                f"'{self.__class__.__name__}' only supports the '{TransformerTrainModule.__name__}' train module"
+                f"'{self.__class__.__name__}' only supports transformer train modules "
+                f"('{TransformerTrainModule.__name__}', '{MoEV2TransformerTrainModule.__name__}')"
             )
 
     def pre_train(self):


### PR DESCRIPTION
Two shared training callbacks `isinstance`-gate on `TransformerTrainModule` / `TransformerPipelineTrainModule` and don't recognize `MoEV2TransformerTrainModule`, so a MoE-v2 run aborts during trainer setup even though the module is eval-capable and schedulable:

- **`EvaluatorCallback.post_attach`** rejected the module outright, so in-loop evaluation couldn't run — despite `MoEV2TransformerTrainModule` implementing `eval_batch()` / `eval_batch_spec` (both abstract on the base `TrainModule`).
- **`BatchSizeSchedulerCallback`** didn't match the module in either `post_attach` (scheduler lookup) or `_update_batch_size_and_lr` (optimizer lookup), so `optimizers` stayed `None` and it raised `NotImplementedError` *after* mutating `data_loader.global_batch_size`. It also only accepted `torch.optim.Adam*` optimizers, which would reject the MoE optimizer even once the module was recognized.

## Changes
- `EvaluatorCallback`: accept `(TransformerTrainModule, MoEV2TransformerTrainModule)`.
- `BatchSizeSchedulerCallback`: add a `MoEV2TransformerTrainModule` branch (uses its `.scheduler` and `.optim`), and accept `MoEFusedV2Optimizer` in the LR-adjustment type check. `MoEFusedV2Optimizer` isn't a `torch.optim.Optimizer` subclass but exposes the same `param_groups`/`lr` surface the `sqrt(new/current)` LR scaling relies on (the annotation is loosened to `List[Any]` accordingly).

Resolves the callback-integration findings deferred from #751.

## Testing
No dedicated unit test: these callbacks are trainer-coupled (their guards read `self.trainer.train_module`), there's no existing evaluator/batch-size callback test to extend, and exercising them needs a constructed `MoEV2TransformerTrainModule` (distributed). The change is a mechanical `isinstance`/type-tuple broadening; `make checks` (ruff/isort/black/mypy) is green and both callbacks import cleanly. End-to-end validation belongs to a real MoE-v2 run configuring these callbacks.