### PR TITLE
Document EP rowwise_nblocks=32 as an intentional default

### DIFF
--- a/src/olmo_core/nn/moe/v2/ep_config.py
+++ b/src/olmo_core/nn/moe/v2/ep_config.py
@@ -90,6 +90,8 @@ class ExpertParallelConfig(Config):
     shared_slots: int = 1
     major_align: int = 1
 
+    # Intentionally 32, not the legacy flat `ep_no_sync_rowwise_nblocks` default of 256: a deliberate
+    # retune for the migrated rowwise dispatch/combine kernels, not a regression.
     rowwise_nblocks: int = 32
     share_dispatch_out: bool = False
     share_combine_out: bool = False


### PR DESCRIPTION
The old flat `ep_no_sync_rowwise_nblocks` field defaulted to 256, whereas `ExpertParallelConfig.rowwise_nblocks` defaults to 32. That value is passed straight into the rowwise dispatch/combine autograd kernels, so the difference is meaningful — a migrated `rowwise_nvshmem` config that omits the field would otherwise look like a silent regression.

32 is the deliberate, retuned default for the migrated kernels. This adds a short note at the field so it isn't mistaken for a regression and "restored" to 256.

No behavior change (comment only); `moe-v2-core` is unreleased.