### PR TITLE
Implement combined_forward_shared_only for shared-only DDP blocks

### DIFF
--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -42,6 +42,7 @@ from olmo_core.nn.moe.v2.fp8 import normalize_rowwise_fp8_config
 from olmo_core.nn.moe.v2.fp8 import (
     refresh_rowwise_fp8_cache as _refresh_rowwise_fp8_cache,
 )
+from olmo_core.nn.moe.v2.fp8 import shared_experts_forward_rowwise_fp8
 from olmo_core.nn.moe.v2.no_ep import combined_forward_no_ep as _combined_forward_no_ep
 from olmo_core.nn.moe.v2.routed_experts import RoutedExperts, RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2, MoERouterV2
@@ -778,6 +779,18 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         return True
 
     @property
+    def has_routed_experts(self) -> bool:
+        return self.routed_experts is not None
+
+    @property
+    def has_shared_experts(self) -> bool:
+        return self.shared_experts is not None
+
+    @property
+    def is_shared_only(self) -> bool:
+        return self.has_shared_experts and not self.has_routed_experts
+
+    @property
     def ep_enabled(self) -> bool:
         return self._ep_enabled
 
@@ -1097,11 +1110,71 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
         **kwargs,
     ) -> torch.Tensor:
-        """Reserved for no-routed-experts case (only shared experts), equivalent to a dense model"""
+        """Forward for shared-only blocks, equivalent to a dense DDP-stack MLP."""
         assert self.routed_experts is None
         assert self.routed_experts_router is None
         assert self.shared_experts is not None
-        raise NotImplementedError("combined_forward_shared_only is not implemented")
+
+        attn_res_out = self._res_norm_attn(x, **kwargs)
+        kwargs.pop("max_doc_len", None)
+        kwargs.pop("cu_doc_lens", None)
+        mlp_inp = self._prepare_moe_input(attn_res_out)
+
+        if self.shared_experts_router is not None:
+            shared_expert_weights, _, _, _ = self.shared_experts_router(
+                mlp_inp,
+                True,
+                loss_div_factor=loss_div_factor,
+            )
+        else:
+            shared_expert_weights = None
+
+        rowwise_fp8_cfg = self.rowwise_fp8
+        use_rowwise_fp8 = rowwise_fp8_cfg is not None and rowwise_fp8_cfg.enabled
+        if use_rowwise_fp8 and not self._rowwise_fp8_checked:
+            assert rowwise_fp8_cfg is not None
+            rowwise_fp8_cfg.assert_runtime_supported()
+            self._rowwise_fp8_checked = True
+
+        if use_rowwise_fp8:
+            assert rowwise_fp8_cfg is not None
+            shared_out = shared_experts_forward_rowwise_fp8(
+                self,
+                mlp_inp,
+                use_fast_accum=rowwise_fp8_cfg.use_fast_accum,
+            )
+        else:
+            shared_out = self.shared_experts(mlp_inp)
+
+        mlp_out = self._mix_shared_out(shared_out, shared_expert_weights, attn_res_out.shape)
+        return self._res_norm_mlp(attn_res_out, mlp_out)
+
+    def _mix_shared_out(
+        self,
+        shared_out: torch.Tensor,
+        shared_expert_weights: Optional[torch.Tensor],
+        output_shape: torch.Size,
+    ) -> torch.Tensor:
+        assert self.shared_experts is not None
+        B, S, D = output_shape
+        if self.shared_experts_router is None:
+            if self.shared_experts.num_experts != 1:
+                raise RuntimeError("shared_experts_router is required for multiple shared experts")
+            return shared_out.squeeze(0)
+
+        if shared_expert_weights is None:
+            raise RuntimeError(
+                "shared_experts_router is enabled but shared expert weights are missing"
+            )
+        _, _, E_s = shared_expert_weights.shape
+        return (
+            torch.bmm(
+                shared_expert_weights.to(shared_out.dtype).reshape(B * S, 1, E_s),
+                shared_out.permute(1, 2, 0, 3).contiguous().view(B * S, E_s, D),
+            )
+            .squeeze(1)
+            .view(B, S, D)
+        )
 
     def combined_forward_no_ep(
         self,

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -776,7 +776,9 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
 
     @property
     def is_moe(self) -> bool:
-        return True
+        # Shared-only (no routed experts) blocks are dense: they must fall through to the dense
+        # forward/dispatch path and stay out of the EP / TBO-MoE loops, which key on is_moe.
+        return self.has_routed_experts
 
     @property
     def has_routed_experts(self) -> bool:

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -1130,7 +1130,11 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
             shared_expert_weights = None
 
         rowwise_fp8_cfg = self.rowwise_fp8
-        use_rowwise_fp8 = rowwise_fp8_cfg is not None and rowwise_fp8_cfg.enabled
+        use_rowwise_fp8 = (
+            rowwise_fp8_cfg is not None
+            and rowwise_fp8_cfg.enabled
+            and mlp_inp.device.type == "cuda"
+        )
         if use_rowwise_fp8 and not self._rowwise_fp8_checked:
             assert rowwise_fp8_cfg is not None
             rowwise_fp8_cfg.assert_runtime_supported()

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -1115,7 +1115,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         assert self.routed_experts_router is None
         assert self.shared_experts is not None
 
-        attn_res_out = self._res_norm_attn(x, **kwargs)
+        attn_res_out = self._checkpointed_res_norm_attn(x, **kwargs)
         kwargs.pop("max_doc_len", None)
         kwargs.pop("cu_doc_lens", None)
         mlp_inp = self._prepare_moe_input(attn_res_out)

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -167,7 +167,11 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                 first_moe_idx = idx
             if block.is_moe:
                 moe_block = cast(OLMoDDPTransformerBlock, block)
-                if moe_block.ep.no_sync and moe_block.ep.shared_slots < 2:
+                if (
+                    not moe_block.is_shared_only
+                    and moe_block.ep.no_sync
+                    and moe_block.ep.shared_slots < 2
+                ):
                     raise OLMoConfigurationError(
                         "When TBO and EP no-sync are enabled, ep.shared_slots must be >= 2 "
                         f"(block={moe_block.block_idx}, got {moe_block.ep.shared_slots})."
@@ -242,7 +246,12 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         return sum(
             1
             for block in self.blocks.values()
-            if block.is_moe and isinstance(block, OLMoDDPTransformerBlock) and block.ep.no_sync
+            if (
+                block.is_moe
+                and isinstance(block, OLMoDDPTransformerBlock)
+                and not block.is_shared_only
+                and block.ep.no_sync
+            )
         )
 
     @torch.no_grad()
@@ -321,7 +330,12 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         ep_blocks = [
             (block_key, cast(OLMoDDPTransformerBlock, block))
             for block_key, block in self.blocks.items()
-            if block.is_moe and isinstance(block, OLMoDDPTransformerBlock) and block.ep.no_sync
+            if (
+                block.is_moe
+                and isinstance(block, OLMoDDPTransformerBlock)
+                and not block.is_shared_only
+                and block.ep.no_sync
+            )
         ]
         if not ep_blocks:
             if pad_to_block_count != 0:

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -167,11 +167,7 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                 first_moe_idx = idx
             if block.is_moe:
                 moe_block = cast(OLMoDDPTransformerBlock, block)
-                if (
-                    not moe_block.is_shared_only
-                    and moe_block.ep.no_sync
-                    and moe_block.ep.shared_slots < 2
-                ):
+                if moe_block.ep.no_sync and moe_block.ep.shared_slots < 2:
                     raise OLMoConfigurationError(
                         "When TBO and EP no-sync are enabled, ep.shared_slots must be >= 2 "
                         f"(block={moe_block.block_idx}, got {moe_block.ep.shared_slots})."
@@ -246,12 +242,7 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         return sum(
             1
             for block in self.blocks.values()
-            if (
-                block.is_moe
-                and isinstance(block, OLMoDDPTransformerBlock)
-                and not block.is_shared_only
-                and block.ep.no_sync
-            )
+            if block.is_moe and isinstance(block, OLMoDDPTransformerBlock) and block.ep.no_sync
         )
 
     @torch.no_grad()
@@ -330,12 +321,7 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         ep_blocks = [
             (block_key, cast(OLMoDDPTransformerBlock, block))
             for block_key, block in self.blocks.items()
-            if (
-                block.is_moe
-                and isinstance(block, OLMoDDPTransformerBlock)
-                and not block.is_shared_only
-                and block.ep.no_sync
-            )
+            if block.is_moe and isinstance(block, OLMoDDPTransformerBlock) and block.ep.no_sync
         ]
         if not ep_blocks:
             if pad_to_block_count != 0:
@@ -588,9 +574,6 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
             if not block.is_moe:
                 continue
             block = cast(OLMoDDPTransformerBlock, block)
-            if block.is_shared_only:
-                # Shared-only (dense) blocks have no routed experts, so there is no EP to apply.
-                continue
             # ep_mp_group is the optional high-priority NCCL group for
             # synchronized EP collectives that should start promptly while shared
             # experts run. It is intentionally not used by no-sync blocks.

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -574,6 +574,9 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
             if not block.is_moe:
                 continue
             block = cast(OLMoDDPTransformerBlock, block)
+            if block.is_shared_only:
+                # Shared-only (dense) blocks have no routed experts, so there is no EP to apply.
+                continue
             # ep_mp_group is the optional high-priority NCCL group for
             # synchronized EP collectives that should start promptly while shared
             # experts run. It is intentionally not used by no-sync blocks.

--- a/src/test/nn/ddp/shared_only_block_test.py
+++ b/src/test/nn/ddp/shared_only_block_test.py
@@ -1,0 +1,44 @@
+import torch
+
+from olmo_core.config import DType
+from olmo_core.nn.attention import AttentionConfig, AttentionType
+from olmo_core.nn.ddp.block import OLMoDDPTransformerBlockConfig
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
+from olmo_core.nn.transformer import TransformerBlockType
+
+
+def _shared_only_block_config() -> OLMoDDPTransformerBlockConfig:
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=DType.float32)
+    return OLMoDDPTransformerBlockConfig(
+        name=TransformerBlockType.moe_fused_v2,
+        sequence_mixer=AttentionConfig(
+            name=AttentionType.default,
+            n_heads=2,
+            n_kv_heads=2,
+            bias=False,
+            use_flash=False,
+            dtype=DType.float32,
+        ),
+        layer_norm=layer_norm,
+        routed_experts=None,
+        routed_experts_router=None,
+        shared_experts=SharedExpertsConfig(
+            d_model=16, hidden_size=32, num_experts=1, bias=False, dtype=DType.float32
+        ),
+        shared_experts_router=None,
+    )
+
+
+def test_shared_only_ddp_block_is_dense_stack_block():
+    block = _shared_only_block_config().build(
+        d_model=16, block_idx=0, n_layers=1, init_device="cpu"
+    )
+
+    assert block.is_shared_only
+    assert not block.has_routed_experts
+    assert block.has_shared_experts
+
+    x = torch.randn(2, 4, 16)
+    out = block(x)
+    assert out.shape == x.shape

--- a/src/test/nn/ddp/shared_only_block_test.py
+++ b/src/test/nn/ddp/shared_only_block_test.py
@@ -38,6 +38,8 @@ def test_shared_only_ddp_block_is_dense_stack_block():
     assert block.is_shared_only
     assert not block.has_routed_experts
     assert block.has_shared_experts
+    # Shared-only blocks are dense: is_moe must be False so they stay off the EP / TBO-MoE paths.
+    assert not block.is_moe
 
     x = torch.randn(2, 4, 16)
     out = block(x)


### PR DESCRIPTION
The shared-only (no routed experts, shared experts only) dispatch path in `OLMoDDPTransformerBlock` previously raised `NotImplementedError`. This implements it as a dense-stack MLP forward.

## What changed
- **`combined_forward_shared_only`** — runs attention residual + norm, the shared experts (rowwise-FP8 when enabled, else dense), mixes shared-expert outputs, and applies the feed-forward residual norm. Equivalent to a dense transformer block.
- **`_mix_shared_out`** — helper that combines shared-expert outputs (single-expert squeeze, or router-weighted `bmm` for multiple shared experts).
- **`has_routed_experts` / `has_shared_experts` / `is_shared_only`** properties.
- Adds a CPU test building a shared-only block and running forward.