### PR TITLE
Pin uv version in GPU CI setup to avoid latest-release API lookup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -265,6 +265,11 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.12"
+          # Pin an explicit uv version so setup-uv resolves from its bundled manifest instead of
+          # querying the GitHub "latest release" API. The GPU matrix launches many jobs at once and
+          # the concurrent unauthenticated lookups were intermittently rate-limited, failing the jobs
+          # in the setup step with "Github API request failed while getting latest release".
+          version: "0.11.29"
 
       - name: Install Gantry
         run:


### PR DESCRIPTION
## What this changes

Pins an explicit `uv` version (`0.11.29`) in the `astral-sh/setup-uv` step of the GPU test jobs.

## Why

The GPU test matrix launches ~9 jobs concurrently. With no version pinned, each `setup-uv` step resolves the latest `uv` release through the GitHub API. The concurrent unauthenticated lookups were getting rate-limited, failing the jobs in the setup step (before any test ran) with:

```
X Github API request failed while getting latest release. Check the GitHub status page for outages. Try again later.
```

Pinning a version makes `setup-uv` resolve from its bundled manifest and skip the API call entirely. The pinned version is the one the runners already resolve today, so install behavior is unchanged.

## Testing

This PR's own GPU jobs exercise the change (the workflow definition for `pull_request` runs comes from the PR branch).