### PR TITLE
Introduce ExpertParallelConfig and refactor the DDP block onto it

### DIFF
--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -33,6 +33,7 @@ from olmo_core.nn.moe.v2.checkpointing import (
 # activation-debug helper are imported lazily at their dispatch sites below, so this module
 # imports cleanly without those files present (they ship in later, stacked PRs). See the
 # combined_forward_ep_no_sync_* wrapper methods and the rowwise metric/symm helper sites.
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig
 from olmo_core.nn.moe.v2.fp8 import MoERowwiseFP8Config
 from olmo_core.nn.moe.v2.fp8 import (
     invalidate_rowwise_fp8_cache as _invalidate_rowwise_fp8_cache,
@@ -157,28 +158,7 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
     # imported lazily and land in follow-up changes; they have no effect on the no-expert-parallel
     # path and are documented when those families land.
     #
-    # TODO(ep-config): revisit and potentially refactor these into per-mode configs. Right now this
-    # is a flat bag of `ep_no_sync_*` flags that conflates *mode selection* (the family is chosen by
-    # the `(ep_no_sync, ep_no_sync_use_rowwise_all_to_all)` pair) with *per-mode tuning* (capacity,
-    # alignment, symm-mem slots) and *rowwise-only* options (`ep_no_sync_rowwise_*`), so many
-    # combinations are meaningless and one flag (`ep_no_sync_use_2d_all_to_all`) is already dead.
-    # The rest of the codebase models this kind of polymorphism with a Registrable base config that
-    # resolves to a per-variant subclass (see e.g. the attention/optimizer/scheduler configs); an
-    # EP-mode config (sync / no-sync VDev / no-sync rowwise) holding only its own fields would be
-    # clearer and self-validating. Do this when the EP families land (PR-M2/M3).
-    ep_no_sync: bool = False
-    ep_no_sync_use_2d_all_to_all: bool = False
-    ep_no_sync_use_rowwise_all_to_all: bool = False
-    ep_no_sync_rowwise_nblocks: int = 256
-    ep_no_sync_share_dispatch_out: bool = False
-    ep_no_sync_capacity_factor: float = 1.25
-    ep_no_sync_shared_slots: int = 1
-    ep_no_sync_share_combine_out: bool = False
-    ep_no_sync_major_align: int = 1
-    ep_no_sync_restore_unpermute_backend: str = "te_fused"
-    ep_no_sync_rowwise_symm_dispatch_in: Optional[bool] = None
-    ep_no_sync_rowwise_symm_combine_out: Optional[bool] = None
-    ep_no_sync_rowwise_symm_combine_gather: Optional[bool] = None
+    ep: Optional[ExpertParallelConfig] = None
 
     def build(
         self,
@@ -372,19 +352,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         checkpoint_permute_moe_unpermute=False,
         checkpoint_combined_ep_tbo=False,
         checkpoint_second_unpermute=False,
-        ep_no_sync: bool = False,
-        ep_no_sync_use_2d_all_to_all: bool = False,
-        ep_no_sync_use_rowwise_all_to_all: bool = False,
-        ep_no_sync_rowwise_nblocks: int = 256,
-        ep_no_sync_share_dispatch_out: bool = False,
-        ep_no_sync_capacity_factor: float = 1.25,
-        ep_no_sync_shared_slots: int = 1,
-        ep_no_sync_share_combine_out: bool = False,
-        ep_no_sync_major_align: int = 1,
-        ep_no_sync_restore_unpermute_backend: str = "te_fused",
-        ep_no_sync_rowwise_symm_dispatch_in: Optional[bool] = None,
-        ep_no_sync_rowwise_symm_combine_out: Optional[bool] = None,
-        ep_no_sync_rowwise_symm_combine_gather: Optional[bool] = None,
+        ep: Optional[ExpertParallelConfig] = None,
         rowwise_fp8: Optional[MoERowwiseFP8Config] = None,
         init_device: str = "cpu",
         cache: Optional[BufferCache] = None,
@@ -547,24 +515,8 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         self.checkpoint_permute_moe_unpermute = checkpoint_permute_moe_unpermute
         self.checkpoint_combined_ep_tbo = checkpoint_combined_ep_tbo
         self.checkpoint_second_unpermute = checkpoint_second_unpermute
-        self.ep_no_sync = ep_no_sync
-        self.ep_no_sync_use_2d_all_to_all = ep_no_sync_use_2d_all_to_all
-        self.ep_no_sync_use_rowwise_all_to_all = ep_no_sync_use_rowwise_all_to_all
-        self.ep_no_sync_rowwise_nblocks = int(ep_no_sync_rowwise_nblocks)
-        self.ep_no_sync_share_dispatch_out = ep_no_sync_share_dispatch_out
-        if self.ep_no_sync_use_2d_all_to_all:
-            raise OLMoConfigurationError(
-                "ep_no_sync_use_2d_all_to_all=True is no longer supported: "
-                "the 2D all_to_all path was removed due to correctness/performance issues."
-            )
-        self.ep_no_sync_capacity_factor = ep_no_sync_capacity_factor
-        self.ep_no_sync_shared_slots = ep_no_sync_shared_slots
-        self.ep_no_sync_share_combine_out = ep_no_sync_share_combine_out
-        self.ep_no_sync_major_align = ep_no_sync_major_align
-        self.ep_no_sync_restore_unpermute_backend = ep_no_sync_restore_unpermute_backend.lower()
-        self.ep_no_sync_rowwise_symm_dispatch_in = ep_no_sync_rowwise_symm_dispatch_in
-        self.ep_no_sync_rowwise_symm_combine_out = ep_no_sync_rowwise_symm_combine_out
-        self.ep_no_sync_rowwise_symm_combine_gather = ep_no_sync_rowwise_symm_combine_gather
+        self.ep = ep.copy(deep=True) if ep is not None else ExpertParallelConfig()
+        self.ep.validate()
         self._ep_symm_group_name: Optional[str] = None
         self._ep_no_sync_symm_cache: Dict[str, torch.Tensor] = {}
         self._ep_no_sync_static_buffer_cache: Dict[Tuple[object, ...], object] = {}
@@ -581,29 +533,6 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         self._ep_no_sync_rowwise_total_tokens_sum: Optional[torch.Tensor] = None
         self._ep_no_sync_rowwise_symm_util_max: Optional[torch.Tensor] = None
         # self._ep_no_sync_forward_call_count: int = 0
-
-        if self.ep_no_sync_capacity_factor <= 0:
-            raise OLMoConfigurationError(
-                f"ep_no_sync_capacity_factor must be > 0 (got {self.ep_no_sync_capacity_factor})"
-            )
-        if self.ep_no_sync_shared_slots < 1:
-            raise OLMoConfigurationError(
-                f"ep_no_sync_shared_slots must be >= 1 (got {self.ep_no_sync_shared_slots})"
-            )
-        if self.ep_no_sync_major_align < 1:
-            raise OLMoConfigurationError(
-                f"ep_no_sync_major_align must be >= 1 (got {self.ep_no_sync_major_align})"
-            )
-        if self.ep_no_sync_rowwise_nblocks < 0:
-            raise OLMoConfigurationError(
-                f"ep_no_sync_rowwise_nblocks must be >= 0 (got {self.ep_no_sync_rowwise_nblocks})"
-            )
-        if self.ep_no_sync_restore_unpermute_backend not in ("te_fused", "te_unfused", "cuda"):
-            raise OLMoConfigurationError(
-                "ep_no_sync_restore_unpermute_backend must be one of "
-                "'te_fused'|'te_unfused'|'cuda' "
-                f"(got {self.ep_no_sync_restore_unpermute_backend!r})"
-            )
 
     def invalidate_rowwise_fp8_cache(self) -> None:
         _invalidate_rowwise_fp8_cache(self)
@@ -777,7 +706,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         # Row-wise EP metrics are only produced by the no-sync rowwise all-to-all path; that
         # helper module is not present unless the rowwise dispatch family is installed, so only
         # import it when the rowwise path is actually configured.
-        if self.ep_no_sync_use_rowwise_all_to_all:
+        if self.ep.is_rowwise:
             from olmo_core.nn.moe.v2.ep_no_sync_rowwise_helpers import (
                 add_ep_no_sync_rowwise_metrics,
                 reset_ep_no_sync_rowwise_metrics,
@@ -795,7 +724,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         #     self.shared_experts_router.reset_metrics()
         if self.routed_experts_router:
             self.routed_experts_router.reset_metrics()
-        if self.ep_no_sync_use_rowwise_all_to_all:
+        if self.ep.is_rowwise:
             from olmo_core.nn.moe.v2.ep_no_sync_rowwise_helpers import (
                 reset_ep_no_sync_rowwise_metrics,
             )
@@ -872,11 +801,11 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         if self.routed_experts:
             if self.ep_enabled:
                 if (
-                    self.ep_no_sync and self.training
+                    self.ep.no_sync and self.training
                 ):  # in eval mode, different ranks might get different input token counts, and no-sync can freeze
                     no_sync_forward = (
                         self.combined_forward_ep_no_sync_rowwise
-                        if self.ep_no_sync_use_rowwise_all_to_all
+                        if self.ep.is_rowwise
                         else self.combined_forward_ep_no_sync_1d
                     )
                     from olmo_core.nn.moe.v2.activation_debug import (
@@ -1037,8 +966,8 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         self._ep_enabled = True
         self.ep_pg = ep_pg if ep_pg is not None else ep_mp_mesh.get_group()
 
-        if self.ep_no_sync:
-            if olmo_symm_mem.is_enabled() and not self.ep_no_sync_use_rowwise_all_to_all:
+        if self.ep.no_sync:
+            if olmo_symm_mem.is_enabled() and not self.ep.is_rowwise:
                 raise RuntimeError(
                     "OLMo-owned symmetric memory currently supports only the rowwise "
                     "EP no-sync path. Set OLMO_USE_OWN_SYMM_MEM=0 to use the legacy "
@@ -1085,7 +1014,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
                     f"(block={self.block_idx}, rank={get_rank(self.ep_pg)}): {e}"
                 ) from e
             self._ep_symm_group_name = group_name
-            if self.ep_no_sync_use_rowwise_all_to_all:
+            if self.ep.is_rowwise:
                 from olmo_core.nn.moe.v2.ep_no_sync_buffers import (
                     resolve_ep_no_sync_rowwise_symm_options,
                 )
@@ -1239,7 +1168,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, object]:
-        if self.ep_no_sync_use_rowwise_all_to_all:
+        if self.ep.is_rowwise:
             from olmo_core.nn.moe.v2.ep_no_sync_tbo_rowwise import (
                 combined_forward_ep_no_sync_tbo_rowwise as _combined_forward_ep_no_sync_tbo_rowwise,
             )
@@ -1293,7 +1222,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         **kwargs,
     ) -> Tuple[torch.Tensor, object]:
         # Dispatch no-sync here so the no-sync TBO path never imports the sync module.
-        if self.ep_no_sync:
+        if self.ep.no_sync:
             return self.combined_forward_ep_no_sync_tbo(
                 x0,
                 x1_ctx,

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -167,10 +167,10 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                 first_moe_idx = idx
             if block.is_moe:
                 moe_block = cast(OLMoDDPTransformerBlock, block)
-                if moe_block.ep_no_sync and moe_block.ep_no_sync_shared_slots < 2:
+                if moe_block.ep.no_sync and moe_block.ep.shared_slots < 2:
                     raise OLMoConfigurationError(
-                        "When TBO and EP no-sync are enabled, ep_no_sync_shared_slots must be >= 2 "
-                        f"(block={moe_block.block_idx}, got {moe_block.ep_no_sync_shared_slots})."
+                        "When TBO and EP no-sync are enabled, ep.shared_slots must be >= 2 "
+                        f"(block={moe_block.block_idx}, got {moe_block.ep.shared_slots})."
                     )
 
         return first_moe_idx
@@ -242,7 +242,7 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         return sum(
             1
             for block in self.blocks.values()
-            if block.is_moe and isinstance(block, OLMoDDPTransformerBlock) and block.ep_no_sync
+            if block.is_moe and isinstance(block, OLMoDDPTransformerBlock) and block.ep.no_sync
         )
 
     @torch.no_grad()
@@ -321,7 +321,7 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         ep_blocks = [
             (block_key, cast(OLMoDDPTransformerBlock, block))
             for block_key, block in self.blocks.items()
-            if block.is_moe and isinstance(block, OLMoDDPTransformerBlock) and block.ep_no_sync
+            if block.is_moe and isinstance(block, OLMoDDPTransformerBlock) and block.ep.no_sync
         ]
         if not ep_blocks:
             if pad_to_block_count != 0:
@@ -356,7 +356,7 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         rank_capacity = compute_ep_no_sync_rank_capacity(first_block, num_out_tokens)
 
         for block_key, block in ep_blocks:
-            if block.ep_no_sync_use_rowwise_all_to_all:
+            if block.ep.is_rowwise:
                 rowwise_fp8_cfg = block.rowwise_fp8
                 use_rowwise_fp8 = (
                     rowwise_fp8_cfg is not None
@@ -401,7 +401,7 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                 lease_dispatch_out = runtime_uses_lifetime_leases
                 lease_combine_out = use_symm_combine_out and runtime_uses_lifetime_leases
                 lease_combine_gather = use_symm_combine_gather and runtime_uses_lifetime_leases
-                slot_indices = range(block.ep_no_sync_shared_slots) if self.tbo else (None,)
+                slot_indices = range(block.ep.shared_slots) if self.tbo else (None,)
                 for slot_idx in slot_indices:
                     get_ep_no_sync_buffers(
                         block,
@@ -582,15 +582,15 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
             # collectives, but can hang inside symm_mem.empty() before the
             # explicit EP rendezvous runs. Use the regular DeviceMesh EP group
             # for no-sync blocks.
-            block.apply_ep(ep_mesh, ep_pg=None if block.ep_no_sync else ep_mp_group)
-            if block.ep_no_sync:
+            block.apply_ep(ep_mesh, ep_pg=None if block.ep.no_sync else ep_mp_group)
+            if block.ep.no_sync:
                 ep_no_sync_blocks.append(block)
 
         if ep_no_sync_blocks:
-            slot_counts = {block.ep_no_sync_shared_slots for block in ep_no_sync_blocks}
+            slot_counts = {block.ep.shared_slots for block in ep_no_sync_blocks}
             if len(slot_counts) != 1:
                 raise OLMoConfigurationError(
-                    "All EP no-sync blocks must use the same ep_no_sync_shared_slots "
+                    "All EP no-sync blocks must use the same ep.shared_slots "
                     f"value, got {sorted(slot_counts)}"
                 )
             shared_slots = next(iter(slot_counts))
@@ -1021,7 +1021,7 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
             # matches the context, so bind them through Any-typed locals.
             stage_c_launch: Any
             stage_tail: Any
-            if block.ep_no_sync_use_rowwise_all_to_all:
+            if block.ep.is_rowwise:
                 from olmo_core.nn.moe.v2.ep_no_sync_tbo_rowwise import (
                     ep_no_sync_rowwise_tbo_stage_c_launch,
                     ep_no_sync_rowwise_tbo_stage_tail,

--- a/src/olmo_core/nn/moe/v2/ep_config.py
+++ b/src/olmo_core/nn/moe/v2/ep_config.py
@@ -140,6 +140,12 @@ class ExpertParallelConfig(Config):
         self.rowwise_wave_mode = self.rowwise_wave_mode.lower()
         self.deepep.validate()
 
+        if self.path in (ExpertParallelPath.rowwise_wave, ExpertParallelPath.deepep_v2):
+            # These backends are declared but not yet wired up: selecting one would silently run a
+            # different path (rowwise_wave -> rowwise_nvshmem) or be rejected downstream (deepep_v2
+            # -> no-sync symm-mem branch). Fail loudly until the backends land.
+            raise OLMoConfigurationError(f"EP path {self.path.value!r} is not yet supported")
+
         if self.capacity_factor <= 0:
             raise OLMoConfigurationError(
                 f"EP capacity_factor must be > 0 (got {self.capacity_factor})"

--- a/src/olmo_core/nn/moe/v2/ep_config.py
+++ b/src/olmo_core/nn/moe/v2/ep_config.py
@@ -34,38 +34,57 @@ class ExpertParallelSchedule(StrEnum):
 
 @dataclass
 class DeepEPConfig(Config):
-    # Optional DeepEP source/build path to add to sys.path before import. If not
-    # set, the backend falls back to OLMO_DEEPEP_PATH or /workspace/DeepEP.
     path: Optional[str] = None
-    # SMs to use for DeepEP dispatch/combine kernels. 0 lets DeepEP estimate a
-    # value from topology, bandwidth, number of experts, and top-k.
+    """
+    Optional DeepEP source/build path to add to ``sys.path`` before import. If not set, the backend
+    falls back to ``OLMO_DEEPEP_PATH`` or ``/workspace/DeepEP``.
+    """
     num_sms: int = 0
-    # RDMA queue pairs to use for DeepEP dispatch/combine. 0 lets DeepEP infer a
-    # value from num_sms and the selected communication mode.
+    """
+    SMs to use for DeepEP dispatch/combine kernels. 0 lets DeepEP estimate a value from topology,
+    bandwidth, number of experts, and top-k.
+    """
     num_qps: int = 0
-    # RDMA queue pairs to pre-allocate in the ElasticBuffer. 0 lets DeepEP choose
-    # its default upper bound; otherwise this must be >= num_qps.
+    """
+    RDMA queue pairs to use for DeepEP dispatch/combine. 0 lets DeepEP infer a value from
+    ``num_sms`` and the selected communication mode.
+    """
     num_allocated_qps: int = 0
-    # Padding alignment for received rows per expert. The current model path
-    # consumes packed rows, so deepep_v2 validates this as 1 for now.
+    """
+    RDMA queue pairs to pre-allocate in the ElasticBuffer. 0 lets DeepEP choose its default upper
+    bound; otherwise this must be >= ``num_qps``.
+    """
     expert_alignment: int = 1
-    # Pass async_with_compute_stream=True to DeepEP. When enabled, DeepEP returns
-    # an event instead of making the current stream wait for comm immediately;
-    # callers must place explicit waits before consuming comm outputs.
+    """
+    Padding alignment for received rows per expert. The current model path consumes packed rows, so
+    ``deepep_v2`` validates this as 1 for now.
+    """
     async_mode: bool = False
-    # Hint DeepEP's auto-tuner to reserve fewer SMs so communication can overlap
-    # with GEMM. If false, DeepEP tends to choose a larger SM count for standalone
-    # communication speed.
+    """
+    Pass ``async_with_compute_stream=True`` to DeepEP. When enabled, DeepEP returns an event instead
+    of making the current stream wait for comm immediately; callers must place explicit waits before
+    consuming comm outputs.
+    """
     prefer_overlap_with_compute: bool = True
-    # Allow DeepEP's hybrid communication mode. This can use more QPs but is the
-    # intended path for mixed NVLink/RDMA topologies.
+    """
+    Hint DeepEP's auto-tuner to reserve fewer SMs so communication can overlap with GEMM. If false,
+    DeepEP tends to choose a larger SM count for standalone communication speed.
+    """
     allow_hybrid_mode: bool = True
-    # Allow DeepEP combine to reduce multiple contributions for a token inside
-    # its communication/reduction path.
+    """
+    Allow DeepEP's hybrid communication mode. This can use more QPs but is the intended path for
+    mixed NVLink/RDMA topologies.
+    """
     allow_multiple_reduction: bool = True
-    # Where to apply top-k weights. "swiglu" fuses the weights into the routed
-    # expert path and currently requires bias-free down projections.
+    """
+    Allow DeepEP combine to reduce multiple contributions for a token inside its
+    communication/reduction path.
+    """
     weighting: str = "swiglu"
+    """
+    Where to apply top-k weights. ``"swiglu"`` fuses the weights into the routed expert path and
+    currently requires bias-free down projections.
+    """
 
     def validate(self) -> None:
         self.weighting = self.weighting.lower()
@@ -84,9 +103,11 @@ class ExpertParallelConfig(Config):
     path: ExpertParallelPath = ExpertParallelPath.sync_1d
     schedule: ExpertParallelSchedule = ExpertParallelSchedule.normal
 
-    # Rowwise and deepep_v2 use this as destination-rank expanded-row capacity
-    # and may tail-drop overflow routes.
     capacity_factor: float = 1.25
+    """
+    Rowwise and ``deepep_v2`` use this as destination-rank expanded-row capacity and may tail-drop
+    overflow routes.
+    """
     shared_slots: int = 1
     major_align: int = 1
 

--- a/src/olmo_core/nn/moe/v2/ep_config.py
+++ b/src/olmo_core/nn/moe/v2/ep_config.py
@@ -8,23 +8,29 @@ from olmo_core.exceptions import OLMoConfigurationError
 
 
 class ExpertParallelPath(StrEnum):
-    # Synchronized all-to-all EP. Does not require symmetric memory.
     sync_1d = "sync_1d"
-    # Legacy no-sync EP over symmetric-memory all_to_all_vdev primitives. It
-    # still pays permute/unpermute overhead, so rowwise_nvshmem is preferred for
-    # no-sync symmetric-memory EP.
+    """Synchronized all-to-all EP. Does not require symmetric memory."""
     no_sync_1d = "no_sync_1d"
-    # Production OLMo-owned rowwise NVSHMEM EP. Uses static rowwise buffers and
-    # device-side dispatch/combine metadata.
+    """
+    Legacy no-sync EP over symmetric-memory ``all_to_all_vdev`` primitives. It still pays
+    permute/unpermute overhead, so ``rowwise_nvshmem`` is preferred for no-sync symmetric-memory EP.
+    """
     rowwise_nvshmem = "rowwise_nvshmem"
-    # Experimental rowwise NVSHMEM waves. This tries to overlap the same batch's
-    # dispatch, expert GEMMs, and combine, but the current NVSHMEM implementation
-    # consumes enough SM resources that overlap has not made this faster. Not
-    # recommended for training.
+    """
+    Production OLMo-owned rowwise NVSHMEM EP. Uses static rowwise buffers and device-side
+    dispatch/combine metadata.
+    """
     rowwise_wave = "rowwise_wave"
-    # DeepEP V2 ElasticBuffer backend. Uses DeepEP's own communication buffers
-    # instead of OLMo symmetric-memory buffers.
+    """
+    Experimental rowwise NVSHMEM waves. This tries to overlap the same batch's dispatch, expert
+    GEMMs, and combine, but the current NVSHMEM implementation consumes enough SM resources that
+    overlap has not made this faster. Not recommended for training.
+    """
     deepep_v2 = "deepep_v2"
+    """
+    DeepEP V2 ElasticBuffer backend. Uses DeepEP's own communication buffers instead of OLMo
+    symmetric-memory buffers.
+    """
 
 
 class ExpertParallelSchedule(StrEnum):

--- a/src/olmo_core/nn/moe/v2/ep_config.py
+++ b/src/olmo_core/nn/moe/v2/ep_config.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from olmo_core.config import Config, StrEnum
+from olmo_core.exceptions import OLMoConfigurationError
+
+
+class ExpertParallelPath(StrEnum):
+    # Synchronized all-to-all EP. Does not require symmetric memory.
+    sync_1d = "sync_1d"
+    # Legacy no-sync EP over symmetric-memory all_to_all_vdev primitives. It
+    # still pays permute/unpermute overhead, so rowwise_nvshmem is preferred for
+    # no-sync symmetric-memory EP.
+    no_sync_1d = "no_sync_1d"
+    # Production OLMo-owned rowwise NVSHMEM EP. Uses static rowwise buffers and
+    # device-side dispatch/combine metadata.
+    rowwise_nvshmem = "rowwise_nvshmem"
+    # Experimental rowwise NVSHMEM waves. This tries to overlap the same batch's
+    # dispatch, expert GEMMs, and combine, but the current NVSHMEM implementation
+    # consumes enough SM resources that overlap has not made this faster. Not
+    # recommended for training.
+    rowwise_wave = "rowwise_wave"
+    # DeepEP V2 ElasticBuffer backend. Uses DeepEP's own communication buffers
+    # instead of OLMo symmetric-memory buffers.
+    deepep_v2 = "deepep_v2"
+
+
+class ExpertParallelSchedule(StrEnum):
+    normal = "normal"
+    tbo = "tbo"
+
+
+@dataclass
+class DeepEPConfig(Config):
+    # Optional DeepEP source/build path to add to sys.path before import. If not
+    # set, the backend falls back to OLMO_DEEPEP_PATH or /workspace/DeepEP.
+    path: Optional[str] = None
+    # SMs to use for DeepEP dispatch/combine kernels. 0 lets DeepEP estimate a
+    # value from topology, bandwidth, number of experts, and top-k.
+    num_sms: int = 0
+    # RDMA queue pairs to use for DeepEP dispatch/combine. 0 lets DeepEP infer a
+    # value from num_sms and the selected communication mode.
+    num_qps: int = 0
+    # RDMA queue pairs to pre-allocate in the ElasticBuffer. 0 lets DeepEP choose
+    # its default upper bound; otherwise this must be >= num_qps.
+    num_allocated_qps: int = 0
+    # Padding alignment for received rows per expert. The current model path
+    # consumes packed rows, so deepep_v2 validates this as 1 for now.
+    expert_alignment: int = 1
+    # Pass async_with_compute_stream=True to DeepEP. When enabled, DeepEP returns
+    # an event instead of making the current stream wait for comm immediately;
+    # callers must place explicit waits before consuming comm outputs.
+    async_mode: bool = False
+    # Hint DeepEP's auto-tuner to reserve fewer SMs so communication can overlap
+    # with GEMM. If false, DeepEP tends to choose a larger SM count for standalone
+    # communication speed.
+    prefer_overlap_with_compute: bool = True
+    # Allow DeepEP's hybrid communication mode. This can use more QPs but is the
+    # intended path for mixed NVLink/RDMA topologies.
+    allow_hybrid_mode: bool = True
+    # Allow DeepEP combine to reduce multiple contributions for a token inside
+    # its communication/reduction path.
+    allow_multiple_reduction: bool = True
+    # Where to apply top-k weights. "swiglu" fuses the weights into the routed
+    # expert path and currently requires bias-free down projections.
+    weighting: str = "swiglu"
+
+    def validate(self) -> None:
+        self.weighting = self.weighting.lower()
+        if self.num_sms < 0:
+            raise OLMoConfigurationError(f"EP DeepEP num_sms must be >= 0 (got {self.num_sms})")
+        if self.num_qps < 0:
+            raise OLMoConfigurationError(f"EP DeepEP num_qps must be >= 0 (got {self.num_qps})")
+        if self.num_allocated_qps < 0:
+            raise OLMoConfigurationError(
+                "EP DeepEP num_allocated_qps must be >= 0 " f"(got {self.num_allocated_qps})"
+            )
+
+
+@dataclass
+class ExpertParallelConfig(Config):
+    path: ExpertParallelPath = ExpertParallelPath.sync_1d
+    schedule: ExpertParallelSchedule = ExpertParallelSchedule.normal
+
+    # Rowwise and deepep_v2 use this as destination-rank expanded-row capacity
+    # and may tail-drop overflow routes.
+    capacity_factor: float = 1.25
+    shared_slots: int = 1
+    major_align: int = 1
+
+    rowwise_nblocks: int = 32
+    share_dispatch_out: bool = False
+    share_combine_out: bool = False
+    restore_unpermute_backend: str = "te_fused"
+    rowwise_symm_dispatch_in: Optional[bool] = None
+    rowwise_symm_combine_out: Optional[bool] = None
+    rowwise_symm_combine_gather: Optional[bool] = None
+
+    rowwise_wave_num_waves: int = 1
+    rowwise_wave_mode: str = "expert"
+    rowwise_wave_recompute_linear1: bool = False
+    rowwise_wave_recompute_act: bool = False
+    checkpoint_tbo: bool = False
+
+    deepep: DeepEPConfig = field(default_factory=DeepEPConfig)
+
+    def validate(self) -> None:
+        self.path = ExpertParallelPath(self.path)
+        self.schedule = ExpertParallelSchedule(self.schedule)
+        self.restore_unpermute_backend = self.restore_unpermute_backend.lower()
+        self.rowwise_wave_mode = self.rowwise_wave_mode.lower()
+        self.deepep.validate()
+
+        if self.capacity_factor <= 0:
+            raise OLMoConfigurationError(
+                f"EP capacity_factor must be > 0 (got {self.capacity_factor})"
+            )
+        if self.shared_slots < 1:
+            raise OLMoConfigurationError(f"EP shared_slots must be >= 1 (got {self.shared_slots})")
+        if self.major_align < 1:
+            raise OLMoConfigurationError(f"EP major_align must be >= 1 (got {self.major_align})")
+        if self.rowwise_nblocks < 0:
+            raise OLMoConfigurationError(
+                f"EP rowwise_nblocks must be >= 0 (got {self.rowwise_nblocks})"
+            )
+        if self.rowwise_wave_num_waves < 1:
+            raise OLMoConfigurationError(
+                "EP rowwise_wave_num_waves must be >= 1 " f"(got {self.rowwise_wave_num_waves})"
+            )
+        if self.rowwise_wave_mode != "expert":
+            raise OLMoConfigurationError(
+                "EP rowwise_wave_mode currently supports only 'expert' "
+                f"(got {self.rowwise_wave_mode!r})"
+            )
+        if self.path != ExpertParallelPath.rowwise_wave and self.rowwise_wave_num_waves != 1:
+            raise OLMoConfigurationError(
+                "EP rowwise_wave_num_waves is only valid with "
+                f"path={ExpertParallelPath.rowwise_wave!r} "
+                f"(got path={self.path!r})"
+            )
+        if self.restore_unpermute_backend not in ("te_fused", "te_unfused", "cuda"):
+            raise OLMoConfigurationError(
+                "EP restore_unpermute_backend must be one of "
+                "'te_fused'|'te_unfused'|'cuda' "
+                f"(got {self.restore_unpermute_backend!r})"
+            )
+        if (
+            self.schedule == ExpertParallelSchedule.tbo
+            and self.path != ExpertParallelPath.rowwise_nvshmem
+        ):
+            raise OLMoConfigurationError(
+                "EP schedule='tbo' is only supported with "
+                f"path={ExpertParallelPath.rowwise_nvshmem!r} "
+                f"(got path={self.path!r})"
+            )
+        if self.checkpoint_tbo and self.path != ExpertParallelPath.rowwise_nvshmem:
+            raise OLMoConfigurationError(
+                "EP checkpoint_tbo=True is only supported with "
+                f"path={ExpertParallelPath.rowwise_nvshmem!r} "
+                f"(got path={self.path!r})"
+            )
+        if self.path == ExpertParallelPath.deepep_v2:
+            if self.deepep.expert_alignment != 1:
+                raise OLMoConfigurationError(
+                    "EP deepep_v2 currently supports only "
+                    "deepep.expert_alignment=1 "
+                    f"(got {self.deepep.expert_alignment})"
+                )
+            if self.deepep.weighting != "swiglu":
+                raise OLMoConfigurationError(
+                    "EP deepep_v2 model path currently supports only "
+                    f"deepep.weighting='swiglu' (got {self.deepep.weighting!r})"
+                )
+
+    @property
+    def no_sync(self) -> bool:
+        return self.path != ExpertParallelPath.sync_1d
+
+    @property
+    def is_no_sync_1d(self) -> bool:
+        return self.path == ExpertParallelPath.no_sync_1d
+
+    @property
+    def is_rowwise(self) -> bool:
+        return self.path in {
+            ExpertParallelPath.rowwise_nvshmem,
+            ExpertParallelPath.rowwise_wave,
+        }
+
+    @property
+    def is_deepep(self) -> bool:
+        return self.path == ExpertParallelPath.deepep_v2
+
+    @property
+    def uses_olmo_symm(self) -> bool:
+        return self.no_sync and not self.is_deepep
+
+    @property
+    def uses_rowwise_buffers(self) -> bool:
+        return self.is_rowwise
+
+    @property
+    def rowwise_transport(self) -> Optional[str]:
+        if self.path in {
+            ExpertParallelPath.rowwise_nvshmem,
+            ExpertParallelPath.rowwise_wave,
+        }:
+            return "nvshmem"
+        return None

--- a/src/olmo_core/nn/moe/v2/ep_config.py
+++ b/src/olmo_core/nn/moe/v2/ep_config.py
@@ -179,15 +179,10 @@ class ExpertParallelConfig(Config):
                 "'te_fused'|'te_unfused'|'cuda' "
                 f"(got {self.restore_unpermute_backend!r})"
             )
-        if (
-            self.schedule == ExpertParallelSchedule.tbo
-            and self.path != ExpertParallelPath.rowwise_nvshmem
-        ):
-            raise OLMoConfigurationError(
-                "EP schedule='tbo' is only supported with "
-                f"path={ExpertParallelPath.rowwise_nvshmem!r} "
-                f"(got path={self.path!r})"
-            )
+        if self.schedule == ExpertParallelSchedule.tbo:
+            # ep.schedule does not drive dispatch yet (TBO is selected by the train module), so a
+            # 'tbo' schedule here would be silently ignored. Reject it until it is wired up.
+            raise OLMoConfigurationError("EP schedule='tbo' is not yet supported")
         if self.checkpoint_tbo and self.path != ExpertParallelPath.rowwise_nvshmem:
             raise OLMoConfigurationError(
                 "EP checkpoint_tbo=True is only supported with "

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
@@ -55,11 +55,6 @@ def combined_forward_ep_no_sync_1d(
     assert (
         not requires_host_side_split_sizes()
     ), "EP no-sync implementation does not support host-side split size communication"
-    if self.ep_no_sync_use_2d_all_to_all:
-        raise RuntimeError(
-            "ep_no_sync_use_2d_all_to_all=True is no longer supported: "
-            "the 2D all_to_all path was removed due to correctness/performance issues."
-        )
 
     group_name = get_ep_no_sync_group_name(self)
     B, S, D = x.shape

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_buffers.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_buffers.py
@@ -1307,7 +1307,7 @@ def get_cached_ep_no_sync_rowwise_fp8_buffers(
 def use_ep_no_sync_rowwise_symm_dispatch_in(block: "MoEFusedV2TransformerBlock") -> bool:
     return _resolve_rowwise_symm_option(
         block,
-        attr_name="ep_no_sync_rowwise_symm_dispatch_in",
+        attr_name="ep.rowwise_symm_dispatch_in",
         env_name="OLMO_MOE_ROWWISE_SYMM_DISPATCH_IN",
     )
 
@@ -1315,7 +1315,7 @@ def use_ep_no_sync_rowwise_symm_dispatch_in(block: "MoEFusedV2TransformerBlock")
 def use_ep_no_sync_rowwise_symm_combine_out(block: "MoEFusedV2TransformerBlock") -> bool:
     return _resolve_rowwise_symm_option(
         block,
-        attr_name="ep_no_sync_rowwise_symm_combine_out",
+        attr_name="ep.rowwise_symm_combine_out",
         env_name="OLMO_MOE_ROWWISE_SYMM_COMBINE_OUT",
         auto_enabled=False,
     )
@@ -1324,7 +1324,7 @@ def use_ep_no_sync_rowwise_symm_combine_out(block: "MoEFusedV2TransformerBlock")
 def use_ep_no_sync_rowwise_symm_combine_gather(block: "MoEFusedV2TransformerBlock") -> bool:
     return _resolve_rowwise_symm_option(
         block,
-        attr_name="ep_no_sync_rowwise_symm_combine_gather",
+        attr_name="ep.rowwise_symm_combine_gather",
         env_name="OLMO_MOE_ROWWISE_SYMM_COMBINE_GATHER",
     )
 

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_buffers.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_buffers.py
@@ -610,7 +610,7 @@ class _NoSyncSymmSharedPool:
 
 
 def get_ep_no_sync_group_name(block: "MoEFusedV2TransformerBlock") -> str:
-    if not block.ep_no_sync:
+    if not block.ep.no_sync:
         raise RuntimeError("EP no-sync is not enabled for this block")
     if block._ep_symm_group_name is None:
         raise RuntimeError(
@@ -1008,7 +1008,7 @@ def get_ep_no_sync_rowwise_fp8_buffers(
         assert dispatch_out_lease is not None
         dispatch_out_q = dispatch_out_lease.tensor("dispatch_out_q")
         dispatch_out_scales = dispatch_out_lease.tensor("dispatch_out_scales")
-    elif block._ep_no_sync_shared_pool is not None and block.ep_no_sync_share_dispatch_out:
+    elif block._ep_no_sync_shared_pool is not None and block.ep.share_dispatch_out:
         dispatch_out_lease = None
         (
             dispatch_out_q,
@@ -1119,7 +1119,10 @@ def _resolve_rowwise_symm_option(
     env_name: str,
     auto_enabled: bool = True,
 ) -> bool:
-    configured = getattr(block, attr_name, None)
+    if attr_name.startswith("ep."):
+        configured = getattr(block.ep, attr_name.split(".", 1)[1], None)
+    else:
+        configured = getattr(block, attr_name, None)
     if configured is not None:
         return bool(configured)
     env_value = os.getenv(env_name)
@@ -1132,23 +1135,23 @@ def _resolve_rowwise_symm_option(
 
 def resolve_ep_no_sync_rowwise_symm_options(block: "MoEFusedV2TransformerBlock") -> None:
     """Resolve rowwise symmetric-buffer policy before compiled forwards run."""
-    if block.ep_no_sync_rowwise_symm_dispatch_in is None:
-        block.ep_no_sync_rowwise_symm_dispatch_in = _resolve_rowwise_symm_option(
+    if block.ep.rowwise_symm_dispatch_in is None:
+        block.ep.rowwise_symm_dispatch_in = _resolve_rowwise_symm_option(
             block,
-            attr_name="ep_no_sync_rowwise_symm_dispatch_in",
+            attr_name="ep.rowwise_symm_dispatch_in",
             env_name="OLMO_MOE_ROWWISE_SYMM_DISPATCH_IN",
         )
-    if block.ep_no_sync_rowwise_symm_combine_out is None:
-        block.ep_no_sync_rowwise_symm_combine_out = _resolve_rowwise_symm_option(
+    if block.ep.rowwise_symm_combine_out is None:
+        block.ep.rowwise_symm_combine_out = _resolve_rowwise_symm_option(
             block,
-            attr_name="ep_no_sync_rowwise_symm_combine_out",
+            attr_name="ep.rowwise_symm_combine_out",
             env_name="OLMO_MOE_ROWWISE_SYMM_COMBINE_OUT",
             auto_enabled=False,
         )
-    if block.ep_no_sync_rowwise_symm_combine_gather is None:
-        block.ep_no_sync_rowwise_symm_combine_gather = _resolve_rowwise_symm_option(
+    if block.ep.rowwise_symm_combine_gather is None:
+        block.ep.rowwise_symm_combine_gather = _resolve_rowwise_symm_option(
             block,
-            attr_name="ep_no_sync_rowwise_symm_combine_gather",
+            attr_name="ep.rowwise_symm_combine_gather",
             env_name="OLMO_MOE_ROWWISE_SYMM_COMBINE_GATHER",
         )
 
@@ -1431,16 +1434,12 @@ def get_ep_no_sync_buffers(
                 need_dispatch_in=need_dispatch_in,
                 need_dispatch_meta=need_dispatch_meta,
                 include_dispatch_out=(
-                    need_dispatch_out
-                    and block.ep_no_sync_share_dispatch_out
-                    and not lease_dispatch_out
+                    need_dispatch_out and block.ep.share_dispatch_out and not lease_dispatch_out
                 ),
                 need_combine_in=need_combine_in,
                 need_combine_meta=need_combine_meta,
                 include_combine_out=(
-                    need_combine_out
-                    and block.ep_no_sync_share_combine_out
-                    and not lease_combine_out
+                    need_combine_out and block.ep.share_combine_out and not lease_combine_out
                 ),
                 d_model=d_model,
                 dtype=dtype,
@@ -1717,5 +1716,5 @@ def compute_ep_no_sync_rank_capacity(
     # same value (not divided by ep_world_size).
     return max(
         1,
-        int(math.ceil(block.ep_no_sync_capacity_factor * float(num_out_tokens))),
+        int(math.ceil(block.ep.capacity_factor * float(num_out_tokens))),
     )

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_common.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_common.py
@@ -187,7 +187,7 @@ def restore_drop_unpermute_1d(
         -1,
         self.routed_experts_router.top_k,
     )
-    backend = self.ep_no_sync_restore_unpermute_backend
+    backend = self.ep.restore_unpermute_backend
 
     if backend == "te_fused":
         return cast(

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
@@ -69,11 +69,6 @@ def combined_forward_ep_no_sync_rowwise(
     assert (
         not requires_host_side_split_sizes()
     ), "EP no-sync implementation does not support host-side split size communication"
-    if self.ep_no_sync_use_2d_all_to_all:
-        raise RuntimeError(
-            "ep_no_sync_use_2d_all_to_all=True is no longer supported: "
-            "the 2D all_to_all path was removed due to correctness/performance issues."
-        )
 
     group_name = get_ep_no_sync_group_name(self)
     B, S, D = x.shape
@@ -125,7 +120,7 @@ def combined_forward_ep_no_sync_rowwise(
         rowwise_fp8_cfg is not None
         and rowwise_fp8_cfg.enabled
         and moe_inp.device.type == "cuda"
-        and self.ep_no_sync_use_rowwise_all_to_all
+        and self.ep.is_rowwise
     )
     if use_rowwise_fp8:
         assert rowwise_fp8_cfg is not None
@@ -352,7 +347,7 @@ def combined_forward_ep_no_sync_rowwise(
             allowed_splits=allowed_splits,
             keep_from_src_dest_local=keep_from_src_dest_local,
         )
-        rowwise_nblocks = self.ep_no_sync_rowwise_nblocks
+        rowwise_nblocks = self.ep.rowwise_nblocks
 
     if self.shared_experts is not None:
         with torch.cuda.stream(self.get_dense_stream()):
@@ -502,7 +497,7 @@ def combined_forward_ep_no_sync_rowwise(
             rowwise_fp8_cfg.block_size,
             group_name,
             self.ep_pg,
-            self.ep_no_sync_rowwise_nblocks,
+            self.ep.rowwise_nblocks,
         )
     else:
         assert buffers is not None
@@ -519,7 +514,7 @@ def combined_forward_ep_no_sync_rowwise(
             route_probs,
             group_name,
             self.ep_pg,
-            self.ep_no_sync_rowwise_nblocks,
+            self.ep.rowwise_nblocks,
             expert_out_aliases_symm_expert_out,
             True,
             False,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_1d.py
@@ -61,14 +61,9 @@ def ep_no_sync_stage_a(
     assert (
         not requires_host_side_split_sizes()
     ), "EP no-sync implementation does not support host-side split size communication"
-    if self.ep_no_sync_use_2d_all_to_all:
+    if self.ep.is_rowwise:
         raise RuntimeError(
-            "ep_no_sync_use_2d_all_to_all=True is no longer supported: "
-            "the 2D all_to_all path was removed due to correctness/performance issues."
-        )
-    if self.ep_no_sync_use_rowwise_all_to_all:
-        raise RuntimeError(
-            "ep_no_sync_use_rowwise_all_to_all=True is only implemented for "
+            "A rowwise EP path is only implemented for "
             "combined_forward_ep_no_sync_rowwise() (non-TBO path) right now."
         )
 

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
@@ -118,11 +118,6 @@ def ep_no_sync_rowwise_tbo_stage_a(
         not requires_host_side_split_sizes()
     ), "EP no-sync implementation does not support host-side split size communication"
     _check_rowwise_tbo_supported(self)
-    if self.ep_no_sync_use_2d_all_to_all:
-        raise RuntimeError(
-            "ep_no_sync_use_2d_all_to_all=True is no longer supported: "
-            "the 2D all_to_all path was removed due to correctness/performance issues."
-        )
 
     group_name = get_ep_no_sync_group_name(self)
     slot_idx = ep_no_sync_slot_for_lane(self, lane_id)
@@ -228,7 +223,7 @@ def ep_no_sync_rowwise_tbo_stage_a(
             allowed_splits=allowed_splits,
             keep_from_src_dest_local=keep_from_src_dest_local,
         )
-        rowwise_nblocks = self.ep_no_sync_rowwise_nblocks
+        rowwise_nblocks = self.ep.rowwise_nblocks
 
     return _NoSyncRowwiseStageAState(
         lane_id=lane_id,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
@@ -90,7 +90,7 @@ class _NoSyncRowwiseTboPendingContext:
 
 
 def _check_rowwise_tbo_supported(block: "MoEFusedV2TransformerBlock") -> None:
-    if not block.ep_no_sync_use_rowwise_all_to_all:
+    if not block.ep.is_rowwise:
         raise RuntimeError("Rowwise no-sync TBO requires ep_no_sync_use_rowwise_all_to_all=True")
     if block.rowwise_fp8 is not None and block.rowwise_fp8.enabled:
         raise NotImplementedError(

--- a/src/test/nn/ddp/block_no_ep_test.py
+++ b/src/test/nn/ddp/block_no_ep_test.py
@@ -9,6 +9,7 @@ from olmo_core.nn.ddp.block import (
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.lm_head import LMHeadConfig
 from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.nn.transformer import (
@@ -76,8 +77,7 @@ def _build_block(
             dtype=DType.float32,
         ),
         feed_forward_norm=layer_norm,
-        ep_no_sync=False,
-        ep_no_sync_major_align=1,
+        ep=ExpertParallelConfig(path=ExpertParallelPath.sync_1d, major_align=1),
         init_device=init_device,
     )
 

--- a/src/test/nn/ddp/block_no_sync_test.py
+++ b/src/test/nn/ddp/block_no_sync_test.py
@@ -1,15 +1,14 @@
 import os
 
-import pytest
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 
 from olmo_core.config import DType
-from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.testing import (
@@ -41,7 +40,6 @@ def _build_block(
     top_k: int = 1,
     uniform_expert_assignment: bool = True,
     init_device: str = "cuda",
-    ep_no_sync_use_2d_all_to_all: bool = False,
 ) -> OLMoDDPTransformerBlock:
     layer_norm = LayerNormConfig(
         name=LayerNormType.rms,
@@ -84,10 +82,11 @@ def _build_block(
             dtype=DType.float32,
         ),
         feed_forward_norm=layer_norm,
-        ep_no_sync=ep_no_sync,
-        ep_no_sync_use_2d_all_to_all=ep_no_sync_use_2d_all_to_all,
-        ep_no_sync_capacity_factor=ep_no_sync_capacity_factor,
-        ep_no_sync_major_align=1,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.no_sync_1d if ep_no_sync else ExpertParallelPath.sync_1d,
+            capacity_factor=ep_no_sync_capacity_factor,
+            major_align=1,
+        ),
         init_device=init_device,
     )
 
@@ -381,8 +380,8 @@ def _run_ep_no_sync_rowwise_matches_synced():
     _install_deterministic_topk_router(block_ep)
     _install_deterministic_topk_router(block_rowwise)
 
-    block_rowwise.ep_no_sync_use_rowwise_all_to_all = True
-    block_rowwise.ep_no_sync_rowwise_nblocks = 128
+    block_rowwise.ep.path = ExpertParallelPath.rowwise_nvshmem
+    block_rowwise.ep.rowwise_nblocks = 128
 
     block_ep.train()
     block_rowwise.train()
@@ -439,11 +438,11 @@ def _run_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
     _install_deterministic_topk_router(block_a)
     _install_deterministic_topk_router(block_b)
 
-    block_a.ep_no_sync_use_rowwise_all_to_all = True
-    block_a.ep_no_sync_rowwise_nblocks = 128
+    block_a.ep.path = ExpertParallelPath.rowwise_nvshmem
+    block_a.ep.rowwise_nblocks = 128
 
-    block_b.ep_no_sync_use_rowwise_all_to_all = True
-    block_b.ep_no_sync_rowwise_nblocks = 128
+    block_b.ep.path = ExpertParallelPath.rowwise_nvshmem
+    block_b.ep.rowwise_nblocks = 128
 
     block_a.train()
     block_b.train()
@@ -503,15 +502,6 @@ def test_v2_ep_no_sync_rowwise_matches_synced():
     run_distributed_test(
         _run_ep_no_sync_rowwise_matches_synced, backend="nccl", start_method="spawn"
     )
-
-
-def test_v2_ep_no_sync_2d_all_to_all_rejected():
-    with pytest.raises(OLMoConfigurationError, match="2D all_to_all path was removed"):
-        _build_block(
-            ep_no_sync=True,
-            init_device="cpu",
-            ep_no_sync_use_2d_all_to_all=True,
-        )
 
 
 @requires_multi_gpu

--- a/src/test/nn/moe/v2/ep_no_sync_1d_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_1d_test.py
@@ -1,19 +1,18 @@
 import os
 
-import pytest
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 
 from olmo_core.config import DType
-from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.attention import AttentionConfig, AttentionType
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
-from olmo_core.testing import requires_gpu, requires_multi_gpu, run_distributed_test
+from olmo_core.testing import requires_multi_gpu, run_distributed_test
 
 
 def _build_ep_mesh() -> DeviceMesh:
@@ -32,7 +31,6 @@ def _build_block(
     top_k: int = 1,
     uniform_expert_assignment: bool = True,
     init_device: str = "cuda",
-    ep_no_sync_use_2d_all_to_all: bool = False,
 ) -> OLMoDDPTransformerBlock:
     layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=DType.float32)
     return OLMoDDPTransformerBlock(
@@ -68,10 +66,11 @@ def _build_block(
             dtype=DType.float32,
         ),
         feed_forward_norm=layer_norm,
-        ep_no_sync=ep_no_sync,
-        ep_no_sync_use_2d_all_to_all=ep_no_sync_use_2d_all_to_all,
-        ep_no_sync_capacity_factor=ep_no_sync_capacity_factor,
-        ep_no_sync_major_align=1,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.no_sync_1d if ep_no_sync else ExpertParallelPath.sync_1d,
+            capacity_factor=ep_no_sync_capacity_factor,
+            major_align=1,
+        ),
         init_device=init_device,
     )
 
@@ -116,13 +115,6 @@ def _install_forced_router(block: OLMoDDPTransformerBlock):
 
     assert block.routed_experts_router is not None
     block.routed_experts_router.forward = _make_forced_forward(block.routed_experts_router)
-
-
-@requires_gpu
-def test_v2_ep_no_sync_2d_all_to_all_rejected():
-    # @requires_gpu (not CPU): block construction allocates CUDA events before the config check.
-    with pytest.raises(OLMoConfigurationError, match="2D all_to_all path was removed"):
-        _build_block(ep_no_sync=True, init_device="cpu", ep_no_sync_use_2d_all_to_all=True)
 
 
 def _run_ep_no_sync_drop_behavior():

--- a/src/test/nn/moe/v2/ep_no_sync_buffers_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_buffers_test.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 import torch
 
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig
 from olmo_core.nn.moe.v2.ep_no_sync_buffers import (
     _cached_symm_tensor_covers,
     _parse_bool_env,
@@ -47,8 +48,8 @@ def test_view_cached_symm_tensor():
 
 
 def test_compute_ep_no_sync_rank_capacity():
-    block: Any = SimpleNamespace(ep_no_sync_capacity_factor=1.25)
+    block: Any = SimpleNamespace(ep=ExpertParallelConfig(capacity_factor=1.25))
     assert compute_ep_no_sync_rank_capacity(block, 10) == 13  # ceil(1.25 * 10)
     assert compute_ep_no_sync_rank_capacity(block, 0) == 1  # floored to at least 1
-    block2: Any = SimpleNamespace(ep_no_sync_capacity_factor=2.0)
+    block2: Any = SimpleNamespace(ep=ExpertParallelConfig(capacity_factor=2.0))
     assert compute_ep_no_sync_rank_capacity(block2, 4) == 8

--- a/src/test/nn/moe/v2/ep_no_sync_rowwise_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_rowwise_test.py
@@ -7,6 +7,7 @@ from olmo_core.nn.attention import AttentionConfig, AttentionType
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.testing import (
@@ -53,9 +54,11 @@ def _build_block(*, ep_no_sync: bool, ep_no_sync_capacity_factor: float = 8.0):
             d_model=512, hidden_size=1024, num_experts=8, bias=False, dtype=DType.float32
         ),
         feed_forward_norm=layer_norm,
-        ep_no_sync=ep_no_sync,
-        ep_no_sync_capacity_factor=ep_no_sync_capacity_factor,
-        ep_no_sync_major_align=1,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.no_sync_1d if ep_no_sync else ExpertParallelPath.sync_1d,
+            capacity_factor=ep_no_sync_capacity_factor,
+            major_align=1,
+        ),
         init_device="cuda",
     )
 
@@ -138,8 +141,8 @@ def _run_rowwise_ep_dropless_matches_no_ep():
     ep_block = _build_block(ep_no_sync=True)
     # Select the rowwise path before apply_ep: apply_ep configures the rowwise symmetric-memory
     # buffers and rejects the non-rowwise (VDev) path under the default OLMo-owned symm-mem backend.
-    ep_block.ep_no_sync_use_rowwise_all_to_all = True
-    ep_block.ep_no_sync_rowwise_nblocks = 128
+    ep_block.ep.path = ExpertParallelPath.rowwise_nvshmem
+    ep_block.ep.rowwise_nblocks = 128
     ep_block.apply_ep(ep_mesh)
 
     _init_block_params(no_ep_block)

--- a/src/test/nn/moe/v2/ep_no_sync_tbo_1d_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_tbo_1d_test.py
@@ -8,6 +8,7 @@ from olmo_core.config import DType
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.testing import requires_multi_gpu, run_distributed_test
@@ -65,10 +66,12 @@ def _build_tbo_model(*, two_batch_overlap: bool, ep_no_sync: bool):
                 d_model=512, hidden_size=1024, num_experts=8, bias=False, dtype=DType.float32
             ),
             layer_norm=layer_norm,
-            ep_no_sync=ep_no_sync,
-            ep_no_sync_capacity_factor=8.0,
-            ep_no_sync_major_align=1,
-            ep_no_sync_shared_slots=2 if two_batch_overlap and ep_no_sync else 1,
+            ep=ExpertParallelConfig(
+                path=ExpertParallelPath.no_sync_1d if ep_no_sync else ExpertParallelPath.sync_1d,
+                capacity_factor=8.0,
+                major_align=1,
+                shared_slots=2 if two_batch_overlap and ep_no_sync else 1,
+            ),
         ),
     )
     return config.build(init_device="cuda")

--- a/src/test/nn/moe/v2/ep_no_sync_tbo_rowwise_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_tbo_rowwise_test.py
@@ -11,6 +11,7 @@ from olmo_core.nn.ddp import block as block_mod
 from olmo_core.nn.ddp import model as model_mod
 from olmo_core.nn.moe.v2 import ep_no_sync_tbo_1d as tbo_1d
 from olmo_core.nn.moe.v2 import ep_no_sync_tbo_rowwise as rowwise_tbo
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 
 
 def test_block_selects_rowwise_no_sync_tbo(monkeypatch):
@@ -27,7 +28,7 @@ def test_block_selects_rowwise_no_sync_tbo(monkeypatch):
     monkeypatch.setattr(rowwise_tbo, "combined_forward_ep_no_sync_tbo_rowwise", fake_rowwise)
     monkeypatch.setattr(tbo_1d, "combined_forward_ep_no_sync_tbo", fake_1d)
 
-    fake_block = SimpleNamespace(ep_no_sync_use_rowwise_all_to_all=True)
+    fake_block = SimpleNamespace(ep=ExpertParallelConfig(path=ExpertParallelPath.rowwise_nvshmem))
     out, ctx = block_mod.OLMoDDPTransformerBlock.combined_forward_ep_no_sync_tbo(
         fake_block,  # type: ignore[arg-type]
         "x0",
@@ -64,7 +65,7 @@ def test_block_keeps_existing_1d_tbo_when_rowwise_disabled(monkeypatch):
 
     monkeypatch.setattr(tbo_1d, "combined_forward_ep_no_sync_tbo", fake_1d)
 
-    fake_block = SimpleNamespace(ep_no_sync_use_rowwise_all_to_all=False)
+    fake_block = SimpleNamespace(ep=ExpertParallelConfig(path=ExpertParallelPath.no_sync_1d))
     out, ctx = block_mod.OLMoDDPTransformerBlock.combined_forward_ep_no_sync_tbo(
         fake_block,  # type: ignore[arg-type]
         "x0",
@@ -78,7 +79,7 @@ def test_block_keeps_existing_1d_tbo_when_rowwise_disabled(monkeypatch):
 
 def test_rowwise_tbo_fails_closed_for_fp8():
     block = SimpleNamespace(
-        ep_no_sync_use_rowwise_all_to_all=True,
+        ep=ExpertParallelConfig(path=ExpertParallelPath.rowwise_nvshmem),
         rowwise_fp8=SimpleNamespace(enabled=True),
     )
 
@@ -105,7 +106,7 @@ def test_model_finalizes_rowwise_pending_context(monkeypatch):
             calls.append(("lm_head", x, lm_head_kwargs, labels))
             return f"head:{x}:{labels}"
 
-    fake_block = SimpleNamespace(ep_no_sync_use_rowwise_all_to_all=True)
+    fake_block = SimpleNamespace(ep=ExpertParallelConfig(path=ExpertParallelPath.rowwise_nvshmem))
     pending = rowwise_tbo._NoSyncRowwiseTboPendingContext(
         block=fake_block,  # type: ignore[arg-type]
         lane_id=1,

--- a/src/test/nn/moe/v2/ep_sync_1d_test.py
+++ b/src/test/nn/moe/v2/ep_sync_1d_test.py
@@ -7,6 +7,7 @@ from olmo_core.nn.attention import AttentionConfig, AttentionType
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.testing import requires_multi_gpu, run_distributed_test
@@ -49,9 +50,9 @@ def _build_block() -> OLMoDDPTransformerBlock:
             d_model=512, hidden_size=1024, num_experts=8, bias=False, dtype=DType.float32
         ),
         feed_forward_norm=layer_norm,
-        # Synchronous (count-synchronized) EP: ep_no_sync=False. The sync path is dropless,
+        # Synchronous (count-synchronized) EP: path=sync_1d. The sync path is dropless,
         # so it should match the no-EP reference exactly (no capacity / no symmetric memory).
-        ep_no_sync=False,
+        ep=ExpertParallelConfig(path=ExpertParallelPath.sync_1d),
         init_device="cuda",
     )
 
@@ -132,7 +133,7 @@ def _run_sync_ep_matches_no_ep():
     ep_mesh = _build_ep_mesh()
     no_ep_block = _build_block()
     ep_block = _build_block()
-    # apply_ep with ep_no_sync=False selects the synchronous all-to-all path
+    # apply_ep with path=sync_1d selects the synchronous all-to-all path
     # (combined_forward_ep_1d). The no-EP block never calls apply_ep, so it runs
     # combined_forward_no_ep as the reference.
     ep_block.apply_ep(ep_mesh)

--- a/src/test/nn/moe/v2/ep_sync_tbo_test.py
+++ b/src/test/nn/moe/v2/ep_sync_tbo_test.py
@@ -6,6 +6,7 @@ from olmo_core.config import DType
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.testing import requires_multi_gpu, run_distributed_test
@@ -63,9 +64,9 @@ def _build_tbo_model(*, two_batch_overlap: bool):
                 d_model=512, hidden_size=1024, num_experts=8, bias=False, dtype=DType.float32
             ),
             layer_norm=layer_norm,
-            # Synchronous EP (ep_no_sync=False): the count-synchronized dispatch is dropless,
+            # Synchronous EP (path=sync_1d): the count-synchronized dispatch is dropless,
             # so TBO and non-TBO must agree exactly.
-            ep_no_sync=False,
+            ep=ExpertParallelConfig(path=ExpertParallelPath.sync_1d),
         ),
     )
     return config.build(init_device="cuda")

--- a/src/test/nn/moe/v2/restore_unpermute_fused_test.py
+++ b/src/test/nn/moe/v2/restore_unpermute_fused_test.py
@@ -179,6 +179,7 @@ def _build_block(backend: str = "te_fused"):
     from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
     from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
     from olmo_core.nn.moe import MoERouterGatingFunction
+    from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
     from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
     from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 
@@ -221,8 +222,10 @@ def _build_block(backend: str = "te_fused"):
             dtype=DType.float32,
         ),
         feed_forward_norm=layer_norm,
-        ep_no_sync=True,
-        ep_no_sync_restore_unpermute_backend=backend,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.no_sync_1d,
+            restore_unpermute_backend=backend,
+        ),
         init_device="cuda",
     )
 
@@ -327,7 +330,7 @@ def test_restore_unpermute_backend_selector_behavior():
         block = _build_block()
     except ImportError as exc:
         pytest.skip(f"Skipping selector behavior test due import error: {exc}")
-    assert block.ep_no_sync_restore_unpermute_backend == "te_fused"
+    assert block.ep.restore_unpermute_backend == "te_fused"
 
     torch.manual_seed(23)
     device = torch.device("cuda")
@@ -366,7 +369,7 @@ def test_restore_unpermute_backend_selector_behavior():
     probs = torch.rand(num_tokens, top_k, device=device, dtype=torch.float32)
     num_kept = packed_keep_mask.to(dtype=torch.long).sum(dtype=torch.long)
 
-    block.ep_no_sync_restore_unpermute_backend = "te_unfused"
+    block.ep.restore_unpermute_backend = "te_unfused"
     out_reference = restore_drop_unpermute_1d(
         block,
         combine_out=combine_out,
@@ -377,7 +380,7 @@ def test_restore_unpermute_backend_selector_behavior():
         local_x_global_routed_expert_weights=probs,
         hidden_shape_before_permute=torch.Size([num_tokens, d_model]),
     )
-    block.ep_no_sync_restore_unpermute_backend = "te_fused"
+    block.ep.restore_unpermute_backend = "te_fused"
     out_fused = restore_drop_unpermute_1d(
         block,
         combine_out=combine_out,
@@ -390,7 +393,7 @@ def test_restore_unpermute_backend_selector_behavior():
     )
     torch.testing.assert_close(out_fused, out_reference, atol=5e-3, rtol=5e-3)
 
-    block.ep_no_sync_restore_unpermute_backend = "cuda"
+    block.ep.restore_unpermute_backend = "cuda"
     with pytest.raises(RuntimeError, match="not implemented yet"):
         _ = restore_drop_unpermute_1d(
             block,

--- a/src/test/nn/moe/v2/tbo_test.py
+++ b/src/test/nn/moe/v2/tbo_test.py
@@ -7,6 +7,7 @@ from torch.distributed.device_mesh import DeviceMesh
 from olmo_core.config import DType
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.testing import requires_multi_gpu, run_distributed_test
@@ -77,10 +78,12 @@ def _build_tbo_model(*, two_batch_overlap: bool, ep_no_sync: bool = False):
                 bias=False,
                 dtype=DType.float32,
             ),
-            ep_no_sync=ep_no_sync,
-            ep_no_sync_capacity_factor=8.0,
-            ep_no_sync_major_align=1,
-            ep_no_sync_shared_slots=2 if two_batch_overlap and ep_no_sync else 1,
+            ep=ExpertParallelConfig(
+                path=ExpertParallelPath.no_sync_1d if ep_no_sync else ExpertParallelPath.sync_1d,
+                capacity_factor=8.0,
+                major_align=1,
+                shared_slots=2 if two_batch_overlap and ep_no_sync else 1,
+            ),
         ),
     )
     return config.build(init_device="cuda")


### PR DESCRIPTION
Replaces the flat `ep_no_sync_*` flag bag on the fused MoE-v2 DDP transformer block with a single `ExpertParallelConfig` (`nn/moe/v2/ep_config.py`).

## What changed
- **`ExpertParallelConfig` / `ExpertParallelPath` / `ExpertParallelSchedule` / `DeepEPConfig`** — a self-contained config type. `ExpertParallelPath` enumerates the EP families (`sync_1d`, `no_sync_1d`, `rowwise_nvshmem`, and the not-yet-wired `rowwise_wave` / `deepep_v2`); mode selection and per-mode tuning live in one place, with validation in `ExpertParallelConfig.validate()`.
- **`OLMoDDPTransformerBlock[Config]`** now takes a single `ep: ExpertParallelConfig` instead of ~13 flat `ep_no_sync_*` fields. Mode is read through `ep.no_sync` / `ep.is_rowwise` properties and tuning through `ep.<field>`.
- **Consumers** (`model.py`, `ep_no_sync_buffers`, `ep_no_sync_tbo_rowwise`) read config via `block.ep.<field>`.
- **Tests** build blocks with `ep=ExpertParallelConfig(path=...)`; rowwise mutations set `ep.path` (`is_rowwise` is now a read-only property).

The experimental `rowwise_wave` / `deepep_v2` paths are declared in the enum but intentionally left unwired here. Removed `test_v2_ep_no_sync_2d_all_to_all_rejected`, which covered the already-removed 2D all-to-all flag.