### PR TITLE
Add opt-in non-finite grad-norm diagnostics to OLMoDDPOptimizer

### DIFF
--- a/src/olmo_core/kernels/build_symm_mem_vdev2d_ext.py
+++ b/src/olmo_core/kernels/build_symm_mem_vdev2d_ext.py
@@ -10,6 +10,9 @@ import sysconfig
 from pathlib import Path
 
 
+# Local copy (not olmo_core.utils.env_bool) to keep this build entrypoint stdlib-only: it runs as
+# `python -m olmo_core.kernels.build_symm_mem_vdev2d_ext` at image-build time and must not import
+# olmo_core (and hence torch).
 def _env_bool(name: str, default: bool = False) -> bool:
     raw = os.getenv(name)
     if raw is None:

--- a/src/olmo_core/kernels/cuda_extension_utils.py
+++ b/src/olmo_core/kernels/cuda_extension_utils.py
@@ -19,24 +19,13 @@ from typing import Any, Callable, Dict, Optional, Sequence, Union
 
 import torch
 
+from olmo_core.utils import env_bool
+
 log = logging.getLogger(__name__)
 
 __all__ = ["load_cuda_extension", "LazyCudaExtension"]
 
 PathLikeStr = Union[str, os.PathLike[str]]
-
-
-def _env_bool(names: Sequence[str], default: bool = False) -> bool:
-    for name in names:
-        raw = os.getenv(name)
-        if raw is None:
-            continue
-        lowered = raw.strip().lower()
-        if lowered in {"1", "true", "yes", "on"}:
-            return True
-        if lowered in {"0", "false", "no", "off"}:
-            return False
-    return default
 
 
 def _env_float(names: Sequence[str], default: float) -> float:
@@ -235,9 +224,9 @@ def load_cuda_extension(
         _env_float(stale_lock_timeout_env_names, stale_lock_timeout_default_seconds),
         0.0,
     )
-    force_rebuild = _env_bool(force_rebuild_env_names, default=False)
+    force_rebuild = env_bool(force_rebuild_env_names, default=False)
     _force_rebuild_build_directory(build_directory, enabled=force_rebuild)
-    verbose = _env_bool(verbose_env_names, default=False)
+    verbose = env_bool(verbose_env_names, default=False)
     max_retries = max(_env_int(("OLMO_MOE_EXT_LOAD_RETRIES",), 8), 1)
     retry_sleep_s = max(_env_float(("OLMO_MOE_EXT_LOAD_RETRY_SLEEP_SEC",), 0.1), 0.0)
 

--- a/src/olmo_core/optim/grad_debug.py
+++ b/src/olmo_core/optim/grad_debug.py
@@ -28,33 +28,28 @@ def debug_nan_inf_grad_norm(
     total_grad_norm_local: torch.Tensor,
     *,
     step: int,
-    enabled: bool,
     component_norms: Callable[[], Mapping[str, torch.Tensor]],
     iter_local_grads: Callable[[], Iterable[Tuple[str, str, str, torch.Tensor]]],
     ranks_filter: str = "all",
-    topk: int = 20,
+    max_log_entries: int = 20,
     dump_dir: Optional[str] = None,
     rank: Optional[int] = None,
 ) -> None:
     """
     When ``total_grad_norm_local`` is non-finite, log the per-parameter local grad norms and the
     per-component local norms to help locate the offending parameter, and -- if ``dump_dir`` is set
-    -- ``torch.save`` the same data there. A no-op unless ``enabled`` and the norm is actually
-    non-finite, so the ``component_norms``/``iter_local_grads`` callables are only invoked once
-    we've decided to report.
+    -- ``torch.save`` the same data there. A no-op when the norm is finite, so the
+    ``component_norms``/``iter_local_grads`` callables are only invoked once we've decided to report.
 
     :param total_grad_norm_local: The (already node-local) total grad norm.
     :param step: Training step to label the report with.
-    :param enabled: Master gate; when ``False`` this returns immediately.
     :param component_norms: Returns a mapping of component name -> local norm tensor.
     :param iter_local_grads: Returns an iterable of ``(name, param_group, placements, local_grad)``.
     :param ranks_filter: Which ranks report (see :func:`olmo_core.utils.rank_matches_filter`).
-    :param topk: How many entries to include in the "top local norms" context list.
+    :param max_log_entries: How many entries to include in the "top local norms" context list.
     :param dump_dir: If set, also ``torch.save`` the report under this directory.
     :param rank: Current rank; defaults to the distributed rank (or 0).
     """
-    if not enabled:
-        return
     if rank is None:
         rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
     if not rank_matches_filter(ranks_filter, rank):
@@ -62,7 +57,7 @@ def debug_nan_inf_grad_norm(
     if bool(torch.isfinite(total_grad_norm_local).all().item()):
         return
 
-    topk = max(topk, 0)
+    max_log_entries = max(max_log_entries, 0)
     component_values = {
         name: float(norm.detach().float().item()) for name, norm in component_norms().items()
     }
@@ -94,7 +89,7 @@ def debug_nan_inf_grad_norm(
         reverse=True, key=lambda item: item[0] if math.isfinite(item[0]) else float("inf")
     )
     top_for_dump = [e for _, e in top_entries]
-    top_for_log = top_for_dump[:topk]
+    top_for_log = top_for_dump[:max_log_entries]
 
     if dump_dir:
         os.makedirs(dump_dir, exist_ok=True)
@@ -111,9 +106,9 @@ def debug_nan_inf_grad_norm(
             os.path.join(dump_dir, f"rank{rank:03d}_step{step:06d}_optim_nonfinite_grad_norm.pt"),
         )
 
-    # NOTE: `topk` caps BOTH lists, including the non-finite ones (bad_entries[:topk]) -- so with
-    # more than `topk` non-finite params the culprit list is truncated. Kept intentionally.
-    bad_lines = "\n".join(f"  BAD {_format_entry(e)}" for e in bad_entries[:topk])
+    # NOTE: `max_log_entries` caps BOTH lists, including the non-finite ones (bad_entries[:max_log_entries]) -- so with
+    # more than `max_log_entries` non-finite params the culprit list is truncated. Kept intentionally.
+    bad_lines = "\n".join(f"  BAD {_format_entry(e)}" for e in bad_entries[:max_log_entries])
     top_lines = "\n".join(f"  {i + 1:02d}. {_format_entry(e)}" for i, e in enumerate(top_for_log))
     log.error(
         "Non-finite grad norm diagnostic on rank %s step %s: total=%s components=%s "

--- a/src/olmo_core/optim/grad_debug.py
+++ b/src/olmo_core/optim/grad_debug.py
@@ -1,10 +1,4 @@
-"""
-Debug helper for locating the parameter behind a non-finite gradient norm.
-
-Decoupled from any specific optimizer: the caller supplies already-node-local tensors and lazy
-callables for the (optimizer-internal) per-parameter and per-component grad data, so the extraction
-only runs once we've decided to report.
-"""
+"""Debug helper for locating the parameter behind a non-finite gradient norm."""
 
 from __future__ import annotations
 

--- a/src/olmo_core/optim/grad_debug.py
+++ b/src/olmo_core/optim/grad_debug.py
@@ -1,0 +1,136 @@
+"""
+Debug helper for locating the parameter behind a non-finite gradient norm.
+
+Decoupled from any specific optimizer: the caller supplies already-node-local tensors and lazy
+callables for the (optimizer-internal) per-parameter and per-component grad data, so the extraction
+only runs once we've decided to report.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+from olmo_core.utils import rank_matches_filter
+
+log = logging.getLogger(__name__)
+
+
+def _format_entry(e: Dict[str, Any]) -> str:
+    return (
+        f"norm={e['local_norm']:.6g} max_abs={e['max_abs']:.6g} "
+        f"norm_finite={e['norm_finite']} max_abs_finite={e['max_abs_finite']} "
+        f"pg={e['param_group']} placements={e['placements']} dtype={e['dtype']} "
+        f"shape={e['shape']} name={e['name']}"
+    )
+
+
+def debug_nan_inf_grad_norm(
+    total_grad_norm_local: torch.Tensor,
+    *,
+    step: int,
+    enabled: bool,
+    component_norms: Callable[[], Mapping[str, torch.Tensor]],
+    iter_local_grads: Callable[[], Iterable[Tuple[str, str, str, torch.Tensor]]],
+    ranks_filter: str = "all",
+    topk: int = 20,
+    dump_dir: Optional[str] = None,
+    rank: Optional[int] = None,
+) -> None:
+    """
+    When ``total_grad_norm_local`` is non-finite, log the per-parameter local grad norms and the
+    per-component local norms to help locate the offending parameter, and -- if ``dump_dir`` is set
+    -- ``torch.save`` the same data there. A no-op unless ``enabled`` and the norm is actually
+    non-finite, so the ``component_norms``/``iter_local_grads`` callables are only invoked once
+    we've decided to report.
+
+    :param total_grad_norm_local: The (already node-local) total grad norm.
+    :param step: Training step to label the report with.
+    :param enabled: Master gate; when ``False`` this returns immediately.
+    :param component_norms: Returns a mapping of component name -> local norm tensor.
+    :param iter_local_grads: Returns an iterable of ``(name, param_group, placements, local_grad)``.
+    :param ranks_filter: Which ranks report (see :func:`olmo_core.utils.rank_matches_filter`).
+    :param topk: How many entries to include in the "top local norms" context list.
+    :param dump_dir: If set, also ``torch.save`` the report under this directory.
+    :param rank: Current rank; defaults to the distributed rank (or 0).
+    """
+    if not enabled:
+        return
+    if rank is None:
+        rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+    if not rank_matches_filter(ranks_filter, rank):
+        return
+    if bool(torch.isfinite(total_grad_norm_local).all().item()):
+        return
+
+    topk = max(topk, 0)
+    component_values = {
+        name: float(norm.detach().float().item()) for name, norm in component_norms().items()
+    }
+
+    bad_entries: List[Dict[str, Any]] = []
+    top_entries: List[Tuple[float, Dict[str, Any]]] = []
+    for name, param_group, placements, local_grad in iter_local_grads():
+        local_grad_float = local_grad.float()
+        local_norm = float(torch.linalg.vector_norm(local_grad_float, ord=2).item())
+        max_abs = float(torch.linalg.vector_norm(local_grad_float, ord=float("inf")).item())
+        norm_finite = math.isfinite(local_norm)
+        max_abs_finite = math.isfinite(max_abs)
+        entry: Dict[str, Any] = {
+            "name": name,
+            "param_group": param_group,
+            "placements": placements,
+            "dtype": str(local_grad.dtype),
+            "shape": tuple(local_grad.shape),
+            "local_norm": local_norm,
+            "max_abs": max_abs,
+            "norm_finite": norm_finite,
+            "max_abs_finite": max_abs_finite,
+        }
+        if not norm_finite or not max_abs_finite:
+            bad_entries.append(entry)
+        top_entries.append((local_norm, entry))
+
+    top_entries.sort(
+        reverse=True, key=lambda item: item[0] if math.isfinite(item[0]) else float("inf")
+    )
+    top_for_dump = [e for _, e in top_entries]
+    top_for_log = top_for_dump[:topk]
+
+    if dump_dir:
+        os.makedirs(dump_dir, exist_ok=True)
+        torch.save(
+            {
+                "kind": "optim_nonfinite_grad_norm",
+                "rank": rank,
+                "step": step,
+                "total_grad_norm": total_grad_norm_local.float().cpu(),
+                "components": component_values,
+                "bad_entries": bad_entries,
+                "top_entries": top_for_dump,
+            },
+            os.path.join(dump_dir, f"rank{rank:03d}_step{step:06d}_optim_nonfinite_grad_norm.pt"),
+        )
+
+    # NOTE: `topk` caps BOTH lists, including the non-finite ones (bad_entries[:topk]) -- so with
+    # more than `topk` non-finite params the culprit list is truncated. Kept intentionally.
+    bad_lines = "\n".join(f"  BAD {_format_entry(e)}" for e in bad_entries[:topk])
+    top_lines = "\n".join(f"  {i + 1:02d}. {_format_entry(e)}" for i, e in enumerate(top_for_log))
+    log.error(
+        "Non-finite grad norm diagnostic on rank %s step %s: total=%s components=%s "
+        "bad_entries=%s/%s\n%s%s%s",
+        rank,
+        step,
+        total_grad_norm_local.float().cpu(),
+        component_values,
+        len(bad_entries),
+        len(top_for_dump),
+        bad_lines,
+        "\nTop local grad norms:\n" if top_lines else "",
+        top_lines,
+    )

--- a/src/olmo_core/optim/moe_optimizer.py
+++ b/src/olmo_core/optim/moe_optimizer.py
@@ -1116,6 +1116,17 @@ class OLMoDDPOptimizer:
         non-finite, log the per-parameter local grad norms and the per-component (dp/ep_dp,
         replicated/sharded) local norms to help locate the offending parameter. A no-op unless the
         env var is set, so it adds no work to the normal path.
+
+        TODO(config-gate this diagnostic): the ad-hoc ``OLMO_DDP_DEBUG_*`` env flags are off
+        convention (core gates behavior via Config fields — cf. ``check_nan_inf_grad``). Migrate to
+        a ``debug_nan_inf_grad: bool`` config field and fire on
+        ``check_nan_inf_grad and debug_nan_inf_grad``; drop the rank filter (log all ranks); drop
+        the disk-dump env vars (``OLMO_DEBUG_DUMP_*``) — they belong with the DDP train-module dump
+        subsystem, ported separately. Keep the ``limit`` cap on *both* the non-finite and top lists
+        (see the join blocks below). For the logged step, source the trainer ``global_step`` via a
+        clean setter on the optimizer (mirroring ``latest_loss``), NOT the Adam ``.step`` state: this
+        is a skip-step optimizer, so its ``.step`` counter lags ``global_step`` by the skip count —
+        which grows precisely during the spikes this diagnostic is for.
         """
         if not _env_flag("OLMO_DDP_DEBUG_NONFINITE_GRAD"):
             return

--- a/src/olmo_core/optim/moe_optimizer.py
+++ b/src/olmo_core/optim/moe_optimizer.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import os
 from collections import OrderedDict
 from dataclasses import dataclass
 from fnmatch import fnmatch
@@ -54,6 +55,20 @@ def _to_local_tensor(tensor: torch.Tensor) -> torch.Tensor:
     if isinstance(tensor, DTensor):
         return tensor.to_local()
     return tensor
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on", "y"}
+
+
+def _rank_matches_filter(rank_filter: str, rank: int) -> bool:
+    rank_filter = rank_filter.strip().lower()
+    if rank_filter in {"all", "*"}:
+        return True
+    return str(rank) in {part.strip() for part in rank_filter.split(",")}
 
 
 def _is_fp8_weight_store(param: Any) -> bool:
@@ -1022,6 +1037,14 @@ class OLMoDDPOptimizer:
             ep_dp_grads_sharded,
         )
 
+        self._maybe_debug_nonfinite_grad_norm(
+            total_grad_norm,
+            dp_grads_replicated,
+            dp_grads_sharded,
+            ep_dp_grads_replicated,
+            ep_dp_grads_sharded,
+        )
+
         clip_coef = self.max_grad_norm / (total_grad_norm + 1e-6)
         # Note: multiplying by the clamped coef is redundant when the coef is clamped to 1, but doing so
         # avoids a `if clip_coef < 1:` conditional which can require a CPU <=> device synchronization
@@ -1079,6 +1102,147 @@ class OLMoDDPOptimizer:
         if "pp" in self.dense_mesh.mesh_dim_names:
             total_grad_norm = self._reduce_norm(total_grad_norm, self.dense_mesh["pp"].get_group())
         return total_grad_norm
+
+    def _maybe_debug_nonfinite_grad_norm(
+        self,
+        total_grad_norm: torch.Tensor,
+        dp_grads_replicated: List[torch.Tensor],
+        dp_grads_sharded: List[torch.Tensor],
+        ep_dp_grads_replicated: List[torch.Tensor],
+        ep_dp_grads_sharded: List[torch.Tensor],
+    ) -> None:
+        """
+        Opt-in diagnostic (gated by ``OLMO_DDP_DEBUG_NONFINITE_GRAD``): when the total grad norm is
+        non-finite, log the per-parameter local grad norms and the per-component (dp/ep_dp,
+        replicated/sharded) local norms to help locate the offending parameter. A no-op unless the
+        env var is set, so it adds no work to the normal path.
+        """
+        if not _env_flag("OLMO_DDP_DEBUG_NONFINITE_GRAD"):
+            return
+
+        rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+        rank_filter = os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_RANKS", "all")
+        if not _rank_matches_filter(rank_filter, rank):
+            return
+
+        total_local = _to_local_tensor(total_grad_norm.detach())
+        if bool(torch.isfinite(total_local).all().item()):
+            return
+
+        step = getattr(self, "_olmo_debug_global_step", -1)
+        try:
+            limit = int(os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_TOPK", "20"))
+        except ValueError:
+            limit = 20
+        limit = max(limit, 0)
+
+        component_tensors: Dict[str, torch.Tensor] = {
+            "dp_replicated_local": self._local_total_norm(dp_grads_replicated),
+            "dp_sharded_local": self._local_total_norm(dp_grads_sharded),
+            "ep_dp_replicated_local": self._local_total_norm(ep_dp_grads_replicated),
+            "ep_dp_sharded_local": self._local_total_norm(ep_dp_grads_sharded),
+        }
+        component_values: Dict[str, float] = {}
+        for name, value in component_tensors.items():
+            local_value = _to_local_tensor(value.detach()).float()
+            component_values[name] = float(local_value.item())
+
+        bad_entries: List[Dict[str, Any]] = []
+        top_entries: List[Tuple[float, Dict[str, Any]]] = []
+        for param_group in self.param_groups:
+            for name, param in param_group["named_params"].items():
+                if not param.requires_grad:
+                    continue
+                grad = self.main_grad.get(name)
+                if grad is None:
+                    continue
+                local_grad = _to_local_tensor(grad.detach())
+                if local_grad.numel() == 0:
+                    continue
+                local_grad_float = local_grad.float()
+                local_norm = torch.linalg.vector_norm(local_grad_float, ord=2)
+                local_norm_value = float(local_norm.item())
+                max_abs_value = float(
+                    torch.linalg.vector_norm(local_grad_float, ord=float("inf")).item()
+                )
+                norm_finite = math.isfinite(local_norm_value)
+                max_abs_finite = math.isfinite(max_abs_value)
+                placements = ",".join(str(p) for p in self.states[f"{name}.main"].placements)
+                entry: Dict[str, Any] = {
+                    "name": name,
+                    "param_group": param_group["pg"],
+                    "placements": placements,
+                    "dtype": str(local_grad.dtype),
+                    "shape": tuple(local_grad.shape),
+                    "local_norm": local_norm_value,
+                    "max_abs": max_abs_value,
+                    "norm_finite": norm_finite,
+                    "max_abs_finite": max_abs_finite,
+                }
+                if (not norm_finite) or (not max_abs_finite):
+                    bad_entries.append(entry)
+                top_entries.append((local_norm_value, entry))
+
+        top_entries.sort(
+            reverse=True,
+            key=lambda item: item[0] if math.isfinite(item[0]) else float("inf"),
+        )
+        top_entries_for_dump = [entry for _, entry in top_entries]
+        top_entries_for_log = top_entries_for_dump[:limit]
+
+        dump_root = (
+            os.getenv("OLMO_DEBUG_DUMP_DIR")
+            if _env_flag("OLMO_DEBUG_DUMP_OPTIM_GRAD_NORMS")
+            else None
+        )
+        if dump_root:
+            run_id = os.getenv("OLMO_DEBUG_RUN_ID", "run")
+            dump_dir = os.path.join(dump_root, run_id, f"rank{rank:03d}")
+            os.makedirs(dump_dir, exist_ok=True)
+            torch.save(
+                {
+                    "kind": "optim_nonfinite_grad_norm",
+                    "rank": rank,
+                    "step": step,
+                    "total_grad_norm": total_local.float().cpu(),
+                    "components": component_values,
+                    "bad_entries": bad_entries,
+                    "top_entries": top_entries_for_dump,
+                },
+                os.path.join(dump_dir, f"step{step:06d}_optim_nonfinite_grad_norm.pt"),
+            )
+
+        bad_lines = "\n".join(
+            "  BAD "
+            f"norm={entry['local_norm']:.6g} max_abs={entry['max_abs']:.6g} "
+            f"norm_finite={entry['norm_finite']} max_abs_finite={entry['max_abs_finite']} "
+            f"pg={entry['param_group']} "
+            f"placements={entry['placements']} dtype={entry['dtype']} "
+            f"shape={entry['shape']} name={entry['name']}"
+            for entry in bad_entries[:limit]
+        )
+        top_lines = "\n".join(
+            f"  {idx + 1:02d}. "
+            f"norm={entry['local_norm']:.6g} max_abs={entry['max_abs']:.6g} "
+            f"norm_finite={entry['norm_finite']} max_abs_finite={entry['max_abs_finite']} "
+            f"pg={entry['param_group']} "
+            f"placements={entry['placements']} dtype={entry['dtype']} "
+            f"shape={entry['shape']} name={entry['name']}"
+            for idx, entry in enumerate(top_entries_for_log)
+        )
+        log.error(
+            "Non-finite grad norm diagnostic on rank %s step %s: total=%s components=%s "
+            "bad_entries=%s/%s\n%s%s%s",
+            rank,
+            step,
+            total_local.float().cpu(),
+            component_values,
+            len(bad_entries),
+            len(top_entries_for_dump),
+            bad_lines,
+            "\nTop local grad norms:\n" if top_lines else "",
+            top_lines,
+        )
 
     def _combine_norm(self, n1, n2) -> torch.Tensor:
         return torch.sqrt(n1.square() + n2.square())

--- a/src/olmo_core/optim/moe_optimizer.py
+++ b/src/olmo_core/optim/moe_optimizer.py
@@ -10,6 +10,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Set,
@@ -37,17 +38,13 @@ from torch.distributed.tensor._utils import (
 
 from olmo_core._nvtx import maybe_nvtx_annotate
 from olmo_core.nn.fp8_weight import FP8WeightStore
-from olmo_core.utils import (
-    env_bool,
-    get_default_device,
-    move_to_device,
-    rank_matches_filter,
-)
+from olmo_core.utils import env_bool, get_default_device, move_to_device
 
 from ..config import Config, DType
 from ..exceptions import OLMoConfigurationError
 from .adamw import foreach_adamw_step
 from .config import INITIAL_LR_FIELD, LR_FIELD, OptimGroupOverride
+from .grad_debug import debug_nan_inf_grad_norm
 
 log = logging.getLogger(__name__)
 
@@ -1028,7 +1025,7 @@ class OLMoDDPOptimizer:
             ep_dp_grads_sharded,
         )
 
-        self._maybe_debug_nonfinite_grad_norm(
+        self._maybe_debug_nan_inf_grad_norm(
             total_grad_norm,
             dp_grads_replicated,
             dp_grads_sharded,
@@ -1094,7 +1091,7 @@ class OLMoDDPOptimizer:
             total_grad_norm = self._reduce_norm(total_grad_norm, self.dense_mesh["pp"].get_group())
         return total_grad_norm
 
-    def _maybe_debug_nonfinite_grad_norm(
+    def _maybe_debug_nan_inf_grad_norm(
         self,
         total_grad_norm: torch.Tensor,
         dp_grads_replicated: List[torch.Tensor],
@@ -1104,55 +1101,43 @@ class OLMoDDPOptimizer:
     ) -> None:
         """
         Opt-in diagnostic (gated by ``OLMO_DDP_DEBUG_NONFINITE_GRAD``): when the total grad norm is
-        non-finite, log the per-parameter local grad norms and the per-component (dp/ep_dp,
-        replicated/sharded) local norms to help locate the offending parameter. A no-op unless the
-        env var is set, so it adds no work to the normal path.
+        non-finite, log/dump the per-parameter and per-component local grad norms to locate the
+        offending parameter. This is just the optimizer-specific adapter — it reads the env knobs
+        and extracts the grad data, then delegates to
+        :func:`olmo_core.optim.grad_debug.debug_nan_inf_grad_norm`. A no-op unless the env var is
+        set and the norm is non-finite (the extraction closures only run then).
 
-        TODO(config-gate this diagnostic): the ad-hoc ``OLMO_DDP_DEBUG_*`` env flags are off
+        TODO(config-gate this diagnostic): the ad-hoc ``OLMO_DDP_DEBUG_*`` env knobs are off
         convention (core gates behavior via Config fields — cf. ``check_nan_inf_grad``). Migrate to
-        a ``debug_nan_inf_grad: bool`` config field and fire on
-        ``check_nan_inf_grad and debug_nan_inf_grad``; keep the rank filter but migrate its
-        ``OLMO_DDP_DEBUG_NONFINITE_GRAD_RANKS`` env var to a config field (the matcher itself lives
-        in :func:`olmo_core.utils.rank_matches_filter`); drop the disk-dump env vars
-        (``OLMO_DEBUG_DUMP_*``) — they belong with the DDP train-module dump subsystem, ported
-        separately. Keep the ``limit`` cap on *both* the non-finite and top lists
-        (see the join blocks below). For the logged step, source the trainer ``global_step`` via a
-        clean setter on the optimizer (mirroring ``latest_loss``), NOT the Adam ``.step`` state: this
-        is a skip-step optimizer, so its ``.step`` counter lags ``global_step`` by the skip count —
-        which grows precisely during the spikes this diagnostic is for.
+        a ``debug_nan_inf_grad: bool`` config field (fire on ``check_nan_inf_grad and
+        debug_nan_inf_grad``) and move the rank / topk / dump-dir knobs to config fields too. The
+        logged step is the trainer ``global_step`` (set on ``_olmo_debug_global_step``, not the Adam
+        ``.step`` state, which lags ``global_step`` by the skip count on this skip-step optimizer);
+        a clean ``global_step`` setter mirroring ``latest_loss`` would replace the raw attribute.
         """
-        if not env_bool("OLMO_DDP_DEBUG_NONFINITE_GRAD"):
-            return
-
-        rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
-        rank_filter = os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_RANKS", "all")
-        if not rank_matches_filter(rank_filter, rank):
-            return
-
-        total_local = _to_local_tensor(total_grad_norm.detach())
-        if bool(torch.isfinite(total_local).all().item()):
-            return
-
-        step = getattr(self, "_olmo_debug_global_step", -1)
         try:
-            limit = int(os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_TOPK", "20"))
+            topk = int(os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_TOPK", "20"))
         except ValueError:
-            limit = 20
-        limit = max(limit, 0)
+            topk = 20
+        debug_nan_inf_grad_norm(
+            _to_local_tensor(total_grad_norm.detach()),
+            step=getattr(self, "_olmo_debug_global_step", -1),
+            enabled=env_bool("OLMO_DDP_DEBUG_NONFINITE_GRAD"),
+            ranks_filter=os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_RANKS", "all"),
+            topk=topk,
+            # A single knob: dump iff a directory is specified.
+            dump_dir=os.getenv("OLMO_DEBUG_DUMP_DIR"),
+            component_norms=lambda: {
+                "dp_replicated_local": self._local_total_norm(dp_grads_replicated),
+                "dp_sharded_local": self._local_total_norm(dp_grads_sharded),
+                "ep_dp_replicated_local": self._local_total_norm(ep_dp_grads_replicated),
+                "ep_dp_sharded_local": self._local_total_norm(ep_dp_grads_sharded),
+            },
+            iter_local_grads=self._iter_local_grads,
+        )
 
-        component_tensors: Dict[str, torch.Tensor] = {
-            "dp_replicated_local": self._local_total_norm(dp_grads_replicated),
-            "dp_sharded_local": self._local_total_norm(dp_grads_sharded),
-            "ep_dp_replicated_local": self._local_total_norm(ep_dp_grads_replicated),
-            "ep_dp_sharded_local": self._local_total_norm(ep_dp_grads_sharded),
-        }
-        component_values: Dict[str, float] = {}
-        for name, value in component_tensors.items():
-            local_value = _to_local_tensor(value.detach()).float()
-            component_values[name] = float(local_value.item())
-
-        bad_entries: List[Dict[str, Any]] = []
-        top_entries: List[Tuple[float, Dict[str, Any]]] = []
+    def _iter_local_grads(self) -> Iterator[Tuple[str, str, str, torch.Tensor]]:
+        """Yield ``(name, param_group, placements, local_grad)`` for each param with a local grad."""
         for param_group in self.param_groups:
             for name, param in param_group["named_params"].items():
                 if not param.requires_grad:
@@ -1163,90 +1148,8 @@ class OLMoDDPOptimizer:
                 local_grad = _to_local_tensor(grad.detach())
                 if local_grad.numel() == 0:
                     continue
-                local_grad_float = local_grad.float()
-                local_norm = torch.linalg.vector_norm(local_grad_float, ord=2)
-                local_norm_value = float(local_norm.item())
-                max_abs_value = float(
-                    torch.linalg.vector_norm(local_grad_float, ord=float("inf")).item()
-                )
-                norm_finite = math.isfinite(local_norm_value)
-                max_abs_finite = math.isfinite(max_abs_value)
                 placements = ",".join(str(p) for p in self.states[f"{name}.main"].placements)
-                entry: Dict[str, Any] = {
-                    "name": name,
-                    "param_group": param_group["pg"],
-                    "placements": placements,
-                    "dtype": str(local_grad.dtype),
-                    "shape": tuple(local_grad.shape),
-                    "local_norm": local_norm_value,
-                    "max_abs": max_abs_value,
-                    "norm_finite": norm_finite,
-                    "max_abs_finite": max_abs_finite,
-                }
-                if (not norm_finite) or (not max_abs_finite):
-                    bad_entries.append(entry)
-                top_entries.append((local_norm_value, entry))
-
-        top_entries.sort(
-            reverse=True,
-            key=lambda item: item[0] if math.isfinite(item[0]) else float("inf"),
-        )
-        top_entries_for_dump = [entry for _, entry in top_entries]
-        top_entries_for_log = top_entries_for_dump[:limit]
-
-        dump_root = (
-            os.getenv("OLMO_DEBUG_DUMP_DIR")
-            if env_bool("OLMO_DEBUG_DUMP_OPTIM_GRAD_NORMS")
-            else None
-        )
-        if dump_root:
-            run_id = os.getenv("OLMO_DEBUG_RUN_ID", "run")
-            dump_dir = os.path.join(dump_root, run_id, f"rank{rank:03d}")
-            os.makedirs(dump_dir, exist_ok=True)
-            torch.save(
-                {
-                    "kind": "optim_nonfinite_grad_norm",
-                    "rank": rank,
-                    "step": step,
-                    "total_grad_norm": total_local.float().cpu(),
-                    "components": component_values,
-                    "bad_entries": bad_entries,
-                    "top_entries": top_entries_for_dump,
-                },
-                os.path.join(dump_dir, f"step{step:06d}_optim_nonfinite_grad_norm.pt"),
-            )
-
-        bad_lines = "\n".join(
-            "  BAD "
-            f"norm={entry['local_norm']:.6g} max_abs={entry['max_abs']:.6g} "
-            f"norm_finite={entry['norm_finite']} max_abs_finite={entry['max_abs_finite']} "
-            f"pg={entry['param_group']} "
-            f"placements={entry['placements']} dtype={entry['dtype']} "
-            f"shape={entry['shape']} name={entry['name']}"
-            for entry in bad_entries[:limit]
-        )
-        top_lines = "\n".join(
-            f"  {idx + 1:02d}. "
-            f"norm={entry['local_norm']:.6g} max_abs={entry['max_abs']:.6g} "
-            f"norm_finite={entry['norm_finite']} max_abs_finite={entry['max_abs_finite']} "
-            f"pg={entry['param_group']} "
-            f"placements={entry['placements']} dtype={entry['dtype']} "
-            f"shape={entry['shape']} name={entry['name']}"
-            for idx, entry in enumerate(top_entries_for_log)
-        )
-        log.error(
-            "Non-finite grad norm diagnostic on rank %s step %s: total=%s components=%s "
-            "bad_entries=%s/%s\n%s%s%s",
-            rank,
-            step,
-            total_local.float().cpu(),
-            component_values,
-            len(bad_entries),
-            len(top_entries_for_dump),
-            bad_lines,
-            "\nTop local grad norms:\n" if top_lines else "",
-            top_lines,
-        )
+                yield name, param_group["pg"], placements, local_grad
 
     def _combine_norm(self, n1, n2) -> torch.Tensor:
         return torch.sqrt(n1.square() + n2.square())

--- a/src/olmo_core/optim/moe_optimizer.py
+++ b/src/olmo_core/optim/moe_optimizer.py
@@ -59,6 +59,18 @@ def _to_local_tensor(tensor: torch.Tensor) -> torch.Tensor:
     return tensor
 
 
+def _assert_finite_async(tensor: torch.Tensor, name: str) -> None:
+    """
+    Device-side assert that ``tensor`` is all-finite, without a host sync (so it's cheap enough to
+    run every step). The process aborts asynchronously if a non-finite value is encountered.
+    """
+    tensor = _to_local_tensor(tensor)
+    torch._assert_async(
+        torch.isfinite(tensor.detach()).all(),
+        f"Non-finite {name} encountered in OLMoDDPOptimizer",
+    )
+
+
 def _is_fp8_weight_store(param: Any) -> bool:
     return isinstance(param, FP8WeightStore)
 
@@ -164,6 +176,13 @@ class OLMoDDPOptimizerConfig(Config):
     """
     When ``True``, ignore checkpointed ``exp_avg`` and ``exp_avg_sq`` values and
     reset them to zero when restoring optimizer state.
+    """
+
+    check_nan_inf_grad: bool = False
+    """
+    When ``True``, device-side assert (without a host sync) that the loss and the total grad norm
+    are finite each step, aborting the run on a non-finite value. Off by default; note this aborts
+    rather than skipping the step, so it interacts with the skip-step spike detection.
     """
 
     @property
@@ -1032,6 +1051,8 @@ class OLMoDDPOptimizer:
             ep_dp_grads_replicated,
             ep_dp_grads_sharded,
         )
+        if self.check_nan_inf_grad:
+            _assert_finite_async(total_grad_norm, "total grad norm")
 
         clip_coef = self.max_grad_norm / (total_grad_norm + 1e-6)
         # Note: multiplying by the clamped coef is redundant when the coef is clamped to 1, but doing so
@@ -1180,12 +1201,11 @@ class OLMoDDPOptimizer:
             # Precondition: DDP model called all-reduce grads, bf16 model grads on dp ranks are the same
             self._copy_model_grads_to_main_grads()
 
-        total_grad_norm = self._clip_grad()
+        if self.check_nan_inf_grad and self.latest_loss is not None:
+            _assert_finite_async(self.latest_loss, "loss")
 
-        if self.check_nan_inf_grad and (total_grad_norm.isnan() or total_grad_norm.isinf()):
-            assert (
-                False
-            ), f"[Error] rank={dist.get_rank()} grad norm is {total_grad_norm}, skipping step"
+        # _clip_grad() also asserts the total grad norm is finite when check_nan_inf_grad is set.
+        total_grad_norm = self._clip_grad()
 
         self.latest_grad_norm = total_grad_norm
 

--- a/src/olmo_core/optim/moe_optimizer.py
+++ b/src/olmo_core/optim/moe_optimizer.py
@@ -37,7 +37,12 @@ from torch.distributed.tensor._utils import (
 
 from olmo_core._nvtx import maybe_nvtx_annotate
 from olmo_core.nn.fp8_weight import FP8WeightStore
-from olmo_core.utils import env_bool, get_default_device, move_to_device
+from olmo_core.utils import (
+    env_bool,
+    get_default_device,
+    move_to_device,
+    rank_matches_filter,
+)
 
 from ..config import Config, DType
 from ..exceptions import OLMoConfigurationError
@@ -55,13 +60,6 @@ def _to_local_tensor(tensor: torch.Tensor) -> torch.Tensor:
     if isinstance(tensor, DTensor):
         return tensor.to_local()
     return tensor
-
-
-def _rank_matches_filter(rank_filter: str, rank: int) -> bool:
-    rank_filter = rank_filter.strip().lower()
-    if rank_filter in {"all", "*"}:
-        return True
-    return str(rank) in {part.strip() for part in rank_filter.split(",")}
 
 
 def _is_fp8_weight_store(param: Any) -> bool:
@@ -1113,9 +1111,11 @@ class OLMoDDPOptimizer:
         TODO(config-gate this diagnostic): the ad-hoc ``OLMO_DDP_DEBUG_*`` env flags are off
         convention (core gates behavior via Config fields — cf. ``check_nan_inf_grad``). Migrate to
         a ``debug_nan_inf_grad: bool`` config field and fire on
-        ``check_nan_inf_grad and debug_nan_inf_grad``; drop the rank filter (log all ranks); drop
-        the disk-dump env vars (``OLMO_DEBUG_DUMP_*``) — they belong with the DDP train-module dump
-        subsystem, ported separately. Keep the ``limit`` cap on *both* the non-finite and top lists
+        ``check_nan_inf_grad and debug_nan_inf_grad``; keep the rank filter but migrate its
+        ``OLMO_DDP_DEBUG_NONFINITE_GRAD_RANKS`` env var to a config field (the matcher itself lives
+        in :func:`olmo_core.utils.rank_matches_filter`); drop the disk-dump env vars
+        (``OLMO_DEBUG_DUMP_*``) — they belong with the DDP train-module dump subsystem, ported
+        separately. Keep the ``limit`` cap on *both* the non-finite and top lists
         (see the join blocks below). For the logged step, source the trainer ``global_step`` via a
         clean setter on the optimizer (mirroring ``latest_loss``), NOT the Adam ``.step`` state: this
         is a skip-step optimizer, so its ``.step`` counter lags ``global_step`` by the skip count —
@@ -1126,7 +1126,7 @@ class OLMoDDPOptimizer:
 
         rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
         rank_filter = os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_RANKS", "all")
-        if not _rank_matches_filter(rank_filter, rank):
+        if not rank_matches_filter(rank_filter, rank):
             return
 
         total_local = _to_local_tensor(total_grad_norm.detach())

--- a/src/olmo_core/optim/moe_optimizer.py
+++ b/src/olmo_core/optim/moe_optimizer.py
@@ -37,7 +37,7 @@ from torch.distributed.tensor._utils import (
 
 from olmo_core._nvtx import maybe_nvtx_annotate
 from olmo_core.nn.fp8_weight import FP8WeightStore
-from olmo_core.utils import get_default_device, move_to_device
+from olmo_core.utils import env_bool, get_default_device, move_to_device
 
 from ..config import Config, DType
 from ..exceptions import OLMoConfigurationError
@@ -55,13 +55,6 @@ def _to_local_tensor(tensor: torch.Tensor) -> torch.Tensor:
     if isinstance(tensor, DTensor):
         return tensor.to_local()
     return tensor
-
-
-def _env_flag(name: str, default: bool = False) -> bool:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in {"1", "true", "yes", "on", "y"}
 
 
 def _rank_matches_filter(rank_filter: str, rank: int) -> bool:
@@ -1128,7 +1121,7 @@ class OLMoDDPOptimizer:
         is a skip-step optimizer, so its ``.step`` counter lags ``global_step`` by the skip count —
         which grows precisely during the spikes this diagnostic is for.
         """
-        if not _env_flag("OLMO_DDP_DEBUG_NONFINITE_GRAD"):
+        if not env_bool("OLMO_DDP_DEBUG_NONFINITE_GRAD"):
             return
 
         rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
@@ -1203,7 +1196,7 @@ class OLMoDDPOptimizer:
 
         dump_root = (
             os.getenv("OLMO_DEBUG_DUMP_DIR")
-            if _env_flag("OLMO_DEBUG_DUMP_OPTIM_GRAD_NORMS")
+            if env_bool("OLMO_DEBUG_DUMP_OPTIM_GRAD_NORMS")
             else None
         )
         if dump_root:

--- a/src/olmo_core/optim/moe_optimizer.py
+++ b/src/olmo_core/optim/moe_optimizer.py
@@ -1110,22 +1110,22 @@ class OLMoDDPOptimizer:
         TODO(config-gate this diagnostic): the ad-hoc ``OLMO_DDP_DEBUG_*`` env knobs are off
         convention (core gates behavior via Config fields — cf. ``check_nan_inf_grad``). Migrate to
         a ``debug_nan_inf_grad: bool`` config field (fire on ``check_nan_inf_grad and
-        debug_nan_inf_grad``) and move the rank / topk / dump-dir knobs to config fields too. The
+        debug_nan_inf_grad``) and move the rank / max_log_entries / dump-dir knobs to config fields too. The
         logged step is the trainer ``global_step`` (set on ``_olmo_debug_global_step``, not the Adam
         ``.step`` state, which lags ``global_step`` by the skip count on this skip-step optimizer);
         a clean ``global_step`` setter mirroring ``latest_loss`` would replace the raw attribute.
         """
+        if not env_bool("OLMO_DDP_DEBUG_NONFINITE_GRAD"):
+            return
         try:
-            topk = int(os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_TOPK", "20"))
+            max_log_entries = int(os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_TOPK", "20"))
         except ValueError:
-            topk = 20
+            max_log_entries = 20
         debug_nan_inf_grad_norm(
             _to_local_tensor(total_grad_norm.detach()),
             step=getattr(self, "_olmo_debug_global_step", -1),
-            enabled=env_bool("OLMO_DDP_DEBUG_NONFINITE_GRAD"),
             ranks_filter=os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_RANKS", "all"),
-            topk=topk,
-            # A single knob: dump iff a directory is specified.
+            max_log_entries=max_log_entries,
             dump_dir=os.getenv("OLMO_DEBUG_DUMP_DIR"),
             component_norms=lambda: {
                 "dp_replicated_local": self._local_total_norm(dp_grads_replicated),

--- a/src/olmo_core/optim/moe_optimizer.py
+++ b/src/olmo_core/optim/moe_optimizer.py
@@ -1111,7 +1111,7 @@ class OLMoDDPOptimizer:
         convention (core gates behavior via Config fields — cf. ``check_nan_inf_grad``). Migrate to
         a ``debug_nan_inf_grad: bool`` config field (fire on ``check_nan_inf_grad and
         debug_nan_inf_grad``) and move the rank / max_log_entries / dump-dir knobs to config fields too. The
-        logged step is the trainer ``global_step`` (set on ``_olmo_debug_global_step``, not the Adam
+        logged step is the trainer ``global_step`` (set on ``_debug_global_step``, not the Adam
         ``.step`` state, which lags ``global_step`` by the skip count on this skip-step optimizer);
         a clean ``global_step`` setter mirroring ``latest_loss`` would replace the raw attribute.
         """
@@ -1123,7 +1123,7 @@ class OLMoDDPOptimizer:
             max_log_entries = 20
         debug_nan_inf_grad_norm(
             _to_local_tensor(total_grad_norm.detach()),
-            step=getattr(self, "_olmo_debug_global_step", -1),
+            step=getattr(self, "_debug_global_step", -1),
             ranks_filter=os.getenv("OLMO_DDP_DEBUG_NONFINITE_GRAD_RANKS", "all"),
             max_log_entries=max_log_entries,
             dump_dir=os.getenv("OLMO_DEBUG_DUMP_DIR"),

--- a/src/olmo_core/optim/moe_optimizer.py
+++ b/src/olmo_core/optim/moe_optimizer.py
@@ -178,11 +178,11 @@ class OLMoDDPOptimizerConfig(Config):
     reset them to zero when restoring optimizer state.
     """
 
-    check_nan_inf_grad: bool = False
+    check_nan_inf_grad: bool = True
     """
     When ``True``, device-side assert (without a host sync) that the loss and the total grad norm
-    are finite each step, aborting the run on a non-finite value. Off by default; note this aborts
-    rather than skipping the step, so it interacts with the skip-step spike detection.
+    are finite each step, aborting the run on a non-finite value; note this aborts rather than
+    skipping the step, so it interacts with the skip-step spike detection.
     """
 
     @property
@@ -511,7 +511,7 @@ class OLMoDDPOptimizer:
         broadcast_bucket_mb: int = 32,
         do_not_shard_tensor_smaller_than: int = 4096,
         use_distributed: bool = True,
-        check_nan_inf_grad: bool = False,
+        check_nan_inf_grad: bool = True,
         reset_optimizer_moments_on_load: bool = False,
     ) -> None:
         assert lr > 0.0

--- a/src/olmo_core/train/train_module/transformer/ddp_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/ddp_train_module.py
@@ -1361,6 +1361,10 @@ class OLMoDDPTrainModule(TrainModule):
                 new_lr = self.scheduler.set_lr(group, self.trainer)
                 self.trainer.record_metric(f"LR (group {group_idx})", new_lr, namespace="optim")
 
+        # Give the optimizer the current global step so its non-finite grad-norm diagnostic can
+        # report it (a skip-step optimizer's own step counter lags global_step by the skip count).
+        optim._olmo_debug_global_step = self.trainer.global_step
+
         # Step optimizer.
         optim.step()
         # TODO(moe-train-module-rowwise-cache-refresh): this per-step refresh looks redundant —

--- a/src/olmo_core/train/train_module/transformer/ddp_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/ddp_train_module.py
@@ -1363,7 +1363,7 @@ class OLMoDDPTrainModule(TrainModule):
 
         # Give the optimizer the current global step so its non-finite grad-norm diagnostic can
         # report it (a skip-step optimizer's own step counter lags global_step by the skip count).
-        optim._olmo_debug_global_step = self.trainer.global_step
+        optim._debug_global_step = self.trainer.global_step
 
         # Step optimizer.
         optim.step()

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -60,6 +60,18 @@ def env_bool(name: Union[str, Sequence[str]], default: bool = False) -> bool:
     return default
 
 
+def rank_matches_filter(rank_filter: str, rank: int) -> bool:
+    """
+    Test a rank against a filter string. ``"all"`` / ``"*"`` matches every rank; otherwise the
+    filter is a comma-separated list of rank numbers (e.g. ``"0,3"``). Useful for gating per-rank
+    debug output.
+    """
+    rank_filter = rank_filter.strip().lower()
+    if rank_filter in {"all", "*"}:
+        return True
+    return str(rank) in {part.strip() for part in rank_filter.split(",")}
+
+
 def generate_uuid() -> str:
     """
     Generate a unique ID.

--- a/src/olmo_core/utils.py
+++ b/src/olmo_core/utils.py
@@ -38,6 +38,28 @@ _LOGGING_CONFIGURED: bool = False
 log = logging.getLogger(__name__)
 
 
+def env_bool(name: Union[str, Sequence[str]], default: bool = False) -> bool:
+    """
+    Parse a boolean from an environment variable.
+
+    :param name: An environment variable name, or a sequence of names tried in order — the first
+        one set to a recognized value wins.
+    :param default: Returned when no name is set to a recognized value. Truthy values are
+        ``1/true/yes/on`` and falsy values are ``0/false/no/off`` (case-insensitive).
+    """
+    names = (name,) if isinstance(name, str) else name
+    for n in names:
+        raw = os.getenv(n)
+        if raw is None:
+            continue
+        lowered = raw.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
 def generate_uuid() -> str:
     """
     Generate a unique ID.

--- a/src/test/kernels/cuda_extension_utils_test.py
+++ b/src/test/kernels/cuda_extension_utils_test.py
@@ -3,24 +3,11 @@ import time
 
 from olmo_core.kernels.cuda_extension_utils import (
     _cuda_arch_tag,
-    _env_bool,
     _env_float,
     _force_rebuild_build_directory,
     _maybe_remove_stale_build_lock,
     _torch_extension_abi_tag,
 )
-
-
-def test_env_bool(monkeypatch):
-    monkeypatch.setenv("OLMO_TEST_FLAG", "true")
-    assert _env_bool(["OLMO_TEST_FLAG"]) is True
-    monkeypatch.setenv("OLMO_TEST_FLAG", "off")
-    assert _env_bool(["OLMO_TEST_FLAG"]) is False
-    monkeypatch.delenv("OLMO_TEST_FLAG", raising=False)
-    assert _env_bool(["OLMO_TEST_FLAG"], default=True) is True
-    # First set name wins.
-    monkeypatch.setenv("OLMO_TEST_FLAG_2", "yes")
-    assert _env_bool(["OLMO_TEST_FLAG", "OLMO_TEST_FLAG_2"]) is True
 
 
 def test_env_float(monkeypatch):


### PR DESCRIPTION
Adds an opt-in diagnostic to `OLMoDDPOptimizer` for debugging training instability: when the total gradient norm goes non-finite, it logs the per-parameter local grad norms (with a "BAD" marker for the non-finite ones) and the per-component (dp/ep_dp × replicated/sharded) local norms, so the offending parameter can be located. An optional `torch.save` dump captures the same data for offline inspection.

Everything is gated behind `OLMO_DDP_DEBUG_NONFINITE_GRAD` (checked first), so it is a no-op on the normal training path — no device→host sync or extra work unless the env var is set. Additional env knobs: `OLMO_DDP_DEBUG_NONFINITE_GRAD_RANKS` (rank filter), `OLMO_DDP_DEBUG_NONFINITE_GRAD_TOPK` (how many top entries to log), and `OLMO_DEBUG_DUMP_OPTIM_GRAD_NORMS` / `OLMO_DEBUG_DUMP_DIR` / `OLMO_DEBUG_RUN_ID` for the dump.

The diagnostic runs inside the existing grad-norm computation where the component grad lists are already in scope, so no restructuring of the grad-norm path. `make checks` clean; `optim/moe_optimizer_test.py` passes.