### PR TITLE
Compile-safe disabled activation diagnostics + rank-0 scheduler warnings

### DIFF
--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -29,7 +29,10 @@ from olmo_core.utils import get_or_init_stream
 from ..attention.base import SequenceMixerConfig
 from ..buffer_cache import BufferCache
 from ..layer_norm import LayerNormConfig
-from ..moe.v2.activation_debug import maybe_dump_ep_no_sync_saved_activations
+from ..moe.v2.activation_debug import (
+    EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENABLED,
+    maybe_dump_ep_no_sync_saved_activations,
+)
 from ..moe.v2.checkpointing import (
     get_rowwise_checkpoint_state,
     is_checkpoint_recomputing,
@@ -833,15 +836,19 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         else:
             raise RuntimeError(f"Unsupported EP no-sync path {self.ep.path!r}")
 
-        debug_out = maybe_dump_ep_no_sync_saved_activations(
-            self,
-            x,
-            loss_div_factor=loss_div_factor,
-            forward_kwargs=kwargs,
-            no_sync_forward=no_sync_forward,
-        )
-        if debug_out is not None:
-            return debug_out
+        # Keep the disabled-by-default activation diagnostic out of the compiled hot path. Its
+        # per-layer block_idx key otherwise forces one Dynamo graph per block (and per grad mode
+        # under reentrant checkpoint), eventually sending unmatched block forwards to eager.
+        if EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENABLED:
+            debug_out = maybe_dump_ep_no_sync_saved_activations(
+                self,
+                x,
+                loss_div_factor=loss_div_factor,
+                forward_kwargs=kwargs,
+                no_sync_forward=no_sync_forward,
+            )
+            if debug_out is not None:
+                return debug_out
         return no_sync_forward(x, loss_div_factor=loss_div_factor, **kwargs)
 
     def apply_pp(self, pp_mesh: DeviceMesh):

--- a/src/olmo_core/nn/moe/v2/activation_debug.py
+++ b/src/olmo_core/nn/moe/v2/activation_debug.py
@@ -27,6 +27,12 @@ def _debug_activation_enabled() -> bool:
     }
 
 
+# This is a startup-only diagnostic. Snapshot its flag before torch.compile() traces transformer
+# blocks so the disabled helper is absent from the hot path. In particular, the helper uses
+# block_idx to name its output; tracing that read specializes the shared block forward on every layer.
+EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENABLED = _debug_activation_enabled()
+
+
 def _get_train_global_arg(key: str, default=None):
     from olmo_core.train.globals import get_global_arg
 
@@ -54,12 +60,16 @@ def maybe_dump_ep_no_sync_saved_activations(
     forward_kwargs: Dict[str, object],
     no_sync_forward: Callable[..., torch.Tensor],
 ) -> Optional[torch.Tensor]:
+    # Keep this defensive check first for direct callers. Do not read block_idx while the diagnostic
+    # is disabled: it creates one Dynamo graph per block.
+    if not _debug_activation_enabled():
+        return None
+
     activation_dump_key = f"ep_no_sync_saved_activations_dumped_block_{block.block_idx}"
     if not (
         _get_train_global_arg("dry_run_done", default=False)
         and block.block_idx == 3
         and not _get_train_global_arg(activation_dump_key, default=False)
-        and _debug_activation_enabled()
     ):
         return None
 

--- a/src/olmo_core/optim/scheduler.py
+++ b/src/olmo_core/optim/scheduler.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 
 from ..config import Config, Registrable, StrEnum
+from ..distributed.utils import get_rank
 from ..exceptions import OLMoConfigurationError
 from .config import INITIAL_LR_FIELD, LR_FIELD
 
@@ -16,6 +17,11 @@ if TYPE_CHECKING:
     from olmo_core.train import Trainer
 
 log = logging.getLogger(__name__)
+
+
+def _warn_rank0(message: str, category: type[Warning], *, stacklevel: int = 1) -> None:
+    if get_rank() == 0:
+        warnings.warn(message, category, stacklevel=stacklevel + 1)
 
 
 class SchedulerUnits(StrEnum):
@@ -761,7 +767,7 @@ class ComposableScheduler(Scheduler):
         """
         if not self._warned_t_max_ignored:
             total_duration = sum(stage.duration for stage in self.stages)
-            warnings.warn(
+            _warn_rank0(
                 f"'{self.__class__.__name__}' ignores 't_max'; the schedule is defined "
                 f"absolutely by stage durations (total={total_duration}, "
                 f"t_max={t_max}). The LR will not rescale to fit the trainer's horizon.",
@@ -933,7 +939,7 @@ class SequentialScheduler(Scheduler):
             return self._sequential_lr(initial_lr, current, t_max)
 
         if not self._warned_t_max_ignored:
-            warnings.warn(
+            _warn_rank0(
                 f"'{self.__class__.__name__}' ignores 't_max' once 'override_decay' is active; "
                 f"the override is defined absolutely by 'start' ({self.override_decay.start}) "
                 f"and 'duration' ({self.override_decay.duration}) (t_max={t_max}).",

--- a/src/test/optim/scheduler_test.py
+++ b/src/test/optim/scheduler_test.py
@@ -1,8 +1,10 @@
 import math
+import warnings
 from typing import List, Tuple, Type
 
 import pytest
 
+import olmo_core.optim.scheduler as scheduler_module
 from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.optim import (
     WSDS,
@@ -325,11 +327,29 @@ def test_sequential_scheduler_override_decay_t_max_warning():
         scheduler.get_lr(10.0, 600, 10_000)
 
     # No further warnings on subsequent calls.
-    import warnings as _warnings
-
-    with _warnings.catch_warnings():
-        _warnings.simplefilter("error", UserWarning)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
         scheduler.get_lr(10.0, 700, 10_000)
+
+
+def test_composable_scheduler_t_max_warning_rank0_only(monkeypatch):
+    monkeypatch.setattr(scheduler_module, "get_rank", lambda: 1)
+    scheduler = ComposableScheduler(
+        stages=[
+            ComposableSchedulerStage(
+                duration=100,
+                shape=ComposableSchedulerStageType.linear,
+                end_lr=0.0,
+            )
+        ],
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        assert scheduler.get_lr(1.0, 50, 1_000) == pytest.approx(0.5)
+
+    assert not [warning for warning in caught if "ignores 't_max'" in str(warning.message)]
+    assert scheduler._warned_t_max_ignored
 
 
 def test_composable_scheduler_override_decay_linear():


### PR DESCRIPTION
Two small safeguards.

## Compile-safe disabled activation diagnostics
The disabled-by-default EP no-sync activation diagnostic was called unconditionally from the OLMoDDP block hot path. Its per-layer `block_idx` key specializes the shared block forward once per block under `torch.compile` (and per grad mode under reentrant checkpoint), eventually falling back to eager. Fix: snapshot the enabled flag at import (`EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENABLED`), gate the block-forward call on it, and move the enabled-check ahead of the `block_idx` read in `maybe_dump_ep_no_sync_saved_activations`.

## Rank-0-only scheduler warnings
`ComposableScheduler` / `SequentialScheduler` emit their "ignores `t_max`" `UserWarning` on every rank. Route those two through a `_warn_rank0()` helper (behaves as rank 0 when non-distributed) to avoid warning storms. Adds a rank-0-only regression test.

`make checks` passes; scheduler tests (46) green.