### PR TITLE
Add MoE-v2 HuggingFace interop (olmo3moe model + conversion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added HuggingFace interop for the MoE-v2 model (beta): the `olmo3moe` HF model (`Olmo3MoeConfig` + `modeling_olmo3moe`, a custom transformers-style implementation since transformers has no OLMoE-MoE architecture) and olmo-core ↔ HF checkpoint conversion wired into `olmo_core.nn.hf` (`convert_olmo3moe_state_{from,to}_hf` + an `Olmo3MoeConfig` builder), including the fused `w_up_gate` routed-expert split.
 - Added `Trainer.eval_checkpoints()` (and the `checkpoints_to_eval` config/trainer field): evaluate a list of checkpoint paths/globs with the configured `EvaluatorCallback`s without training. `TrainerConfig.build()` gained an `eval_only` pass-through for a uniform calling convention with the train-module config's `build()`.
 - Added `MoEV2TransformerTrainModule` (and `MoEV2TransformerTrainModuleConfig`), the train module for the fused MoE-v2 transformer. It builds the fused MoE distributed optimizer (`MoEFusedV2OptimizerConfig`), wraps model parts in `MultiGroupDistributedDataParallel`, and supports DP/EP/TP/CP/PP parallelism.
 - Added a custom pipeline-parallel layer (`olmo_core.train.train_module.transformer.pipeline`) with `CustomPipelineStage` and the `CustomSchedule1F1BV` / `CustomScheduleInterleaved1F1B` schedules, which re-use point-to-point receive buffers across micro-batches over a NCCL-RMA transport. Enabled via `TransformerPipelineParallelConfig.use_custom_stage_implementation` and `PipelineP2PBackend`.

--- a/src/olmo_core/nn/hf/checkpoint.py
+++ b/src/olmo_core/nn/hf/checkpoint.py
@@ -98,13 +98,18 @@ def load_hf_model(
     else:
         raise NotImplementedError
 
-    # Warm up the HF local cache by downloading the model on just local rank 0
+    # Warm up the HF local cache by downloading the model on just local rank 0. ``trust_remote_code``
+    # lets us reload custom architectures (e.g. olmo3moe) whose code is bundled in the checkpoint.
     if get_fs_local_rank() == 0:
-        hf_model = AutoModelForCausalLM.from_pretrained(model_name_or_path, revision=revision)
+        hf_model = AutoModelForCausalLM.from_pretrained(
+            model_name_or_path, revision=revision, trust_remote_code=True
+        )
         del hf_model
     barrier(group=process_group)
 
-    hf_model = AutoModelForCausalLM.from_pretrained(model_name_or_path, revision=revision)
+    hf_model = AutoModelForCausalLM.from_pretrained(
+        model_name_or_path, revision=revision, trust_remote_code=True
+    )
     log.info(f"Loaded hf model: {hf_model}")
     hf_model.resize_token_embeddings(num_embeddings)
 

--- a/src/olmo_core/nn/hf/config.py
+++ b/src/olmo_core/nn/hf/config.py
@@ -13,13 +13,16 @@ from olmo_core.nn.transformer.block import (
     ReorderedNormTransformerBlock,
     TransformerBlock,
 )
-from olmo_core.nn.transformer.model import (
-    MoETransformer,
-    NormalizedTransformer,
-    Transformer,
-)
+from olmo_core.nn.transformer.model import MoETransformer, NormalizedTransformer, Transformer
 
 log = logging.getLogger(__name__)
+
+try:
+    from olmo_core.nn.moe.v2.hf.configuration_olmo3moe import Olmo3MoeConfig  # type: ignore
+    from olmo_core.nn.moe.v2.model import MoEFusedV2Transformer  # type: ignore
+except ImportError:
+    Olmo3MoeConfig = None  # type: ignore[assignment,misc]
+    MoEFusedV2Transformer = None  # type: ignore[assignment,misc]
 
 try:
     from transformers import FlexOlmoConfig  # type: ignore
@@ -83,8 +86,133 @@ def _get_flex_olmo_config(model: MoETransformer) -> PretrainedConfig:
     )
 
 
+def _get_olmo3moe_config(model: "MoEFusedV2Transformer") -> PretrainedConfig:
+    from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlock
+
+    if Olmo3MoeConfig is None:
+        raise RuntimeError(
+            "Building an Olmo3MoeConfig requires the olmo3moe HF model files "
+            "(olmo_core.nn.moe.v2.hf)."
+        )
+
+    blocks = list(model.blocks.values())
+
+    # Identify the dense (non-MoE) layers and pick a representative MoE and dense block.
+    dense_layers_indices: List[int] = []
+    moe_block: Optional[MoEFusedV2TransformerBlock] = None
+    dense_block: Optional[TransformerBlock] = None
+    for idx, block in enumerate(blocks):
+        if isinstance(block, MoEFusedV2TransformerBlock):
+            if moe_block is None:
+                moe_block = block
+        else:
+            dense_layers_indices.append(idx)
+            if dense_block is None:
+                dense_block = block
+
+    if moe_block is None:
+        raise NotImplementedError(
+            f"No {MoEFusedV2TransformerBlock.__name__} found, unable to build HF config for "
+            f"{model.__class__.__name__}"
+        )
+
+    if moe_block.use_peri_norm:
+        raise NotImplementedError(
+            "Building an Olmo3MoeConfig is not supported for peri-LN (use_peri_norm=True) models."
+        )
+
+    attention = moe_block.attention
+    if not isinstance(attention, Attention):
+        raise NotImplementedError(
+            f"Attention is not a {Attention.__name__}, unable to build HF config for "
+            f"{model.__class__.__name__}"
+        )
+    if attention.rope is None:
+        raise NotImplementedError(
+            f"Attention does not use rope, unable to build HF config for "
+            f"{model.__class__.__name__}"
+        )
+
+    if moe_block.routed_experts is None or moe_block.routed_experts_router is None:
+        raise NotImplementedError("MoE block is missing routed experts or its router.")
+
+    routed_experts = moe_block.routed_experts
+    router = moe_block.routed_experts_router
+
+    # Dense MLP intermediate size, if there are any dense layers.
+    dense_mlp_intermediate_size: Optional[int] = None
+    if dense_block is not None:
+        dense_mlp_intermediate_size = dense_block.feed_forward.hidden_size
+
+    # Shared experts (optional).
+    shared_expert_intermediate_size: Optional[int] = None
+    if moe_block.shared_experts is not None:
+        shared_expert_intermediate_size = moe_block.shared_experts.hidden_size
+
+    # Sliding window: OLMo-core stores a per-layer window on the attention backend; a value of
+    # (-1, -1) means full attention. HF expects a value one larger than the flash-attention window
+    # (which excludes the current position); see the OLMo 3 handling in `get_hf_config`.
+    layer_types: List[str] = []
+    window_sizes = set()
+    for block in blocks:
+        window = block.attention.backend.window_size
+        if window != (-1, -1):
+            layer_types.append("sliding_attention")
+            window_sizes.add(window[0])
+        else:
+            layer_types.append("full_attention")
+
+    if len(window_sizes) > 1:
+        raise ValueError(
+            "All sliding window attention layers must have the same window size for "
+            f"Olmo3MoeConfig. Found different window sizes: {window_sizes}."
+        )
+    sliding_window = (window_sizes.pop() + 1) if window_sizes else attention.head_dim
+
+    attention_hidden_size = attention.n_heads * attention.head_dim
+
+    return Olmo3MoeConfig(
+        vocab_size=model.vocab_size,
+        hidden_size=model.d_model,
+        attention_hidden_size=attention_hidden_size,
+        head_dim=attention.head_dim,
+        dense_mlp_intermediate_size=dense_mlp_intermediate_size,
+        moe_intermediate_size=routed_experts.hidden_size,
+        shared_expert_intermediate_size=shared_expert_intermediate_size,
+        n_routed_experts=routed_experts.num_experts,
+        num_experts_per_tok=router.top_k,
+        original_num_experts_per_tok=router.original_top_k,
+        num_hidden_layers=model.n_layers,
+        num_attention_heads=attention.n_heads,
+        num_key_value_heads=attention.n_kv_heads,
+        hidden_act="silu",
+        gating_function=str(router.gating_function),
+        normalize_expert_weights=router.normalize_expert_weights,
+        restore_weight_scale=router.restore_weight_scale,
+        max_position_embeddings=-1,
+        attention_bias=attention.w_out.bias is not None,
+        rope_theta=attention.rope.theta,
+        rope_scaling=None,
+        rms_norm_eps=moe_block.feed_forward_norm.eps,
+        use_head_qk_norm=attention.use_head_qk_norm,
+        sliding_window=sliding_window,
+        layer_types=layer_types,
+        dense_layers_indices=dense_layers_indices,
+        embed_scale=model.embed_scale if model.embed_scale is not None else 1.0,
+        embed_norm=model.embedding_norm is not None,
+        use_peri_ln=False,
+        pad_token_id=None,  # type: ignore
+        bos_token_id=None,
+        eos_token_id=None,  # type: ignore
+        tie_word_embeddings=model.tie_word_embeddings,
+    )
+
+
 @beta_feature
 def get_hf_config(model: Transformer) -> PretrainedConfig:
+    if MoEFusedV2Transformer is not None and isinstance(model, MoEFusedV2Transformer):
+        return _get_olmo3moe_config(model)
+
     if isinstance(model, NormalizedTransformer):
         raise NotImplementedError(
             f"Building HF config not implemented for {model.__class__.__name__}"

--- a/src/olmo_core/nn/hf/config.py
+++ b/src/olmo_core/nn/hf/config.py
@@ -96,9 +96,12 @@ def _register_olmo3moe_auto_classes() -> None:
     """
     Register the standalone ``olmo3moe`` config/model with transformers' ``Auto*`` mappings.
 
-    transformers ships no ``olmo3moe`` architecture, so ``AutoModelForCausalLM.from_config`` (used
-    when exporting a checkpoint to HF) can't resolve it until the custom classes are registered.
-    Registration is idempotent — transformers raises :class:`ValueError` on a duplicate.
+    transformers ships no ``olmo3moe`` architecture. The in-memory ``Auto*.register`` calls let
+    ``AutoModelForCausalLM.from_config`` resolve it while exporting a checkpoint. The
+    ``register_for_auto_class`` calls additionally persist an ``auto_map`` into the exported
+    ``config.json`` and bundle the model code alongside it, so a fresh process can reload the
+    checkpoint with ``trust_remote_code=True``. In-memory registration is idempotent —
+    transformers raises :class:`ValueError` on a duplicate.
     """
     from transformers import AutoConfig, AutoModelForCausalLM
 
@@ -112,6 +115,9 @@ def _register_olmo3moe_auto_classes() -> None:
         AutoModelForCausalLM.register(Olmo3MoeConfig, Olmo3MoeForCausalLM)
     except ValueError:
         pass  # already registered
+
+    Olmo3MoeConfig.register_for_auto_class("AutoConfig")
+    Olmo3MoeForCausalLM.register_for_auto_class("AutoModelForCausalLM")
 
 
 def _get_olmo3moe_config(model: "MoEFusedV2Transformer") -> PretrainedConfig:
@@ -136,6 +142,13 @@ def _get_olmo3moe_config(model: "MoEFusedV2Transformer") -> PretrainedConfig:
             if moe_block is None:
                 moe_block = block
         else:
+            # olmo3moe places the layernorms after attention/MLP (reordered norm); a standard
+            # pre-norm dense block would export with its norms in the wrong position.
+            if not isinstance(block, ReorderedNormTransformerBlock):
+                raise NotImplementedError(
+                    f"Exporting olmo3moe requires reordered-norm dense blocks, got "
+                    f"{type(block).__name__}."
+                )
             dense_layers_indices.append(idx)
             if dense_block is None:
                 dense_block = block

--- a/src/olmo_core/nn/hf/config.py
+++ b/src/olmo_core/nn/hf/config.py
@@ -162,21 +162,57 @@ def _get_olmo3moe_config(model: "MoEFusedV2Transformer") -> PretrainedConfig:
             f"Attention does not use rope, unable to build HF config for "
             f"{model.__class__.__name__}"
         )
+    # The olmo3moe converter only round-trips head-wise QK-norm, unscaled RoPE, and bias-free
+    # attention; reject anything else rather than silently exporting a divergent model.
+    if attention.rope.scaling is not None:
+        raise NotImplementedError("Exporting olmo3moe with scaled RoPE is not supported.")
+    if any(
+        proj.bias is not None
+        for proj in (attention.w_q, attention.w_k, attention.w_v, attention.w_out)
+    ):
+        raise NotImplementedError("Exporting olmo3moe with attention biases is not supported.")
+    if not attention.use_head_qk_norm or attention.q_norm is None:
+        raise NotImplementedError(
+            "Exporting olmo3moe requires head-wise QK-norm (use_head_qk_norm=True); other "
+            "QK-norm configurations are not supported."
+        )
 
     if moe_block.routed_experts is None or moe_block.routed_experts_router is None:
         raise NotImplementedError("MoE block is missing routed experts or its router.")
 
     routed_experts = moe_block.routed_experts
     router = moe_block.routed_experts_router
+    # Selection modifiers change which experts a token routes to at inference; the HF router has no
+    # equivalent state, so exporting them would silently diverge.
+    if router.bias_gamma is not None or router.use_quant_scores:
+        raise NotImplementedError(
+            "Exporting olmo3moe with router selection modifiers (bias_gamma / use_quant_scores) "
+            "is not supported."
+        )
 
     # Dense MLP intermediate size, if there are any dense layers.
     dense_mlp_intermediate_size: Optional[int] = None
     if dense_block is not None:
+        if any(
+            proj.bias is not None
+            for proj in (
+                dense_block.feed_forward.w1,
+                dense_block.feed_forward.w2,
+                dense_block.feed_forward.w3,
+            )
+        ):
+            raise NotImplementedError(
+                "Exporting olmo3moe with biased dense feed-forward layers is not supported."
+            )
         dense_mlp_intermediate_size = dense_block.feed_forward.hidden_size
 
-    # Shared experts (optional).
+    # Shared experts (optional). The HF model has a single shared expert.
     shared_expert_intermediate_size: Optional[int] = None
     if moe_block.shared_experts is not None:
+        if moe_block.shared_experts.num_experts > 1:
+            raise NotImplementedError(
+                "Exporting olmo3moe with more than one shared expert is not supported."
+            )
         shared_expert_intermediate_size = moe_block.shared_experts.hidden_size
 
     # Sliding window: OLMo-core stores a per-layer window on the attention backend; a value of

--- a/src/olmo_core/nn/hf/config.py
+++ b/src/olmo_core/nn/hf/config.py
@@ -13,12 +13,18 @@ from olmo_core.nn.transformer.block import (
     ReorderedNormTransformerBlock,
     TransformerBlock,
 )
-from olmo_core.nn.transformer.model import MoETransformer, NormalizedTransformer, Transformer
+from olmo_core.nn.transformer.model import (
+    MoETransformer,
+    NormalizedTransformer,
+    Transformer,
+)
 
 log = logging.getLogger(__name__)
 
 try:
-    from olmo_core.nn.moe.v2.hf.configuration_olmo3moe import Olmo3MoeConfig  # type: ignore
+    from olmo_core.nn.moe.v2.hf.configuration_olmo3moe import (
+        Olmo3MoeConfig,  # type: ignore
+    )
     from olmo_core.nn.moe.v2.model import MoEFusedV2Transformer  # type: ignore
 except ImportError:
     Olmo3MoeConfig = None  # type: ignore[assignment,misc]
@@ -86,6 +92,28 @@ def _get_flex_olmo_config(model: MoETransformer) -> PretrainedConfig:
     )
 
 
+def _register_olmo3moe_auto_classes() -> None:
+    """
+    Register the standalone ``olmo3moe`` config/model with transformers' ``Auto*`` mappings.
+
+    transformers ships no ``olmo3moe`` architecture, so ``AutoModelForCausalLM.from_config`` (used
+    when exporting a checkpoint to HF) can't resolve it until the custom classes are registered.
+    Registration is idempotent — transformers raises :class:`ValueError` on a duplicate.
+    """
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    from olmo_core.nn.moe.v2.hf.modeling_olmo3moe import Olmo3MoeForCausalLM
+
+    try:
+        AutoConfig.register("olmo3moe", Olmo3MoeConfig)
+    except ValueError:
+        pass  # already registered
+    try:
+        AutoModelForCausalLM.register(Olmo3MoeConfig, Olmo3MoeForCausalLM)
+    except ValueError:
+        pass  # already registered
+
+
 def _get_olmo3moe_config(model: "MoEFusedV2Transformer") -> PretrainedConfig:
     from olmo_core.nn.moe.v2.block import MoEFusedV2TransformerBlock
 
@@ -94,6 +122,8 @@ def _get_olmo3moe_config(model: "MoEFusedV2Transformer") -> PretrainedConfig:
             "Building an Olmo3MoeConfig requires the olmo3moe HF model files "
             "(olmo_core.nn.moe.v2.hf)."
         )
+
+    _register_olmo3moe_auto_classes()
 
     blocks = list(model.blocks.values())
 

--- a/src/olmo_core/nn/hf/convert.py
+++ b/src/olmo_core/nn/hf/convert.py
@@ -739,7 +739,10 @@ def convert_olmo3moe_state_from_hf(
 
     olmo_state["embeddings.weight"] = hf_state["model.embed_tokens.weight"]
     olmo_state["lm_head.norm.weight"] = hf_state["model.norm.weight"]
-    olmo_state["lm_head.w_out.weight"] = hf_state["lm_head.weight"]
+    # With tied embeddings transformers omits ``lm_head.weight``; fall back to the input embeddings.
+    olmo_state["lm_head.w_out.weight"] = hf_state.get(
+        "lm_head.weight", hf_state["model.embed_tokens.weight"]
+    )
     if getattr(config, "embed_norm", False):
         olmo_state["embedding_norm.weight"] = hf_state["model.embed_norm.weight"]
 

--- a/src/olmo_core/nn/hf/convert.py
+++ b/src/olmo_core/nn/hf/convert.py
@@ -669,6 +669,284 @@ def convert_qwen3_5_state_from_hf(
     return _apply_qwen3_5_norm_transform(olmo_state)
 
 
+# ---------------------------------------------------------------------------
+# olmo3moe (MoE-v2) conversion.
+#
+# The MoE-v2 routed experts store a *fused* up+gate projection weight
+# ``blocks.{i}.routed_experts.w_up_gate`` of shape ``(E, 2H, D)`` (the first ``H``
+# rows are the up-projection, the next ``H`` are the gate-projection), plus a
+# per-expert down-projection ``blocks.{i}.routed_experts.w_down`` of shape
+# ``(E, H, D)``. HF ``olmo3moe`` instead expects a separate ``nn.Linear`` per
+# expert: ``gate_proj``/``up_proj`` of shape ``(H, D)`` and ``down_proj`` of
+# shape ``(D, H)``.
+#
+# The :class:`StateMappingTemplate` pipeline (cat -> unflatten -> permute ->
+# flatten -> chunk) cannot express this fused up/gate split: isolating the up
+# (or gate) half requires a slice, and fanning that half out per-expert requires
+# a second, independent split along a different dimension. There is no slice op
+# and only one ``dest_chunk_dim``/``EXPERT`` expansion is available per template.
+# So, following the standalone-converter precedent used for Qwen3.5
+# (:func:`convert_qwen3_5_state_from_hf`), olmo3moe uses dedicated functions.
+#
+# These mirror ``convert_checkpoint.py`` from the standalone MoE-v2 HF converter.
+# Norm handling only covers the default reordered-norm scheme (``use_peri_ln`` is
+# False): ``attention_norm`` -> ``post_attention_layernorm`` and
+# ``feed_forward_norm`` -> ``post_feedforward_layernorm``, uniformly across dense
+# and MoE layers. The peri-LN scheme is not supported here because it maps the
+# same OLMo-core norm key (``attention_norm``) to different HF keys depending on
+# whether the layer is dense or MoE, which cannot be expressed uniformly.
+# ---------------------------------------------------------------------------
+
+
+def _olmo3moe_dense_layer_indices(config: PretrainedConfig) -> set:
+    indices = getattr(config, "dense_layers_indices", None)
+    if indices is None:
+        return set()
+    return set(indices)
+
+
+def _require_no_peri_ln(config: PretrainedConfig) -> None:
+    if getattr(config, "use_peri_ln", False):
+        raise NotImplementedError(
+            "olmo3moe checkpoint conversion does not support use_peri_ln=True: the peri-LN "
+            "scheme maps the same OLMo-core norm parameter to different HF layernorms depending "
+            "on whether a layer is dense or MoE, which the conversion framework cannot express."
+        )
+
+
+@beta_feature
+def convert_olmo3moe_state_from_hf(
+    config: PretrainedConfig,
+    hf_state: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Convert a Hugging Face ``olmo3moe`` state dict to OLMo-core MoE-v2 format.
+
+    Handles the fused ``w_up_gate`` routed-expert layout and the mixed dense / MoE
+    layer structure that the template-based converter cannot express.
+
+    :param config: The Hugging Face ``Olmo3MoeConfig``.
+    :param hf_state: A model state dict in HF format.
+    """
+    _require_no_peri_ln(config)
+
+    n_layers: int = config.num_hidden_layers
+    n_experts: int = config.n_routed_experts
+    dense_indices = _olmo3moe_dense_layer_indices(config)
+    has_shared = getattr(config, "shared_expert_intermediate_size", None) is not None
+
+    olmo_state: Dict[str, Any] = {}
+
+    olmo_state["embeddings.weight"] = hf_state["model.embed_tokens.weight"]
+    olmo_state["lm_head.norm.weight"] = hf_state["model.norm.weight"]
+    olmo_state["lm_head.w_out.weight"] = hf_state["lm_head.weight"]
+    if getattr(config, "embed_norm", False):
+        olmo_state["embedding_norm.weight"] = hf_state["model.embed_norm.weight"]
+
+    for layer_idx in range(n_layers):
+        prefix = f"model.layers.{layer_idx}."
+        olmo_prefix = f"blocks.{layer_idx}."
+
+        # Attention projections.
+        olmo_state[f"{olmo_prefix}attention.w_q.weight"] = hf_state[
+            f"{prefix}self_attn.q_proj.weight"
+        ]
+        olmo_state[f"{olmo_prefix}attention.w_k.weight"] = hf_state[
+            f"{prefix}self_attn.k_proj.weight"
+        ]
+        olmo_state[f"{olmo_prefix}attention.w_v.weight"] = hf_state[
+            f"{prefix}self_attn.v_proj.weight"
+        ]
+        olmo_state[f"{olmo_prefix}attention.w_out.weight"] = hf_state[
+            f"{prefix}self_attn.o_proj.weight"
+        ]
+        olmo_state[f"{olmo_prefix}attention.q_norm.weight"] = hf_state[
+            f"{prefix}self_attn.q_norm.weight"
+        ]
+        olmo_state[f"{olmo_prefix}attention.k_norm.weight"] = hf_state[
+            f"{prefix}self_attn.k_norm.weight"
+        ]
+
+        # Reordered norms (uniform across dense and MoE layers).
+        olmo_state[f"{olmo_prefix}attention_norm.weight"] = hf_state[
+            f"{prefix}post_attention_layernorm.weight"
+        ]
+        olmo_state[f"{olmo_prefix}feed_forward_norm.weight"] = hf_state[
+            f"{prefix}post_feedforward_layernorm.weight"
+        ]
+
+        if layer_idx in dense_indices:
+            # Dense feed-forward.
+            olmo_state[f"{olmo_prefix}feed_forward.w1.weight"] = hf_state[
+                f"{prefix}mlp.gate_proj.weight"
+            ]
+            olmo_state[f"{olmo_prefix}feed_forward.w2.weight"] = hf_state[
+                f"{prefix}mlp.down_proj.weight"
+            ]
+            olmo_state[f"{olmo_prefix}feed_forward.w3.weight"] = hf_state[
+                f"{prefix}mlp.up_proj.weight"
+            ]
+            continue
+
+        # Router: HF gate weight is (E, D); OLMo-core stores it flattened (E * D,).
+        olmo_state[f"{olmo_prefix}routed_experts_router.weight"] = hf_state[
+            f"{prefix}mlp.router.gate.weight"
+        ].reshape(-1)
+
+        # Routed experts: stack per-expert HF up/gate into fused (E, 2H, D), up first.
+        up_list = [hf_state[f"{prefix}mlp.experts.{e}.up_proj.weight"] for e in range(n_experts)]
+        gate_list = [
+            hf_state[f"{prefix}mlp.experts.{e}.gate_proj.weight"] for e in range(n_experts)
+        ]
+        down_list = [
+            hf_state[f"{prefix}mlp.experts.{e}.down_proj.weight"] for e in range(n_experts)
+        ]
+
+        w_up = torch.stack(up_list, dim=0)  # (E, H, D)
+        w_gate = torch.stack(gate_list, dim=0)  # (E, H, D)
+        olmo_state[f"{olmo_prefix}routed_experts.w_up_gate"] = torch.cat(
+            [w_up, w_gate], dim=1
+        ).contiguous()  # (E, 2H, D)
+        # HF down_proj is (D, H); OLMo-core w_down is (E, H, D).
+        olmo_state[f"{olmo_prefix}routed_experts.w_down"] = torch.stack(
+            [d.T for d in down_list], dim=0
+        ).contiguous()  # (E, H, D)
+
+        # Shared expert (single expert): HF up/gate (H, D) -> fused w_up_gate (D, 2H), up first.
+        if has_shared:
+            shared_up = hf_state[f"{prefix}mlp.shared_expert.up_proj.weight"]  # (H, D)
+            shared_gate = hf_state[f"{prefix}mlp.shared_expert.gate_proj.weight"]  # (H, D)
+            olmo_state[f"{olmo_prefix}shared_experts.w_up_gate"] = torch.cat(
+                [shared_up.T, shared_gate.T], dim=1
+            ).contiguous()  # (D, 2H)
+            shared_down = hf_state[f"{prefix}mlp.shared_expert.down_proj.weight"]  # (D, H)
+            olmo_state[f"{olmo_prefix}shared_experts.w_down"] = shared_down.T.unsqueeze(
+                0
+            ).contiguous()  # (1, H, D)
+
+    return olmo_state
+
+
+@beta_feature
+def convert_olmo3moe_state_to_hf(
+    config: PretrainedConfig,
+    olmo_core_state: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Convert an *unsharded* OLMo-core MoE-v2 state dict to HF ``olmo3moe`` format.
+
+    Inverse of :func:`convert_olmo3moe_state_from_hf`. Splits the fused
+    ``w_up_gate`` routed-expert weight into per-expert HF ``up_proj``/``gate_proj``
+    and reshapes ``w_down`` into per-expert HF ``down_proj``.
+
+    :param config: The Hugging Face ``Olmo3MoeConfig``.
+    :param olmo_core_state: An unsharded OLMo-core model state dict.
+    """
+    _require_no_peri_ln(config)
+
+    n_layers: int = config.num_hidden_layers
+    n_experts: int = config.n_routed_experts
+    d_model: int = config.hidden_size
+    moe_hidden: int = config.moe_intermediate_size
+    dense_indices = _olmo3moe_dense_layer_indices(config)
+    has_shared = getattr(config, "shared_expert_intermediate_size", None) is not None
+    shared_hidden = getattr(config, "shared_expert_intermediate_size", None)
+
+    hf_state: Dict[str, Any] = {}
+
+    hf_state["model.embed_tokens.weight"] = olmo_core_state["embeddings.weight"]
+    hf_state["model.norm.weight"] = olmo_core_state["lm_head.norm.weight"]
+    hf_state["lm_head.weight"] = olmo_core_state["lm_head.w_out.weight"]
+    if getattr(config, "embed_norm", False):
+        hf_state["model.embed_norm.weight"] = olmo_core_state["embedding_norm.weight"]
+
+    for layer_idx in range(n_layers):
+        prefix = f"model.layers.{layer_idx}."
+        olmo_prefix = f"blocks.{layer_idx}."
+
+        hf_state[f"{prefix}self_attn.q_proj.weight"] = olmo_core_state[
+            f"{olmo_prefix}attention.w_q.weight"
+        ]
+        hf_state[f"{prefix}self_attn.k_proj.weight"] = olmo_core_state[
+            f"{olmo_prefix}attention.w_k.weight"
+        ]
+        hf_state[f"{prefix}self_attn.v_proj.weight"] = olmo_core_state[
+            f"{olmo_prefix}attention.w_v.weight"
+        ]
+        hf_state[f"{prefix}self_attn.o_proj.weight"] = olmo_core_state[
+            f"{olmo_prefix}attention.w_out.weight"
+        ]
+        hf_state[f"{prefix}self_attn.q_norm.weight"] = olmo_core_state[
+            f"{olmo_prefix}attention.q_norm.weight"
+        ]
+        hf_state[f"{prefix}self_attn.k_norm.weight"] = olmo_core_state[
+            f"{olmo_prefix}attention.k_norm.weight"
+        ]
+
+        hf_state[f"{prefix}post_attention_layernorm.weight"] = olmo_core_state[
+            f"{olmo_prefix}attention_norm.weight"
+        ]
+        hf_state[f"{prefix}post_feedforward_layernorm.weight"] = olmo_core_state[
+            f"{olmo_prefix}feed_forward_norm.weight"
+        ]
+
+        if layer_idx in dense_indices:
+            hf_state[f"{prefix}mlp.gate_proj.weight"] = olmo_core_state[
+                f"{olmo_prefix}feed_forward.w1.weight"
+            ]
+            hf_state[f"{prefix}mlp.down_proj.weight"] = olmo_core_state[
+                f"{olmo_prefix}feed_forward.w2.weight"
+            ]
+            hf_state[f"{prefix}mlp.up_proj.weight"] = olmo_core_state[
+                f"{olmo_prefix}feed_forward.w3.weight"
+            ]
+            continue
+
+        # Router: OLMo-core stores it flattened (E * D,); HF gate weight is (E, D).
+        hf_state[f"{prefix}mlp.router.gate.weight"] = olmo_core_state[
+            f"{olmo_prefix}routed_experts_router.weight"
+        ].reshape(n_experts, d_model)
+
+        # Routed experts: split fused (E, 2H, D) into per-expert up/gate (H, D), up first.
+        w_up_gate = olmo_core_state[f"{olmo_prefix}routed_experts.w_up_gate"].reshape(
+            n_experts, 2 * moe_hidden, d_model
+        )
+        w_up = w_up_gate[:, :moe_hidden, :]  # (E, H, D)
+        w_gate = w_up_gate[:, moe_hidden:, :]  # (E, H, D)
+        w_down = olmo_core_state[f"{olmo_prefix}routed_experts.w_down"].reshape(
+            n_experts, moe_hidden, d_model
+        )
+        for e in range(n_experts):
+            hf_state[f"{prefix}mlp.experts.{e}.up_proj.weight"] = w_up[e].contiguous()
+            hf_state[f"{prefix}mlp.experts.{e}.gate_proj.weight"] = w_gate[e].contiguous()
+            hf_state[f"{prefix}mlp.experts.{e}.down_proj.weight"] = w_down[
+                e
+            ].T.contiguous()  # (D, H)
+
+        # Shared expert (single expert): fused (D, 2H) -> HF up/gate (H, D), up first.
+        if has_shared:
+            assert shared_hidden is not None
+            shared_up_gate = olmo_core_state[f"{olmo_prefix}shared_experts.w_up_gate"].reshape(
+                d_model, 2 * shared_hidden
+            )
+            shared_up = shared_up_gate[:, :shared_hidden]  # (D, H)
+            shared_gate = shared_up_gate[:, shared_hidden:]  # (D, H)
+            hf_state[
+                f"{prefix}mlp.shared_expert.up_proj.weight"
+            ] = shared_up.T.contiguous()  # (H, D)
+            hf_state[
+                f"{prefix}mlp.shared_expert.gate_proj.weight"
+            ] = shared_gate.T.contiguous()  # (H, D)
+            shared_down = olmo_core_state[f"{olmo_prefix}shared_experts.w_down"].reshape(
+                shared_hidden, d_model
+            )
+            hf_state[
+                f"{prefix}mlp.shared_expert.down_proj.weight"
+            ] = shared_down.T.contiguous()  # (D, H)
+
+    return hf_state
+
+
 def _convert_state(
     config: PretrainedConfig,
     state: Dict[str, Any],
@@ -708,6 +986,9 @@ def convert_state_from_hf(
 
     if model_type in {"qwen3_5", "qwen3_5_text"}:
         return convert_qwen3_5_state_from_hf(config, hf_state)
+
+    if model_type == "olmo3moe":
+        return convert_olmo3moe_state_from_hf(config, hf_state)
 
     converted_state = _convert_state(config, hf_state, converter)
 
@@ -780,6 +1061,9 @@ def convert_state_to_hf(
     :param olmo_core_state: An unsharded OLMo Core model state dict. None of the states can be
         :class:`DTensor` or :class:`ShardedTensor`
     """
+
+    if config.model_type == "olmo3moe":
+        return convert_olmo3moe_state_to_hf(config, olmo_core_state)
 
     converter = _get_converter_to_hf(config.model_type)
 

--- a/src/olmo_core/nn/moe/v2/hf/configuration_olmo3moe.py
+++ b/src/olmo_core/nn/moe/v2/hf/configuration_olmo3moe.py
@@ -1,0 +1,152 @@
+from typing import List, Optional
+
+from transformers.configuration_utils import PretrainedConfig, layer_type_validation
+from transformers.modeling_rope_utils import rope_config_validation
+
+
+class Olmo3MoeConfig(PretrainedConfig):
+    model_type = "olmo3moe"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    base_model_tp_plan = {
+        "layers.*.self_attn.q_proj": "colwise_rep",  # we need to replicate here due to the added norm on q and k
+        "layers.*.self_attn.k_proj": "colwise_rep",  # we need to replicate here due to the added norm on q and k
+        "layers.*.self_attn.v_proj": "colwise_rep",  # we need to replicate here due to the added norm on q and k
+        "layers.*.self_attn.o_proj": "rowwise_rep",  # we need to replicate here due to the added norm on q and k
+        "layers.*.mlp.gate_proj": "colwise",
+        "layers.*.mlp.up_proj": "colwise",
+        "layers.*.mlp.down_proj": "rowwise",
+    }
+    base_model_pp_plan = {
+        "embed_tokens": (["input_ids"], ["inputs_embeds"]),
+        "layers": (["hidden_states", "attention_mask"], ["hidden_states"]),
+        "norm": (["hidden_states"], ["hidden_states"]),
+    }
+
+    def __init__(
+        self,
+        vocab_size=50304,
+        hidden_size=4096,
+        attention_hidden_size=4096,
+        head_dim=None,
+        dense_mlp_intermediate_size=11008,
+        moe_intermediate_size=2048,
+        shared_expert_intermediate_size=2048,
+        n_routed_experts=64,
+        num_experts_per_tok=4,
+        original_num_experts_per_tok=None,
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        num_key_value_heads=None,
+        hidden_act="silu",
+        gating_function="softmax",
+        normalize_expert_weights=1.0,
+        restore_weight_scale=True,
+        max_position_embeddings=2048,
+        initializer_range=0.02,
+        use_cache=True,
+        pad_token_id=1,
+        bos_token_id=None,
+        eos_token_id=50279,
+        tie_word_embeddings=False,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        attention_bias=False,
+        attention_dropout=0.0,
+        rms_norm_eps=1e-5,
+        sliding_window=4096,
+        use_head_qk_norm=False,
+        layer_types: Optional[List[str]] = None,
+        dense_layers_indices: Optional[List[int]] = None,
+        embed_scale=1.0,
+        embed_norm=False,
+        use_peri_ln=False,
+        **kwargs,
+    ):
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.attention_hidden_size = (
+            attention_hidden_size if attention_hidden_size is not None else hidden_size
+        )
+        self.head_dim = (
+            head_dim if head_dim is not None else self.attention_hidden_size // num_attention_heads
+        )
+
+        # for dense MLP layers
+        self.dense_mlp_intermediate_size = dense_mlp_intermediate_size
+
+        # for sparse MLP layers
+        self.moe_intermediate_size = moe_intermediate_size
+        self.shared_expert_intermediate_size = (
+            shared_expert_intermediate_size  # if None, no shared experts
+        )
+        self.n_routed_experts = n_routed_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.original_num_experts_per_tok = original_num_experts_per_tok
+        assert gating_function in [
+            "softmax",
+            "sigmoid",
+        ], "supported gating function: 'softmax' or 'sigmoid'"
+        self.gating_function = gating_function
+        self.normalize_expert_weights = normalize_expert_weights
+        self.restore_weight_scale = restore_weight_scale
+
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+
+        # for backward compatibility
+        if num_key_value_heads is None:
+            num_key_value_heads = num_attention_heads
+
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self._rope_scaling_validation()
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+
+        self.rms_norm_eps = rms_norm_eps
+        self.use_head_qk_norm = use_head_qk_norm
+
+        self.embed_scale = embed_scale
+        self.embed_norm = embed_norm
+        self.use_peri_ln = use_peri_ln
+
+        self.sliding_window = sliding_window
+        self.layer_types: List[str]
+        if layer_types is None:
+            self.layer_types = [
+                "sliding_attention" if (i + 1) % 2 != 0 else "full_attention"
+                for i in range(self.num_hidden_layers)
+            ]
+        else:
+            self.layer_types = layer_types
+
+        layer_type_validation(self.layer_types)
+
+        self.dense_layers_indices = (
+            dense_layers_indices
+            if dense_layers_indices is not None
+            else [
+                0,
+            ]
+        )
+
+    def _rope_scaling_validation(self):
+        """
+        Validate the `rope_scaling` configuration.
+        """
+        rope_config_validation(self)
+
+
+__all__ = ["Olmo3MoeConfig"]

--- a/src/olmo_core/nn/moe/v2/hf/modeling_olmo3moe.py
+++ b/src/olmo_core/nn/moe/v2/hf/modeling_olmo3moe.py
@@ -1,0 +1,706 @@
+from collections.abc import Callable
+from typing import Optional, Union, cast
+
+import torch
+import torch.nn as nn
+from transformers.activations import ACT2FN
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.generation.utils import GenerationMixin
+from transformers.masking_utils import (
+    create_causal_mask,
+    create_sliding_window_causal_mask,
+)
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
+from transformers.models.olmo3.modeling_olmo3 import eager_attention_forward
+from transformers.processing_utils import Unpack
+from transformers.utils.auto_docstring import auto_docstring
+from transformers.utils.deprecation import deprecate_kwarg
+from transformers.utils.generic import TransformersKwargs, can_return_tuple
+
+from .configuration_olmo3moe import Olmo3MoeConfig
+
+
+class Olmo3MoeRotaryEmbedding(nn.Module):
+    inv_freq: torch.Tensor  # fix linting for `register_buffer`
+
+    def __init__(self, config: Olmo3MoeConfig, device=None):
+        super().__init__()
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+
+        self.rope_type = self.config.rope_parameters["rope_type"]
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, device)
+
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
+
+    @staticmethod
+    def compute_default_rope_parameters(
+        config: Olmo3MoeConfig | None = None,
+        device: Optional["torch.device"] = None,
+        seq_len: int | None = None,
+    ) -> tuple["torch.Tensor", float]:
+        """
+        Computes the inverse frequencies according to the original RoPE implementation
+        Args:
+            config ([`~transformers.PreTrainedConfig`]):
+                The model configuration.
+            device (`torch.device`):
+                The device to use for initialization of the inverse frequencies.
+            seq_len (`int`, *optional*):
+                The current sequence length. Unused for this type of RoPE.
+        Returns:
+            Tuple of (`torch.Tensor`, `float`), containing the inverse frequencies for the RoPE embeddings and the
+            post-processing scaling factor applied to the computed cos/sin (unused in this type of RoPE).
+        """
+        assert config is not None
+        base = config.rope_parameters["rope_theta"]
+        dim = (
+            getattr(config, "head_dim", None)
+            or config.attention_hidden_size // config.num_attention_heads
+        )
+
+        attention_factor = 1.0  # Unused in this type of RoPE
+
+        # Compute the inverse frequencies
+        inv_freq = 1.0 / (
+            base
+            ** (
+                torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+                / dim
+            )
+        )
+        return inv_freq, attention_factor
+
+    @torch.no_grad()
+    @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
+    def forward(self, x, position_ids):
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = (
+            x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        )
+        with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+            return cos, sin
+
+
+class Olmo3MoeDenseMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.dense_mlp_intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        return down_proj
+
+
+class Olmo3MoeExpert(nn.Module):
+    def __init__(self, hidden_size, moe_intermediate_size, hidden_act):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.moe_intermediate_size = moe_intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.moe_intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.moe_intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.moe_intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[hidden_act]
+
+    def forward(self, x):
+        down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        return down_proj
+
+
+class Olmo3MoeExperts(nn.ModuleList):
+    """Container for routed experts.
+
+    vLLM detects a child module named ``experts`` that is a ``ModuleList`` and
+    replaces it with a fused implementation at load time (TransformersFusedMoE).
+    This class provides an eager reference implementation, and a compile-safe
+    fallback (very slow) to avoid TorchDynamo graph breaks if it is ever traced.
+    """
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,  # (N, H)
+        topk_ids: torch.Tensor,  # (N, K)
+        topk_weights: torch.Tensor,  # (N, K)
+    ) -> torch.Tensor:
+        # Use a compile-safe fallback if TorchDynamo is tracing this module.
+        # NOTE: This is extremely slow because it runs every expert on every token.
+        try:
+            is_compiling = torch._dynamo.is_compiling()
+        except Exception:
+            is_compiling = False
+
+        if is_compiling:
+            out = hidden_states.new_zeros(hidden_states.shape)
+            for expert_id, expert in enumerate(self):
+                # Aggregate the routing weights for this expert across the K slots.
+                w = (topk_weights * (topk_ids == expert_id).to(topk_weights.dtype)).sum(
+                    dim=1, keepdim=True
+                )  # (N, 1)
+                out = out + expert(hidden_states) * w
+            return out
+
+        # Eager reference routing (faster), but uses data-dependent shapes.
+        N, H = hidden_states.shape
+        out = hidden_states.new_zeros((N, H))
+        for expert_id, expert in enumerate(self):
+            mask = topk_ids == expert_id  # (N, K) bool
+            if not mask.any():
+                continue
+            token_ids, k_ids = mask.nonzero(as_tuple=True)  # both (M,)
+            x_sel = hidden_states.index_select(0, token_ids)  # (M, H)
+            y_sel = expert(x_sel)  # (M, H)
+            w_sel = (
+                topk_weights[token_ids, k_ids].unsqueeze(-1).to(dtype=hidden_states.dtype)
+            )  # (M, 1)
+            out.index_add_(0, token_ids, y_sel * w_sel)
+        return out
+
+
+class Olmo3MoeSparseMLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.router = Olmo3MoeRouter(config)
+        self.experts = Olmo3MoeExperts()
+        for _ in range(config.n_routed_experts):
+            expert = Olmo3MoeExpert(
+                hidden_size=config.hidden_size,
+                moe_intermediate_size=config.moe_intermediate_size,
+                hidden_act=config.hidden_act,
+            )
+            self.experts.append(expert)
+        self.shared_expert: Optional[Olmo3MoeExpert]
+        if config.shared_expert_intermediate_size is not None:
+            self.shared_expert = Olmo3MoeExpert(
+                hidden_size=config.hidden_size,
+                moe_intermediate_size=config.shared_expert_intermediate_size,
+                hidden_act=config.hidden_act,
+            )
+        else:
+            self.shared_expert = None
+
+    def forward(self, x):
+        # x: (batch_size, seq_len, hidden_size)
+        B, S, H = x.shape
+
+        # Compute gating weights and expert indices
+        # expert_weights: (batch_size, seq_len, top_k)
+        # expert_indices: (batch_size, seq_len, top_k)
+        expert_weights, expert_indices = self.router(x)
+        K = expert_indices.size(-1)
+        # Flatten tokens: N = B*S. vLLM's fused experts expects (N, H), (N, K), (N, K).
+        x_flat = x.reshape(B * S, H)  # (N, H)
+        idx_flat = expert_indices.reshape(B * S, K)  # (N, K)
+        w_flat = expert_weights.reshape(B * S, K).to(dtype=x.dtype)  # (N, K)
+
+        out_flat = self.experts(x_flat, topk_ids=idx_flat, topk_weights=w_flat)  # (N, H)
+        routed_expert_out = out_flat.view(B, S, H)
+
+        # shared expert
+        if self.shared_expert is None:
+            out = routed_expert_out
+        else:
+            shared_expert_out = self.shared_expert(x)
+            out = routed_expert_out + shared_expert_out
+
+        return out
+
+
+class Olmo3MoeRouter(nn.Module):
+    def __init__(self, config: Olmo3MoeConfig):
+        super().__init__()
+        self.config = config
+        self.gating_function = config.gating_function
+        self.hidden_size = config.hidden_size
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.original_num_experts_per_tok = config.original_num_experts_per_tok
+        self.gate = nn.Linear(self.hidden_size, config.n_routed_experts, bias=False)
+        self.normalize_expert_weights = config.normalize_expert_weights
+        self.restore_weight_scale = config.restore_weight_scale
+
+    def forward(self, x):
+        logits = self.gate(x)
+
+        if self.gating_function == "softmax":
+            scores = logits.softmax(dim=-1)
+        elif self.gating_function == "sigmoid":
+            scores = torch.sigmoid(logits)
+            # to avoid NaNs in the load balancing loss
+            # if all logits of a token are very negative for all experts, sigmoid gives 0 for all experts, causing NaNs when we div by the sum.
+            scores = scores + 1e-7
+        else:
+            raise NotImplementedError(self.gating_function)
+
+        expert_weights, expert_indices = torch.topk(scores, self.num_experts_per_tok, dim=-1)
+
+        if self.normalize_expert_weights is not None:
+            expert_weights = expert_weights.div(
+                torch.norm(
+                    expert_weights,
+                    p=self.normalize_expert_weights,
+                    dim=-1,
+                    keepdim=True,
+                )
+            )
+
+        if self.restore_weight_scale:
+            expert_weights = expert_weights * self.num_experts_per_tok
+
+        if (
+            self.original_num_experts_per_tok is not None
+            and self.num_experts_per_tok != self.original_num_experts_per_tok
+        ):
+            expert_weights = (
+                expert_weights
+                * (self.original_num_experts_per_tok / self.num_experts_per_tok) ** 0.5
+            )
+
+        return expert_weights, expert_indices
+
+
+class Olmo3MoeDecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: Olmo3MoeConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = Olmo3MoeAttention(config=config, layer_idx=layer_idx)
+
+        if layer_idx in config.dense_layers_indices:
+            self.mlp = Olmo3MoeDenseMLP(config)
+        else:
+            self.mlp = Olmo3MoeSparseMLP(config)
+
+        self.post_attention_layernorm = Olmo3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = Olmo3MoeRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+        self.pre_attention_layernorm: Optional[Olmo3MoeRMSNorm]
+        self.pre_feedforward_layernorm: Optional[Olmo3MoeRMSNorm]
+        if config.use_peri_ln:
+            self.pre_attention_layernorm = Olmo3MoeRMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.pre_feedforward_layernorm = Olmo3MoeRMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+        else:
+            self.pre_attention_layernorm = None
+            self.pre_feedforward_layernorm = None
+
+    @deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[
+            tuple[torch.Tensor, torch.Tensor]
+        ] = None,  # necessary, but kept here for BC
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        if self.pre_attention_layernorm is not None:
+            hidden_states = self.pre_attention_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        if self.pre_feedforward_layernorm is not None:
+            hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    q_type, k_type = q.dtype, k.dtype
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.to(q_type), k_embed.to(k_type)
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+class Olmo3MoeAttention(nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
+    def __init__(self, config: Olmo3MoeConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(
+            config, "head_dim", config.attention_hidden_size // config.num_attention_heads
+        )
+        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = True
+        self.use_head_qk_norm = config.use_head_qk_norm
+
+        self.q_proj = nn.Linear(
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        if config.use_head_qk_norm:
+            self.q_norm = Olmo3MoeRMSNorm(self.head_dim, config.rms_norm_eps)
+            self.k_norm = Olmo3MoeRMSNorm(self.head_dim, config.rms_norm_eps)
+        else:
+            self.q_norm = Olmo3MoeRMSNorm(
+                config.num_attention_heads * self.head_dim, config.rms_norm_eps
+            )
+            self.k_norm = Olmo3MoeRMSNorm(
+                config.num_key_value_heads * self.head_dim, config.rms_norm_eps
+            )
+        assert config.layer_types is not None
+        self.attention_type = config.layer_types[layer_idx]
+        self.sliding_window = (
+            config.sliding_window if self.attention_type == "sliding_attention" else None
+        )
+
+    @deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        # QK norm behavior:
+        # - use_head_qk_norm=False: normalize over the flattened projection dim (matches File 1 "full-dim" norm path)
+        # - use_head_qk_norm=True: reshape into heads first, then normalize per head over head_dim (matches File 1 head-wise path)
+        if not self.use_head_qk_norm:
+            query_states = self.q_norm(query_states)
+            key_states = self.k_norm(key_states)
+
+        query_states = query_states.view(hidden_shape).transpose(1, 2)  # (B, n_heads, T, head_dim)
+        key_states = key_states.view(hidden_shape).transpose(1, 2)  # (B, n_kv_heads, T, head_dim)
+        value_states = value_states.view(hidden_shape).transpose(
+            1, 2
+        )  # (B, n_kv_heads, T, head_dim)
+
+        if self.use_head_qk_norm:
+            query_states = self.q_norm(query_states.contiguous())
+            key_states = self.k_norm(key_states.contiguous())
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        if past_key_values is not None:
+            # sin and cos are specific to RoPE models; cache_position needed for the static cache
+            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+            key_states, value_states = past_key_values.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+@auto_docstring
+class Olmo3MoePreTrainedModel(PreTrainedModel):
+    config: Olmo3MoeConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Olmo3MoeDecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = True
+
+    _can_compile_fullgraph = True
+    _supports_attention_backend = True
+    _can_record_outputs = {
+        "hidden_states": Olmo3MoeDecoderLayer,
+        "attentions": Olmo3MoeAttention,
+    }
+
+
+class Olmo3MoeRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return (self.weight * hidden_states).to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+@auto_docstring
+class Olmo3MoeModel(Olmo3MoePreTrainedModel):
+    def __init__(self, config: Olmo3MoeConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+
+        self.embed_scale = config.embed_scale
+        self.embed_norm = (
+            Olmo3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if config.embed_norm
+            else None
+        )
+
+        self.layers = nn.ModuleList(
+            [
+                Olmo3MoeDecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = Olmo3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.gradient_checkpointing = False
+        self.rotary_embs = Olmo3MoeRotaryEmbedding(config=config)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    @auto_docstring
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        cache_position: Optional[torch.Tensor] = None,
+        use_cache: Optional[bool] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BaseModelOutputWithPast:
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+            assert inputs_embeds is not None
+            inputs_embeds = inputs_embeds * self.embed_scale
+            if self.embed_norm is not None:
+                inputs_embeds = self.embed_norm(inputs_embeds)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
+        if cache_position is None:
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
+            assert inputs_embeds is not None
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        # It may already have been prepared by e.g. `generate`
+        if not isinstance(causal_mask_mapping := attention_mask, dict):
+            # Prepare mask arguments
+            mask_kwargs = {
+                "config": self.config,
+                "input_embeds": inputs_embeds,
+                "attention_mask": attention_mask,
+                "cache_position": cache_position,
+                "past_key_values": past_key_values,
+                "position_ids": position_ids,
+            }
+            # Create the masks
+            causal_mask_mapping = {
+                "full_attention": create_causal_mask(**mask_kwargs),
+                "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+            }
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_embs(hidden_states, position_ids)
+
+        for decoder_layer in self.layers:
+            # if used in vllm with PP, a few layers will be replaced by PPMissingLayer(), which just passes the inputs through, so we need to skip the attention mask and position embeddings in that case
+            if not isinstance(decoder_layer, Olmo3MoeDecoderLayer):
+                hidden_states = decoder_layer(hidden_states)
+                continue
+
+            decoder_layer = cast(Olmo3MoeDecoderLayer, decoder_layer)
+            attention_mask = causal_mask_mapping[decoder_layer.self_attn.attention_type]
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+        )
+
+
+@auto_docstring
+class Olmo3MoeForCausalLM(Olmo3MoePreTrainedModel, GenerationMixin):
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    _tp_plan = {"lm_head": "colwise_rep"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = Olmo3MoeModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    @can_return_tuple
+    @auto_docstring
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> CausalLMOutputWithPast:
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        slice_indices = (
+            slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        )
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+
+__all__ = [
+    "Olmo3MoeConfig",
+    "Olmo3MoeForCausalLM",
+    "Olmo3MoeModel",
+    "Olmo3MoePreTrainedModel",
+]

--- a/src/olmo_core/nn/moe/v2/hf/modeling_olmo3moe.py
+++ b/src/olmo_core/nn/moe/v2/hf/modeling_olmo3moe.py
@@ -595,7 +595,7 @@ class Olmo3MoeModel(Olmo3MoePreTrainedModel):
             # Prepare mask arguments
             mask_kwargs = {
                 "config": self.config,
-                "input_embeds": inputs_embeds,
+                "inputs_embeds": inputs_embeds,
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,

--- a/src/olmo_core/nn/moe/v2/hf/modeling_olmo3moe.py
+++ b/src/olmo_core/nn/moe/v2/hf/modeling_olmo3moe.py
@@ -593,11 +593,12 @@ class Olmo3MoeModel(Olmo3MoePreTrainedModel):
         # It may already have been prepared by e.g. `generate`
         if not isinstance(causal_mask_mapping := attention_mask, dict):
             # Prepare mask arguments
+            # ``cache_position`` was dropped from the mask builders in transformers >5.6 (it was
+            # already unused before that), so we don't pass it.
             mask_kwargs = {
                 "config": self.config,
                 "inputs_embeds": inputs_embeds,
                 "attention_mask": attention_mask,
-                "cache_position": cache_position,
                 "past_key_values": past_key_values,
                 "position_ids": position_ids,
             }

--- a/src/test/nn/hf/olmo3moe_conversion_test.py
+++ b/src/test/nn/hf/olmo3moe_conversion_test.py
@@ -1,0 +1,90 @@
+"""
+Roundtrip tests for the ``olmo3moe`` <-> OLMo-core MoE-v2 state-dict conversion.
+
+These exercise the conversion functions directly on synthetic tensor dicts with a stub config, so
+they don't require ``transformers`` or a built model — they verify the HF<->OLMo-core mapping is a
+faithful bijection (including the fused ``w_up_gate`` split and the mixed dense/MoE layer layout).
+"""
+
+import types
+
+import pytest
+import torch
+
+from olmo_core.nn.hf.convert import (
+    convert_olmo3moe_state_from_hf,
+    convert_olmo3moe_state_to_hf,
+)
+
+
+def _fake_config():
+    # Distinct hidden sizes (dense/moe/shared) so a transpose or shape slip can't roundtrip by
+    # accident. Layer 0 is dense, layer 1 is MoE.
+    return types.SimpleNamespace(
+        num_hidden_layers=2,
+        n_routed_experts=3,
+        hidden_size=8,
+        moe_intermediate_size=5,
+        shared_expert_intermediate_size=4,
+        dense_layers_indices=[0],
+        embed_norm=True,
+        use_peri_ln=False,
+    )
+
+
+def _synthetic_hf_state(config):
+    torch.manual_seed(0)
+    d = config.hidden_size
+    e = config.n_routed_experts
+    h = config.moe_intermediate_size
+    hs = config.shared_expert_intermediate_size
+    vocab, dense_h = 6, 7
+    dense = set(config.dense_layers_indices)
+
+    hf = {
+        "model.embed_tokens.weight": torch.randn(vocab, d),
+        "model.norm.weight": torch.randn(d),
+        "lm_head.weight": torch.randn(vocab, d),
+        "model.embed_norm.weight": torch.randn(d),
+    }
+    for layer in range(config.num_hidden_layers):
+        p = f"model.layers.{layer}."
+        for proj in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            hf[f"{p}self_attn.{proj}.weight"] = torch.randn(d, d)
+        for norm in ("q_norm", "k_norm"):
+            hf[f"{p}self_attn.{norm}.weight"] = torch.randn(d)
+        hf[f"{p}post_attention_layernorm.weight"] = torch.randn(d)
+        hf[f"{p}post_feedforward_layernorm.weight"] = torch.randn(d)
+        if layer in dense:
+            hf[f"{p}mlp.gate_proj.weight"] = torch.randn(dense_h, d)
+            hf[f"{p}mlp.up_proj.weight"] = torch.randn(dense_h, d)
+            hf[f"{p}mlp.down_proj.weight"] = torch.randn(d, dense_h)
+        else:
+            hf[f"{p}mlp.router.gate.weight"] = torch.randn(e, d)
+            for expert in range(e):
+                hf[f"{p}mlp.experts.{expert}.up_proj.weight"] = torch.randn(h, d)
+                hf[f"{p}mlp.experts.{expert}.gate_proj.weight"] = torch.randn(h, d)
+                hf[f"{p}mlp.experts.{expert}.down_proj.weight"] = torch.randn(d, h)
+            hf[f"{p}mlp.shared_expert.up_proj.weight"] = torch.randn(hs, d)
+            hf[f"{p}mlp.shared_expert.gate_proj.weight"] = torch.randn(hs, d)
+            hf[f"{p}mlp.shared_expert.down_proj.weight"] = torch.randn(d, hs)
+    return hf
+
+
+def test_olmo3moe_hf_conversion_roundtrips():
+    config = _fake_config()
+    hf = _synthetic_hf_state(config)
+
+    olmo = convert_olmo3moe_state_from_hf(config, hf)
+    hf_roundtrip = convert_olmo3moe_state_to_hf(config, olmo)
+
+    assert set(hf_roundtrip.keys()) == set(hf.keys())
+    for key, tensor in hf.items():
+        assert torch.equal(hf_roundtrip[key], tensor), f"roundtrip mismatch for '{key}'"
+
+
+def test_olmo3moe_conversion_rejects_peri_ln():
+    config = _fake_config()
+    config.use_peri_ln = True
+    with pytest.raises(NotImplementedError, match="use_peri_ln"):
+        convert_olmo3moe_state_from_hf(config, {})

--- a/src/test/nn/hf/olmo3moe_modeling_test.py
+++ b/src/test/nn/hf/olmo3moe_modeling_test.py
@@ -1,0 +1,79 @@
+"""
+Forward/parity test for the ``olmo3moe`` HF model + its conversion.
+
+Builds a small ``Olmo3MoeForCausalLM`` in memory, runs its forward, then does a full
+``HF -> OLMo-core -> HF`` conversion roundtrip and checks the reloaded model produces the same
+logprobs. This exercises the ``modeling_olmo3moe`` forward and validates the conversion against the
+model's real parameter set (strict ``load_state_dict``). Requires ``transformers``.
+"""
+
+import pytest
+import torch
+
+
+def _has_olmo3moe() -> bool:
+    try:
+        from olmo_core.nn.moe.v2.hf.modeling_olmo3moe import (  # noqa: F401
+            Olmo3MoeForCausalLM,
+        )
+
+        return True
+    except ImportError:
+        return False
+
+
+requires_olmo3moe = pytest.mark.skipif(
+    not _has_olmo3moe(), reason="requires transformers (for the olmo3moe HF model)"
+)
+
+
+def _small_config():
+    from olmo_core.nn.moe.v2.hf.configuration_olmo3moe import Olmo3MoeConfig
+
+    # Layer 0 is dense, layer 1 is MoE (dense_layers_indices=[0]); head qk-norm on so the
+    # q_norm/k_norm params the converter maps exist.
+    return Olmo3MoeConfig(
+        vocab_size=64,
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=16,
+        dense_mlp_intermediate_size=16,
+        shared_expert_intermediate_size=16,
+        max_position_embeddings=32,
+        use_head_qk_norm=True,
+        dense_layers_indices=[0],
+    )
+
+
+@requires_olmo3moe
+def test_olmo3moe_logprobs_match_after_conversion_roundtrip():
+    from olmo_core.nn.hf.convert import convert_state_from_hf, convert_state_to_hf
+    from olmo_core.nn.moe.v2.hf.modeling_olmo3moe import Olmo3MoeForCausalLM
+
+    config = _small_config()
+    model = Olmo3MoeForCausalLM(config)
+    model.eval()
+
+    input_ids = torch.randint(
+        0, config.vocab_size, (1, 8), generator=torch.Generator().manual_seed(0)
+    )
+    with torch.no_grad():
+        ref_logits = model(input_ids).logits
+    ref_logprobs = torch.log_softmax(ref_logits, dim=-1)
+
+    hf_state = {k: v.detach().cpu().clone() for k, v in model.state_dict().items()}
+    oc_state = convert_state_from_hf(config, hf_state, model_type="olmo3moe")
+    hf_roundtrip = convert_state_to_hf(config, oc_state)
+
+    model.load_state_dict(hf_roundtrip, strict=True)
+    model.eval()
+    with torch.no_grad():
+        rt_logits = model(input_ids).logits
+    rt_logprobs = torch.log_softmax(rt_logits, dim=-1)
+
+    torch.testing.assert_close(rt_logprobs, ref_logprobs, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
Adds HuggingFace interop for the MoE-v2 model (C5, the last Tier C piece). Two parts:

## 1. The `olmo3moe` HF model (`nn/moe/v2/hf/`)
`configuration_olmo3moe.py` (`Olmo3MoeConfig`, `model_type="olmo3moe"`) + `modeling_olmo3moe.py` (`Olmo3Moe*` `PreTrainedModel`) — a **custom transformers-style implementation**, required because `transformers` has no OLMoE-MoE architecture to map to (it reuses `transformers.models.olmo3` for the dense parts). Self-contained (only `transformers` + the sibling config; no `olmo_core` imports), so it can be published as custom HF-Hub code. Ported ~verbatim from the dev branch.

## 2. Checkpoint conversion wired into core's `nn/hf/` framework
Per the design decision, conversion goes through core's existing `nn/hf/` system rather than dev's standalone `convert_checkpoint.py`:
- `convert_olmo3moe_state_from_hf` / `_to_hf` in `nn/hf/convert.py`, dispatched for `model_type="olmo3moe"`. These are **standalone functions** (like the existing `convert_qwen3_5_state_from_hf`) because the fused routed-expert weight `w_up_gate` of shape `(E, 2H, D)` ↔ per-expert HF `gate_proj`/`up_proj` requires a slice+per-expert split that the `StateMappingTemplate` pipeline (cat→unflatten→permute→flatten→chunk, no slice) can't express.
- `Olmo3MoeConfig` builder in `nn/hf/config.py`, mirroring the v1-MoE `_get_flex_olmo_config`.
- Covers attention (q/k/v/o + q/k norm), reordered norms, embeddings/lm_head/embed_norm, router, shared experts, mixed dense/MoE layers, and the fused routed-expert split. All mappings grounded in dev's `convert_checkpoint.py` (the source of truth) — nothing invented.

The 6 dev scratch scripts (`cmp_*`, `generate_copylabels_*`, `test_*copycolors/copylabels/dynamick`) are intentionally excluded (ad-hoc experiment drivers, 0 pytest funcs).

## Testing
`olmo3moe_conversion_test.py` — a synthetic **roundtrip** test (stub config + tensor dicts, **no transformers needed**) asserting the HF↔olmo-core mapping is a faithful bijection (incl. the fused `w_up_gate` split, mixed dense/MoE layers, shared expert), plus that peri-LN is rejected. I validated the roundtrip locally (bijection holds, zero mismatches) by loading `convert.py` in isolation — my venv's `transformers`/`hf_hub` is skewed so the module can't import here normally, but the CPU `Test` CI job (installs `.[all]`) will run it.

## Known limitations (flagged, not guessed)
- **peri-LN (`use_peri_ln=True`) conversion is rejected** (`NotImplementedError`): peri-LN maps the same OLMo-core norm to different HF layernorms depending on dense vs MoE layer, which the converter treats uniformly.
- `rms_norm_eps` is read from `feed_forward_norm.eps` (assumes all norms share one eps, matching dev).
- `max_position_embeddings` is `-1` (matches the sibling `get_hf_config` builders; not available off the model).
- The `modeling_olmo3moe.py` forward isn't exercised here (needs transformers + a real forward); a GPU/transformers parity test is a follow-up.