### PR TITLE
Fix detection of flash-attention 2 and 4

### DIFF
--- a/src/olmo_core/nn/attention/flash_attn_api.py
+++ b/src/olmo_core/nn/attention/flash_attn_api.py
@@ -9,13 +9,14 @@ from .ring import RingAttentionLoadBalancerType
 
 _flash_attn_pkgs = importlib.metadata.packages_distributions().get("flash_attn", [])
 
+flash_attn_2 = None
 try:
     _is_flash_attn_2_available = "flash-attn" in [pkg.replace("_", "-") for pkg in _flash_attn_pkgs]
 
     if _is_flash_attn_2_available:
         import flash_attn as flash_attn_2  # type: ignore
 except ImportError:
-    flash_attn_2 = None
+    pass
 
 try:
     # NOTE: The flash-attn 3 API might be available under the name 'flash_attn_3.flash_attn_interface'
@@ -28,6 +29,7 @@ except ImportError:
         flash_attn_3 = None  # type: ignore
 
 # match transformers fa4 detection - cute submodule available in both fa2/fa4
+flash_attn_4 = None
 try:
     _is_flash_attn_4_available = "flash-attn-4" in [
         pkg.replace("_", "-") for pkg in _flash_attn_pkgs
@@ -36,7 +38,7 @@ try:
     if _is_flash_attn_4_available:
         import flash_attn.cute as flash_attn_4  # type: ignore
 except ImportError:
-    flash_attn_4 = None
+    pass
 
 try:
     import ring_flash_attn  # type: ignore

--- a/src/olmo_core/nn/attention/flash_attn_api.py
+++ b/src/olmo_core/nn/attention/flash_attn_api.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import logging
 from typing import Optional, Tuple
 
@@ -6,10 +7,15 @@ import torch.distributed as dist
 
 from .ring import RingAttentionLoadBalancerType
 
+_flash_attn_pkgs = importlib.metadata.packages_distributions().get("flash_attn", [])
+
 try:
-    import flash_attn as flash_attn_2  # type: ignore
+    _is_flash_attn_2_available = "flash-attn" in [pkg.replace("_", "-") for pkg in _flash_attn_pkgs]
+
+    if _is_flash_attn_2_available:
+        import flash_attn as flash_attn_2  # type: ignore
 except ImportError:
-    flash_attn_2 = None  # type: ignore
+    flash_attn_2 = None
 
 try:
     # NOTE: The flash-attn 3 API might be available under the name 'flash_attn_3.flash_attn_interface'
@@ -21,10 +27,16 @@ except ImportError:
     except ImportError:
         flash_attn_3 = None  # type: ignore
 
+# match transformers fa4 detection - cute submodule available in both fa2/fa4
 try:
-    import flash_attn.cute as flash_attn_4  # type: ignore
+    _is_flash_attn_4_available = "flash-attn-4" in [
+        pkg.replace("_", "-") for pkg in _flash_attn_pkgs
+    ]
+
+    if _is_flash_attn_4_available:
+        import flash_attn.cute as flash_attn_4  # type: ignore
 except ImportError:
-    flash_attn_4 = None  # type: ignore
+    flash_attn_4 = None
 
 try:
     import ring_flash_attn  # type: ignore


### PR DESCRIPTION
Flash attention 2 still distributes the cute submodule, so the current flash-attention 4 detection will give a false positive and cause later errors. I've changed the detection to match transformers, which has the correct behaviour https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py#L1102-L1109