### PR TITLE
Port net-new MoE-v2 / EP test coverage from olmo-ddp

### DIFF
--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -1266,6 +1266,11 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
             **kwargs,
         )
 
+    # TODO(ep-tbo-dispatch): this two-batch-overlap forward (and its checkpointed wrapper below) is
+    # currently unreachable — the block's no-sync dispatch selects on ep.path only and never routes
+    # to it, so ep.schedule=tbo is rejected by ep_config.validate() as "not yet supported". Wire a
+    # path==rowwise_nvshmem & schedule==tbo branch into the forward dispatch, then lift that
+    # rejection.
     def combined_forward_rowwise_nvshmem_tbo(
         self,
         x0: torch.Tensor,

--- a/src/test/kernels/grouped_mm_row_offset_test.py
+++ b/src/test/kernels/grouped_mm_row_offset_test.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import torch
+
+from olmo_core.kernels.grouped_mm_row_offset import grouped_mm_row_offset
+from olmo_core.testing import requires_gpu
+
+
+@requires_gpu
+def test_grouped_mm_row_offset_writes_only_shifted_groups():
+    device = torch.device("cuda")
+    torch.manual_seed(1234)
+
+    capacity = 64
+    k = 32
+    n = 48
+    counts = torch.tensor([8, 16, 8], device=device, dtype=torch.int32)
+    row_start = torch.tensor(24, device=device, dtype=torch.int64)
+    a = torch.randn(capacity, k, device=device, dtype=torch.bfloat16)
+    b = torch.randn(counts.numel(), k, n, device=device, dtype=torch.bfloat16)
+    out = torch.full((capacity, n), -7.0, device=device, dtype=torch.bfloat16)
+
+    grouped_mm_row_offset(a, b, counts, row_start=row_start, out=out)
+    torch.cuda.synchronize()
+
+    expected = torch.full_like(out, -7.0)
+    start = int(row_start.item())
+    cursor = start
+    for group_idx, count in enumerate(counts.cpu().tolist()):
+        expected[cursor : cursor + count] = a[cursor : cursor + count] @ b[group_idx]
+        cursor += count
+
+    torch.testing.assert_close(out, expected, rtol=1e-2, atol=1e-2)

--- a/src/test/kernels/grouped_mm_row_offset_test.py
+++ b/src/test/kernels/grouped_mm_row_offset_test.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import torch
 
 from olmo_core.kernels.grouped_mm_row_offset import grouped_mm_row_offset
-from olmo_core.testing import requires_gpu
+from olmo_core.testing import requires_grouped_mm_row_offset
 
 
-@requires_gpu
+@requires_grouped_mm_row_offset
 def test_grouped_mm_row_offset_writes_only_shifted_groups():
     device = torch.device("cuda")
     torch.manual_seed(1234)

--- a/src/test/kernels/swiglu_valid_prefix_test.py
+++ b/src/test/kernels/swiglu_valid_prefix_test.py
@@ -1,0 +1,146 @@
+import torch
+import torch.nn.functional as F
+
+from olmo_core.kernels.swiglu import swiglu_backward_valid_prefix, swiglu_valid_prefix
+from olmo_core.testing import requires_gpu
+
+
+def test_swiglu_valid_prefix_torch_fallback():
+    rows = 5
+    hidden = 4
+    valid_rows = 3
+    x = torch.randn((rows, hidden * 2), dtype=torch.float32)
+    num_elements = torch.tensor(valid_rows, dtype=torch.long)
+    out = torch.full((rows, hidden), 7.0, dtype=torch.float32)
+
+    actual = swiglu_valid_prefix(x, num_elements, out=out)
+    expected = x[:valid_rows, :hidden] * F.silu(x[:valid_rows, hidden:])
+
+    torch.testing.assert_close(actual[:valid_rows], expected)
+    torch.testing.assert_close(actual[valid_rows:], torch.full_like(actual[valid_rows:], 7.0))
+
+
+def _swiglu_backward_reference(x: torch.Tensor, grad_h: torch.Tensor) -> torch.Tensor:
+    hidden = x.shape[-1] // 2
+    up = x[:, :hidden]
+    gate = x[:, hidden:]
+    gate_f32 = gate.to(torch.float32)
+    grad_h_f32 = grad_h.to(torch.float32)
+    up_f32 = up.to(torch.float32)
+    sig = torch.sigmoid(gate_f32)
+    silu_gate = gate_f32 * sig
+    dsilu = sig * (1.0 + gate_f32 * (1.0 - sig))
+    grad_up = grad_h_f32 * silu_gate
+    grad_gate = grad_h_f32 * up_f32 * dsilu
+    return torch.cat((grad_up, grad_gate), dim=-1).to(dtype=x.dtype)
+
+
+def test_swiglu_backward_valid_prefix_torch_fallback():
+    rows = 5
+    hidden = 4
+    valid_rows = 3
+    x = torch.randn((rows, hidden * 2), dtype=torch.float32)
+    grad_h = torch.randn((rows, hidden), dtype=torch.float32)
+    num_elements = torch.tensor(valid_rows, dtype=torch.long)
+    out = torch.full_like(x, 7.0)
+
+    actual = swiglu_backward_valid_prefix(x, grad_h, num_elements, out=out)
+    expected = _swiglu_backward_reference(x[:valid_rows], grad_h[:valid_rows])
+
+    torch.testing.assert_close(actual[:valid_rows], expected)
+    torch.testing.assert_close(actual[valid_rows:], torch.full_like(actual[valid_rows:], 7.0))
+
+
+@requires_gpu
+def test_swiglu_valid_prefix_matches_torch_and_leaves_tail_untouched():
+    rows = 37
+    hidden = 64
+    valid_rows = 19
+    x = torch.randn((rows, hidden * 2), device="cuda", dtype=torch.bfloat16)
+    num_elements = torch.tensor(valid_rows, device="cuda", dtype=torch.long)
+    out = torch.full((rows, hidden), 7.0, device="cuda", dtype=torch.bfloat16)
+
+    actual = swiglu_valid_prefix(x, num_elements, out=out)
+    expected = x[:valid_rows, :hidden] * F.silu(x[:valid_rows, hidden:])
+
+    torch.testing.assert_close(actual[:valid_rows], expected, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(
+        actual[valid_rows:],
+        torch.full_like(actual[valid_rows:], 7.0),
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+@requires_gpu
+def test_swiglu_backward_valid_prefix_accepts_device_start_offset():
+    rows = 37
+    hidden = 64
+    start_row = 7
+    valid_rows = 19
+    x = torch.randn((rows, hidden * 2), device="cuda", dtype=torch.bfloat16)
+    grad_h = torch.randn((rows, hidden), device="cuda", dtype=torch.bfloat16)
+    start = torch.tensor(start_row, device="cuda", dtype=torch.long)
+    num_elements = torch.tensor(valid_rows, device="cuda", dtype=torch.long)
+    out = torch.full_like(x, 7.0)
+
+    actual = swiglu_backward_valid_prefix(x, grad_h, num_elements, start=start, out=out)
+    expected = _swiglu_backward_reference(
+        x[start_row : start_row + valid_rows],
+        grad_h[start_row : start_row + valid_rows],
+    )
+
+    torch.testing.assert_close(
+        actual[start_row : start_row + valid_rows],
+        expected,
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    torch.testing.assert_close(
+        actual[:start_row],
+        torch.full_like(actual[:start_row], 7.0),
+        atol=0.0,
+        rtol=0.0,
+    )
+    torch.testing.assert_close(
+        actual[start_row + valid_rows :],
+        torch.full_like(actual[start_row + valid_rows :], 7.0),
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
+@requires_gpu
+def test_swiglu_valid_prefix_accepts_device_start_offset():
+    rows = 37
+    hidden = 64
+    start_row = 7
+    valid_rows = 19
+    x = torch.randn((rows, hidden * 2), device="cuda", dtype=torch.bfloat16)
+    start = torch.tensor(start_row, device="cuda", dtype=torch.long)
+    num_elements = torch.tensor(valid_rows, device="cuda", dtype=torch.long)
+    out = torch.full((rows, hidden), 7.0, device="cuda", dtype=torch.bfloat16)
+
+    actual = swiglu_valid_prefix(x, num_elements, start=start, out=out)
+    expected = x[start_row : start_row + valid_rows, :hidden] * F.silu(
+        x[start_row : start_row + valid_rows, hidden:]
+    )
+
+    torch.testing.assert_close(
+        actual[start_row : start_row + valid_rows],
+        expected,
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    torch.testing.assert_close(
+        actual[:start_row],
+        torch.full_like(actual[:start_row], 7.0),
+        atol=0.0,
+        rtol=0.0,
+    )
+    torch.testing.assert_close(
+        actual[start_row + valid_rows :],
+        torch.full_like(actual[start_row + valid_rows :], 7.0),
+        atol=0.0,
+        rtol=0.0,
+    )

--- a/src/test/kernels/swiglu_valid_prefix_test.py
+++ b/src/test/kernels/swiglu_valid_prefix_test.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 
 from olmo_core.kernels.swiglu import swiglu_backward_valid_prefix, swiglu_valid_prefix
-from olmo_core.testing import requires_gpu
+from olmo_core.testing import requires_gpu, requires_triton
 
 
 def test_swiglu_valid_prefix_torch_fallback():
@@ -52,6 +52,7 @@ def test_swiglu_backward_valid_prefix_torch_fallback():
 
 
 @requires_gpu
+@requires_triton
 def test_swiglu_valid_prefix_matches_torch_and_leaves_tail_untouched():
     rows = 37
     hidden = 64
@@ -73,6 +74,7 @@ def test_swiglu_valid_prefix_matches_torch_and_leaves_tail_untouched():
 
 
 @requires_gpu
+@requires_triton
 def test_swiglu_backward_valid_prefix_accepts_device_start_offset():
     rows = 37
     hidden = 64
@@ -111,6 +113,7 @@ def test_swiglu_backward_valid_prefix_accepts_device_start_offset():
 
 
 @requires_gpu
+@requires_triton
 def test_swiglu_valid_prefix_accepts_device_start_offset():
     rows = 37
     hidden = 64

--- a/src/test/nn/ddp/block_no_ep_parity_test.py
+++ b/src/test/nn/ddp/block_no_ep_parity_test.py
@@ -1,0 +1,153 @@
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from olmo_core.testing import requires_multi_gpu, run_distributed_test
+
+from .block_no_sync_test import (
+    _build_block,
+    _build_ep_mesh,
+    _init_block_params,
+    _install_deterministic_topk_router,
+)
+
+
+def _copy_no_ep_weights_to_ep_shard(no_ep_block, ep_block):
+    no_ep_params = dict(no_ep_block.named_parameters())
+    no_ep_buffers = dict(no_ep_block.named_buffers())
+    local_experts = ep_block.routed_experts.num_local_experts
+    start = ep_block.routed_experts.ep_rank * local_experts
+    end = start + local_experts
+
+    with torch.no_grad():
+        for name, param in ep_block.named_parameters():
+            if name == "routed_experts.w_up_gate":
+                param.copy_(no_ep_block.routed_experts.w_up_gate[start:end])
+            elif name == "routed_experts.w_down":
+                param.copy_(no_ep_block.routed_experts.w_down[start:end])
+            else:
+                param.copy_(no_ep_params[name])
+
+        for name, buffer in ep_block.named_buffers():
+            if name in no_ep_buffers and buffer.shape == no_ep_buffers[name].shape:
+                buffer.copy_(no_ep_buffers[name])
+
+
+def _assert_expert_grad_matches_no_ep_global_sum(
+    no_ep_block, ep_block, *, atol: float, rtol: float
+):
+    local_experts = ep_block.routed_experts.num_local_experts
+    start = ep_block.routed_experts.ep_rank * local_experts
+    end = start + local_experts
+
+    for name in ("w_up_gate", "w_down"):
+        no_ep_grad = getattr(no_ep_block.routed_experts, name).grad
+        ep_grad = getattr(ep_block.routed_experts, name).grad
+        assert no_ep_grad is not None
+        assert ep_grad is not None
+
+        no_ep_grad_global = no_ep_grad.detach().clone()
+        dist.all_reduce(no_ep_grad_global, op=dist.ReduceOp.SUM)
+        torch.testing.assert_close(
+            ep_grad,
+            no_ep_grad_global[start:end],
+            atol=atol,
+            rtol=rtol,
+        )
+
+
+def _run_dropless_path_matches_no_ep(
+    *,
+    rowwise: bool,
+    shared: bool = False,
+):
+    ep_mesh = _build_ep_mesh()
+    shared_kwargs: dict[str, Any] = (
+        {"num_shared_experts": 1, "shared_hidden_size": 512} if shared else {}
+    )
+
+    no_ep_block = _build_block(
+        ep_no_sync=False,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=2,
+        uniform_expert_assignment=False,
+        **shared_kwargs,
+    )
+    ep_block = _build_block(
+        ep_no_sync=rowwise,
+        ep_no_sync_use_rowwise_all_to_all=rowwise,
+        ep_no_sync_capacity_factor=8.0,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=2,
+        uniform_expert_assignment=False,
+        **shared_kwargs,
+    )
+    ep_block.apply_ep(ep_mesh)
+
+    _init_block_params(no_ep_block)
+    _copy_no_ep_weights_to_ep_shard(no_ep_block, ep_block)
+    _install_deterministic_topk_router(no_ep_block)
+    _install_deterministic_topk_router(ep_block)
+
+    if rowwise:
+        ep_block.ep.rowwise_nblocks = 128
+        ep_block.ep.validate()
+
+    no_ep_block.train()
+    ep_block.train()
+
+    x = torch.randn(
+        1,
+        8,
+        no_ep_block.d_model,
+        device="cuda",
+        dtype=torch.float32,
+        requires_grad=True,
+    )
+    x_ep = x.detach().clone().requires_grad_(True)
+
+    y_no_ep = no_ep_block(x)
+    y_ep = ep_block(x_ep)
+    torch.testing.assert_close(y_ep, y_no_ep, atol=5e-4, rtol=5e-4)
+    if rowwise:
+        drop_tokens_sum = ep_block._ep_no_sync_rowwise_drop_tokens_sum
+        assert drop_tokens_sum is not None
+        assert drop_tokens_sum.item() == 0
+
+    loss_no_ep = y_no_ep.square().mean() + (0.1 * y_no_ep.sum())
+    loss_ep = y_ep.square().mean() + (0.1 * y_ep.sum())
+    loss_no_ep.backward()
+    loss_ep.backward()
+
+    torch.testing.assert_close(x_ep.grad, x.grad, atol=5e-4, rtol=5e-4)
+    _assert_expert_grad_matches_no_ep_global_sum(
+        no_ep_block,
+        ep_block,
+        atol=1e-3,
+        rtol=1e-3,
+    )
+
+
+@requires_multi_gpu
+def test_v2_synced_ep_dropless_matches_no_ep():
+    run_distributed_test(
+        _run_dropless_path_matches_no_ep,
+        func_kwargs={"rowwise": False},
+        backend="nccl",
+        start_method="spawn",
+    )
+
+
+@requires_multi_gpu
+def test_v2_rowwise_ep_dropless_matches_no_ep():
+    run_distributed_test(
+        _run_dropless_path_matches_no_ep,
+        func_kwargs={"rowwise": True},
+        backend="nccl",
+        start_method="spawn",
+    )

--- a/src/test/nn/ddp/block_no_ep_parity_test.py
+++ b/src/test/nn/ddp/block_no_ep_parity_test.py
@@ -3,7 +3,11 @@ from typing import Any
 import torch
 import torch.distributed as dist
 
-from olmo_core.testing import requires_multi_gpu, run_distributed_test
+from olmo_core.testing import (
+    requires_multi_gpu,
+    requires_symm_mem_vdev2d,
+    run_distributed_test,
+)
 
 from .block_no_sync_test import (
     _build_block,
@@ -144,6 +148,7 @@ def test_v2_synced_ep_dropless_matches_no_ep():
 
 
 @requires_multi_gpu
+@requires_symm_mem_vdev2d
 def test_v2_rowwise_ep_dropless_matches_no_ep():
     run_distributed_test(
         _run_dropless_path_matches_no_ep,

--- a/src/test/nn/ddp/block_no_sync_test.py
+++ b/src/test/nn/ddp/block_no_sync_test.py
@@ -16,6 +16,7 @@ from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
 from olmo_core.testing import (
     requires_gpu,
     requires_grouped_gemm,
+    requires_grouped_mm_row_offset,
     requires_multi_gpu,
     requires_symm_mem_vdev2d,
     run_distributed_test,
@@ -983,6 +984,7 @@ def _run_ep_no_sync_rowwise_wave_matches_rowwise():
 
 @requires_multi_gpu
 @requires_grouped_gemm
+@requires_grouped_mm_row_offset
 @requires_symm_mem_vdev2d
 def test_v2_ep_no_sync_rowwise_wave_matches_rowwise():
     run_distributed_test(

--- a/src/test/nn/ddp/block_no_sync_test.py
+++ b/src/test/nn/ddp/block_no_sync_test.py
@@ -19,6 +19,7 @@ from olmo_core.testing import (
     requires_grouped_mm_row_offset,
     requires_multi_gpu,
     requires_symm_mem_vdev2d,
+    requires_triton,
     run_distributed_test,
 )
 
@@ -986,6 +987,7 @@ def _run_ep_no_sync_rowwise_wave_matches_rowwise():
 @requires_grouped_gemm
 @requires_grouped_mm_row_offset
 @requires_symm_mem_vdev2d
+@requires_triton
 def test_v2_ep_no_sync_rowwise_wave_matches_rowwise():
     run_distributed_test(
         _run_ep_no_sync_rowwise_wave_matches_rowwise,

--- a/src/test/nn/ddp/block_no_sync_test.py
+++ b/src/test/nn/ddp/block_no_sync_test.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
@@ -11,6 +12,7 @@ from olmo_core.nn.moe import MoERouterGatingFunction
 from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
 from olmo_core.testing import (
     requires_gpu,
     requires_grouped_gemm,
@@ -33,14 +35,32 @@ def _build_ep_mesh() -> DeviceMesh:
 def _build_block(
     *,
     ep_no_sync: bool,
+    ep: ExpertParallelConfig | None = None,
     ep_no_sync_capacity_factor: float = 2.0,
     d_model: int = 512,
     hidden_size: int = 1024,
     num_experts: int = 4,
     top_k: int = 1,
+    num_shared_experts: int = 0,
+    shared_hidden_size: int = 512,
     uniform_expert_assignment: bool = True,
+    ep_no_sync_use_rowwise_all_to_all: bool = False,
     init_device: str = "cuda",
 ) -> OLMoDDPTransformerBlock:
+    if ep is None:
+        if not ep_no_sync:
+            path = ExpertParallelPath.sync_1d
+        elif ep_no_sync_use_rowwise_all_to_all:
+            path = ExpertParallelPath.rowwise_nvshmem
+        else:
+            path = ExpertParallelPath.no_sync_1d
+        ep = ExpertParallelConfig(
+            path=path,
+            capacity_factor=ep_no_sync_capacity_factor,
+            rowwise_nblocks=256,
+            major_align=1,
+        )
+
     layer_norm = LayerNormConfig(
         name=LayerNormType.rms,
         eps=1e-6,
@@ -73,7 +93,17 @@ def _build_block(
             dtype=DType.float32,
         ),
         shared_experts_router=None,
-        shared_experts=None,
+        shared_experts=(
+            SharedExpertsConfig(
+                d_model=d_model,
+                hidden_size=shared_hidden_size,
+                num_experts=num_shared_experts,
+                bias=False,
+                dtype=DType.float32,
+            )
+            if num_shared_experts > 0
+            else None
+        ),
         routed_experts=RoutedExpertsConfig(
             d_model=d_model,
             hidden_size=hidden_size,
@@ -82,11 +112,7 @@ def _build_block(
             dtype=DType.float32,
         ),
         feed_forward_norm=layer_norm,
-        ep=ExpertParallelConfig(
-            path=ExpertParallelPath.no_sync_1d if ep_no_sync else ExpertParallelPath.sync_1d,
-            capacity_factor=ep_no_sync_capacity_factor,
-            major_align=1,
-        ),
+        ep=ep,
         init_device=init_device,
     )
 
@@ -512,3 +538,510 @@ def test_v2_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
         backend="nccl",
         start_method="spawn",
     )
+
+
+def test_v2_extracted_forward_module_names_importable():
+    from olmo_core.nn.moe.v2 import (
+        activation_debug,
+        checkpointing,
+        ep_no_sync_1d,
+        ep_no_sync_buffers,
+        ep_no_sync_rowwise,
+        ep_no_sync_rowwise_wave,
+        ep_sync_1d,
+        no_ep,
+    )
+
+    assert hasattr(activation_debug, "maybe_dump_ep_no_sync_saved_activations")
+    assert hasattr(ep_sync_1d, "combined_forward_ep_1d")
+    assert hasattr(no_ep, "combined_forward_no_ep")
+    assert hasattr(checkpointing, "checkpoint_recompute_context_fn")
+    assert hasattr(ep_no_sync_buffers, "get_ep_no_sync_buffers")
+    assert hasattr(ep_no_sync_buffers, "_NoSyncSymmBuffers")
+    assert hasattr(ep_no_sync_1d, "combined_forward_ep_no_sync_1d")
+    assert hasattr(ep_no_sync_rowwise, "combined_forward_ep_no_sync_rowwise")
+    assert hasattr(ep_no_sync_rowwise_wave, "combined_forward_ep_no_sync_rowwise_wave")
+
+
+def test_v2_rowwise_nvshmem_tbo_forward_method_is_available():
+    block = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_use_rowwise_all_to_all=True,
+        init_device="cpu",
+    )
+    assert block.ep.path == ExpertParallelPath.rowwise_nvshmem
+    assert callable(block.combined_forward_rowwise_nvshmem_tbo)
+
+
+def test_v2_rowwise_wave_forward_method_is_available():
+    block = _build_block(
+        ep_no_sync=False,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.rowwise_wave,
+            rowwise_wave_num_waves=2,
+        ),
+        init_device="cpu",
+    )
+    assert callable(block.combined_forward_ep_no_sync_rowwise_wave)
+
+
+def _install_local_deterministic_topk_router(block: OLMoDDPTransformerBlock):
+    """Deterministic router for single-process tests that do not initialize dist."""
+
+    def _make_deterministic_forward(router):
+        def _deterministic_forward(local_x, scores_only, loss_div_factor=None):
+            del scores_only, loss_div_factor
+            B, S, _ = local_x.shape
+            tokens = B * S
+            token_ids = torch.arange(tokens, device=local_x.device).unsqueeze(1)
+            route_offsets = torch.arange(router.top_k, device=local_x.device).unsqueeze(0)
+            expert_indices = (token_ids * 3 + route_offsets * 5) % router.num_experts
+            logits = torch.linspace(
+                0.25,
+                0.75,
+                steps=router.top_k,
+                device=local_x.device,
+                dtype=torch.float32,
+            ).view(1, router.top_k)
+            expert_weights = torch.softmax(logits.expand(tokens, router.top_k), dim=-1).to(
+                dtype=local_x.dtype
+            )
+            batch_size_per_expert = torch.bincount(
+                expert_indices.reshape(-1),
+                minlength=router.num_experts,
+            ).to(dtype=torch.int32)
+            return expert_weights, expert_indices.to(dtype=torch.long), batch_size_per_expert, None
+
+        return _deterministic_forward
+
+    assert block.routed_experts_router is not None
+    block.routed_experts_router.forward = _make_deterministic_forward(block.routed_experts_router)  # type: ignore[method-assign]
+    if block.shared_experts_router is not None:
+        block.shared_experts_router.forward = _make_deterministic_forward(  # type: ignore[method-assign]
+            block.shared_experts_router
+        )
+
+
+def _poison_rowwise_capacity_tails(block: OLMoDDPTransformerBlock, *, value: float) -> int:
+    recv_splits = getattr(block, "_debug_rowwise_recv_splits_by_src_local", None)
+    if recv_splits is None:
+        raise RuntimeError("rowwise debug tensors were not captured")
+    valid_rows = int(recv_splits.sum().item())
+    poisoned_rows = 0
+
+    def poison_tensor(tensor: torch.Tensor | None) -> None:
+        nonlocal poisoned_rows
+        if tensor is None or tensor.ndim != 2 or not tensor.is_floating_point():
+            return
+        tail_rows = int(tensor.shape[0]) - valid_rows
+        if tail_rows <= 0:
+            return
+        tensor.narrow(0, valid_rows, tail_rows).fill_(value)
+        poisoned_rows += tail_rows
+
+    with torch.no_grad():
+        pools = getattr(block, "_ep_no_sync_symm_lease_pools", {})
+        dispatch_pool = pools.get("dispatch_out")
+        if dispatch_pool is not None:
+            for slot in dispatch_pool._slots:
+                poison_tensor(slot.get("dispatch_out"))
+
+        for buffers in getattr(block, "_ep_no_sync_static_buffer_cache", {}).values():
+            poison_tensor(getattr(buffers, "combine_in", None))
+
+    return poisoned_rows
+
+
+def _reference_rowwise_dispatch_bf16(
+    source_input: torch.Tensor,
+    dst_ranks: torch.Tensor,
+    dst_rows: torch.Tensor,
+    *,
+    ep_world_size: int,
+    rank_capacity: int,
+) -> torch.Tensor:
+    output = torch.zeros(
+        (ep_world_size, rank_capacity, source_input.shape[1]),
+        dtype=source_input.dtype,
+        device=source_input.device,
+    )
+    for token_idx in range(dst_ranks.shape[0]):
+        for topk_idx in range(dst_ranks.shape[1]):
+            rank = int(dst_ranks[token_idx, topk_idx].item())
+            row = int(dst_rows[token_idx, topk_idx].item())
+            if rank >= 0 and row >= 0:
+                output[rank, row] = source_input[token_idx]
+    return output
+
+
+def _reference_rowwise_combine_bf16(
+    expert_out_by_rank: torch.Tensor,
+    src_ranks: torch.Tensor,
+    src_rows: torch.Tensor,
+    *,
+    probs: torch.Tensor,
+) -> torch.Tensor:
+    output = torch.zeros(
+        (src_ranks.shape[0], expert_out_by_rank.shape[2]),
+        dtype=torch.float32,
+        device=expert_out_by_rank.device,
+    )
+    for token_idx in range(src_ranks.shape[0]):
+        for topk_idx in range(src_ranks.shape[1]):
+            rank = int(src_ranks[token_idx, topk_idx].item())
+            row = int(src_rows[token_idx, topk_idx].item())
+            if rank >= 0 and row >= 0:
+                output[token_idx] += (
+                    expert_out_by_rank[rank, row].float() * probs[token_idx, topk_idx]
+                )
+    return output.to(dtype=torch.bfloat16)
+
+
+def _run_ep_no_sync_rowwise_capacity_tail_poison_does_not_change_backward():
+    old_debug = os.environ.get("OLMO_MOE_ROWWISE_DEBUG_TENSORS")
+    os.environ["OLMO_MOE_ROWWISE_DEBUG_TENSORS"] = "1"
+    try:
+        ep_mesh = _build_ep_mesh()
+
+        block_a = _build_block(
+            ep_no_sync=True,
+            ep_no_sync_use_rowwise_all_to_all=True,
+            ep_no_sync_capacity_factor=8.0,
+            d_model=512,
+            hidden_size=1024,
+            num_experts=8,
+            top_k=4,
+            uniform_expert_assignment=False,
+        )
+        block_b = _build_block(
+            ep_no_sync=True,
+            ep_no_sync_use_rowwise_all_to_all=True,
+            ep_no_sync_capacity_factor=8.0,
+            d_model=512,
+            hidden_size=1024,
+            num_experts=8,
+            top_k=4,
+            uniform_expert_assignment=False,
+        )
+        block_a.apply_ep(ep_mesh)
+        block_b.apply_ep(ep_mesh)
+
+        _init_block_params(block_a)
+        block_b.load_state_dict(block_a.state_dict())
+        _install_deterministic_topk_router(block_a)
+        _install_deterministic_topk_router(block_b)
+
+        block_a.ep.rowwise_nblocks = 128
+        block_b.ep.rowwise_nblocks = 128
+        block_a.ep.validate()
+        block_b.ep.validate()
+        block_a.train()
+        block_b.train()
+
+        x = torch.randn(
+            2, 64, block_a.d_model, device="cuda", dtype=torch.float32, requires_grad=True
+        )
+        x_b = x.detach().clone().requires_grad_(True)
+
+        y_a = block_a(x)
+        y_b = block_b(x_b)
+        torch.testing.assert_close(y_b, y_a, atol=8e-4, rtol=8e-4)
+
+        poisoned_rows = _poison_rowwise_capacity_tails(block_b, value=2048.0)
+        assert poisoned_rows > 0
+
+        loss_a = y_a.square().mean() + (0.1 * y_a.sum())
+        loss_b = y_b.square().mean() + (0.1 * y_b.sum())
+        loss_a.backward()
+        loss_b.backward()
+
+        assert x.grad is not None
+        assert x_b.grad is not None
+        torch.testing.assert_close(x_b.grad, x.grad, atol=2e-3, rtol=2e-3)
+
+        params_a = dict(block_a.named_parameters())
+        params_b = dict(block_b.named_parameters())
+        for name, p_a in params_a.items():
+            p_b = params_b[name]
+            if p_a.grad is None or p_b.grad is None:
+                continue
+            torch.testing.assert_close(
+                p_b.grad,
+                p_a.grad,
+                atol=3e-3,
+                rtol=3e-3,
+                msg=f"capacity tail poison changed gradient for {name}",
+            )
+    finally:
+        if old_debug is None:
+            os.environ.pop("OLMO_MOE_ROWWISE_DEBUG_TENSORS", None)
+        else:
+            os.environ["OLMO_MOE_ROWWISE_DEBUG_TENSORS"] = old_debug
+
+
+def _run_ep_no_sync_rowwise_wave_matches_rowwise():
+    ep_mesh = _build_ep_mesh()
+
+    block_rowwise = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_use_rowwise_all_to_all=True,
+        d_model=128,
+        hidden_size=256,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_wave = _build_block(
+        ep_no_sync=False,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.rowwise_wave,
+            capacity_factor=2.0,
+            rowwise_nblocks=128,
+            rowwise_wave_num_waves=2,
+        ),
+        d_model=128,
+        hidden_size=256,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_rowwise.apply_ep(ep_mesh)
+    block_wave.apply_ep(ep_mesh)
+
+    _init_block_params(block_rowwise)
+    block_wave.load_state_dict(block_rowwise.state_dict())
+    _install_deterministic_topk_router(block_rowwise)
+    _install_deterministic_topk_router(block_wave)
+
+    block_rowwise.ep.rowwise_nblocks = 128
+    block_wave.ep.rowwise_nblocks = 128
+    block_rowwise.ep.validate()
+    block_wave.ep.validate()
+    block_rowwise.train()
+    block_wave.train()
+
+    x = torch.randn(
+        1, 16, block_rowwise.d_model, device="cuda", dtype=torch.float32, requires_grad=True
+    )
+    x_wave = x.detach().clone().requires_grad_(True)
+
+    with pytest.warns(RuntimeWarning, match="rowwise_wave"):
+        y_wave = block_wave(x_wave)
+    y_rowwise = block_rowwise(x)
+    assert y_wave.shape == y_rowwise.shape
+    assert torch.isfinite(y_wave).all()
+    torch.testing.assert_close(y_wave, y_rowwise, atol=1e-3, rtol=1e-3)
+
+    loss_rowwise = y_rowwise.square().mean() + (0.1 * y_rowwise.sum())
+    loss_wave = y_wave.square().mean() + (0.1 * y_wave.sum())
+    loss_rowwise.backward()
+    loss_wave.backward()
+
+    assert x_wave.grad is not None
+    assert x.grad is not None
+    torch.testing.assert_close(x_wave.grad, x.grad, atol=2e-3, rtol=2e-3)
+
+    rowwise_params = dict(block_rowwise.named_parameters())
+    wave_params = dict(block_wave.named_parameters())
+    for name, p_rowwise in rowwise_params.items():
+        p_wave = wave_params[name]
+        if p_rowwise.grad is None or p_wave.grad is None:
+            continue
+        torch.testing.assert_close(
+            p_wave.grad,
+            p_rowwise.grad,
+            atol=3e-3,
+            rtol=3e-3,
+            msg=f"rowwise_wave gradient mismatch for {name}",
+        )
+
+    block_rowwise_bf16 = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_use_rowwise_all_to_all=True,
+        d_model=128,
+        hidden_size=256,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_wave_bf16 = _build_block(
+        ep_no_sync=False,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.rowwise_wave,
+            capacity_factor=2.0,
+            rowwise_nblocks=32,
+            rowwise_wave_num_waves=2,
+        ),
+        d_model=128,
+        hidden_size=256,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_rowwise_bf16.apply_ep(ep_mesh)
+    block_wave_bf16.apply_ep(ep_mesh)
+
+    _init_block_params(block_rowwise_bf16)
+    block_wave_bf16.load_state_dict(block_rowwise_bf16.state_dict())
+    _install_deterministic_topk_router(block_rowwise_bf16)
+    _install_deterministic_topk_router(block_wave_bf16)
+
+    block_rowwise_bf16.to(dtype=torch.bfloat16)
+    block_wave_bf16.to(dtype=torch.bfloat16)
+    block_rowwise_bf16.ep.rowwise_nblocks = 32
+    block_wave_bf16.ep.rowwise_nblocks = 32
+    block_rowwise_bf16.ep.validate()
+    block_wave_bf16.ep.validate()
+    block_rowwise_bf16.train()
+    block_wave_bf16.train()
+
+    x_bf16 = (0.2 * torch.randn(1, 16, block_rowwise_bf16.d_model, device="cuda")).to(
+        dtype=torch.bfloat16
+    )
+    x_bf16.requires_grad_(True)
+    x_wave_bf16 = x_bf16.detach().clone().requires_grad_(True)
+
+    y_rowwise_bf16 = block_rowwise_bf16(x_bf16)
+    y_wave_bf16 = block_wave_bf16(x_wave_bf16)
+    assert y_wave_bf16.shape == y_rowwise_bf16.shape
+    assert torch.isfinite(y_wave_bf16).all()
+    torch.testing.assert_close(y_wave_bf16, y_rowwise_bf16, atol=2e-2, rtol=2e-2)
+
+    loss_rowwise_bf16 = y_rowwise_bf16.square().mean() + (0.1 * y_rowwise_bf16.sum())
+    loss_wave_bf16 = y_wave_bf16.square().mean() + (0.1 * y_wave_bf16.sum())
+    loss_rowwise_bf16.backward()
+    loss_wave_bf16.backward()
+
+    assert x_wave_bf16.grad is not None
+    assert x_bf16.grad is not None
+    torch.testing.assert_close(x_wave_bf16.grad, x_bf16.grad, atol=2e-2, rtol=2e-2)
+
+    rowwise_bf16_params = dict(block_rowwise_bf16.named_parameters())
+    wave_bf16_params = dict(block_wave_bf16.named_parameters())
+    for name, p_rowwise in rowwise_bf16_params.items():
+        p_wave = wave_bf16_params[name]
+        if p_rowwise.grad is None or p_wave.grad is None:
+            continue
+        torch.testing.assert_close(
+            p_wave.grad,
+            p_rowwise.grad,
+            atol=3e-2,
+            rtol=3e-2,
+            msg=f"bf16 rowwise_wave gradient mismatch for {name}",
+        )
+
+    block_rowwise_eval = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_use_rowwise_all_to_all=True,
+        d_model=128,
+        hidden_size=256,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_wave_eval = _build_block(
+        ep_no_sync=False,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.rowwise_wave,
+            capacity_factor=2.0,
+            rowwise_nblocks=32,
+            rowwise_wave_num_waves=4,
+        ),
+        d_model=128,
+        hidden_size=256,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_rowwise_eval.apply_ep(ep_mesh)
+    block_wave_eval.apply_ep(ep_mesh)
+
+    _init_block_params(block_rowwise_eval)
+    block_wave_eval.load_state_dict(block_rowwise_eval.state_dict())
+    _install_deterministic_topk_router(block_rowwise_eval)
+    _install_deterministic_topk_router(block_wave_eval)
+
+    block_rowwise_eval.to(dtype=torch.bfloat16)
+    block_wave_eval.to(dtype=torch.bfloat16)
+    block_rowwise_eval.ep.rowwise_nblocks = 32
+    block_wave_eval.ep.rowwise_nblocks = 32
+    block_rowwise_eval.ep.validate()
+    block_wave_eval.ep.validate()
+    block_rowwise_eval.eval()
+    block_wave_eval.eval()
+
+    x_eval = (0.2 * torch.randn(1, 16, block_rowwise_eval.d_model, device="cuda")).to(
+        dtype=torch.bfloat16
+    )
+    with torch.no_grad():
+        y_rowwise_eval = block_rowwise_eval(x_eval)
+        y_wave_eval = block_wave_eval(x_eval.detach().clone())
+    assert y_wave_eval.shape == y_rowwise_eval.shape
+    assert torch.isfinite(y_wave_eval).all()
+    torch.testing.assert_close(y_wave_eval, y_rowwise_eval, atol=2e-2, rtol=2e-2)
+
+
+@requires_multi_gpu
+@requires_grouped_gemm
+@requires_symm_mem_vdev2d
+def test_v2_ep_no_sync_rowwise_wave_matches_rowwise():
+    run_distributed_test(
+        _run_ep_no_sync_rowwise_wave_matches_rowwise,
+        backend="nccl",
+        start_method="spawn",
+    )
+
+
+@requires_multi_gpu
+@requires_symm_mem_vdev2d
+def test_v2_ep_no_sync_rowwise_capacity_tail_poison_does_not_change_backward():
+    run_distributed_test(
+        _run_ep_no_sync_rowwise_capacity_tail_poison_does_not_change_backward,
+        backend="nccl",
+        start_method="spawn",
+    )
+
+
+@requires_gpu
+@requires_grouped_gemm
+def test_v2_no_ep_repeated_forward_backward_is_stable():
+    block = _build_block(
+        ep_no_sync=False,
+        d_model=256,
+        hidden_size=512,
+        num_experts=8,
+        top_k=4,
+        num_shared_experts=1,
+        shared_hidden_size=256,
+        uniform_expert_assignment=False,
+        init_device="cuda",
+    )
+    _init_block_params(block)
+    _install_local_deterministic_topk_router(block)
+    block.train()
+
+    torch.manual_seed(1234)
+    x0 = torch.randn(2, 256, block.d_model, device="cuda", dtype=torch.float32)
+
+    def run_once():
+        block.zero_grad(set_to_none=True)
+        x = x0.detach().clone().requires_grad_(True)
+        y = block(x)
+        loss = y.float().square().mean() + 0.03125 * y.float().sum()
+        loss.backward()
+        torch.cuda.synchronize()
+        grads = {
+            name: p.grad.detach().clone()
+            for name, p in block.named_parameters()
+            if p.grad is not None
+        }
+        assert x.grad is not None
+        return y.detach().clone(), x.grad.detach().clone(), grads
+
+    ref_y, ref_x_grad, ref_grads = run_once()
+    for _ in range(3):
+        y, x_grad, grads = run_once()
+        torch.testing.assert_close(y, ref_y, atol=0.0, rtol=0.0)
+        torch.testing.assert_close(x_grad, ref_x_grad, atol=2e-8, rtol=0.0)
+        for name, ref_grad in ref_grads.items():
+            torch.testing.assert_close(grads[name], ref_grad, atol=1e-6, rtol=0.0)

--- a/src/test/nn/ddp/ddp_promotion_test.py
+++ b/src/test/nn/ddp/ddp_promotion_test.py
@@ -1,0 +1,108 @@
+"""
+The MoE-v2 stack was promoted/renamed to the canonical ``OLMoDDP*`` names. These tests pin the
+back-compat aliases (old ``MoEFusedV2*`` / ``MoEV2*`` names resolve to the same objects) and that
+configs serialized under the old ``_CLASS_`` paths still deserialize.
+"""
+
+from olmo_core.config import Config
+from olmo_core.nn.ddp import OLMoDDPModel as OLMoDDPModelFromDDP
+from olmo_core.nn.ddp import OLMoDDPTransformerBlock as OLMoDDPTransformerBlockFromDDP
+from olmo_core.nn.ddp import (
+    OLMoDDPTransformerBlockConfig as OLMoDDPTransformerBlockConfigFromDDP,
+)
+from olmo_core.nn.ddp.block import (
+    OLMoDDPTransformerBlock,
+    OLMoDDPTransformerBlockConfig,
+)
+from olmo_core.nn.ddp.model import OLMoDDPModel as OLMoDDPModelFromCanonicalModule
+from olmo_core.nn.moe.v2.block import (
+    MoEFusedV2TransformerBlock,
+    MoEFusedV2TransformerBlockConfig,
+)
+from olmo_core.nn.moe.v2.block import MoERouterConfigV2 as MoERouterConfigV2FromOldBlock
+from olmo_core.nn.moe.v2.block import (
+    RoutedExpertsConfig as RoutedExpertsConfigFromOldBlock,
+)
+from olmo_core.nn.moe.v2.block import (
+    SharedExpertsConfig as SharedExpertsConfigFromOldBlock,
+)
+from olmo_core.nn.moe.v2.model import MoEFusedV2Transformer, OLMoDDPModel
+from olmo_core.nn.moe.v2.qwen import build_debug_qwen3_moe_config
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
+from olmo_core.nn.transformer import MoEFusedV2TransformerConfig, OLMoDDPModelConfig
+from olmo_core.optim import (
+    MoEFusedV2Optimizer,
+    MoEFusedV2OptimizerConfig,
+    OLMoDDPOptimizer,
+    OLMoDDPOptimizerConfig,
+)
+from olmo_core.train.train_module.transformer import (
+    MoEV2TransformerTrainModule,
+    MoEV2TransformerTrainModuleConfig,
+    OLMoDDPTrainModule,
+    OLMoDDPTrainModuleConfig,
+)
+from olmo_core.train.train_module.transformer.ddp_train_module import (
+    OLMoDDPTrainModule as OLMoDDPTrainModuleFromBridge,
+)
+from olmo_core.train.train_module.transformer.moe_train_module import (
+    MoEV2TransformerTrainModule as MoEV2TransformerTrainModuleFromOldModule,
+)
+
+
+def test_olmo_ddp_promoted_names_keep_moe_v2_compatibility():
+    assert MoEFusedV2Transformer is OLMoDDPModel
+    assert OLMoDDPModelFromCanonicalModule is OLMoDDPModel
+    assert OLMoDDPModelFromDDP is OLMoDDPModel
+    assert MoEFusedV2TransformerConfig is OLMoDDPModelConfig
+    assert MoEFusedV2TransformerBlock is OLMoDDPTransformerBlock
+    assert MoEFusedV2TransformerBlockConfig is OLMoDDPTransformerBlockConfig
+    assert OLMoDDPTransformerBlockFromDDP is OLMoDDPTransformerBlock
+    assert OLMoDDPTransformerBlockConfigFromDDP is OLMoDDPTransformerBlockConfig
+    assert MoERouterConfigV2FromOldBlock is MoERouterConfigV2
+    assert RoutedExpertsConfigFromOldBlock is RoutedExpertsConfig
+    assert SharedExpertsConfigFromOldBlock is SharedExpertsConfig
+    assert MoEV2TransformerTrainModule is OLMoDDPTrainModule
+    assert MoEV2TransformerTrainModuleFromOldModule is OLMoDDPTrainModule
+    assert MoEV2TransformerTrainModuleConfig is OLMoDDPTrainModuleConfig
+    assert OLMoDDPTrainModuleFromBridge is OLMoDDPTrainModule
+    assert MoEFusedV2OptimizerConfig is OLMoDDPOptimizerConfig
+    assert MoEFusedV2Optimizer is OLMoDDPOptimizer
+
+
+def test_olmo_ddp_promoted_config_names_round_trip():
+    model_config = build_debug_qwen3_moe_config(vocab_size=128)
+    model_config_dict = model_config.as_config_dict()
+    assert model_config_dict["_CLASS_"] == "olmo_core.nn.transformer.config.OLMoDDPModelConfig"
+    assert isinstance(Config.from_dict(model_config_dict), OLMoDDPModelConfig)
+
+    old_model_config_dict = dict(model_config_dict)
+    old_model_config_dict["_CLASS_"] = "olmo_core.nn.transformer.config.MoEFusedV2TransformerConfig"
+    assert isinstance(Config.from_dict(old_model_config_dict), OLMoDDPModelConfig)
+
+    block_config = build_debug_qwen3_moe_config(vocab_size=128, n_layers=1).block
+    assert isinstance(block_config, OLMoDDPTransformerBlockConfig)
+    block_config_dict = block_config.as_config_dict()
+    assert block_config_dict["_CLASS_"] == "olmo_core.nn.ddp.block.OLMoDDPTransformerBlockConfig"
+    assert isinstance(Config.from_dict(block_config_dict), OLMoDDPTransformerBlockConfig)
+
+    old_path_block_config_dict = dict(block_config_dict)
+    old_path_block_config_dict[
+        "_CLASS_"
+    ] = "olmo_core.nn.moe.v2.block.OLMoDDPTransformerBlockConfig"
+    assert isinstance(Config.from_dict(old_path_block_config_dict), OLMoDDPTransformerBlockConfig)
+
+    old_block_config_dict = dict(block_config_dict)
+    old_block_config_dict["_CLASS_"] = "olmo_core.nn.moe.v2.block.MoEFusedV2TransformerBlockConfig"
+    assert isinstance(Config.from_dict(old_block_config_dict), OLMoDDPTransformerBlockConfig)
+
+    optim_config = OLMoDDPOptimizerConfig()
+    optim_config_dict = optim_config.as_config_dict()
+    assert optim_config_dict["_CLASS_"] == "olmo_core.optim.moe_optimizer.OLMoDDPOptimizerConfig"
+    assert isinstance(Config.from_dict(optim_config_dict), OLMoDDPOptimizerConfig)
+
+    old_optim_config_dict = dict(optim_config_dict)
+    old_optim_config_dict["_CLASS_"] = "olmo_core.optim.moe_optimizer.MoEFusedV2OptimizerConfig"
+    assert isinstance(Config.from_dict(old_optim_config_dict), OLMoDDPOptimizerConfig)

--- a/src/test/nn/ddp/shared_only_block_test.py
+++ b/src/test/nn/ddp/shared_only_block_test.py
@@ -4,8 +4,17 @@ from olmo_core.config import DType
 from olmo_core.nn.attention import AttentionConfig, AttentionType
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlockConfig
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.lm_head import LMHeadConfig
+from olmo_core.nn.moe import MoERouterGatingFunction
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
-from olmo_core.nn.transformer import TransformerBlockType
+from olmo_core.nn.transformer import (
+    OLMoDDPModelConfig,
+    TransformerBlockType,
+    TransformerType,
+)
 
 
 def _shared_only_block_config() -> OLMoDDPTransformerBlockConfig:
@@ -28,6 +37,61 @@ def _shared_only_block_config() -> OLMoDDPTransformerBlockConfig:
         ),
         shared_experts_router=None,
     )
+
+
+def _routed_block_config() -> OLMoDDPTransformerBlockConfig:
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=DType.float32)
+    return OLMoDDPTransformerBlockConfig(
+        name=TransformerBlockType.moe_fused_v2,
+        sequence_mixer=AttentionConfig(
+            name=AttentionType.default,
+            n_heads=2,
+            n_kv_heads=2,
+            bias=False,
+            use_flash=False,
+            dtype=DType.float32,
+        ),
+        layer_norm=layer_norm,
+        routed_experts=RoutedExpertsConfig(
+            d_model=16, hidden_size=32, num_experts=4, bias=False, dtype=DType.float32
+        ),
+        routed_experts_router=MoERouterConfigV2(
+            d_model=16,
+            num_experts=4,
+            top_k=1,
+            gating_function=MoERouterGatingFunction.softmax,
+            uniform_expert_assignment=False,
+            lb_loss_weight=None,
+            z_loss_weight=None,
+            dtype=DType.float32,
+        ),
+        shared_experts=None,
+        shared_experts_router=None,
+        ep=ExpertParallelConfig(path=ExpertParallelPath.no_sync_1d),
+    )
+
+
+def test_ddp_model_topology_iterators_split_shared_and_routed_blocks():
+    model_config = OLMoDDPModelConfig(
+        name=TransformerType.moe_fused_v2,
+        d_model=16,
+        vocab_size=64,
+        n_layers=2,
+        lm_head=LMHeadConfig(bias=False, dtype=DType.float32),
+        block=_routed_block_config(),
+        block_overrides={0: _shared_only_block_config()},
+        recompute_each_block=False,
+        recompute_all_blocks_by_chunk=False,
+    )
+    model = model_config.build(init_device="cpu")
+
+    assert [key for key, _ in model.named_ddp_blocks()] == ["0", "1"]
+    assert [key for key, _ in model.named_shared_blocks()] == ["0"]
+    assert [key for key, _ in model.named_routed_blocks()] == ["1"]
+    assert [key for key, _ in model.named_ep_no_sync_blocks()] == ["1"]
+    assert model.count_ep_no_sync_blocks() == 1
+    assert model.count_non_rowwise_ep_no_sync_blocks() == 1
+    assert model.has_routed_blocks
 
 
 def test_shared_only_ddp_block_is_dense_stack_block():


### PR DESCRIPTION
Ports the net-new MoE-v2 / EP test coverage that olmo-ddp added (in its flattened `test/nn/moe/v2_*`
layout) onto core's test layout, mapping content rather than paths.

## New kernel tests (`src/test/kernels/`)
- `swiglu_valid_prefix_test.py` — torch-fallback (CPU) + GPU parity for `swiglu_valid_prefix` /
  `swiglu_backward_valid_prefix`, incl. device start-offset handling.
- `grouped_mm_row_offset_test.py` — row-offset grouped-mm writes only the shifted groups (GPU).

## New DDP-stack tests (`src/test/nn/ddp/`)
- `ddp_promotion_test.py` — the `MoEFusedV2*` / `MoEV2*` back-compat aliases resolve to the canonical
  `OLMoDDP*` objects, and configs serialized under old `_CLASS_` paths still deserialize.
- `shared_only_block_test.py` — add the topology-iterator test
  (`named_{ddp,shared,routed,ep_no_sync}_blocks` + counts).
- `block_no_sync_test.py` — extend `_build_block` (shared experts, rowwise-all-to-all, `ep` override)
  and add the net-new forward-method-availability / module-importable tests plus GPU multi-GPU
  rowwise-wave-matches-rowwise, capacity-tail-poison, and no-EP fwd/bwd-stability tests.
- `block_no_ep_parity_test.py` — rowwise / synced EP dropless forward+backward matches the no-EP path.

Rowwise GPU tests carry `@requires_symm_mem_vdev2d` (the ext isn't built in CI). Three olmo-ddp tests
were intentionally not ported because they target APIs core diverged from (`tbo` schedule rejected,
`no_sync_2d` path removed, rowwise-backend-string concept absent); the rowwise_wave config tests are
already covered by `ep_experimental_backends_test.py`.

## Testing
CPU tests run here (all pass). The GPU / multi-GPU tests are collection-verified (they import and
skip cleanly without a GPU); they exercise on the GPU CI runners.
