### PR TITLE
Add Trainer.eval_checkpoints for offline checkpoint evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Trainer.eval_checkpoints()` (and the `checkpoints_to_eval` config/trainer field): evaluate a list of checkpoint paths/globs with the configured `EvaluatorCallback`s without training. `TrainerConfig.build()` gained an `eval_only` pass-through for a uniform calling convention with the train-module config's `build()`.
 - Added `MoEV2TransformerTrainModule` (and `MoEV2TransformerTrainModuleConfig`), the train module for the fused MoE-v2 transformer. It builds the fused MoE distributed optimizer (`MoEFusedV2OptimizerConfig`), wraps model parts in `MultiGroupDistributedDataParallel`, and supports DP/EP/TP/CP/PP parallelism.
 - Added a custom pipeline-parallel layer (`olmo_core.train.train_module.transformer.pipeline`) with `CustomPipelineStage` and the `CustomSchedule1F1BV` / `CustomScheduleInterleaved1F1B` schedules, which re-use point-to-point receive buffers across micro-batches over a NCCL-RMA transport. Enabled via `TransformerPipelineParallelConfig.use_custom_stage_implementation` and `PipelineP2PBackend`.
 - Added `MultiGroupDistributedDataParallel` (`olmo_core.nn.parallel`), a data-parallel wrapper that accumulates gradients into flat bucket views and supports per-parameter process groups (`param_process_group_fn`), overlapped bucketed all-reduce (finalized via `finalize_grad_reduce()`), and optional fp32 gradient accumulation/reduction.

--- a/src/olmo_core/train/config.py
+++ b/src/olmo_core/train/config.py
@@ -52,6 +52,11 @@ class TrainerConfig(Config):
     no_checkpoints: bool = False
     no_evals: bool = False
     steps_to_skip: Optional[List[StepSkipRange]] = None
+    checkpoints_to_eval: Optional[List[str]] = None
+    """
+    Checkpoint paths (or globs) to evaluate with :meth:`Trainer.eval_checkpoints`. No effect during
+    training.
+    """
 
     def add_callback(self, name: str, callback: Callback):
         """
@@ -144,6 +149,7 @@ class TrainerConfig(Config):
         train_module: TrainModule,
         data_loader: DataLoaderBase,
         *,
+        eval_only: bool = False,
         dp_process_group: Optional[dist.ProcessGroup] = None,
         checkpointer_pg: Optional[dist.ProcessGroup] = None,
     ) -> Trainer:
@@ -152,9 +158,14 @@ class TrainerConfig(Config):
 
         :param train_module: The train module to fit.
         :param data_loader: The data loader to train on.
+        :param eval_only: Accepted for a uniform calling convention with the train-module config's
+            ``build()`` (which uses it to skip building the optimizer). The trainer itself needs no
+            special eval-only state, so it's ignored here.
         :param dp_process_group: The data parallel process group. Defaults to
             :data:`olmo_core.train.train_module.TrainModule.dp_process_group`.
         """
+        del eval_only
+
         kwargs = self.as_dict(exclude_none=True, recurse=False)
 
         if dp_process_group is None:

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -833,9 +833,10 @@ class Trainer:
                     f"Evaluating checkpoint {checkpoint_num:,d}/{len(checkpoint_paths):,d} "
                     f"from '{checkpoint_path}'..."
                 )
-                self.load_checkpoint(
-                    checkpoint_path, load_trainer_state=True, load_optim_state=True
-                )
+                # Offline eval only needs model weights: skip optimizer state (never needed, and
+                # eval-only/weights-only checkpoints have none), and leave trainer state at the
+                # trainer's default (load-if-present) so it isn't required either.
+                self.load_checkpoint(checkpoint_path, load_optim_state=False)
 
                 self.record_metric("throughput/total tokens", self.global_train_tokens_seen)
                 # Duck-typed so this stays train-module-agnostic (transformer train modules expose

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -50,6 +50,7 @@ from ..io import (
     copy_file,
     dir_is_empty,
     file_exists,
+    glob_directory,
     is_url,
     join_path,
     normalize_path,
@@ -287,6 +288,11 @@ class Trainer:
     steps_to_skip: Optional[List[StepSkipRange]] = None
     """
     Ranges of steps to completely skip training on.
+    """
+
+    checkpoints_to_eval: Optional[List[str]] = None
+    """
+    Checkpoint paths (or globs) to evaluate with :meth:`eval_checkpoints`. No effect during training.
     """
 
     # Internal bookkeeping
@@ -762,6 +768,186 @@ class Trainer:
         # Wait for any bookkeeping tasks to finish.
         self._shutdown()
         log.info("Training complete")
+
+    def eval_checkpoints(self):
+        """
+        Evaluate each checkpoint in :data:`checkpoints_to_eval` with the configured
+        :class:`~olmo_core.train.callbacks.EvaluatorCallback`\\ s, without training.
+
+        Loads each checkpoint in turn, runs every evaluator, and logs the results. Checkpointer and
+        evaluator callbacks' ``pre_train``/``post_train`` hooks are skipped (only the evaluators'
+        ``perform_eval()`` runs).
+
+        :raises OLMoConfigurationError: If ``no_evals=True``, no ``EvaluatorCallback`` is configured,
+            or ``checkpoints_to_eval`` is unset.
+        """
+        if self.no_evals:
+            raise OLMoConfigurationError(
+                f"'{self.__class__.__name__}.eval_checkpoints()' requires 'no_evals=False'"
+            )
+
+        checkpoint_paths = self._get_checkpoints_to_eval()
+        evaluator_callbacks = [
+            cb for cb in self._iter_callbacks() if isinstance(cb, EvaluatorCallback)
+        ]
+        if not evaluator_callbacks:
+            raise OLMoConfigurationError(
+                f"'{self.__class__.__name__}.eval_checkpoints()' requires at least one "
+                f"'{EvaluatorCallback.__name__}'"
+            )
+
+        self._canceled = False
+        self._cancel_reason = None
+        self._canceling_rank = None
+
+        log.info("Callback order:")
+        for i, callback_name in enumerate(self.callbacks.keys()):
+            log.info(f"  - Callback {i + 1}: {callback_name}")
+
+        log.info(f"Evaluating {len(checkpoint_paths):,d} checkpoints")
+
+        callback_blacklist = (CheckpointerCallback, EvaluatorCallback)
+
+        # Install SIGTERM + SIGINT handlers.
+        og_sigterm_handler = signal.signal(signal.SIGTERM, self._handle_os_signal)
+        og_sigint_handler = signal.signal(signal.SIGINT, self._handle_os_signal)
+
+        try:
+            for callback in self._iter_callbacks():
+                if not isinstance(callback, callback_blacklist):
+                    callback.pre_train()
+            self.train_module.pre_train()
+
+            if self.is_canceled:
+                for callback in self._iter_callbacks():
+                    if not isinstance(callback, callback_blacklist):
+                        callback.post_train()
+                self._shutdown()
+                return
+
+            for checkpoint_num, checkpoint_path in enumerate(checkpoint_paths, start=1):
+                if self.is_canceled:
+                    break
+
+                log.info(
+                    f"Evaluating checkpoint {checkpoint_num:,d}/{len(checkpoint_paths):,d} "
+                    f"from '{checkpoint_path}'..."
+                )
+                self.load_checkpoint(
+                    checkpoint_path, load_trainer_state=True, load_optim_state=True
+                )
+
+                self.record_metric("throughput/total tokens", self.global_train_tokens_seen)
+                # Duck-typed so this stays train-module-agnostic (transformer train modules expose
+                # these; the base TrainModule doesn't).
+                num_flops_fn = getattr(self.train_module, "num_flops_per_token", None)
+                max_seq_len = getattr(self.train_module, "max_sequence_length", None)
+                if callable(num_flops_fn) and max_seq_len is not None:
+                    num_flops_per_token = num_flops_fn(max_seq_len)
+                    if num_flops_per_token is not None:
+                        self.record_metric(
+                            "throughput/total petaflops",
+                            self.global_train_tokens_seen * num_flops_per_token / 1e15,
+                        )
+
+                for callback in evaluator_callbacks:
+                    callback.perform_eval()
+
+                self._log_metrics()
+        except BaseException as exc:
+            log.error(f"Checkpoint evaluation failed due to:\n{exc}")
+            for callback in self._iter_callbacks():
+                if not isinstance(callback, callback_blacklist):
+                    callback.on_error(exc)
+            for callback in self._iter_callbacks():
+                callback.close()
+            raise
+        finally:
+            # Restore original signal handlers.
+            signal.signal(signal.SIGTERM, og_sigterm_handler)
+            signal.signal(signal.SIGINT, og_sigint_handler)
+
+        # Flush metrics + await queued bookkeeping ops before the post-train hooks run.
+        self._log_metrics()
+        self._join_bookkeeping_ops()
+        for callback in self._iter_callbacks():
+            if not isinstance(callback, callback_blacklist):
+                callback.post_train()
+
+        self._shutdown()
+        log.info("Checkpoint evaluation complete")
+
+    def _get_checkpoints_to_eval(self) -> List[str]:
+        if not self.checkpoints_to_eval:
+            raise OLMoConfigurationError(
+                f"'{self.__class__.__name__}.eval_checkpoints()' requires "
+                "'checkpoints_to_eval' to be set"
+            )
+
+        checkpoint_paths: List[str] = []
+        error_type: Optional[str] = None
+        error_msg: Optional[str] = None
+
+        if get_rank() == 0:
+            seen = set()
+            try:
+                for raw_path in self.checkpoints_to_eval:
+                    path = normalize_path(raw_path)
+                    candidate_paths = sorted(glob_directory(path)) if "*" in path else [path]
+                    if not candidate_paths:
+                        raise FileNotFoundError(f"No checkpoints found in '{path}'")
+
+                    expanded_paths: List[str] = []
+                    for candidate_path in candidate_paths:
+                        if self.checkpointer.dir_is_checkpoint(candidate_path):
+                            expanded_paths.append(candidate_path)
+                        else:
+                            expanded_paths.extend(
+                                checkpoint_path
+                                for _, checkpoint_path in sorted(
+                                    self.checkpointer.find_checkpoints(candidate_path),
+                                    key=lambda item: item[0],
+                                )
+                            )
+
+                    if not expanded_paths:
+                        raise FileNotFoundError(f"No checkpoints found in '{path}'")
+
+                    for checkpoint_path in expanded_paths:
+                        if checkpoint_path not in seen:
+                            checkpoint_paths.append(checkpoint_path)
+                            seen.add(checkpoint_path)
+            except FileNotFoundError as exc:
+                error_type = "FileNotFoundError"
+                error_msg = str(exc)
+            except OLMoConfigurationError as exc:
+                error_type = "OLMoConfigurationError"
+                error_msg = str(exc)
+            except Exception as exc:
+                error_type = exc.__class__.__name__
+                error_msg = str(exc)
+
+        checkpoint_paths, error_type, error_msg = broadcast_object(
+            (checkpoint_paths, error_type, error_msg)
+        )
+
+        if error_type == "FileNotFoundError":
+            assert error_msg is not None
+            raise FileNotFoundError(error_msg)
+        elif error_type == "OLMoConfigurationError":
+            assert error_msg is not None
+            raise OLMoConfigurationError(error_msg)
+        elif error_type is not None:
+            assert error_msg is not None
+            raise RuntimeError(error_msg)
+
+        if checkpoint_paths and all(
+            (name := Path(path).name).startswith("step") and name[4:].isdigit()
+            for path in checkpoint_paths
+        ):
+            checkpoint_paths = sorted(checkpoint_paths, key=lambda path: int(Path(path).name[4:]))
+
+        return checkpoint_paths
 
     def _shutdown(self, gracefully: bool = True):
         if gracefully:


### PR DESCRIPTION
Adds `Trainer.eval_checkpoints()` — evaluate a set of checkpoints with the configured `EvaluatorCallback`s **without training**. Point it at checkpoint paths (or globs) via the new `checkpoints_to_eval` field; it loads each in turn, runs every evaluator, and logs the results.

## What it adds
- **`Trainer.eval_checkpoints()`** — resolve the checkpoint list, then for each: `load_checkpoint` → record `throughput/total tokens` (+ `total petaflops` when the train module exposes flops) → run each evaluator's `perform_eval()` → log. Installs SIGTERM/SIGINT handlers; blacklists `CheckpointerCallback`/`EvaluatorCallback` from the `pre_train`/`post_train` hooks (only `perform_eval()` runs).
- **`Trainer._get_checkpoints_to_eval()`** — rank-0 glob/expand (a path can be a single checkpoint or a folder of them) + step-sort, broadcast to all ranks.
- **`checkpoints_to_eval`** on `Trainer` and `TrainerConfig`.
- **`eval_only` pass-through** on `TrainerConfig.build()` — accepted for a uniform calling convention with the *train-module* config's `build()` (which uses it to skip the optimizer); the trainer itself needs no eval-only state, so it's ignored.

## Generalized from dev (per plan)
The dev version hard-restricted to `MoEV2TransformerTrainModule`. Since the load→eval→log flow is train-module-agnostic, this version:
- **drops the train-module type gate** — any eval-capable transformer train module works (`EvaluatorCallback` already enforces the module type at attach);
- keeps the flops metric **duck-typed** (`getattr` on `num_flops_per_token`/`max_sequence_length`), so `trainer.py` stays MoE-agnostic (no MoE import);
- reuses the existing `_log_metrics()` + `_join_bookkeeping_ops()` for the drain (no new helper, `fit()` untouched);
- drops `UpcycleCheckpointerCallback` (absent in this branch) from the callback blacklist.

## Testing
No dedicated unit test: `eval_checkpoints`/`_get_checkpoints_to_eval` are `Trainer`-level (need a constructed trainer + checkpointer + distributed rank/broadcast), and there's no existing trainer-eval test to extend. The logic is a faithful (generalized) port; `make checks` (ruff/isort/black/mypy) is green and the module imports cleanly. End-to-end validation belongs to a real run pointed at a folder of checkpoints.