### PR TITLE
Dense-MLP parity tests + temporary GPU timing benchmark

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,11 +232,9 @@ jobs:
             image: akshitab/olmo-core-tch2100cu128-rma-2026-07-08
             gpus: 1
             run: |
-              for dims in "1024 4096" "2048 8192" "4096 11008" "4096 14336"; do
-                set -- $dims
-                python src/test/nn/moe/shared_experts_dense_bench.py \
-                  --d-model "$1" --hidden-size "$2" --seq-len 2048 --batch-size 4
-              done
+              python src/test/nn/moe/shared_experts_dense_bench.py \
+                --sizes 1024:4096 2048:8192 4096:11008 4096:14336 \
+                --seq-len 2048 --batch-size 4
 
           - name: Test optim (GPU)
             image: *gpu_test_image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,6 +224,16 @@ jobs:
                 --ignore-glob='src/test/nn/moe/v2*' \
                 src/test/nn/moe*
 
+          # TEMPORARY: not a correctness test — a timing comparison of the two dense-MLP
+          # implementations (MoE-v2 single-expert SharedExperts vs standard FeedForward), run as a
+          # script so CI logs the bf16 GPU numbers. Remove once the comparison is recorded.
+          - name: Dense MLP benchmark (GPU) [temporary]
+            image: *gpu_test_image
+            gpus: 1
+            run: |
+              python src/test/nn/moe/shared_experts_dense_bench.py \
+                --d-model 4096 --hidden-size 11008 --seq-len 2048 --batch-size 4
+
           - name: Test optim (GPU)
             image: *gpu_test_image
             gpus: 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,13 +226,17 @@ jobs:
 
           # TEMPORARY: not a correctness test — a timing comparison of the two dense-MLP
           # implementations (MoE-v2 single-expert SharedExperts vs standard FeedForward), run as a
-          # script so CI logs the bf16 GPU numbers. Remove once the comparison is recorded.
+          # script across a few sizes so CI logs the bf16 GPU numbers. Uses the torch 2.10 image
+          # (the MoE-v2 target). Remove once the comparison is recorded.
           - name: Dense MLP benchmark (GPU) [temporary]
-            image: *gpu_test_image
+            image: akshitab/olmo-core-tch2100cu128-rma-2026-07-08
             gpus: 1
             run: |
-              python src/test/nn/moe/shared_experts_dense_bench.py \
-                --d-model 4096 --hidden-size 11008 --seq-len 2048 --batch-size 4
+              for dims in "1024 4096" "2048 8192" "4096 11008" "4096 14336"; do
+                set -- $dims
+                python src/test/nn/moe/shared_experts_dense_bench.py \
+                  --d-model "$1" --hidden-size "$2" --seq-len 2048 --batch-size 4
+              done
 
           - name: Test optim (GPU)
             image: *gpu_test_image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,18 +224,6 @@ jobs:
                 --ignore-glob='src/test/nn/moe/v2*' \
                 src/test/nn/moe*
 
-          # TEMPORARY: not a correctness test — a timing comparison of the two dense-MLP
-          # implementations (MoE-v2 single-expert SharedExperts vs standard FeedForward), run as a
-          # script across a few sizes so CI logs the bf16 GPU numbers. Uses the torch 2.10 image
-          # (the MoE-v2 target). Remove once the comparison is recorded.
-          - name: Dense MLP benchmark (GPU) [temporary]
-            image: akshitab/olmo-core-tch2100cu128-rma-2026-07-08
-            gpus: 1
-            run: |
-              python src/test/nn/moe/shared_experts_dense_bench.py \
-                --sizes 1024:4096 2048:8192 4096:11008 4096:14336 \
-                --seq-len 2048 --batch-size 4
-
           - name: Test optim (GPU)
             image: *gpu_test_image
             gpus: 2

--- a/src/test/nn/moe/shared_experts_dense_bench.py
+++ b/src/test/nn/moe/shared_experts_dense_bench.py
@@ -1,0 +1,109 @@
+"""
+Quick forward-time comparison of the two dense-MLP implementations: MoE-v2's single-expert
+``SharedExperts`` vs the standard ``FeedForward``. See ``shared_experts_v2_test.py`` for the
+correctness/parity checks.
+
+Run as a script (any device; auto-selects CUDA + bf16 when available):
+    python src/test/nn/moe/shared_experts_dense_bench.py --d-model 4096 --hidden-size 11008
+"""
+
+import argparse
+import time
+from typing import Callable, Tuple
+
+import torch
+
+from olmo_core.config import DType
+from olmo_core.nn.feed_forward import FeedForwardConfig
+from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
+
+
+def _timed_ms(fn: Callable[[], object], *, warmup: int, iters: int, device: torch.device) -> float:
+    for _ in range(warmup):
+        fn()
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            fn()
+        end.record()
+        torch.cuda.synchronize()
+        return float(start.elapsed_time(end) / iters)
+
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    return (time.perf_counter() - t0) * 1e3 / iters
+
+
+def benchmark(
+    *,
+    batch_size: int,
+    seq_len: int,
+    d_model: int,
+    hidden_size: int,
+    warmup: int,
+    iters: int,
+    device: torch.device,
+    dtype: DType,
+) -> Tuple[float, float]:
+    """Time ``FeedForward`` and single-expert ``SharedExperts`` forwards; return (ff_ms, se_ms)."""
+    torch.manual_seed(0)
+
+    feed_forward = FeedForwardConfig(hidden_size=hidden_size, bias=False, dtype=dtype).build(
+        d_model=d_model, init_device=device.type
+    )
+    shared = SharedExpertsConfig(
+        d_model=d_model, hidden_size=hidden_size, num_experts=1, bias=False, dtype=dtype
+    ).build(init_device=device.type)
+
+    x = torch.randn(batch_size, seq_len, d_model, device=device, dtype=dtype.as_pt())
+
+    with torch.no_grad():
+        ff_ms = _timed_ms(lambda: feed_forward(x), warmup=warmup, iters=iters, device=device)
+        se_ms = _timed_ms(lambda: shared(x), warmup=warmup, iters=iters, device=device)
+
+    print(f"Dense MLP forward ({device.type}, {dtype.value}, {tuple(x.shape)})")
+    print(f"  FeedForward (standard):          {ff_ms:.3f} ms")
+    print(f"  SharedExperts (dense, E=1):      {se_ms:.3f} ms")
+    print(f"  SharedExperts / FeedForward:     {se_ms / max(ff_ms, 1e-6):.3f}x")
+    return ff_ms, se_ms
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--batch-size", type=int, default=4)
+    p.add_argument("--seq-len", type=int, default=2048)
+    p.add_argument("--d-model", type=int, default=2048)
+    p.add_argument("--hidden-size", type=int, default=8192)
+    p.add_argument("--warmup", type=int, default=10)
+    p.add_argument("--iters", type=int, default=50)
+    p.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    p.add_argument("--dtype", choices=[d.value for d in DType], default=None)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    device = torch.device(args.device)
+    dtype = (
+        DType(args.dtype)
+        if args.dtype is not None
+        else (DType.bfloat16 if device.type == "cuda" else DType.float32)
+    )
+    benchmark(
+        batch_size=args.batch_size,
+        seq_len=args.seq_len,
+        d_model=args.d_model,
+        hidden_size=args.hidden_size,
+        warmup=args.warmup,
+        iters=args.iters,
+        device=device,
+        dtype=dtype,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/test/nn/moe/shared_experts_dense_bench.py
+++ b/src/test/nn/moe/shared_experts_dense_bench.py
@@ -5,6 +5,9 @@ correctness/parity checks.
 
 Run as a script (any device; auto-selects CUDA + bf16 when available):
     python src/test/nn/moe/shared_experts_dense_bench.py --d-model 4096 --hidden-size 11008
+
+Sweep several (d_model, hidden_size) sizes in one run:
+    python src/test/nn/moe/shared_experts_dense_bench.py --sizes 1024:4096 4096:11008
 """
 
 import argparse
@@ -78,6 +81,14 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--seq-len", type=int, default=2048)
     p.add_argument("--d-model", type=int, default=2048)
     p.add_argument("--hidden-size", type=int, default=8192)
+    p.add_argument(
+        "--sizes",
+        nargs="+",
+        default=None,
+        metavar="D_MODEL:HIDDEN_SIZE",
+        help="Sweep several sizes in one run, e.g. --sizes 1024:4096 4096:11008. "
+        "Overrides --d-model/--hidden-size.",
+    )
     p.add_argument("--warmup", type=int, default=10)
     p.add_argument("--iters", type=int, default=50)
     p.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
@@ -93,16 +104,23 @@ def main() -> None:
         if args.dtype is not None
         else (DType.bfloat16 if device.type == "cuda" else DType.float32)
     )
-    benchmark(
-        batch_size=args.batch_size,
-        seq_len=args.seq_len,
-        d_model=args.d_model,
-        hidden_size=args.hidden_size,
-        warmup=args.warmup,
-        iters=args.iters,
-        device=device,
-        dtype=dtype,
-    )
+
+    if args.sizes:
+        sizes = [tuple(int(v) for v in s.split(":", 1)) for s in args.sizes]
+    else:
+        sizes = [(args.d_model, args.hidden_size)]
+
+    for d_model, hidden_size in sizes:
+        benchmark(
+            batch_size=args.batch_size,
+            seq_len=args.seq_len,
+            d_model=d_model,
+            hidden_size=hidden_size,
+            warmup=args.warmup,
+            iters=args.iters,
+            device=device,
+            dtype=dtype,
+        )
 
 
 if __name__ == "__main__":

--- a/src/test/nn/moe/shared_experts_dense_bench.py
+++ b/src/test/nn/moe/shared_experts_dense_bench.py
@@ -3,11 +3,15 @@ Quick forward-time comparison of the two dense-MLP implementations: MoE-v2's sin
 ``SharedExperts`` vs the standard ``FeedForward``. See ``shared_experts_v2_test.py`` for the
 correctness/parity checks.
 
-Run as a script (any device; auto-selects CUDA + bf16 when available):
-    python src/test/nn/moe/shared_experts_dense_bench.py --d-model 4096 --hidden-size 11008
+Run as a script (any device; auto-selects CUDA + bf16 when available). The size sweep used to
+compare the two implementations (run on a GPU with the torch 2.10 image):
 
-Sweep several (d_model, hidden_size) sizes in one run:
-    python src/test/nn/moe/shared_experts_dense_bench.py --sizes 1024:4096 4096:11008
+    python src/test/nn/moe/shared_experts_dense_bench.py \
+        --sizes 1024:4096 2048:8192 4096:11008 4096:14336 \
+        --seq-len 2048 --batch-size 4
+
+Or a single size:
+    python src/test/nn/moe/shared_experts_dense_bench.py --d-model 4096 --hidden-size 11008
 """
 
 import argparse

--- a/src/test/nn/moe/shared_experts_v2_test.py
+++ b/src/test/nn/moe/shared_experts_v2_test.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn.functional as F
 
 from olmo_core.config import DType
+from olmo_core.nn.feed_forward import FeedForwardConfig
 from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
 
 
@@ -81,3 +82,42 @@ def test_shared_experts_forward_matches_per_expert_reference():
     expected = torch.stack(expected, dim=0).view(E, B, S, D)
 
     torch.testing.assert_close(module(x), expected)
+
+
+def test_dense_shared_experts_matches_standard_feed_forward():
+    """
+    MoE-v2 represents a dense (non-routed) MLP as a single shared expert. Verify that this reuses
+    the same SwiGLU math as the standard ``FeedForward`` rather than diverging: with matching
+    weights, a 1-expert ``SharedExperts`` produces the same output as ``FeedForward``.
+    """
+    torch.manual_seed(0)
+    d_model, hidden_size = 16, 32
+
+    feed_forward = FeedForwardConfig(
+        hidden_size=hidden_size, bias=False, dtype=DType.float32
+    ).build(d_model=d_model)
+    shared = _build(d_model=d_model, hidden_size=hidden_size, num_experts=1)
+
+    # Map the standard SwiGLU FeedForward weights onto the fused single-expert layout. FeedForward
+    # computes ``w2(silu(w1(x)) * w3(x))`` (w1=gate, w3=up, w2=down); SharedExperts packs
+    # ``w_up_gate = [up | gate]`` (column-major, out dim last) and ``w_down`` as (E, H, D).
+    with torch.no_grad():
+        shared.w_up_gate[:, :hidden_size].copy_(feed_forward.w3.weight.t())  # up
+        shared.w_up_gate[:, hidden_size:].copy_(feed_forward.w1.weight.t())  # gate
+        shared.w_down[0].copy_(feed_forward.w2.weight.t())  # down
+
+    x = torch.randn(2, 4, d_model)
+    torch.testing.assert_close(shared(x)[0], feed_forward(x), rtol=1e-5, atol=1e-5)
+
+
+def test_dense_shared_experts_num_params_match_feed_forward():
+    # A dense (single-expert) shared MLP must have the same parameter budget as the standard
+    # FeedForward it replaces (SwiGLU, no bias: up + gate + down = 3 * d_model * hidden_size).
+    d_model, hidden_size = 16, 32
+    shared_cfg = SharedExpertsConfig(
+        d_model=d_model, hidden_size=hidden_size, num_experts=1, bias=False, dtype=DType.float32
+    )
+    feed_forward_cfg = FeedForwardConfig(hidden_size=hidden_size, bias=False, dtype=DType.float32)
+
+    assert shared_cfg.num_params() == feed_forward_cfg.num_params(d_model)
+    assert shared_cfg.num_params() == 3 * d_model * hidden_size


### PR DESCRIPTION
MoE-v2 represents a dense (non-routed) MLP as a single shared expert (`SharedExperts`, num_experts=1). The rest of the dense stack (attention, layer norm, LM head) already reuses the standard configs/modules directly, so the MLP is the only distinct reimplementation to check.

## Parity tests (`shared_experts_v2_test.py`)
- **Forward parity:** map a standard `FeedForward`'s SwiGLU weights (w1=gate, w3=up, w2=down) onto the fused single-expert layout (`w_up_gate=[up|gate]`, `w_down`) and assert identical outputs on the same input.
- **Param-count parity:** `SharedExpertsConfig(num_experts=1).num_params() == FeedForwardConfig.num_params(d_model) == 3·d_model·hidden_size`.

## Temporary GPU timing benchmark
`shared_experts_dense_bench.py` is a script (not a pytest test) that times both dense-MLP forwards — CUDA events + bf16 on GPU, wall-clock + fp32 on CPU. It complements the parity tests with a perf comparison.

A temporary `gpu_checks` matrix section ("Dense MLP benchmark (GPU) [temporary]") runs it as a script so CI logs the bf16 GPU numbers. It's a timing comparison, not a correctness assertion, and is marked TEMPORARY — to be removed once the numbers are recorded.

`make checks` passes; the benchmark script is not collected by any pytest job.