### PR TITLE
DeepEP v2 MXFP8 expert-parallel dispatch with activation recompute + MXFP8 scale mode

### DIFF
--- a/src/olmo_core/__init__.py
+++ b/src/olmo_core/__init__.py
@@ -4,6 +4,10 @@ import os
 import socket
 from pathlib import Path
 
+from . import mxfp8_config as _mxfp8_config
+
+_mxfp8_config.get_mxfp8_default_scale_mode()  # Resolves OLMO_MXFP8_SCALE_MODE once.
+
 # Marks a ``TRITON_CACHE_DIR`` value that we set ourselves (vs. a user-provided override), so
 # processes that inherit our env — e.g. ranks spawned after this module was first imported — can
 # tell the difference and recompute their own directory instead of reusing the parent's.

--- a/src/olmo_core/kernels/mxfp8_utils.py
+++ b/src/olmo_core/kernels/mxfp8_utils.py
@@ -5,6 +5,12 @@ from typing import Optional, Tuple
 
 import torch
 
+from olmo_core.mxfp8_config import MXFP8_SCALE_MODE_RCEIL as _MXFP8_SCALE_MODE_RCEIL
+from olmo_core.mxfp8_config import MXFP8ScaleMode
+from olmo_core.mxfp8_config import (
+    normalize_mxfp8_scale_mode as _normalize_mxfp8_scale_mode,
+)
+
 try:
     import nvtx
 except ImportError:
@@ -57,22 +63,54 @@ _MXFP8_DOT_NUM_STAGES = 2
 
 _TE_MXFP8_IMPORT_ATTEMPTED = False
 _TE_MXFP8_STATE = None
+_MXFP8_BACKEND_OLMO = "olmo"
+_MXFP8_BACKEND_TE = "te"
+_MXFP8_BACKEND_ENV = "OLMO_MXFP8_QDQ_BACKEND"
+_MXFP8_BACKEND_ALIASES = {
+    _MXFP8_BACKEND_OLMO: _MXFP8_BACKEND_OLMO,
+    "triton": _MXFP8_BACKEND_OLMO,
+    _MXFP8_BACKEND_TE: _MXFP8_BACKEND_TE,
+    "transformer_engine": _MXFP8_BACKEND_TE,
+    "transformerengine": _MXFP8_BACKEND_TE,
+}
 
 
 def ceil_div(a: int, b: int) -> int:
     return (a + b - 1) // b
 
 
+def _normalize_mxfp8_backend(value: str, *, env_name: str) -> str:
+    normalized = _MXFP8_BACKEND_ALIASES.get(value.strip().lower())
+    if normalized is None:
+        raise ValueError(
+            f"{env_name}/{_MXFP8_BACKEND_ENV} must be 'olmo' or 'te' "
+            f"(legacy alias 'triton' means 'olmo'), got {value!r}"
+        )
+    return normalized
+
+
 def _mxfp8_backend(kind: str) -> str:
-    specific_backend = os.environ.get(f"OLMO_MXFP8_{kind}_BACKEND")
-    backend = specific_backend
-    if backend is None:
-        backend = os.environ.get("OLMO_MXFP8_QDQ_BACKEND", "triton")
-    return backend.strip().lower()
+    specific_env = f"OLMO_MXFP8_{kind}_BACKEND"
+    specific_backend = os.environ.get(specific_env)
+    if specific_backend is not None:
+        return _normalize_mxfp8_backend(specific_backend, env_name=specific_env)
+    return _normalize_mxfp8_backend(
+        os.environ.get(_MXFP8_BACKEND_ENV, _MXFP8_BACKEND_OLMO),
+        env_name=_MXFP8_BACKEND_ENV,
+    )
 
 
 def _mxfp8_backend_wants_te(kind: str) -> bool:
-    return _mxfp8_backend(kind) in {"te", "transformer_engine"}
+    return _mxfp8_backend(kind) == _MXFP8_BACKEND_TE
+
+
+def _te_backend_requested_error(kind: str, reason: str) -> RuntimeError:
+    specific_env = f"OLMO_MXFP8_{kind}_BACKEND"
+    return RuntimeError(
+        f"TransformerEngine MXFP8 {kind} backend was requested via "
+        f"{specific_env}/{_MXFP8_BACKEND_ENV}, but it cannot run for this call: "
+        f"{reason}. Unset the backend env var to use OLMo, or set it to 'olmo'."
+    )
 
 
 def _get_te_mxfp8_state():
@@ -104,6 +142,49 @@ def _get_te_mxfp8_state():
 def _te_mxfp8_compact_scale_layout(rows: int, cols: int, block_size: int) -> bool:
     scale_cols = cols // block_size
     return rows % 128 == 0 and scale_cols % 4 == 0
+
+
+def _te_quantize_unavailable_reason(
+    x: torch.Tensor,
+    *,
+    block_size: int,
+    scale_mode: MXFP8ScaleMode,
+    out: Optional[torch.Tensor],
+    scales_out: Optional[torch.Tensor],
+) -> str:
+    if scale_mode != _MXFP8_SCALE_MODE_RCEIL:
+        return "TransformerEngine MXFP8 quantize currently supports only rceil scale mode"
+    if block_size != 32:
+        return f"TransformerEngine MXFP8 quantize requires block_size=32, got {block_size}"
+    if not x.is_cuda:
+        return "TransformerEngine MXFP8 quantize requires a CUDA input tensor"
+    if x.ndim != 2:
+        return f"TransformerEngine MXFP8 quantize requires rank-2 input, got shape={tuple(x.shape)}"
+    if not x.is_contiguous():
+        return "TransformerEngine MXFP8 quantize requires contiguous input"
+    if x.dtype not in {torch.bfloat16, torch.float16, torch.float32}:
+        return f"TransformerEngine MXFP8 quantize does not support input dtype {x.dtype}"
+
+    rows, cols = x.shape
+    if rows % 32 != 0 or cols % block_size != 0:
+        return (
+            "TransformerEngine MXFP8 quantize requires rows divisible by 32 and "
+            f"cols divisible by {block_size}, got shape={tuple(x.shape)}"
+        )
+    if not _te_mxfp8_compact_scale_layout(rows, cols, block_size):
+        return (
+            "TransformerEngine compact rowwise scale layout requires rows divisible "
+            "by 128 and scale columns divisible by 4"
+        )
+    if _get_te_mxfp8_state() is None:
+        return "TransformerEngine MXFP8 is not installed/importable"
+    if (out is None) != (scales_out is None):
+        return "TransformerEngine MXFP8 quantize requires both out and scales_out, or neither"
+    if out is not None and not out.is_contiguous():
+        return "TransformerEngine MXFP8 quantize requires contiguous out"
+    if scales_out is not None and not scales_out.is_contiguous():
+        return "TransformerEngine MXFP8 quantize requires contiguous scales_out"
+    return "unsupported TransformerEngine MXFP8 quantize call"
 
 
 def to_blocked(input_matrix: torch.Tensor) -> torch.Tensor:
@@ -140,9 +221,11 @@ if triton is not None:
         triton.Config({"BLOCK_M": 8, "BLOCK_N": 256}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_M": 8, "BLOCK_N": 512}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_M": 8, "BLOCK_N": 1024}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 2048}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_M": 16, "BLOCK_N": 256}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 16, "BLOCK_N": 512}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 16, "BLOCK_N": 1024}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 1024}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_M": 32, "BLOCK_N": 128}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 32, "BLOCK_N": 256}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 32, "BLOCK_N": 256}, num_warps=4, num_stages=3),
@@ -156,13 +239,16 @@ if triton is not None:
         triton.Config({"BLOCK_M": 8, "BLOCK_N": 256}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_M": 8, "BLOCK_N": 512}, num_warps=4, num_stages=1),
         triton.Config({"BLOCK_M": 8, "BLOCK_N": 1024}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 2048}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_M": 16, "BLOCK_N": 256}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 16, "BLOCK_N": 512}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 16, "BLOCK_N": 1024}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 16, "BLOCK_N": 2048}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_M": 32, "BLOCK_N": 128}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 32, "BLOCK_N": 256}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 32, "BLOCK_N": 256}, num_warps=4, num_stages=3),
         triton.Config({"BLOCK_M": 32, "BLOCK_N": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 1024}, num_warps=8, num_stages=1),
         triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 64, "BLOCK_N": 128}, num_warps=4, num_stages=2),
         triton.Config({"BLOCK_M": 64, "BLOCK_N": 256}, num_warps=8, num_stages=2),
@@ -288,12 +374,79 @@ if triton is not None:
         block_offset = pid_col * local_numel + (pid_row * output_block_stride)
         tl.store(output_ptr + block_offset + dest_indices_flat, scales_flat)
 
+    @triton.jit
+    def _triton_mxfp8_scale_byte_and_inv_scale(
+        max_abs,
+        RCEIL_SCALE: tl.constexpr,
+        USE_BF16_EXP: tl.constexpr,
+    ):
+        F8E4M3_MAX_RCP: tl.constexpr = 1.0 / 448.0
+        E8M0_EXP_BIAS: tl.constexpr = 127.0
+        E8M0_EXP_BIAS_INT: tl.constexpr = 127
+        F8E4M3_LARGEST_POW2: tl.constexpr = 8.0
+        F8E4M3_LARGEST_POW2_INT: tl.constexpr = 8
+        BF16_MBITS: tl.constexpr = 7
+
+        if RCEIL_SCALE and USE_BF16_EXP:
+            max_abs_bf16 = max_abs.to(tl.bfloat16)
+            max_abs_i16 = max_abs_bf16.to(tl.int16, bitcast=True)
+            largest_p2 = ((max_abs_i16 >> BF16_MBITS) & 0xFF) - E8M0_EXP_BIAS_INT
+            mantissa = max_abs_i16 & 0x7F
+            # For E4M3 max=448=1.75*2^8, round-up increments the scale
+            # exactly when the normalized bf16 mantissa is greater than 1.75.
+            round_up = tl.where(mantissa > 0x60, 1, 0)
+            scale_unbiased_i32 = largest_p2 - F8E4M3_LARGEST_POW2_INT + round_up
+            scale_unbiased_i32 = tl.maximum(scale_unbiased_i32, -E8M0_EXP_BIAS_INT)
+            scale_unbiased_i32 = tl.minimum(scale_unbiased_i32, E8M0_EXP_BIAS_INT)
+            scale_biased_i32 = (scale_unbiased_i32 + E8M0_EXP_BIAS_INT).to(tl.int32)
+            scale_biased_u8 = scale_biased_i32.to(tl.uint8)
+            inv_exp = 254 - scale_biased_i32
+            inv_bits = inv_exp.to(tl.uint32) << 23
+            inv_bits = tl.where(inv_exp == 0, 0x00400000, inv_bits)
+            inv_scale = inv_bits.to(tl.float32, bitcast=True)
+        elif RCEIL_SCALE:
+            # NVIDIA MXFP8 paper round-up scale recipe: https://arxiv.org/html/2506.08027v2
+            scale_unbiased = -tl.floor(-tl.log2(max_abs * F8E4M3_MAX_RCP))
+            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
+            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
+            scale_biased_i32 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.int32)
+            scale_biased_u8 = scale_biased_i32.to(tl.uint8)
+            inv_exp = 254 - scale_biased_i32
+            inv_bits = inv_exp.to(tl.uint32) << 23
+            inv_bits = tl.where(inv_exp == 0, 0x00400000, inv_bits)
+            inv_scale = inv_bits.to(tl.float32, bitcast=True)
+        elif USE_BF16_EXP:
+            max_abs_bf16 = max_abs.to(tl.bfloat16)
+            max_abs_i16 = max_abs_bf16.to(tl.int16, bitcast=True)
+            largest_p2 = ((max_abs_i16 >> BF16_MBITS) & 0xFF) - E8M0_EXP_BIAS_INT
+            scale_unbiased_i32 = largest_p2 - F8E4M3_LARGEST_POW2_INT
+            scale_unbiased_i32 = tl.maximum(scale_unbiased_i32, -E8M0_EXP_BIAS_INT)
+            scale_unbiased_i32 = tl.minimum(scale_unbiased_i32, E8M0_EXP_BIAS_INT)
+            scale_biased_i32 = (scale_unbiased_i32 + E8M0_EXP_BIAS_INT).to(tl.int32)
+            scale_biased_u8 = scale_biased_i32.to(tl.uint8)
+            inv_exp = 254 - scale_biased_i32
+            inv_bits = inv_exp.to(tl.uint32) << 23
+            inv_bits = tl.where(inv_exp == 0, 0x00400000, inv_bits)
+            inv_scale = inv_bits.to(tl.float32, bitcast=True)
+        else:
+            largest_p2 = tl.floor(tl.log2(max_abs))
+            scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2
+            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
+            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
+            scale_biased_i32 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.int32)
+            scale_biased_u8 = scale_biased_i32.to(tl.uint8)
+            inv_exp = 254 - scale_biased_i32
+            inv_bits = inv_exp.to(tl.uint32) << 23
+            inv_bits = tl.where(inv_exp == 0, 0x00400000, inv_bits)
+            inv_scale = inv_bits.to(tl.float32, bitcast=True)
+        return scale_biased_u8, inv_scale
+
     # Broader Q autotune while we characterize B200 codegen. The routed up/gate
     # save path defaults to two chunks, so the widest activation no longer
     # depends on one fragile full-width specialization.
     @triton.autotune(
         configs=_MXFP8_Q_AUTOTUNE_CONFIGS,
-        key=["n_rows", "n_cols", "BLOCK_SIZE", "USE_BF16_EXP"],
+        key=["n_rows", "n_cols", "BLOCK_SIZE", "USE_BF16_EXP", "RCEIL_SCALE"],
     )
     @triton.jit
     def _triton_mxfp8_quantize_dim0(
@@ -312,17 +465,13 @@ if triton is not None:
         BLOCK_M: tl.constexpr,
         BLOCK_N: tl.constexpr,
         USE_BF16_EXP: tl.constexpr,
+        RCEIL_SCALE: tl.constexpr,
     ):
         # Quantizes contiguous [M, K] to:
         # - q_ptr: e4m3 values [M, K]
         # - scale_ptr: e8m0 biased exponents [M, K//BLOCK_SIZE] as uint8
         FP32_TINY: tl.constexpr = 1.1754943508222875e-38
         F8E4M3_MAX: tl.constexpr = 448.0
-        E8M0_EXP_BIAS: tl.constexpr = 127.0
-        E8M0_EXP_BIAS_INT: tl.constexpr = 127
-        F8E4M3_LARGEST_POW2: tl.constexpr = 8.0
-        F8E4M3_LARGEST_POW2_INT: tl.constexpr = 8
-        BF16_MBITS: tl.constexpr = 7
         SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
 
         pid_m = tl.program_id(0)
@@ -341,29 +490,12 @@ if triton is not None:
         max_abs = tl.where(max_abs == max_abs, max_abs, 0.0)  # NaN -> 0
         max_abs = tl.maximum(max_abs, FP32_TINY)
 
-        if USE_BF16_EXP:
-            max_abs_bf16 = max_abs.to(tl.bfloat16)
-            max_abs_i16 = max_abs_bf16.to(tl.int16, bitcast=True)
-            largest_p2 = ((max_abs_i16 >> BF16_MBITS) & 0xFF) - E8M0_EXP_BIAS_INT
-            scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2_INT
-            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS_INT)
-            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS_INT)
-            scale_biased_i32 = (scale_unbiased + E8M0_EXP_BIAS_INT).to(tl.int32)
-            scale_biased_u8 = scale_biased_i32.to(tl.uint8)
-            inv_exp = 254 - scale_biased_i32
-            inv_bits = inv_exp.to(tl.uint32) << 23
-            inv_bits = tl.where(inv_exp == 0, 0x00400000, inv_bits)
-            inv_scale = inv_bits.to(tl.float32, bitcast=True)
-            q_hp = x_r * inv_scale[:, None]
-        else:
-            largest_p2 = tl.floor(tl.log2(max_abs))
-            scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2
-            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
-            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
-
-            scale_biased_u8 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.uint8)
-            dequant_scale = tl.exp2(scale_unbiased).to(tl.float32)
-            q_hp = x_r / dequant_scale[:, None]
+        scale_biased_u8, inv_scale = _triton_mxfp8_scale_byte_and_inv_scale(
+            max_abs,
+            RCEIL_SCALE=RCEIL_SCALE,
+            USE_BF16_EXP=USE_BF16_EXP,
+        )
+        q_hp = x_r * inv_scale[:, None]
 
         q_hp = tl.where(q_hp == q_hp, q_hp, 0.0)
         q_hp = tl.maximum(q_hp, -F8E4M3_MAX)
@@ -376,6 +508,86 @@ if triton is not None:
         scale_col_idx = pid_n * SCALE_BLOCKS_PER_TILE + tl.arange(0, SCALE_BLOCKS_PER_TILE)[None, :]
         scale_offsets = row_idx * s_stride_0 + scale_col_idx * s_stride_1
         scale_mask = (row_idx < n_rows) & (scale_col_idx < n_scale_cols)
+        scale_tile = tl.reshape(scale_biased_u8, (BLOCK_M, SCALE_BLOCKS_PER_TILE))
+        tl.store(scale_ptr + scale_offsets, scale_tile, mask=scale_mask)
+
+    @triton.autotune(
+        configs=_MXFP8_Q_AUTOTUNE_CONFIGS,
+        key=["n_rows", "top_k", "n_cols", "BLOCK_SIZE", "RCEIL_SCALE"],
+    )
+    @triton.jit
+    def _triton_mxfp8_weighted_quantize_dim0(
+        x_ptr,
+        x_stride_0,
+        x_stride_1,
+        weights_ptr,
+        w_stride_0,
+        w_stride_1,
+        q_ptr,
+        q_stride_0,
+        q_stride_1,
+        scale_ptr,
+        s_stride_0,
+        s_stride_1,
+        n_rows,
+        top_k,
+        n_cols,
+        BLOCK_SIZE: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+        RCEIL_SCALE: tl.constexpr,
+    ):
+        # Quantizes logical rows:
+        #   out[n * top_k + k, :] = x[n, :] * bf16(weights[n, k])
+        # to MXFP8. This matches the current bf16 materialized path used by
+        # rowwise MoE backward before quantization.
+        FP32_TINY: tl.constexpr = 1.1754943508222875e-38
+        F8E4M3_MAX: tl.constexpr = 448.0
+        SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
+
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+
+        route_row = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+        source_row = route_row // top_k
+        route_lane = route_row - source_row * top_k
+        col_idx = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+
+        total_rows = n_rows * top_k
+        q_mask = (route_row < total_rows) & (col_idx < n_cols)
+        x_offsets = source_row * x_stride_0 + col_idx * x_stride_1
+        x = tl.load(x_ptr + x_offsets, mask=q_mask, other=0.0).to(tl.float32)
+
+        weight_offsets = source_row * w_stride_0 + route_lane * w_stride_1
+        weight_mask = route_row < total_rows
+        weight = tl.load(weights_ptr + weight_offsets, mask=weight_mask, other=0.0)
+        weight = weight.to(tl.bfloat16).to(tl.float32)
+        weighted = (x * weight).to(tl.bfloat16)
+
+        x_r = weighted.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE, BLOCK_SIZE).to(tl.float32)
+        max_abs = tl.max(tl.abs(x_r), axis=1)
+        max_abs = tl.where(max_abs == max_abs, max_abs, 0.0)  # NaN -> 0
+        max_abs = tl.maximum(max_abs, FP32_TINY)
+
+        scale_biased_u8, inv_scale = _triton_mxfp8_scale_byte_and_inv_scale(
+            max_abs,
+            RCEIL_SCALE=RCEIL_SCALE,
+            USE_BF16_EXP=True,
+        )
+        q_hp = x_r * inv_scale[:, None]
+
+        q_hp = tl.where(q_hp == q_hp, q_hp, 0.0)
+        q_hp = tl.maximum(q_hp, -F8E4M3_MAX)
+        q_hp = tl.minimum(q_hp, F8E4M3_MAX)
+
+        q_tile = tl.reshape(q_hp, (BLOCK_M, BLOCK_N)).to(tl.float8e4nv)
+        q_offsets = route_row * q_stride_0 + col_idx * q_stride_1
+        tl.store(q_ptr + q_offsets, q_tile, mask=q_mask)
+
+        n_scale_cols = tl.cdiv(n_cols, BLOCK_SIZE)
+        scale_col_idx = pid_n * SCALE_BLOCKS_PER_TILE + tl.arange(0, SCALE_BLOCKS_PER_TILE)[None, :]
+        scale_offsets = route_row * s_stride_0 + scale_col_idx * s_stride_1
+        scale_mask = (route_row < total_rows) & (scale_col_idx < n_scale_cols)
         scale_tile = tl.reshape(scale_biased_u8, (BLOCK_M, SCALE_BLOCKS_PER_TILE))
         tl.store(scale_ptr + scale_offsets, scale_tile, mask=scale_mask)
 
@@ -398,16 +610,12 @@ if triton is not None:
         BLOCK_N: tl.constexpr,
         NUM_GROUPS: tl.constexpr,
         USE_BF16_EXP: tl.constexpr,
+        RCEIL_SCALE: tl.constexpr,
     ):
         # Same quantization tile shape as _triton_mxfp8_quantize_dim0, but
         # writes scale bytes directly in grouped SWIZZLE_32_4_4 layout.
         FP32_TINY: tl.constexpr = 1.1754943508222875e-38
         F8E4M3_MAX: tl.constexpr = 448.0
-        E8M0_EXP_BIAS: tl.constexpr = 127.0
-        E8M0_EXP_BIAS_INT: tl.constexpr = 127
-        F8E4M3_LARGEST_POW2: tl.constexpr = 8.0
-        F8E4M3_LARGEST_POW2_INT: tl.constexpr = 8
-        BF16_MBITS: tl.constexpr = 7
         SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
 
         pid_m = tl.program_id(0)
@@ -426,29 +634,12 @@ if triton is not None:
         max_abs = tl.where(max_abs == max_abs, max_abs, 0.0)  # NaN -> 0
         max_abs = tl.maximum(max_abs, FP32_TINY)
 
-        if USE_BF16_EXP:
-            max_abs_bf16 = max_abs.to(tl.bfloat16)
-            max_abs_i16 = max_abs_bf16.to(tl.int16, bitcast=True)
-            largest_p2 = ((max_abs_i16 >> BF16_MBITS) & 0xFF) - E8M0_EXP_BIAS_INT
-            scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2_INT
-            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS_INT)
-            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS_INT)
-            scale_biased_i32 = (scale_unbiased + E8M0_EXP_BIAS_INT).to(tl.int32)
-            scale_biased_u8 = scale_biased_i32.to(tl.uint8)
-            inv_exp = 254 - scale_biased_i32
-            inv_bits = inv_exp.to(tl.uint32) << 23
-            inv_bits = tl.where(inv_exp == 0, 0x00400000, inv_bits)
-            inv_scale = inv_bits.to(tl.float32, bitcast=True)
-            q_hp = x_r * inv_scale[:, None]
-        else:
-            largest_p2 = tl.floor(tl.log2(max_abs))
-            scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2
-            scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
-            scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
-
-            scale_biased_u8 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.uint8)
-            dequant_scale = tl.exp2(scale_unbiased).to(tl.float32)
-            q_hp = x_r / dequant_scale[:, None]
+        scale_biased_u8, inv_scale = _triton_mxfp8_scale_byte_and_inv_scale(
+            max_abs,
+            RCEIL_SCALE=RCEIL_SCALE,
+            USE_BF16_EXP=USE_BF16_EXP,
+        )
+        q_hp = x_r * inv_scale[:, None]
 
         q_hp = tl.where(q_hp == q_hp, q_hp, 0.0)
         q_hp = tl.maximum(q_hp, -F8E4M3_MAX)
@@ -521,12 +712,11 @@ if triton is not None:
         BLOCK_N: tl.constexpr,
         EVEN_M: tl.constexpr,
         EVEN_N: tl.constexpr,
+        RCEIL_SCALE: tl.constexpr,
     ):
         # Computes h = up * silu(gate) and quantizes h to MXFP8 in one pass.
         FP32_TINY: tl.constexpr = 1.1754943508222875e-38
         F8E4M3_MAX: tl.constexpr = 448.0
-        E8M0_EXP_BIAS: tl.constexpr = 127.0
-        F8E4M3_LARGEST_POW2: tl.constexpr = 8.0
         SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
 
         pid_m = tl.program_id(0)
@@ -558,14 +748,12 @@ if triton is not None:
         max_abs = tl.where(max_abs == max_abs, max_abs, 0.0)  # NaN -> 0
         max_abs = tl.maximum(max_abs, FP32_TINY)
 
-        largest_p2 = tl.floor(tl.log2(max_abs))
-        scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2
-        scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
-        scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
-        scale_biased_u8 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.uint8)
-
-        inv_dequant_scale = tl.exp2(-scale_unbiased).to(tl.float32)
-        q_hp = h_r * inv_dequant_scale[:, None]
+        scale_biased_u8, inv_scale = _triton_mxfp8_scale_byte_and_inv_scale(
+            max_abs,
+            RCEIL_SCALE=RCEIL_SCALE,
+            USE_BF16_EXP=False,
+        )
+        q_hp = h_r * inv_scale[:, None]
         q_hp = tl.where(q_hp == q_hp, q_hp, 0.0)
         q_hp = tl.maximum(q_hp, -F8E4M3_MAX)
         q_hp = tl.minimum(q_hp, F8E4M3_MAX)
@@ -610,12 +798,12 @@ if triton is not None:
         BLOCK_SIZE: tl.constexpr,
         BLOCK_M: tl.constexpr,
         BLOCK_N: tl.constexpr,
+        RCEIL_SCALE: tl.constexpr,
     ):
         # Computes h = up * silu(gate) from MXFP8 input and requantizes h to MXFP8.
         FP32_TINY: tl.constexpr = 1.1754943508222875e-38
         F8E4M3_MAX: tl.constexpr = 448.0
         E8M0_EXP_BIAS: tl.constexpr = 127.0
-        F8E4M3_LARGEST_POW2: tl.constexpr = 8.0
         SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
 
         pid_m = tl.program_id(0)
@@ -660,14 +848,12 @@ if triton is not None:
         max_abs = tl.where(max_abs == max_abs, max_abs, 0.0)  # NaN -> 0
         max_abs = tl.maximum(max_abs, FP32_TINY)
 
-        largest_p2 = tl.floor(tl.log2(max_abs))
-        scale_unbiased = largest_p2 - F8E4M3_LARGEST_POW2
-        scale_unbiased = tl.maximum(scale_unbiased, -E8M0_EXP_BIAS)
-        scale_unbiased = tl.minimum(scale_unbiased, E8M0_EXP_BIAS)
-        scale_biased_u8 = (scale_unbiased + E8M0_EXP_BIAS).to(tl.uint8)
-
-        inv_dequant_scale = tl.exp2(-scale_unbiased).to(tl.float32)
-        q_hp = h_r * inv_dequant_scale[:, None]
+        scale_biased_u8, inv_scale = _triton_mxfp8_scale_byte_and_inv_scale(
+            max_abs,
+            RCEIL_SCALE=RCEIL_SCALE,
+            USE_BF16_EXP=False,
+        )
+        q_hp = h_r * inv_scale[:, None]
         q_hp = tl.where(q_hp == q_hp, q_hp, 0.0)
         q_hp = tl.maximum(q_hp, -F8E4M3_MAX)
         q_hp = tl.minimum(q_hp, F8E4M3_MAX)
@@ -796,7 +982,6 @@ if triton is not None:
         BLOCK_M: tl.constexpr,
         BLOCK_N: tl.constexpr,
     ):
-        E8M0_EXP_BIAS: tl.constexpr = 127.0
         SCALE_BLOCKS_PER_TILE: tl.constexpr = BLOCK_N // BLOCK_SIZE
         pid_m = tl.program_id(0)
         pid_n = tl.program_id(1)
@@ -813,7 +998,9 @@ if triton is not None:
         scale_mask = (row_idx < n_rows) & (scale_col_idx < n_scale_cols)
         s_offsets = row_idx * s_stride_0 + scale_col_idx * s_stride_1
         s_u8 = tl.load(scales_u8_ptr + s_offsets, mask=scale_mask, other=0).to(tl.int32)
-        scales = tl.exp2(s_u8.to(tl.float32) - E8M0_EXP_BIAS)
+        scale_bits = s_u8.to(tl.uint32) << 23
+        scale_bits = tl.where(s_u8 == 0, 0x00400000, scale_bits)
+        scales = scale_bits.to(tl.float32, bitcast=True)
 
         q_blocks = q.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE, BLOCK_SIZE)
         scale_blocks = scales.reshape(BLOCK_M * SCALE_BLOCKS_PER_TILE)
@@ -1044,15 +1231,21 @@ def _quantize_to_mxfp8_torch(
     x: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     orig_shape = x.shape
     x_blocks = x.reshape(*orig_shape[:-1], orig_shape[-1] // block_size, block_size)
 
     max_abs = torch.amax(torch.abs(x_blocks), dim=-1)
     max_abs = torch.clamp(max_abs, min=torch.finfo(torch.float32).tiny)
 
-    largest_p2 = torch.floor(torch.log2(max_abs))
-    scale_unbiased = largest_p2 - _F8E4M3_LARGEST_POW2
+    if scale_mode == _MXFP8_SCALE_MODE_RCEIL:
+        # NVIDIA MXFP8 paper round-up scale recipe: https://arxiv.org/html/2506.08027v2
+        scale_unbiased = torch.ceil(torch.log2(max_abs / _F8E4M3_MAX))
+    else:
+        largest_p2 = torch.floor(torch.log2(max_abs))
+        scale_unbiased = largest_p2 - _F8E4M3_LARGEST_POW2
     scale_unbiased = torch.clamp(scale_unbiased, -_F8E8M0_EXP_BIAS, _F8E8M0_EXP_BIAS)
     scale_biased = (scale_unbiased + _F8E8M0_EXP_BIAS).to(torch.uint8)
     scales = scale_biased.view(torch.float8_e8m0fnu)
@@ -1076,9 +1269,11 @@ def _quantize_to_mxfp8_triton(
     x: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
     out: Optional[torch.Tensor] = None,
     scales_out: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if triton is None or tl is None:
         raise RuntimeError("Triton is not available")
     if not x.is_cuda:
@@ -1116,6 +1311,7 @@ def _quantize_to_mxfp8_triton(
         cols,
         BLOCK_SIZE=block_size,
         USE_BF16_EXP=x.dtype == torch.bfloat16,
+        RCEIL_SCALE=scale_mode == _MXFP8_SCALE_MODE_RCEIL,
     )
     if scales_out is not None:
         return qdata, scales_out
@@ -1126,11 +1322,16 @@ def _swiglu_quantize_rows_to_mxfp8_torch(
     up_gate: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     hidden = up_gate.shape[1] // 2
     up, gate = up_gate.split(hidden, dim=-1)
     h = up * torch.nn.functional.silu(gate)
-    qdata, scales = quantize_to_mxfp8(h, block_size=block_size)
+    qdata, scales = quantize_to_mxfp8(
+        h,
+        block_size=block_size,
+        scale_mode=scale_mode,
+    )
     return h, qdata, scales
 
 
@@ -1138,7 +1339,9 @@ def _swiglu_quantize_rows_to_mxfp8_triton(
     up_gate: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if triton is None or tl is None:
         raise RuntimeError("Triton is not available")
     if not up_gate.is_cuda:
@@ -1195,6 +1398,7 @@ def _swiglu_quantize_rows_to_mxfp8_triton(
         BLOCK_N=_MXFP8_SWIGLU_BLOCK_N,
         EVEN_M=rows % _MXFP8_SWIGLU_BLOCK_M == 0,
         EVEN_N=hidden % _MXFP8_SWIGLU_BLOCK_N == 0,
+        RCEIL_SCALE=scale_mode == _MXFP8_SCALE_MODE_RCEIL,
         num_warps=_MXFP8_SWIGLU_NUM_WARPS,
         num_stages=_MXFP8_SWIGLU_NUM_STAGES,
     )
@@ -1205,6 +1409,7 @@ def swiglu_quantize_rows_to_mxfp8(
     up_gate: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Compute SwiGLU activation and quantize it to MXFP8 in one API.
@@ -1214,6 +1419,7 @@ def swiglu_quantize_rows_to_mxfp8(
       qdata: float8_e4m3fn [M, H]
       scales: float8_e8m0fnu [M, H//block_size]
     """
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if up_gate.ndim != 2:
         raise ValueError(f"Expected rank-2 up_gate [M, 2H], got {tuple(up_gate.shape)}")
     if block_size != 32:
@@ -1229,9 +1435,17 @@ def swiglu_quantize_rows_to_mxfp8(
     if up_gate.is_cuda:
         if triton is None:
             raise RuntimeError("Triton is required for CUDA SwiGLU MXFP8 quantization")
-        return _swiglu_quantize_rows_to_mxfp8_triton(up_gate, block_size=block_size)
+        return _swiglu_quantize_rows_to_mxfp8_triton(
+            up_gate,
+            block_size=block_size,
+            scale_mode=scale_mode,
+        )
 
-    return _swiglu_quantize_rows_to_mxfp8_torch(up_gate, block_size=block_size)
+    return _swiglu_quantize_rows_to_mxfp8_torch(
+        up_gate,
+        block_size=block_size,
+        scale_mode=scale_mode,
+    )
 
 
 def _swiglu_quantize_rows_from_mxfp8_torch(
@@ -1239,6 +1453,7 @@ def _swiglu_quantize_rows_from_mxfp8_torch(
     up_gate_scales: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     up_gate = dequantize_from_mxfp8(
         up_gate_q,
@@ -1246,7 +1461,11 @@ def _swiglu_quantize_rows_from_mxfp8_torch(
         block_size=block_size,
         out_dtype=torch.bfloat16,
     )
-    return _swiglu_quantize_rows_to_mxfp8_torch(up_gate, block_size=block_size)
+    return _swiglu_quantize_rows_to_mxfp8_torch(
+        up_gate,
+        block_size=block_size,
+        scale_mode=scale_mode,
+    )
 
 
 def _swiglu_quantize_rows_from_mxfp8_triton(
@@ -1254,7 +1473,9 @@ def _swiglu_quantize_rows_from_mxfp8_triton(
     up_gate_scales: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if triton is None or tl is None:
         raise RuntimeError("Triton is not available")
     if not up_gate_q.is_cuda or not up_gate_scales.is_cuda:
@@ -1325,6 +1546,7 @@ def _swiglu_quantize_rows_from_mxfp8_triton(
         BLOCK_SIZE=block_size,
         BLOCK_M=_MXFP8_SWIGLU_FROM_FP8_BLOCK_M,
         BLOCK_N=_MXFP8_SWIGLU_FROM_FP8_BLOCK_N,
+        RCEIL_SCALE=scale_mode == _MXFP8_SCALE_MODE_RCEIL,
         num_warps=_MXFP8_SWIGLU_FROM_FP8_NUM_WARPS,
         num_stages=_MXFP8_SWIGLU_FROM_FP8_NUM_STAGES,
     )
@@ -1336,6 +1558,7 @@ def swiglu_quantize_rows_from_mxfp8(
     up_gate_scales: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Compute SwiGLU from MXFP8 input and requantize output to MXFP8.
@@ -1349,6 +1572,7 @@ def swiglu_quantize_rows_from_mxfp8(
       qdata: float8_e4m3fn [M, H]
       scales: float8_e8m0fnu [M, H//block_size]
     """
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if block_size != 32:
         raise ValueError(f"Only block_size=32 is supported (got {block_size})")
     if up_gate_q.ndim != 2 or up_gate_scales.ndim != 2:
@@ -1364,12 +1588,14 @@ def swiglu_quantize_rows_from_mxfp8(
             up_gate_q,
             up_gate_scales,
             block_size=block_size,
+            scale_mode=scale_mode,
         )
 
     return _swiglu_quantize_rows_from_mxfp8_torch(
         up_gate_q,
         up_gate_scales,
         block_size=block_size,
+        scale_mode=scale_mode,
     )
 
 
@@ -1377,9 +1603,12 @@ def _quantize_to_mxfp8_te(
     x: torch.Tensor,
     *,
     block_size: int,
+    scale_mode: MXFP8ScaleMode,
     out: Optional[torch.Tensor],
     scales_out: Optional[torch.Tensor],
 ) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+    if scale_mode != _MXFP8_SCALE_MODE_RCEIL:
+        return None
     if (
         block_size != 32
         or not x.is_cuda
@@ -1420,6 +1649,7 @@ def _quantize_to_mxfp8_te(
         columnwise_scale_inv=None,
         fp8_dtype=tex.DType.kFloat8E4M3,
         quantizer=quantizer,
+        with_gemm_swizzled_scales=False,
     )
     quantizer.update_quantized(x, te_tensor)
     return out, scales_out
@@ -1430,6 +1660,7 @@ def quantize_to_mxfp8(
     x: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
     out: Optional[torch.Tensor] = None,
     scales_out: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -1440,6 +1671,7 @@ def quantize_to_mxfp8(
       qdata: float8_e4m3fn [M, K]
       scales: float8_e8m0fnu [M, K//block_size]
     """
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if x.ndim != 2:
         raise ValueError(f"Expected rank-2 tensor, got shape={tuple(x.shape)}")
     if block_size != 32:
@@ -1476,27 +1708,216 @@ def quantize_to_mxfp8(
     if out is not None and not out.is_contiguous():
         raise ValueError("out must be contiguous")
 
-    # CUDA fast path: fused Triton quantization avoids eager pointwise op chains.
-    if x.is_cuda:
-        if _mxfp8_backend_wants_te("Q"):
-            te_result = _quantize_to_mxfp8_te(
+    q_backend = _mxfp8_backend("Q")
+    if q_backend == _MXFP8_BACKEND_TE:
+        te_result = _quantize_to_mxfp8_te(
+            x,
+            block_size=block_size,
+            scale_mode=scale_mode,
+            out=out,
+            scales_out=scales_out,
+        )
+        if te_result is not None:
+            return te_result
+        raise _te_backend_requested_error(
+            "Q",
+            _te_quantize_unavailable_reason(
                 x,
                 block_size=block_size,
+                scale_mode=scale_mode,
                 out=out,
                 scales_out=scales_out,
-            )
-            if te_result is not None:
-                return te_result
+            ),
+        )
+
+    # CUDA fast path: fused OLMo Triton quantization avoids eager pointwise op chains.
+    if x.is_cuda:
         if triton is None:
             raise RuntimeError("Triton is required for CUDA MXFP8 quantization")
         return _quantize_to_mxfp8_triton(
             x,
             block_size=block_size,
+            scale_mode=scale_mode,
             out=out,
             scales_out=scales_out,
         )
 
-    qdata, scales = _quantize_to_mxfp8_torch(x, block_size=block_size)
+    qdata, scales = _quantize_to_mxfp8_torch(
+        x,
+        block_size=block_size,
+        scale_mode=scale_mode,
+    )
+    if out is not None:
+        out.copy_(qdata)
+        qdata = out
+    if scales_out is not None:
+        scales_out.copy_(scales)
+        scales = scales_out
+    return qdata, scales
+
+
+def _weighted_quantize_rows_to_mxfp8_torch(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    block_size: int,
+    scale_mode: MXFP8ScaleMode,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    weighted = (x.unsqueeze(1) * weights.to(device=x.device, dtype=x.dtype).unsqueeze(-1)).reshape(
+        x.shape[0] * weights.shape[1], x.shape[1]
+    )
+    if not weighted.is_contiguous():
+        weighted = weighted.contiguous()
+    return quantize_to_mxfp8(
+        weighted,
+        block_size=block_size,
+        scale_mode=scale_mode,
+    )
+
+
+def _weighted_quantize_rows_to_mxfp8_triton(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    block_size: int,
+    scale_mode: MXFP8ScaleMode,
+    out: Optional[torch.Tensor],
+    scales_out: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
+    if triton is None or tl is None:
+        raise RuntimeError("Triton is not available")
+    if not x.is_cuda or not weights.is_cuda:
+        raise RuntimeError("Triton weighted MXFP8 quantization requires CUDA tensors")
+    if x.dtype != torch.bfloat16:
+        raise ValueError(f"Triton weighted MXFP8 quantization expects bf16 input, got {x.dtype}")
+
+    rows, cols = x.shape
+    top_k = weights.shape[1]
+    output_rows = rows * top_k
+    if out is not None:
+        qdata = out
+    else:
+        qdata = torch.empty((output_rows, cols), device=x.device, dtype=torch.float8_e4m3fn)
+    if scales_out is not None:
+        scales_u8 = scales_out.view(torch.uint8)
+    else:
+        scales_u8 = torch.empty(
+            (output_rows, cols // block_size), device=x.device, dtype=torch.uint8
+        )
+
+    def grid(meta):
+        return (
+            triton.cdiv(output_rows, meta["BLOCK_M"]),
+            triton.cdiv(cols, meta["BLOCK_N"]),
+        )
+
+    _triton_mxfp8_weighted_quantize_dim0[grid](
+        x,
+        x.stride(0),
+        x.stride(1),
+        weights,
+        weights.stride(0),
+        weights.stride(1),
+        qdata,
+        qdata.stride(0),
+        qdata.stride(1),
+        scales_u8,
+        scales_u8.stride(0),
+        scales_u8.stride(1),
+        rows,
+        top_k,
+        cols,
+        BLOCK_SIZE=block_size,
+        RCEIL_SCALE=scale_mode == _MXFP8_SCALE_MODE_RCEIL,
+    )
+    if scales_out is not None:
+        return qdata, scales_out
+    return qdata, scales_u8.view(torch.float8_e8m0fnu)
+
+
+@nvtx.annotate("weighted_quantize_rows_to_mxfp8", color="red")
+def weighted_quantize_rows_to_mxfp8(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
+    out: Optional[torch.Tensor] = None,
+    scales_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Quantize route-weighted rows to MXFP8 without materializing [N, K, H].
+
+    The returned tensors are flattened over routes:
+      qdata: [N * K, H]
+      scales: [N * K, H // block_size]
+
+    For CUDA bf16 input, the Triton path matches:
+      (x[:, None, :] * weights.to(x.dtype)[:, :, None]).reshape(N * K, H)
+      quantize_rows_to_mxfp8(...)
+    """
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
+    if x.ndim != 2:
+        raise ValueError(f"Expected x rank-2 [N, H], got {tuple(x.shape)}")
+    if weights.ndim != 2:
+        raise ValueError(f"Expected weights rank-2 [N, K], got {tuple(weights.shape)}")
+    if weights.shape[0] != x.shape[0]:
+        raise ValueError(
+            f"weights first dim must match x rows: {tuple(weights.shape)} vs {tuple(x.shape)}"
+        )
+    if block_size != 32:
+        raise ValueError(f"Only block_size=32 is supported (got {block_size})")
+    if x.shape[1] % block_size != 0:
+        raise ValueError(f"x hidden dim must be divisible by {block_size}, got {tuple(x.shape)}")
+    expected_q_shape = (x.shape[0] * weights.shape[1], x.shape[1])
+    expected_scales_shape = (expected_q_shape[0], x.shape[1] // block_size)
+    if out is not None:
+        if tuple(out.shape) != expected_q_shape:
+            raise ValueError(
+                f"out shape mismatch: expected {expected_q_shape}, got {tuple(out.shape)}"
+            )
+        if out.dtype != torch.float8_e4m3fn:
+            raise ValueError(f"out dtype mismatch: expected {torch.float8_e4m3fn}, got {out.dtype}")
+        if out.device != x.device:
+            raise ValueError(f"out device mismatch: expected {x.device}, got {out.device}")
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous")
+    if scales_out is not None:
+        if tuple(scales_out.shape) != expected_scales_shape:
+            raise ValueError(
+                "scales_out shape mismatch: "
+                f"expected {expected_scales_shape}, got {tuple(scales_out.shape)}"
+            )
+        if scales_out.dtype != torch.float8_e8m0fnu:
+            raise ValueError(
+                f"scales_out dtype mismatch: expected {torch.float8_e8m0fnu}, got {scales_out.dtype}"
+            )
+        if scales_out.device != x.device:
+            raise ValueError(
+                f"scales_out device mismatch: expected {x.device}, got {scales_out.device}"
+            )
+        if not scales_out.is_contiguous():
+            raise ValueError("scales_out must be contiguous")
+
+    if x.is_cuda and weights.is_cuda and x.dtype == torch.bfloat16:
+        if triton is None:
+            raise RuntimeError("Triton is required for CUDA weighted MXFP8 quantization")
+        return _weighted_quantize_rows_to_mxfp8_triton(
+            x,
+            weights,
+            block_size=block_size,
+            scale_mode=scale_mode,
+            out=out,
+            scales_out=scales_out,
+        )
+
+    qdata, scales = _weighted_quantize_rows_to_mxfp8_torch(
+        x,
+        weights,
+        block_size=block_size,
+        scale_mode=scale_mode,
+    )
     if out is not None:
         out.copy_(qdata)
         qdata = out
@@ -1547,8 +1968,50 @@ def _dequantize_from_mxfp8_te(
         columnwise_scale_inv=None,
         fp8_dtype=tex.DType.kFloat8E4M3,
         quantizer=quantizer,
+        with_gemm_swizzled_scales=False,
     )
     return te_tensor.dequantize(dtype=out_dtype)
+
+
+def _te_dequantize_unavailable_reason(
+    qdata: torch.Tensor,
+    scales: torch.Tensor,
+    *,
+    block_size: int,
+    out_dtype: torch.dtype,
+    out: Optional[torch.Tensor],
+) -> str:
+    if out is not None:
+        return (
+            "TransformerEngine MXFP8 dequantize does not support preallocated out in this wrapper"
+        )
+    if block_size != 32:
+        return f"TransformerEngine MXFP8 dequantize requires block_size=32, got {block_size}"
+    if not qdata.is_cuda or not scales.is_cuda:
+        return "TransformerEngine MXFP8 dequantize requires CUDA qdata and scales"
+    if not qdata.is_contiguous() or not scales.is_contiguous():
+        return "TransformerEngine MXFP8 dequantize requires contiguous qdata and scales"
+    if qdata.dtype != torch.float8_e4m3fn:
+        return f"TransformerEngine MXFP8 dequantize requires qdata dtype float8_e4m3fn, got {qdata.dtype}"
+    if scales.dtype != torch.float8_e8m0fnu:
+        return f"TransformerEngine MXFP8 dequantize requires scales dtype float8_e8m0fnu, got {scales.dtype}"
+    if out_dtype not in {torch.bfloat16, torch.float16, torch.float32}:
+        return f"TransformerEngine MXFP8 dequantize does not support output dtype {out_dtype}"
+
+    rows, cols = qdata.shape
+    if rows % 32 != 0 or cols % block_size != 0:
+        return (
+            "TransformerEngine MXFP8 dequantize requires rows divisible by 32 and "
+            f"cols divisible by {block_size}, got shape={tuple(qdata.shape)}"
+        )
+    if not _te_mxfp8_compact_scale_layout(rows, cols, block_size):
+        return (
+            "TransformerEngine compact rowwise scale layout requires rows divisible "
+            "by 128 and scale columns divisible by 4"
+        )
+    if _get_te_mxfp8_state() is None:
+        return "TransformerEngine MXFP8 is not installed/importable"
+    return "unsupported TransformerEngine MXFP8 dequantize call"
 
 
 @nvtx.annotate("dequantize_from_mxfp8", color="red")
@@ -1594,9 +2057,21 @@ def dequantize_from_mxfp8(
             raise ValueError(f"out dtype mismatch: expected {out_dtype}, got {out.dtype}")
         if out.device != qdata.device:
             raise ValueError(f"out device mismatch: expected {qdata.device}, got {out.device}")
+        if _mxfp8_backend("DQ") == _MXFP8_BACKEND_TE:
+            raise _te_backend_requested_error(
+                "DQ",
+                _te_dequantize_unavailable_reason(
+                    qdata,
+                    scales,
+                    block_size=block_size,
+                    out_dtype=out_dtype,
+                    out=out,
+                ),
+            )
         out_tensor = out
     else:
-        if _mxfp8_backend_wants_te("DQ"):
+        dq_backend = _mxfp8_backend("DQ")
+        if dq_backend == _MXFP8_BACKEND_TE:
             te_out = _dequantize_from_mxfp8_te(
                 qdata,
                 scales,
@@ -1606,6 +2081,16 @@ def dequantize_from_mxfp8(
             )
             if te_out is not None:
                 return te_out
+            raise _te_backend_requested_error(
+                "DQ",
+                _te_dequantize_unavailable_reason(
+                    qdata,
+                    scales,
+                    block_size=block_size,
+                    out_dtype=out_dtype,
+                    out=out,
+                ),
+            )
         out_tensor = torch.empty((m, k), device=qdata.device, dtype=out_dtype)
 
     use_triton = qdata.is_cuda and scales.is_cuda and triton is not None
@@ -1939,6 +2424,7 @@ def quantize_grouped_2d_to_mxfp8_blocked(
     offs: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize grouped 2D input for scaled_grouped_mm (2D-3D).
@@ -1947,6 +2433,7 @@ def quantize_grouped_2d_to_mxfp8_blocked(
       qdata: [M, K] float8_e4m3fn
       scales_blocked: [>=M, K//block_size] float8_e8m0fnu in grouped blocked layout packing.
     """
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if x.ndim != 2:
         raise ValueError(f"Expected x to be rank-2, got {tuple(x.shape)}")
     if offs.ndim != 1:
@@ -1972,7 +2459,11 @@ def quantize_grouped_2d_to_mxfp8_blocked(
         offs = offs.to(device=x.device)
 
     # Keep capacity/static shape for mat_a and avoid active-row compaction.
-    qdata, scales = quantize_to_mxfp8(x, block_size=block_size)
+    qdata, scales = quantize_to_mxfp8(
+        x,
+        block_size=block_size,
+        scale_mode=scale_mode,
+    )
 
     if x.is_cuda:
         scales_blocked = _to_blocked_m_groups_triton(scales, offs)
@@ -2002,10 +2493,12 @@ def _quantize_grouped_2d_to_mxfp8_blocked_fused_triton(
     offs: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
     out: Optional[torch.Tensor] = None,
     blocked_scales_out: Optional[torch.Tensor] = None,
     zero_unwritten_tail: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if triton is None or tl is None:
         raise RuntimeError("Triton is required for fused grouped MXFP8 quantize+swizzle")
     if not x.is_cuda:
@@ -2081,6 +2574,7 @@ def _quantize_grouped_2d_to_mxfp8_blocked_fused_triton(
         BLOCK_N=_MXFP8_Q_BLOCK_N,
         NUM_GROUPS=num_groups,
         USE_BF16_EXP=x.dtype == torch.bfloat16,
+        RCEIL_SCALE=scale_mode == _MXFP8_SCALE_MODE_RCEIL,
         num_warps=_MXFP8_Q_NUM_WARPS,
         num_stages=_MXFP8_Q_NUM_STAGES,
     )
@@ -2092,6 +2586,7 @@ def quantize_grouped_2d_to_mxfp8_blocked_fused(
     offs: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
     out: Optional[torch.Tensor] = None,
     blocked_scales_out: Optional[torch.Tensor] = None,
     zero_unwritten_tail: bool = True,
@@ -2103,6 +2598,7 @@ def quantize_grouped_2d_to_mxfp8_blocked_fused(
     grouped_scales_to_mxfp8_blocked(scales, offs), but fuses the scale swizzle
     into the quantization kernel for CUDA inputs.
     """
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if x.ndim != 2:
         raise ValueError(f"Expected x to be rank-2, got {tuple(x.shape)}")
     if offs.ndim != 1:
@@ -2122,6 +2618,7 @@ def quantize_grouped_2d_to_mxfp8_blocked_fused(
             x,
             offs,
             block_size=block_size,
+            scale_mode=scale_mode,
             out=out,
             blocked_scales_out=blocked_scales_out,
             zero_unwritten_tail=zero_unwritten_tail,
@@ -2131,6 +2628,7 @@ def quantize_grouped_2d_to_mxfp8_blocked_fused(
         x,
         offs,
         block_size=block_size,
+        scale_mode=scale_mode,
     )
     if out is not None:
         out.copy_(qdata)
@@ -2172,6 +2670,7 @@ def quantize_grouped_weight_3d_to_mxfp8_blocked(
     mat_b: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize grouped 3D RHS operand [G, K, N] for scaled_grouped_mm.
@@ -2180,6 +2679,7 @@ def quantize_grouped_weight_3d_to_mxfp8_blocked(
       qdata: [G, K, N] float8_e4m3fn
       scales_blocked: [G, blocked_scale_K * blocked_scale_N] float8_e8m0fnu
     """
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if mat_b.ndim != 3:
         raise ValueError(f"Expected mat_b rank-3 [G, K, N], got {tuple(mat_b.shape)}")
 
@@ -2193,14 +2693,22 @@ def quantize_grouped_weight_3d_to_mxfp8_blocked(
     # transposed views so trailing dims are already column-major (stride [1, K]).
     mat_b_nk = mat_b.transpose(-2, -1)  # [G, N, K]
     if mat_b_nk.is_contiguous():
-        q_nk, s_nk = quantize_to_mxfp8(mat_b_nk.reshape(g * n, k), block_size=block_size)
+        q_nk, s_nk = quantize_to_mxfp8(
+            mat_b_nk.reshape(g * n, k),
+            block_size=block_size,
+            scale_mode=scale_mode,
+        )
         q_nk = q_nk.reshape(g, n, k)
         s_nk = s_nk.reshape(g, n, k // block_size)
     else:
         q_parts = []
         s_parts = []
         for i in range(g):
-            q_i, s_i = quantize_to_mxfp8(mat_b_nk[i], block_size=block_size)
+            q_i, s_i = quantize_to_mxfp8(
+                mat_b_nk[i],
+                block_size=block_size,
+                scale_mode=scale_mode,
+            )
             q_parts.append(q_i)
             s_parts.append(s_i)
         q_nk = torch.stack(q_parts, dim=0)
@@ -2215,12 +2723,14 @@ def quantize_grouped_weight_3d_to_mxfp8_unblocked(
     mat_b: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize grouped 3D RHS operand [G, K, N] to:
       qdata: [G, K, N] float8_e4m3fn (column-major trailing dims)
       scales_nk: [G, N, K//block_size] float8_e8m0fnu (unblocked, non-swizzled)
     """
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if mat_b.ndim != 3:
         raise ValueError(f"Expected mat_b rank-3 [G, K, N], got {tuple(mat_b.shape)}")
 
@@ -2234,14 +2744,22 @@ def quantize_grouped_weight_3d_to_mxfp8_unblocked(
     # transposed views so trailing dims are column-major (stride [1, K]).
     mat_b_nk = mat_b.transpose(-2, -1)  # [G, N, K]
     if mat_b_nk.is_contiguous():
-        q_nk, s_nk = quantize_to_mxfp8(mat_b_nk.reshape(g * n, k), block_size=block_size)
+        q_nk, s_nk = quantize_to_mxfp8(
+            mat_b_nk.reshape(g * n, k),
+            block_size=block_size,
+            scale_mode=scale_mode,
+        )
         q_nk = q_nk.reshape(g, n, k)
         s_nk = s_nk.reshape(g, n, k // block_size)
     else:
         q_parts = []
         s_parts = []
         for i in range(g):
-            q_i, s_i = quantize_to_mxfp8(mat_b_nk[i], block_size=block_size)
+            q_i, s_i = quantize_to_mxfp8(
+                mat_b_nk[i],
+                block_size=block_size,
+                scale_mode=scale_mode,
+            )
             q_parts.append(q_i)
             s_parts.append(s_i)
         q_nk = torch.stack(q_parts, dim=0)
@@ -2255,6 +2773,7 @@ def quantize_rows_to_mxfp8(
     x: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
     out: Optional[torch.Tensor] = None,
     scales_out: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -2262,6 +2781,7 @@ def quantize_rows_to_mxfp8(
     return quantize_to_mxfp8(
         x,
         block_size=block_size,
+        scale_mode=scale_mode,
         out=out,
         scales_out=scales_out,
     )
@@ -2272,6 +2792,7 @@ def quantize_row_halves_to_mxfp8(
     x: torch.Tensor,
     *,
     block_size: int = 32,
+    scale_mode: Optional[MXFP8ScaleMode] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize a row-major [M, 2H] tensor as two [M, H] halves.
@@ -2282,6 +2803,7 @@ def quantize_row_halves_to_mxfp8(
     Inductor generate an fp8 masked-load fill constant that Triton cannot lower.
     The useful work is still done by the two explicit Triton quantize kernels.
     """
+    scale_mode = _normalize_mxfp8_scale_mode(scale_mode)
     if x.ndim != 2:
         raise ValueError(f"Expected rank-2 tensor, got shape={tuple(x.shape)}")
     if block_size != 32:
@@ -2293,7 +2815,11 @@ def quantize_row_halves_to_mxfp8(
     if hidden % block_size != 0:
         raise ValueError(f"Split dim must be divisible by {block_size}, got hidden={hidden}")
     if not x.is_cuda or triton is None or _mxfp8_backend_wants_te("Q"):
-        return quantize_rows_to_mxfp8(x, block_size=block_size)
+        return quantize_rows_to_mxfp8(
+            x,
+            block_size=block_size,
+            scale_mode=scale_mode,
+        )
 
     rows = x.shape[0]
     qdata = torch.empty((rows, 2 * hidden), device=x.device, dtype=torch.float8_e4m3fn)
@@ -2306,12 +2832,14 @@ def quantize_row_halves_to_mxfp8(
     _quantize_to_mxfp8_triton(
         x[:, :hidden],
         block_size=block_size,
+        scale_mode=scale_mode,
         out=qdata[:, :hidden],
         scales_out=scales[:, :scale_hidden],
     )
     _quantize_to_mxfp8_triton(
         x[:, hidden:],
         block_size=block_size,
+        scale_mode=scale_mode,
         out=qdata[:, hidden:],
         scales_out=scales[:, scale_hidden:],
     )

--- a/src/olmo_core/mxfp8_config.py
+++ b/src/olmo_core/mxfp8_config.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Literal
+
+MXFP8ScaleMode = Literal["floor", "rceil"]
+
+MXFP8_SCALE_MODE_FLOOR: MXFP8ScaleMode = "floor"
+MXFP8_SCALE_MODE_RCEIL: MXFP8ScaleMode = "rceil"
+MXFP8_SCALE_MODE_ENV = "OLMO_MXFP8_SCALE_MODE"
+
+
+def normalize_mxfp8_scale_mode_value(scale_mode: Any) -> MXFP8ScaleMode:
+    value = getattr(scale_mode, "value", scale_mode)
+    if isinstance(value, str):
+        value = value.strip().lower()
+    if value == MXFP8_SCALE_MODE_FLOOR:
+        return MXFP8_SCALE_MODE_FLOOR
+    if value == MXFP8_SCALE_MODE_RCEIL:
+        return MXFP8_SCALE_MODE_RCEIL
+    raise ValueError(
+        f"{MXFP8_SCALE_MODE_ENV}/scale_mode must be 'floor' or 'rceil', " f"got {scale_mode!r}"
+    )
+
+
+_MXFP8_DEFAULT_SCALE_MODE = normalize_mxfp8_scale_mode_value(
+    os.environ.get(MXFP8_SCALE_MODE_ENV, MXFP8_SCALE_MODE_RCEIL)
+)
+
+
+def normalize_mxfp8_scale_mode(scale_mode: Any) -> MXFP8ScaleMode:
+    if scale_mode is None:
+        return _MXFP8_DEFAULT_SCALE_MODE
+    return normalize_mxfp8_scale_mode_value(scale_mode)
+
+
+def get_mxfp8_default_scale_mode() -> MXFP8ScaleMode:
+    return _MXFP8_DEFAULT_SCALE_MODE

--- a/src/olmo_core/mxfp8_config.py
+++ b/src/olmo_core/mxfp8_config.py
@@ -11,6 +11,12 @@ MXFP8_SCALE_MODE_ENV = "OLMO_MXFP8_SCALE_MODE"
 
 
 def normalize_mxfp8_scale_mode_value(scale_mode: Any) -> MXFP8ScaleMode:
+    """
+    Coerce a scale-mode value (a string or an enum-like object with a ``.value``) to a
+    canonical :data:`MXFP8ScaleMode` literal.
+
+    :raises ValueError: If the value is not ``"floor"`` or ``"rceil"``.
+    """
     value = getattr(scale_mode, "value", scale_mode)
     if isinstance(value, str):
         value = value.strip().lower()
@@ -29,10 +35,15 @@ _MXFP8_DEFAULT_SCALE_MODE = normalize_mxfp8_scale_mode_value(
 
 
 def normalize_mxfp8_scale_mode(scale_mode: Any) -> MXFP8ScaleMode:
+    """
+    Like :func:`normalize_mxfp8_scale_mode_value`, but resolve ``None`` to the import-time
+    default (from ``OLMO_MXFP8_SCALE_MODE``).
+    """
     if scale_mode is None:
         return _MXFP8_DEFAULT_SCALE_MODE
     return normalize_mxfp8_scale_mode_value(scale_mode)
 
 
 def get_mxfp8_default_scale_mode() -> MXFP8ScaleMode:
+    """Return the MXFP8 scale mode resolved once from ``OLMO_MXFP8_SCALE_MODE`` at import time."""
     return _MXFP8_DEFAULT_SCALE_MODE

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -547,7 +547,6 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         self._ep_no_sync_te_backend_warned: bool = False
         self._deepep_v2_runtime: Optional[object] = None
         self._deepep_v2_runtime_cache: Optional[dict[object, object]] = None
-        self._deepep_v2_max_capacity_factor: float = self.ep.capacity_factor
         # EP no-sync tail-drop metrics, populated by rowwise and DeepEP paths.
         self._ep_no_sync_rowwise_drop_tokens_sum: Optional[torch.Tensor] = None
         self._ep_no_sync_rowwise_total_tokens_sum: Optional[torch.Tensor] = None
@@ -988,7 +987,6 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         self.ep_pg = ep_pg if ep_pg is not None else ep_mp_mesh.get_group()
         self._deepep_v2_runtime = None
         self._deepep_v2_runtime_cache = None
-        self._deepep_v2_max_capacity_factor = self.ep.capacity_factor
 
         if self.ep.uses_olmo_symm:
             if olmo_symm_mem.is_enabled() and not self.ep.uses_rowwise_buffers:
@@ -1254,6 +1252,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         self,
         x: torch.Tensor,
         *,
+        deepep_reentrant_checkpoint: bool = False,
         loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
         **kwargs,
     ) -> torch.Tensor:
@@ -1269,6 +1268,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
             self,
             x,
             accumulate_routed_aux_loss_metrics=accumulate_routed_aux_loss_metrics,
+            accumulate_router_aux_loss_metrics=(True if deepep_reentrant_checkpoint else None),
             loss_div_factor=loss_div_factor,
             **kwargs,
         )

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -315,6 +315,35 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         self.zero_fp8_weight_store_grads(set_to_none=set_to_none)
 
     @torch.no_grad()
+    def prewarm_deepep_v2_runtimes(
+        self,
+        *,
+        max_local_microbatch_size: int,
+    ) -> None:
+        deepep_blocks = [block for block in self.routed_blocks() if block.ep.is_deepep]
+        if not deepep_blocks:
+            return
+
+        param = next((p for p in self.parameters() if p.is_floating_point()), None)
+        if param is None:
+            raise RuntimeError("Cannot infer device for DeepEP runtime prewarm")
+
+        # Import locally to keep the model/block module initialization order
+        # simple: block.py also installs the DeepEP combined-forward method.
+        from ..moe.v2.ep_deepep_v2 import prewarm_deepep_v2_runtime
+
+        for block in deepep_blocks:
+            if block.routed_experts_router is None:
+                raise RuntimeError("DeepEP block is missing its routed router during prewarm")
+            prewarm_deepep_v2_runtime(
+                block,
+                max_local_tokens=max_local_microbatch_size,
+                hidden=self.d_model,
+                top_k=block.routed_experts_router.top_k,
+                device=param.device,
+            )
+
+    @torch.no_grad()
     def prewarm_ep_no_sync_symm_buffers(
         self,
         *,
@@ -660,7 +689,6 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
             first_pg = deepep_blocks[0].ep_pg
             if first_pg is None:
                 raise RuntimeError("DeepEP block is missing ep_pg after apply_ep()")
-            max_capacity_factor = max(block.ep.capacity_factor for block in deepep_blocks)
             for block in deepep_blocks:
                 if block.ep_pg is not first_pg:
                     raise RuntimeError(
@@ -668,7 +696,6 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                         f"(block={block.block_idx})"
                     )
                 block._deepep_v2_runtime_cache = self._deepep_v2_runtime_cache
-                block._deepep_v2_max_capacity_factor = max_capacity_factor
 
         self.ep_enabled = True
         return shared_pool_to_return
@@ -1146,15 +1173,44 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
             if (self.recompute_each_block and (block_idx not in do_not_recompute)) or (
                 self.recompute_block_keys and block_key in self.recompute_block_keys
             ):
-                h = checkpoint(
-                    self._forwrad_one_block,
-                    h,
-                    block_key,
-                    combined_kwargs,
-                    use_reentrant=False,
-                    context_fn=(noop_context_fn if self.compile_enabled else recompute_context_fn),
-                    # determinism_check='none',
+                use_reentrant = (
+                    isinstance(block, OLMoDDPTransformerBlock)
+                    and block.has_routed_experts
+                    and block.ep_enabled
+                    and block.training
+                    and block.ep.is_deepep
                 )
+                if use_reentrant:
+                    # DeepEP's custom autograd function builds a private expert
+                    # graph and invokes its backward from the communication
+                    # backward. Non-reentrant checkpointing restores its saved
+                    # leaf tensors as different wrappers, so gradients land on
+                    # a different recv_x leaf. Reentrant checkpointing rebuilds
+                    # the complete block and keeps the DeepEP handle, expert
+                    # graph, and recv_x leaf from the same recomputed forward.
+                    combined_kwargs["deepep_reentrant_checkpoint"] = True
+                    h = checkpoint(
+                        self._forwrad_one_block,
+                        h,
+                        block_key,
+                        combined_kwargs,
+                        use_reentrant=True,
+                        # The user config can randomize expert assignment. The
+                        # recompute must replay the same routing decisions.
+                        preserve_rng_state=True,
+                    )
+                else:
+                    h = checkpoint(
+                        self._forwrad_one_block,
+                        h,
+                        block_key,
+                        combined_kwargs,
+                        use_reentrant=False,
+                        context_fn=(
+                            noop_context_fn if self.compile_enabled else recompute_context_fn
+                        ),
+                        # determinism_check='none',
+                    )
                 h = cast(torch.Tensor, h)
             else:
                 h = self._forwrad_one_block(h, block_key, combined_kwargs)

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -1189,11 +1189,22 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                     # the complete block and keeps the DeepEP handle, expert
                     # graph, and recv_x leaf from the same recomputed forward.
                     combined_kwargs["deepep_reentrant_checkpoint"] = True
+                    # Reentrant checkpointing only reruns the block (and backprops
+                    # the DeepEP expert graph) if an input requires grad. In
+                    # expert-only / frozen-lower-layer runs h can be detached, which
+                    # would silently drop expert grads, so pass a grad-requiring
+                    # anchor; expert grads still flow through the module params.
+                    grad_anchor = (
+                        None
+                        if h.requires_grad
+                        else torch.zeros((), device=h.device, requires_grad=True)
+                    )
                     h = checkpoint(
                         self._forwrad_one_block,
                         h,
                         block_key,
                         combined_kwargs,
+                        grad_anchor,
                         use_reentrant=True,
                         # The user config can randomize expert assignment. The
                         # recompute must replay the same routing decisions.
@@ -1217,7 +1228,16 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
 
         return h
 
-    def _forwrad_one_block(self, h, block_key: str, block_kwargs: Dict[str, Any]) -> torch.Tensor:
+    def _forwrad_one_block(
+        self,
+        h,
+        block_key: str,
+        block_kwargs: Dict[str, Any],
+        grad_anchor: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        # grad_anchor only keeps reentrant checkpointing's recompute alive when h is
+        # detached (see _forward_blocks); it is intentionally unused here.
+        del grad_anchor
         if self.compile_enabled:
             mark_dynamic(h, (0, 1), strict=False)
         block = self.blocks[block_key]

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -103,6 +103,19 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         assert not (
             self.tbo and self.recompute_each_block
         ), "Cannot use TBO when recompute_each_block is True."
+        # Chunk recompute wraps all blocks in one non-reentrant checkpoint, which
+        # breaks DeepEP's recv_x leaf identity and drops expert grads. Only the
+        # per-block reentrant path in _forward_blocks handles DeepEP correctly.
+        if self.recompute_all_blocks_by_chunk and any(
+            isinstance(block, OLMoDDPTransformerBlock)
+            and block.has_routed_experts
+            and block.ep.is_deepep
+            for block in self.blocks.values()
+        ):
+            raise OLMoConfigurationError(
+                "recompute_all_blocks_by_chunk is not supported with DeepEP expert "
+                "parallelism; use recompute_each_block instead."
+            )
 
     def named_ddp_blocks(self) -> Iterator[tuple[str, OLMoDDPTransformerBlock]]:
         for block_key, block in self.blocks.items():

--- a/src/olmo_core/nn/fp8_weight.py
+++ b/src/olmo_core/nn/fp8_weight.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Mapping, Optional, Sequence, Union
 
-import nvtx
 import torch
 
+from olmo_core._nvtx import nvtx
 from olmo_core.doc_utils import beta_feature
 from olmo_core.kernels import (
     ScaledGroupedMMPrequantizedRHS,

--- a/src/olmo_core/nn/fp8_weight.py
+++ b/src/olmo_core/nn/fp8_weight.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Mapping, Optional, Sequence, Union
 
+import nvtx
 import torch
 
 from olmo_core.doc_utils import beta_feature
@@ -285,19 +286,20 @@ class FP8WeightStore:
     def iter_prequantized_caches(self):
         return self.cache_values.values()
 
+    @nvtx.annotate("FP8WeightStore.accumulate_wgrad")
     def accumulate_wgrad(self, grad: torch.Tensor) -> None:
+        grad = grad.detach()
         if self.accumulate_wgrad_in_fp32:
-            grad_fp32 = grad.detach().to(torch.float32)
             if self.main_grad_fp32 is None:
-                self.main_grad_fp32 = grad_fp32.contiguous()
+                self.main_grad_fp32 = grad.to(torch.float32).contiguous()
             else:
-                self.main_grad_fp32.add_(grad_fp32)
+                self.main_grad_fp32.add_(grad)
             self.grad_bf16 = None
         else:
-            grad_bf16 = grad.detach().to(torch.bfloat16)
             if self.grad_bf16 is None:
-                self.grad_bf16 = grad_bf16.contiguous()
+                self.grad_bf16 = grad.to(torch.bfloat16).contiguous()
             else:
+                grad_bf16 = grad if grad.dtype == torch.bfloat16 else grad.to(torch.bfloat16)
                 self.grad_bf16.add_(grad_bf16)
             self.main_grad_fp32 = None
 

--- a/src/olmo_core/nn/moe/v2/comm.py
+++ b/src/olmo_core/nn/moe/v2/comm.py
@@ -14,6 +14,7 @@ from olmo_core.kernels.mxfp8_utils import (
     quantize_row_halves_to_mxfp8,
     quantize_rows_to_mxfp8,
     swiglu_quantize_rows_to_mxfp8,
+    weighted_quantize_rows_to_mxfp8,
 )
 from olmo_core.kernels.scaled_grouped_mm import (
     ScaledGroupedMMPrequantizedLHS,
@@ -123,6 +124,45 @@ def _rowwise_fp8_prequantized_lhs(
         scale_a=scales,
         mat_a_shape=shape,
         scales_are_blocked=scales_are_blocked,
+    )
+
+
+def _rowwise_dispatch_put_weighted_mxfp8(
+    input_hp: torch.Tensor,
+    probs: torch.Tensor,
+    out_q: torch.Tensor,
+    out_scales: torch.Tensor,
+    dst_ranks: torch.Tensor,
+    dst_rows: torch.Tensor,
+    group_name: str,
+    *,
+    block_size: int,
+    nblocks: int,
+) -> None:
+    qdata, scales = weighted_quantize_rows_to_mxfp8(
+        input_hp,
+        probs,
+        block_size=block_size,
+    )
+    flat_ranks = dst_ranks.reshape(-1, 1).contiguous()
+    flat_rows = dst_rows.reshape(-1, 1).contiguous()
+    symm_mem_vdev2d_kernels.rowwise_dispatch_put(
+        qdata,
+        out_q,
+        flat_ranks,
+        flat_rows,
+        group_name,
+        nblocks=nblocks,
+        post_barrier=False,
+    )
+    symm_mem_vdev2d_kernels.rowwise_dispatch_put(
+        scales,
+        out_scales,
+        flat_ranks,
+        flat_rows,
+        group_name,
+        nblocks=nblocks,
+        pre_barrier=False,
     )
 
 
@@ -533,24 +573,13 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
 
         # Combine backward first weights each route by its router probability,
         # then dispatches the weighted token grads into combine_in_q/scales.
-        # This materialized weighted_flat is the main remaining eager overhead;
-        # replacing it with a fused weighted rowwise FP8 dispatch kernel is the
-        # next obvious performance cleanup.
-        num_rows, top_k = dst_ranks.shape
-        hidden = grad_out_contig.shape[1]
-        weighted_flat = (
-            grad_out_contig.unsqueeze(1) * probs.to(dtype=grad_out_contig.dtype).unsqueeze(-1)
-        ).reshape(num_rows * top_k, hidden)
-        if not weighted_flat.is_contiguous():
-            weighted_flat = weighted_flat.contiguous()
-        flat_ranks = dst_ranks.reshape(-1, 1).contiguous()
-        flat_rows = dst_rows.reshape(-1, 1).contiguous()
-        symm_mem_vdev2d_kernels.rowwise_dispatch_put_scaled(
-            weighted_flat,
+        _rowwise_dispatch_put_weighted_mxfp8(
+            grad_out_contig,
+            probs,
             ctx.combine_in_q,
             ctx.combine_in_scales,
-            flat_ranks,
-            flat_rows,
+            dst_ranks,
+            dst_rows,
             ctx.group_name,
             block_size=ctx.block_size,
             nblocks=ctx.nblocks,
@@ -1603,32 +1632,23 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
 
         grad_expert_out = None
         if ctx.needs_input_grad[0]:
-            num_rows, top_k = src_ranks.shape
-            hidden = grad_out_contig.shape[1]
-            weighted_flat = (
-                grad_out_contig.unsqueeze(1) * probs.to(dtype=grad_out_contig.dtype).unsqueeze(-1)
-            ).reshape(num_rows * top_k, hidden)
-            if not weighted_flat.is_contiguous():
-                weighted_flat = weighted_flat.contiguous()
-
-            flat_ranks = src_ranks.reshape(-1, 1).contiguous()
-            flat_rows = src_rows.reshape(-1, 1).contiguous()
             # _rowwise_debug_print(
             #     "rowwise_fp8_combine_backward_dispatch_put_scaled",
             #     "enter",
             #     ctx.group_name,
-            #     input=weighted_flat,
+            #     input=grad_out_contig,
             #     out_q=ctx.symm_expert_out_q,
             #     out_scales=ctx.symm_expert_out_scales,
-            #     dst_ranks=flat_ranks,
-            #     dst_rows=flat_rows,
+            #     dst_ranks=src_ranks,
+            #     dst_rows=src_rows,
             # )
-            symm_mem_vdev2d_kernels.rowwise_dispatch_put_scaled(
-                weighted_flat,
+            _rowwise_dispatch_put_weighted_mxfp8(
+                grad_out_contig,
+                probs,
                 ctx.symm_expert_out_q,
                 ctx.symm_expert_out_scales,
-                flat_ranks,
-                flat_rows,
+                src_ranks,
+                src_rows,
                 ctx.group_name,
                 block_size=ctx.block_size,
                 nblocks=ctx.nblocks,
@@ -1638,7 +1658,7 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
             #     "rowwise_fp8_combine_backward_dispatch_put_scaled",
             #     "exit",
             #     ctx.group_name,
-            #     input=weighted_flat,
+            #     input=grad_out_contig,
             #     out_q=ctx.symm_expert_out_q,
             #     out_scales=ctx.symm_expert_out_scales,
             # )

--- a/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
+++ b/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import os
 import sys
 from dataclasses import dataclass
@@ -12,6 +11,7 @@ import torch.distributed as dist
 
 from olmo_core._nvtx import nvtx
 from olmo_core.distributed.utils import get_rank
+from olmo_core.kernels.mxfp8_utils import quantize_rows_to_mxfp8
 
 from ...moe.utils import wait_stream_no_compile
 from .ep_config import ExpertParallelPath
@@ -22,7 +22,12 @@ from .ep_no_sync_rowwise_helpers import (
     build_rowwise_route_maps,
     should_accumulate_ep_no_sync_rowwise_metrics,
 )
-from .routed_experts import requires_host_side_split_sizes, use_torch_grouped_mm
+from .fp8 import shared_experts_forward_rowwise_fp8
+from .routed_experts import (
+    ExpertActivation,
+    requires_host_side_split_sizes,
+    use_torch_grouped_mm,
+)
 
 if TYPE_CHECKING:
     from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
@@ -50,6 +55,7 @@ class _DeepEpV2Runtime:
     num_sms: int
     num_qps: int
     async_with_compute_stream: bool
+    use_fp8_dispatch: bool
 
 
 @dataclass(frozen=True)
@@ -68,6 +74,7 @@ class _DeepEpV2RuntimeKey:
     prefer_overlap_with_compute: bool
     allow_hybrid_mode: bool
     allow_multiple_reduction: bool
+    use_fp8_dispatch: bool
 
 
 @lru_cache(maxsize=None)
@@ -108,6 +115,47 @@ def is_deepep_available(deepep_path: Optional[str] = None) -> bool:
 def _deep_ep_wait(event: Any, *, async_with_compute_stream: bool) -> None:
     if async_with_compute_stream:
         event.current_stream_wait()
+
+
+def _deepep_v2_uses_fp8(block: OLMoDDPTransformerBlock) -> bool:
+    cfg = getattr(block, "rowwise_fp8", None)
+    return cfg is not None and cfg.enabled
+
+
+def _pack_deepep_mxfp8_scales(scales: torch.Tensor) -> torch.Tensor:
+    """Pack four UE8M0 scales into each DeepEP ``sf_pack_t`` entry."""
+    if scales.dtype != torch.float8_e8m0fnu:
+        raise RuntimeError(
+            "DeepEP MXFP8 dispatch expects float8_e8m0fnu scales, " f"got {scales.dtype}"
+        )
+    if scales.ndim != 2 or scales.shape[1] % 4 != 0:
+        raise RuntimeError(
+            "DeepEP MXFP8 dispatch requires a rank-2 scale tensor with four-scale "
+            f"packing, got shape={tuple(scales.shape)}"
+        )
+    return scales.contiguous().view(torch.int32)
+
+
+def _unpack_deepep_mxfp8_scales(packed_scales: torch.Tensor) -> torch.Tensor:
+    """Expose opaque DeepEP ``sf_pack_t`` payloads as OLMo UE8M0 scales."""
+    if packed_scales.dtype != torch.int32 or packed_scales.ndim != 2:
+        raise RuntimeError(
+            "DeepEP MXFP8 received scales must be a rank-2 int32 tensor, "
+            f"got dtype={packed_scales.dtype} shape={tuple(packed_scales.shape)}"
+        )
+    return packed_scales.contiguous().view(torch.float8_e8m0fnu)
+
+
+def _logical_rank2_tensor(
+    shape: tuple[int, int],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    # The scaled grouped-MM reads q/scales in forward. This storage-free BF16
+    # view supplies the logical shape and the leaf whose gradient DeepEP sends
+    # back to the source ranks.
+    return torch.empty((), dtype=dtype, device=device).expand(shape)
 
 
 def _expanded_expert_counts(handle: Any, expert_alignment: int) -> torch.Tensor:
@@ -226,8 +274,26 @@ def _validate_deepep_v2_block(
             "deepep_v2 EP with deepep.weighting='swiglu' requires bias-free "
             "routed expert down projections."
         )
-    if block.rowwise_fp8 is not None and block.rowwise_fp8.enabled and x.device.type == "cuda":
-        raise RuntimeError("deepep_v2 EP does not support rowwise FP8 experts yet")
+    if _deepep_v2_uses_fp8(block):
+        assert block.rowwise_fp8 is not None
+        routed_fp8 = block.routed_experts.rowwise_fp8
+        if routed_fp8 is None or not routed_fp8.enabled:
+            raise RuntimeError(
+                "deepep_v2 FP8 requires rowwise FP8 on both the transformer "
+                "block and its routed experts"
+            )
+        if block.routed_experts.b_up_gate is not None:
+            raise RuntimeError("deepep_v2 FP8 routed experts do not support expert biases")
+        if block.rowwise_fp8.block_size != 32:
+            raise RuntimeError(
+                "deepep_v2 FP8 dispatch requires MXFP8 block_size=32, "
+                f"got {block.rowwise_fp8.block_size}"
+            )
+        if (
+            block.shared_experts is not None
+            and block.shared_experts.activation != ExpertActivation.swiglu
+        ):
+            raise RuntimeError("deepep_v2 FP8 shared experts currently require swiglu")
     if not use_torch_grouped_mm():
         raise RuntimeError("deepep_v2 EP requires torch.grouped_mm support")
     if requires_host_side_split_sizes():
@@ -240,19 +306,45 @@ def _global_num_max_tokens_per_rank(
     requested_tokens: int,
     device: torch.device,
 ) -> int:
-    requested_tensor = torch.tensor([requested_tokens], device=device, dtype=torch.long)
+    # Construct the scalar on-device. torch.tensor([value], device="cuda")
+    # stages through pageable CPU memory and synchronizes the CUDA stream.
+    requested_tensor = torch.empty((1,), device=device, dtype=torch.long)
+    requested_tensor.fill_(requested_tokens)
     dist.all_reduce(requested_tensor, op=dist.ReduceOp.MAX, group=block.ep_pg)
     return int(requested_tensor.item())
 
 
 def _requested_num_max_tokens_per_rank(
-    block: OLMoDDPTransformerBlock,
     local_tokens: int,
 ) -> int:
-    max_capacity_factor = float(
-        getattr(block, "_deepep_v2_max_capacity_factor", block.ep.capacity_factor)
-    )
-    return max(local_tokens, int(math.ceil(local_tokens * max_capacity_factor)))
+    if local_tokens <= 0:
+        raise ValueError(f"DeepEP requires a positive source-token capacity, got {local_tokens}")
+    # DeepEP uses this value as a source-token bound and as the stride in
+    # `src_token_global_idx = src_rank * num_max_tokens_per_rank + src_token`.
+    # It is not the destination expanded-route capacity; top-k and
+    # capacity_factor are already accounted for by `rank_capacity` below.
+    return int(local_tokens)
+
+
+def _warm_deepep_v2_process_group(
+    block: OLMoDDPTransformerBlock,
+    device: torch.device,
+) -> None:
+    # DeepEP reuses PyTorch's NCCL communicator by default. For a freshly
+    # created ProcessGroupNCCL, backend._comm_ptr() is null until that exact
+    # group has launched its first CUDA collective. Passing the null pointer to
+    # DeepEP's ncclTeamWorld() segfaults during ElasticBuffer size calculation.
+    # Initialize it entirely on-device; no host readback is needed.
+    if not int(os.getenv("EP_REUSE_NCCL_COMM", "1")):
+        return
+    ready = torch.empty((1,), device=device, dtype=torch.int32)
+    ready.zero_()
+    dist.all_reduce(ready, group=block.ep_pg)
+    # ElasticBuffer queries NCCL's device-team metadata immediately after this
+    # helper. Finish the one-time communicator initialization before exposing
+    # its raw pointer to DeepEP. ElasticBuffer initialization synchronizes
+    # anyway; this never runs in forward or recompute.
+    torch.cuda.synchronize(device)
 
 
 def _runtime_key(block: OLMoDDPTransformerBlock, hidden: int, top_k: int) -> _DeepEpV2RuntimeKey:
@@ -275,6 +367,7 @@ def _runtime_key(block: OLMoDDPTransformerBlock, hidden: int, top_k: int) -> _De
         prefer_overlap_with_compute=deepep_cfg.prefer_overlap_with_compute,
         allow_hybrid_mode=deepep_cfg.allow_hybrid_mode,
         allow_multiple_reduction=deepep_cfg.allow_multiple_reduction,
+        use_fp8_dispatch=_deepep_v2_uses_fp8(block),
     )
 
 
@@ -286,17 +379,13 @@ def _get_deepep_v2_runtime(
     hidden: int,
     top_k: int,
     device: torch.device,
+    static_num_max_tokens_per_rank: Optional[int] = None,
 ) -> _DeepEpV2Runtime:
     assert block.ep_pg is not None
     assert block.routed_experts_router is not None
     assert block.num_local_routed_experts is not None
 
-    requested_tokens = _requested_num_max_tokens_per_rank(block, local_tokens)
-    num_max_tokens_per_rank = _global_num_max_tokens_per_rank(
-        block,
-        requested_tokens,
-        device,
-    )
+    requested_tokens = _requested_num_max_tokens_per_rank(local_tokens)
     runtime_cache = getattr(block, "_deepep_v2_runtime_cache", None)
     if runtime_cache is None:
         runtime_cache = {}
@@ -304,16 +393,50 @@ def _get_deepep_v2_runtime(
     key = _runtime_key(block, hidden, top_k)
     runtime = runtime_cache.get(key)
     if runtime is not None:
-        if num_max_tokens_per_rank <= runtime.num_max_tokens_per_rank:
+        # The model shares this cache across matching DeepEP blocks. Capacity
+        # was fixed when the runtime was created, so the normal fixed-shape hot
+        # path only needs this host-side local bound check. Do
+        # not repeat the CUDA scalar copy, NCCL MAX, and .item() here: those
+        # operations introduced two stream synchronizations per DeepEP call.
+        if requested_tokens <= runtime.num_max_tokens_per_rank:
             block._deepep_v2_runtime = runtime
             return runtime
         raise RuntimeError(
             "deepep_v2 EP saw more tokens than its shared ElasticBuffer "
-            f"capacity: requested={num_max_tokens_per_rank}, "
-            f"capacity={runtime.num_max_tokens_per_rank}. Initialize "
-            "deepep_v2 with the largest local token shape first; "
-            "the shared runtime sizes num_max_tokens_per_rank from the "
-            "largest DeepEP capacity_factor seen in apply_ep()."
+            f"capacity: local_requested={requested_tokens}, "
+            f"capacity={runtime.num_max_tokens_per_rank}. Prewarm deepep_v2 "
+            "with the largest configured local microbatch token count."
+        )
+
+    if key.use_fp8_dispatch:
+        assert block.rowwise_fp8 is not None
+        # Runtime capability discovery can query the CUDA device. Keep it in
+        # this one-time, compile-disabled construction path rather than the
+        # per-block forward validation.
+        block.rowwise_fp8.assert_runtime_supported()
+
+    if static_num_max_tokens_per_rank is not None:
+        # Normal training prewarms from the configured rank microbatch size,
+        # which is identical across the EP group. This avoids capacity MAX
+        # negotiation and host readback even on the first model forward; the
+        # startup-only collective below merely makes the NCCL communicator
+        # safe for DeepEP to reuse.
+        num_max_tokens_per_rank = int(static_num_max_tokens_per_rank)
+        if num_max_tokens_per_rank < requested_tokens:
+            raise ValueError(
+                "Static DeepEP source-token capacity is smaller than the "
+                f"requested shape: capacity={num_max_tokens_per_rank}, "
+                f"requested={requested_tokens}"
+            )
+        _warm_deepep_v2_process_group(block, device)
+    else:
+        # Fallback for direct callers that bypass model prewarm. ElasticBuffer
+        # construction requires a host capacity identical on every EP rank, so
+        # this cold path must negotiate and read back the maximum once.
+        num_max_tokens_per_rank = _global_num_max_tokens_per_rank(
+            block,
+            requested_tokens,
+            device,
         )
 
     deepep_cfg = block.ep.deepep
@@ -324,6 +447,7 @@ def _get_deepep_v2_runtime(
         num_max_tokens_per_rank=num_max_tokens_per_rank,
         hidden=hidden,
         num_topk=top_k,
+        use_fp8_dispatch=key.use_fp8_dispatch,
         deterministic=False,
         allow_hybrid_mode=deepep_cfg.allow_hybrid_mode,
         allow_multiple_reduction=deepep_cfg.allow_multiple_reduction,
@@ -360,6 +484,7 @@ def _get_deepep_v2_runtime(
         num_sms=num_sms,
         num_qps=num_qps,
         async_with_compute_stream=deepep_cfg.async_mode,
+        use_fp8_dispatch=key.use_fp8_dispatch,
     )
     runtime_cache[key] = runtime
     block._deepep_v2_runtime = runtime
@@ -378,6 +503,25 @@ def _routed_experts_need_grad(routed_experts: Optional[Any]) -> bool:
     return False
 
 
+def prewarm_deepep_v2_runtime(
+    block: OLMoDDPTransformerBlock,
+    *,
+    max_local_tokens: int,
+    hidden: int,
+    top_k: int,
+    device: torch.device,
+) -> _DeepEpV2Runtime:
+    """Create a DeepEP runtime from a configured, globally identical token bound."""
+    return _get_deepep_v2_runtime(
+        block,
+        local_tokens=max_local_tokens,
+        hidden=hidden,
+        top_k=top_k,
+        device=device,
+        static_num_max_tokens_per_rank=max_local_tokens,
+    )
+
+
 class _DeepEpV2Autograd(torch.autograd.Function):
     @staticmethod
     def forward(  # type: ignore[override]
@@ -391,36 +535,76 @@ class _DeepEpV2Autograd(torch.autograd.Function):
         grad_anchor: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         del grad_anchor  # only present to force this Function into the autograd graph
-        recv_x_out = torch.empty(
-            (int(rank_capacity), runtime.hidden),
-            device=source_input.device,
-            dtype=source_input.dtype,
-        )
         recv_topk_weights_out = torch.empty(
             (int(rank_capacity),),
             device=topk_weights.device,
             dtype=topk_weights.dtype,
         )
-        (
-            recv_x,
-            _recv_topk_idx,
-            expanded_topk_weights,
-            handle,
-            event,
-        ) = runtime.buffer.dispatch_expanded_into(
-            source_input,
-            topk_idx=topk_idx,
-            topk_weights=topk_weights,
-            recv_x_out=recv_x_out,
-            recv_topk_weights_out=recv_topk_weights_out,
-            num_experts=runtime.num_experts,
-            num_max_tokens_per_rank=runtime.num_max_tokens_per_rank,
-            expert_alignment=runtime.expert_alignment,
-            num_sms=runtime.num_sms,
-            num_qps=runtime.num_qps,
-            async_with_compute_stream=runtime.async_with_compute_stream,
-            do_cpu_sync=False,
-        )
+        if runtime.use_fp8_dispatch:
+            assert block.rowwise_fp8 is not None
+            source_q, source_scales = quantize_rows_to_mxfp8(
+                source_input,
+                block_size=int(block.rowwise_fp8.block_size),
+                scale_mode=block.rowwise_fp8.scale_mode.value,
+            )
+            source_packed_scales = _pack_deepep_mxfp8_scales(source_scales)
+            recv_q_out = torch.empty(
+                (int(rank_capacity), runtime.hidden),
+                device=source_input.device,
+                dtype=source_q.dtype,
+            )
+            recv_packed_scales_out = torch.empty(
+                (int(rank_capacity), source_packed_scales.shape[1]),
+                device=source_input.device,
+                dtype=source_packed_scales.dtype,
+            )
+            (
+                recv_payload,
+                _recv_topk_idx,
+                expanded_topk_weights,
+                handle,
+                event,
+            ) = runtime.buffer.dispatch_expanded_into(
+                (source_q, source_packed_scales),
+                topk_idx=topk_idx,
+                topk_weights=topk_weights,
+                recv_x_out=recv_q_out,
+                recv_sf_out=recv_packed_scales_out,
+                recv_topk_weights_out=recv_topk_weights_out,
+                num_experts=runtime.num_experts,
+                num_max_tokens_per_rank=runtime.num_max_tokens_per_rank,
+                expert_alignment=runtime.expert_alignment,
+                num_sms=runtime.num_sms,
+                num_qps=runtime.num_qps,
+                async_with_compute_stream=runtime.async_with_compute_stream,
+                do_cpu_sync=False,
+            )
+        else:
+            recv_x_out = torch.empty(
+                (int(rank_capacity), runtime.hidden),
+                device=source_input.device,
+                dtype=source_input.dtype,
+            )
+            (
+                recv_payload,
+                _recv_topk_idx,
+                expanded_topk_weights,
+                handle,
+                event,
+            ) = runtime.buffer.dispatch_expanded_into(
+                source_input,
+                topk_idx=topk_idx,
+                topk_weights=topk_weights,
+                recv_x_out=recv_x_out,
+                recv_topk_weights_out=recv_topk_weights_out,
+                num_experts=runtime.num_experts,
+                num_max_tokens_per_rank=runtime.num_max_tokens_per_rank,
+                expert_alignment=runtime.expert_alignment,
+                num_sms=runtime.num_sms,
+                num_qps=runtime.num_qps,
+                async_with_compute_stream=runtime.async_with_compute_stream,
+                do_cpu_sync=False,
+            )
         _deep_ep_wait(event, async_with_compute_stream=runtime.async_with_compute_stream)
         if expanded_topk_weights is None:
             raise RuntimeError("deepep_v2 expanded dispatch did not return top-k weights")
@@ -430,17 +614,50 @@ class _DeepEpV2Autograd(torch.autograd.Function):
         expanded_weights = expanded_topk_weights.reshape(-1, 1)
         if need_grad_topk_weights:
             expanded_weights = expanded_weights.detach().requires_grad_(True)
-        recv_x_for_experts = recv_x.detach().requires_grad_(True)
         assert block.routed_experts is not None
-        with torch.enable_grad():
-            expert_out = block.routed_experts(
-                recv_x_for_experts,
-                batch_size_per_expert,
-                row_weights=expanded_weights,
+        if runtime.use_fp8_dispatch:
+            if not isinstance(recv_payload, tuple) or len(recv_payload) != 2:
+                raise RuntimeError("DeepEP FP8 expanded dispatch did not return (q, scales)")
+            recv_q, recv_packed_scales = recv_payload
+            recv_scales = _unpack_deepep_mxfp8_scales(recv_packed_scales)
+            recv_x_for_experts = (
+                _logical_rank2_tensor(
+                    (int(rank_capacity), runtime.hidden),
+                    dtype=source_input.dtype,
+                    device=source_input.device,
+                )
+                .detach()
+                .requires_grad_(True)
             )
+            with torch.enable_grad():
+                unweighted_expert_out = block.routed_experts(
+                    recv_x_for_experts,
+                    batch_size_per_expert,
+                    use_rowwise_fp8=True,
+                    rowwise_fp8_input_q=recv_q,
+                    rowwise_fp8_input_scales=recv_scales,
+                )
+                # DeepEP combine is BF16-only. Weighting the bias-free down
+                # projection output is mathematically equivalent to weighting
+                # its SwiGLU input, while keeping the received payload MXFP8.
+                expert_graph_out = unweighted_expert_out * expanded_weights.to(
+                    dtype=unweighted_expert_out.dtype
+                )
+        else:
+            if isinstance(recv_payload, tuple):
+                raise RuntimeError(
+                    "DeepEP BF16 expanded dispatch unexpectedly returned FP8 payload"
+                )
+            recv_x_for_experts = recv_payload.detach().requires_grad_(True)
+            with torch.enable_grad():
+                expert_graph_out = block.routed_experts(
+                    recv_x_for_experts,
+                    batch_size_per_expert,
+                    row_weights=expanded_weights,
+                )
 
         combined_x, _combined_topk_weights, event = runtime.buffer.combine(
-            expert_out,
+            expert_graph_out,
             handle=handle,
             num_sms=runtime.num_sms,
             num_qps=runtime.num_qps,
@@ -454,7 +671,7 @@ class _DeepEpV2Autograd(torch.autograd.Function):
         ctx.local_num_tokens = int(topk_weights.shape[0])
         ctx.topk_weights_dtype = topk_weights.dtype
         ctx.need_grad_topk_weights = need_grad_topk_weights
-        ctx.save_for_backward(recv_x_for_experts, expert_out, expanded_weights)
+        ctx.save_for_backward(recv_x_for_experts, expert_graph_out, expanded_weights)
         return combined_x
 
     @staticmethod
@@ -462,7 +679,7 @@ class _DeepEpV2Autograd(torch.autograd.Function):
         runtime: _DeepEpV2Runtime = ctx.runtime
         block: OLMoDDPTransformerBlock = ctx.block
         handle = ctx.handle
-        recv_x, expert_out, expanded_weights = ctx.saved_tensors
+        recv_x, expert_graph_out, expanded_weights = ctx.saved_tensors
 
         grad_weighted_expert_out = torch.empty_like(recv_x)
         (
@@ -481,7 +698,7 @@ class _DeepEpV2Autograd(torch.autograd.Function):
         )
         _deep_ep_wait(event, async_with_compute_stream=runtime.async_with_compute_stream)
 
-        torch.autograd.backward(expert_out, grad_weighted_expert_out)
+        torch.autograd.backward(expert_graph_out, grad_weighted_expert_out)
         if recv_x.grad is None:
             raise RuntimeError("deepep_v2 expert backward did not produce grad for recv_x")
         grad_topk_weights = None
@@ -517,6 +734,7 @@ def combined_forward_ep_deepep_v2(
     x: torch.Tensor,
     *,
     accumulate_routed_aux_loss_metrics: Optional[bool] = None,
+    accumulate_router_aux_loss_metrics: Optional[bool] = None,
     loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
     **kwargs,
 ) -> torch.Tensor:
@@ -580,7 +798,15 @@ def combined_forward_ep_deepep_v2(
             other_stream=torch.cuda.current_stream(),
         )
         with torch.cuda.stream(self.get_dense_stream()):
-            shared_out = self.shared_experts(moe_inp)
+            if _deepep_v2_uses_fp8(self):
+                assert self.rowwise_fp8 is not None
+                shared_out = shared_experts_forward_rowwise_fp8(
+                    self,
+                    moe_inp,
+                    use_fast_accum=self.rowwise_fp8.use_fast_accum,
+                )
+            else:
+                shared_out = self.shared_experts(moe_inp)
             mixed_shared_out = self._mix_shared_out(
                 shared_out,
                 local_x_global_shared_expert_weights,
@@ -691,4 +917,5 @@ def combined_forward_ep_deepep_v2(
     return self._attach_routed_aux_loss(
         final_out,
         routed_expert_router_aux_loss_info,
+        accumulate_metrics=accumulate_router_aux_loss_metrics,
     )

--- a/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
+++ b/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
@@ -212,22 +212,28 @@ def _expanded_weight_grad_to_topk_grad(
     src_token = src_global - src_rank * runtime.num_max_tokens_per_rank
     expanded_slots_by_lane = metadata[:, 2 : 2 + runtime.num_topk].to(dtype=torch.long)
     flat_grad_by_src = grad_by_src.reshape(-1)
-    for lane in range(runtime.num_topk):
-        expanded_slots = expanded_slots_by_lane[:, lane]
-        valid = (
+    grad_flat_numel = grad_flat.numel()
+    if grad_flat_numel > 0:
+        safe_src_rank = src_rank.clamp(0, block.ep_world_size - 1)
+        safe_src_token = src_token.clamp(0, runtime.num_max_tokens_per_rank - 1)
+        base_flat_dst = (
+            safe_src_rank * runtime.num_max_tokens_per_rank + safe_src_token
+        ) * runtime.num_topk
+        lane_ids = torch.arange(runtime.num_topk, device=metadata.device, dtype=torch.long)
+        flat_dst = base_flat_dst.unsqueeze(1) + lane_ids.unsqueeze(0)
+        valid_rows = (
             (metadata_row < actual_recv_tokens)
             & (src_rank >= 0)
             & (src_rank < block.ep_world_size)
             & (src_token >= 0)
             & (src_token < runtime.num_max_tokens_per_rank)
-            & (expanded_slots >= 0)
-            & (expanded_slots < grad_flat.numel())
         )
-        valid_slots = expanded_slots[valid]
-        flat_dst = (
-            src_rank[valid] * runtime.num_max_tokens_per_rank + src_token[valid]
-        ) * runtime.num_topk + lane
-        flat_grad_by_src.scatter_add_(0, flat_dst, grad_flat.index_select(0, valid_slots))
+        valid_slots = (expanded_slots_by_lane >= 0) & (expanded_slots_by_lane < grad_flat_numel)
+        valid = valid_rows.unsqueeze(1) & valid_slots
+        safe_slots = expanded_slots_by_lane.clamp(0, grad_flat_numel - 1)
+        slot_grad = grad_flat.index_select(0, safe_slots.reshape(-1))
+        slot_grad = slot_grad * valid.reshape(-1).to(dtype=slot_grad.dtype)
+        flat_grad_by_src.scatter_add_(0, flat_dst.reshape(-1), slot_grad)
 
     # Every receiving rank owns a different subset of expanded rows. Sum those
     # per-source contributions so the original token owner can return a normal

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_helpers.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_helpers.py
@@ -180,11 +180,6 @@ def build_rowwise_route_maps(
         self.num_local_routed_experts,
         rounding_mode="floor",
     )
-    torch.remainder(
-        safe_experts,
-        self.num_local_routed_experts,
-    )
-
     prefix_by_source = torch.cumsum(keep_matrix, dim=0) - keep_matrix
     src_rank = get_rank(self.ep_pg)
     send_base_by_dest_local = prefix_by_source[src_rank]
@@ -195,41 +190,28 @@ def build_rowwise_route_maps(
 
     base_rows_by_expert = (local_expert_base_by_dest + send_base_by_dest_local).reshape(-1)
 
-    # Compute stable in-bucket positions without argsort. torch.argsort lowers
-    # through tuple-returning aten.sort, which AOTAutograd cannot partition when
-    # compiled rowwise EP is combined with recompute and stream control deps.
-    #
-    # Keep the lowering 1-D per expert: a single wide [routes, experts] equality
-    # matrix currently trips Inductor Triton codegen in the full rowwise graph.
-    pos_in_bucket = torch.zeros_like(bucket_ids)
-    keep_limits = torch.zeros_like(bucket_ids)
-    base_rows = torch.zeros_like(bucket_ids)
+    # Compute stable in-expert route positions without argsort and without a
+    # per-expert Python loop. Scatter each route into a sparse [expert, route]
+    # marker matrix, prefix-sum along route order, then gather each route's
+    # prefix. The extra invalid bucket keeps dropped/invalid routes masked while
+    # preserving dense indexing.
+    route_positions = torch.arange(num_routes, device=routing_map.device, dtype=torch.long)
+    flat_bucket_idx = bucket_ids * num_routes + route_positions
+    bucket_marks = torch.zeros(
+        (expert_count + 1) * num_routes,
+        device=routing_map.device,
+        dtype=torch.long,
+    )
+    bucket_marks.scatter_(0, flat_bucket_idx, 1)
+    bucket_prefix = torch.cumsum(
+        bucket_marks.view(expert_count + 1, num_routes),
+        dim=1,
+        dtype=torch.long,
+    ).reshape(-1)
+    pos_in_bucket = bucket_prefix.index_select(0, flat_bucket_idx) - 1
 
-    # Keep this as a static Python loop over experts. A sort/scatter formulation
-    # produces tuple-returning ops that have been fragile under compiled rowwise
-    # EP with recompute, while a wide one-hot [routes, experts] cumsum has
-    # tripped Inductor codegen in the full graph.
-    for expert_id in range(expert_count):
-        expert_mask = bucket_ids == expert_id
-        expert_pos = (
-            torch.cumsum(
-                expert_mask.to(dtype=torch.long),
-                dim=0,
-                dtype=torch.long,
-            )
-            - 1
-        )
-        pos_in_bucket = torch.where(expert_mask, expert_pos, pos_in_bucket)
-        keep_limits = torch.where(
-            expert_mask,
-            allowed_splits_i64[expert_id],
-            keep_limits,
-        )
-        base_rows = torch.where(
-            expert_mask,
-            base_rows_by_expert[expert_id],
-            base_rows,
-        )
+    keep_limits = allowed_splits_i64.index_select(0, safe_experts)
+    base_rows = base_rows_by_expert.index_select(0, safe_experts)
     kept_mask = valid_mask & (pos_in_bucket < keep_limits)
 
     dst_rows_all = base_rows + pos_in_bucket

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_helpers.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_helpers.py
@@ -190,25 +190,21 @@ def build_rowwise_route_maps(
 
     base_rows_by_expert = (local_expert_base_by_dest + send_base_by_dest_local).reshape(-1)
 
-    # Compute stable in-expert route positions without argsort and without a
-    # per-expert Python loop. Scatter each route into a sparse [expert, route]
-    # marker matrix, prefix-sum along route order, then gather each route's
-    # prefix. The extra invalid bucket keeps dropped/invalid routes masked while
-    # preserving dense indexing.
-    route_positions = torch.arange(num_routes, device=routing_map.device, dtype=torch.long)
-    flat_bucket_idx = bucket_ids * num_routes + route_positions
-    bucket_marks = torch.zeros(
-        (expert_count + 1) * num_routes,
-        device=routing_map.device,
-        dtype=torch.long,
-    )
-    bucket_marks.scatter_(0, flat_bucket_idx, 1)
-    bucket_prefix = torch.cumsum(
-        bucket_marks.view(expert_count + 1, num_routes),
-        dim=1,
-        dtype=torch.long,
-    ).reshape(-1)
-    pos_in_bucket = bucket_prefix.index_select(0, flat_bucket_idx) - 1
+    # Stable in-expert route position (rank within each expert bucket, in route
+    # order). A stable sort groups equal buckets while preserving route order, so
+    # each route's position is its offset from the start of its group. This keeps
+    # O(routes) memory instead of a dense [expert, route] matrix, which would be
+    # (expert_count + 1) * num_routes and blow up for large expert counts.
+    seq = torch.arange(num_routes, device=routing_map.device, dtype=torch.long)
+    order = torch.argsort(bucket_ids, stable=True)
+    sorted_buckets = bucket_ids.index_select(0, order)
+    is_group_start = torch.ones(num_routes, device=routing_map.device, dtype=torch.bool)
+    is_group_start[1:] = sorted_buckets[1:] != sorted_buckets[:-1]
+    group_start = torch.cummax(
+        torch.where(is_group_start, seq, torch.zeros_like(seq)), dim=0
+    ).values
+    pos_in_bucket = torch.empty(num_routes, device=routing_map.device, dtype=torch.long)
+    pos_in_bucket.scatter_(0, order, seq - group_start)
 
     keep_limits = allowed_splits_i64.index_select(0, safe_experts)
     base_rows = base_rows_by_expert.index_select(0, safe_experts)

--- a/src/olmo_core/nn/moe/v2/fp8.py
+++ b/src/olmo_core/nn/moe/v2/fp8.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Mapping, Optional, Tuple
 
 import torch
@@ -12,20 +12,27 @@ from olmo_core.kernels import (
     scaled_grouped_mm_q,
     scaled_grouped_mm_q_fp8_weight,
 )
+from olmo_core.mxfp8_config import get_mxfp8_default_scale_mode
 
 if TYPE_CHECKING:
     from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 
 
 class MoERowwiseFP8ScaleMode(StrEnum):
+    floor = "floor"  # current / OCP-style conversion
+    # NVIDIA MXFP8 paper round-up scale recipe: https://arxiv.org/html/2506.08027v2
     rceil = "rceil"
+
+
+def _default_rowwise_fp8_scale_mode() -> MoERowwiseFP8ScaleMode:
+    return MoERowwiseFP8ScaleMode(get_mxfp8_default_scale_mode())
 
 
 @dataclass
 class MoERowwiseFP8Config(Config):
     enabled: bool = True
     block_size: int = 32
-    scale_mode: MoERowwiseFP8ScaleMode = MoERowwiseFP8ScaleMode.rceil
+    scale_mode: MoERowwiseFP8ScaleMode = field(default_factory=_default_rowwise_fp8_scale_mode)
     use_fast_accum: bool = True
     fp8_only_params: bool = True
     fused_autograd: bool = True
@@ -35,6 +42,14 @@ class MoERowwiseFP8Config(Config):
         if self.block_size != 32:
             raise ValueError(
                 f"Only block_size=32 is supported for MoE rowwise FP8 (got {self.block_size})"
+            )
+        self.scale_mode = MoERowwiseFP8ScaleMode(self.scale_mode)
+        if self.scale_mode.value != get_mxfp8_default_scale_mode():
+            raise ValueError(
+                "MoE rowwise FP8 scale_mode is resolved from OLMO_MXFP8_SCALE_MODE "
+                "when olmo_core is imported. Set "
+                f"OLMO_MXFP8_SCALE_MODE={self.scale_mode.value!r} before importing "
+                "olmo_core, or leave rowwise_fp8.scale_mode unset."
             )
 
     def assert_runtime_supported(self) -> None:

--- a/src/olmo_core/train/train_module/transformer/ddp_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/ddp_train_module.py
@@ -2832,6 +2832,10 @@ class OLMoDDPTrainModule(TrainModule):
             # for n, p in m.named_parameters():
             #     print(f'{n} {p.shape}: mean={p.data.mean().item()}, std={p.data.std().item()}')
 
+        self._prewarm_deepep_v2_runtimes(
+            model_parts=model_parts,
+            rank_microbatch_size=rank_microbatch_size,
+        )
         self._prewarm_ep_no_sync_symm_buffers(
             model_parts=model_parts,
             rank_microbatch_size=rank_microbatch_size,
@@ -2865,6 +2869,21 @@ class OLMoDDPTrainModule(TrainModule):
             math.ceil(self.max_sequence_length / length_multiple) * length_multiple
         )
         return sequence_batch_size * (padded_sequence_length // cp_degree)
+
+    def _prewarm_deepep_v2_runtimes(
+        self,
+        *,
+        model_parts,
+        rank_microbatch_size: int,
+    ) -> None:
+        if self.world_mesh.get("moe") is None:
+            return
+
+        prewarm_rank_microbatch_size = self._cp_local_rank_microbatch_size(rank_microbatch_size)
+        for model_part in model_parts:
+            cast(OLMoDDPModel, model_part).prewarm_deepep_v2_runtimes(
+                max_local_microbatch_size=prewarm_rank_microbatch_size,
+            )
 
     def _prewarm_ep_no_sync_symm_buffers(
         self,

--- a/src/test/kernels/scaled_grouped_mm_q_test.py
+++ b/src/test/kernels/scaled_grouped_mm_q_test.py
@@ -146,9 +146,9 @@ def test_quantize_rows_to_mxfp8_supports_output_buffers():
     assert scales.shape == (x.shape[0], x.shape[1] // 32)
 
 
+@requires_gpu
+@requires_compute_capability(min_cc=9)
 def test_weighted_quantize_rows_to_mxfp8_matches_materialized_cuda():
-    if not torch.cuda.is_available():
-        return
     torch.manual_seed(1984)
     rows, top_k, hidden = 37, 4, 512
     x = torch.randn(rows, hidden, device="cuda", dtype=torch.bfloat16) * 0.25
@@ -166,9 +166,9 @@ def test_weighted_quantize_rows_to_mxfp8_matches_materialized_cuda():
     assert torch.equal(scales.view(torch.uint8), scales_ref.view(torch.uint8))
 
 
+@requires_gpu
+@requires_compute_capability(min_cc=9)
 def test_weighted_quantize_rows_to_mxfp8_supports_output_buffers_cuda():
-    if not torch.cuda.is_available():
-        return
     torch.manual_seed(1985)
     rows, top_k, hidden = 17, 3, 256
     x = torch.randn(rows, hidden, device="cuda", dtype=torch.bfloat16)

--- a/src/test/kernels/scaled_grouped_mm_q_test.py
+++ b/src/test/kernels/scaled_grouped_mm_q_test.py
@@ -10,6 +10,7 @@ from olmo_core.kernels.mxfp8_utils import (
     quantize_grouped_2d_to_mxfp8_blocked_fused,
     quantize_grouped_weight_3d_to_mxfp8_blocked,
     quantize_rows_to_mxfp8,
+    weighted_quantize_rows_to_mxfp8,
 )
 from olmo_core.kernels.scaled_grouped_mm import (
     ScaledGroupedMMPrequantizedRHS,
@@ -143,6 +144,55 @@ def test_quantize_rows_to_mxfp8_supports_output_buffers():
     assert scales.untyped_storage().data_ptr() == out_scales.untyped_storage().data_ptr()
     assert qdata.shape == x.shape
     assert scales.shape == (x.shape[0], x.shape[1] // 32)
+
+
+def test_weighted_quantize_rows_to_mxfp8_matches_materialized_cuda():
+    if not torch.cuda.is_available():
+        return
+    torch.manual_seed(1984)
+    rows, top_k, hidden = 37, 4, 512
+    x = torch.randn(rows, hidden, device="cuda", dtype=torch.bfloat16) * 0.25
+    weights = torch.randn(rows, top_k, device="cuda", dtype=torch.float32)
+
+    weighted = (x.unsqueeze(1) * weights.to(dtype=x.dtype).unsqueeze(-1)).reshape(
+        rows * top_k, hidden
+    )
+    q_ref, scales_ref = quantize_rows_to_mxfp8(weighted.contiguous(), block_size=32)
+    q, scales = weighted_quantize_rows_to_mxfp8(x, weights, block_size=32)
+
+    assert q.shape == q_ref.shape
+    assert scales.shape == scales_ref.shape
+    assert torch.equal(q.view(torch.uint8), q_ref.view(torch.uint8))
+    assert torch.equal(scales.view(torch.uint8), scales_ref.view(torch.uint8))
+
+
+def test_weighted_quantize_rows_to_mxfp8_supports_output_buffers_cuda():
+    if not torch.cuda.is_available():
+        return
+    torch.manual_seed(1985)
+    rows, top_k, hidden = 17, 3, 256
+    x = torch.randn(rows, hidden, device="cuda", dtype=torch.bfloat16)
+    weights = torch.rand(rows, top_k, device="cuda", dtype=torch.float32)
+    out_q = torch.empty((rows * top_k, hidden), device="cuda", dtype=torch.float8_e4m3fn)
+    out_scales = torch.empty(
+        (rows * top_k, hidden // 32),
+        device="cuda",
+        dtype=torch.float8_e8m0fnu,
+    )
+
+    q_ref, scales_ref = weighted_quantize_rows_to_mxfp8(x, weights, block_size=32)
+    q, scales = weighted_quantize_rows_to_mxfp8(
+        x,
+        weights,
+        block_size=32,
+        out=out_q,
+        scales_out=out_scales,
+    )
+
+    assert q.untyped_storage().data_ptr() == out_q.untyped_storage().data_ptr()
+    assert scales.untyped_storage().data_ptr() == out_scales.untyped_storage().data_ptr()
+    assert torch.equal(q.view(torch.uint8), q_ref.view(torch.uint8))
+    assert torch.equal(scales.view(torch.uint8), scales_ref.view(torch.uint8))
 
 
 def test_scaled_grouped_mm_q_forward_matches_grouped_mm_reference(monkeypatch):

--- a/src/test/nn/ddp/model_test.py
+++ b/src/test/nn/ddp/model_test.py
@@ -1,10 +1,14 @@
 """Tests for ``OLMoDDPModel`` construction and FLOP accounting."""
 
+import pytest
+
 from olmo_core.config import DType
+from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.attention import AttentionConfig, AttentionType
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlockConfig
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.lm_head import LMHeadConfig
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.nn.transformer import (
@@ -48,3 +52,12 @@ def test_moe_v2_model_builds():
     assert len(model.blocks) == 2
     assert any(p.numel() > 0 for p in model.parameters())
     assert model.num_flops_per_token(seq_len=512) > 0
+
+
+def test_deepep_rejects_chunk_recompute():
+    config = _build_model_config(n_layers=2)
+    config.recompute_all_blocks_by_chunk = True
+    assert isinstance(config.block, OLMoDDPTransformerBlockConfig)
+    config.block.ep = ExpertParallelConfig(path=ExpertParallelPath.deepep_v2)
+    with pytest.raises(OLMoConfigurationError, match="recompute_all_blocks_by_chunk"):
+        config.build(init_device="cpu")

--- a/src/test/nn/moe/mxfp8_scale_mode_test.py
+++ b/src/test/nn/moe/mxfp8_scale_mode_test.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from olmo_core.kernels import mxfp8_utils
+from olmo_core.kernels.mxfp8_utils import (
+    dequantize_rows_from_mxfp8,
+    quantize_rows_to_mxfp8,
+)
+from olmo_core.mxfp8_config import get_mxfp8_default_scale_mode
+from olmo_core.nn.moe.v2.fp8 import MoERowwiseFP8Config, MoERowwiseFP8ScaleMode
+
+
+def _one_block(value: float) -> torch.Tensor:
+    x = torch.zeros(1, 32, dtype=torch.float32)
+    x[0, 0] = value
+    return x
+
+
+def _scale_byte(scales: torch.Tensor) -> int:
+    return int(scales.view(torch.uint8)[0, 0].item())
+
+
+def test_mxfp8_scale_mode_boundary_saturates_only_floor() -> None:
+    x = _one_block(500.0)
+
+    q_floor, s_floor = quantize_rows_to_mxfp8(x, block_size=32, scale_mode="floor")
+    q_rceil, s_rceil = quantize_rows_to_mxfp8(x, block_size=32, scale_mode="rceil")
+
+    assert _scale_byte(s_floor) == 127  # scale 1
+    assert _scale_byte(s_rceil) == 128  # scale 2
+    assert q_floor.to(torch.float32)[0, 0].item() == torch.finfo(torch.float8_e4m3fn).max
+    assert q_rceil.to(torch.float32)[0, 0].item() < torch.finfo(torch.float8_e4m3fn).max
+
+    dq_floor = dequantize_rows_from_mxfp8(
+        q_floor,
+        s_floor,
+        block_size=32,
+        out_dtype=torch.float32,
+    )
+    dq_rceil = dequantize_rows_from_mxfp8(
+        q_rceil,
+        s_rceil,
+        block_size=32,
+        out_dtype=torch.float32,
+    )
+    assert dq_floor[0, 0].item() == 448.0
+    assert dq_rceil[0, 0].item() == 512.0
+
+
+def test_mxfp8_scale_mode_agrees_at_exact_fp8_boundary() -> None:
+    x = _one_block(448.0)
+
+    q_floor, s_floor = quantize_rows_to_mxfp8(x, block_size=32, scale_mode="floor")
+    q_rceil, s_rceil = quantize_rows_to_mxfp8(x, block_size=32, scale_mode="rceil")
+
+    assert _scale_byte(s_floor) == 127
+    assert _scale_byte(s_rceil) == 127
+    torch.testing.assert_close(q_floor.to(torch.float32), q_rceil.to(torch.float32))
+
+
+def test_rowwise_fp8_config_scale_mode_reflects_import_time_default() -> None:
+    default_mode = get_mxfp8_default_scale_mode()
+
+    assert default_mode == "rceil"
+
+    cfg = MoERowwiseFP8Config()
+    assert cfg.scale_mode.value == default_mode
+    cfg.validate()
+
+    cfg_from_string = MoERowwiseFP8Config(scale_mode=default_mode)  # type: ignore[arg-type]
+    cfg_from_string.validate()
+    assert cfg_from_string.scale_mode is MoERowwiseFP8ScaleMode(default_mode)
+
+    other_mode = "rceil" if default_mode == "floor" else "floor"
+    with pytest.raises(ValueError, match="OLMO_MXFP8_SCALE_MODE"):
+        MoERowwiseFP8Config(scale_mode=other_mode).validate()  # type: ignore[arg-type]
+
+
+def test_mxfp8_scale_mode_env_is_resolved_at_olmo_core_import() -> None:
+    src_dir = Path(__file__).parents[3]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    env["OLMO_MXFP8_SCALE_MODE"] = "rceil"
+
+    code = """
+import os
+import olmo_core
+from olmo_core.mxfp8_config import get_mxfp8_default_scale_mode
+print(get_mxfp8_default_scale_mode())
+os.environ["OLMO_MXFP8_SCALE_MODE"] = "floor"
+print(get_mxfp8_default_scale_mode())
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    assert result.stdout.strip().splitlines() == ["rceil", "rceil"]
+
+
+def test_mxfp8_scale_mode_floor_env_is_resolved_at_olmo_core_import() -> None:
+    src_dir = Path(__file__).parents[3]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(src_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    env["OLMO_MXFP8_SCALE_MODE"] = "floor"
+
+    code = """
+from olmo_core.mxfp8_config import get_mxfp8_default_scale_mode
+print(get_mxfp8_default_scale_mode())
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    assert result.stdout.strip() == "floor"
+
+
+def test_mxfp8_backend_env_defaults_to_olmo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OLMO_MXFP8_QDQ_BACKEND", raising=False)
+    monkeypatch.delenv("OLMO_MXFP8_Q_BACKEND", raising=False)
+    monkeypatch.delenv("OLMO_MXFP8_DQ_BACKEND", raising=False)
+
+    assert mxfp8_utils._mxfp8_backend("Q") == "olmo"  # type: ignore[attr-defined]
+
+    monkeypatch.setenv("OLMO_MXFP8_QDQ_BACKEND", "triton")
+    assert mxfp8_utils._mxfp8_backend("Q") == "olmo"  # type: ignore[attr-defined]
+
+    monkeypatch.setenv("OLMO_MXFP8_Q_BACKEND", "transformer_engine")
+    assert mxfp8_utils._mxfp8_backend("Q") == "te"  # type: ignore[attr-defined]
+
+    monkeypatch.setenv("OLMO_MXFP8_Q_BACKEND", "nope")
+    with pytest.raises(ValueError, match="OLMO_MXFP8_Q_BACKEND"):
+        mxfp8_utils._mxfp8_backend("Q")  # type: ignore[attr-defined]
+
+
+def test_mxfp8_te_backend_request_raises_for_cpu_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OLMO_MXFP8_Q_BACKEND", "te")
+    x = torch.zeros((1, 32), dtype=torch.float32)
+
+    with pytest.raises(RuntimeError, match="requires a CUDA input tensor"):
+        quantize_rows_to_mxfp8(x, block_size=32, scale_mode="rceil")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_mxfp8_te_preallocated_rceil_matches_olmo(monkeypatch: pytest.MonkeyPatch) -> None:
+    if mxfp8_utils._get_te_mxfp8_state() is None:  # type: ignore[attr-defined]
+        pytest.skip("TransformerEngine MXFP8 is unavailable")
+
+    monkeypatch.setenv("OLMO_MXFP8_Q_BACKEND", "olmo")
+    x = torch.randn((128, 128), device="cuda", dtype=torch.bfloat16)
+    q_olmo, s_olmo = quantize_rows_to_mxfp8(x, block_size=32, scale_mode="rceil")
+
+    q_te = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    s_te = torch.empty((128, 4), device=x.device, dtype=torch.float8_e8m0fnu)
+    result = mxfp8_utils._quantize_to_mxfp8_te(  # type: ignore[attr-defined]
+        x,
+        block_size=32,
+        scale_mode="rceil",
+        out=q_te,
+        scales_out=s_te,
+    )
+
+    assert result is not None
+    assert torch.equal(q_olmo.view(torch.uint8), q_te.view(torch.uint8))
+    assert torch.equal(s_olmo.view(torch.uint8), s_te.view(torch.uint8))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_mxfp8_te_backend_request_raises_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OLMO_MXFP8_Q_BACKEND", "te")
+    monkeypatch.setattr(mxfp8_utils, "_get_te_mxfp8_state", lambda: None)
+
+    x = torch.randn((128, 128), device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(RuntimeError, match="TransformerEngine MXFP8 Q backend was requested"):
+        quantize_rows_to_mxfp8(x, block_size=32, scale_mode="rceil")

--- a/src/test/nn/moe/mxfp8_scale_mode_test.py
+++ b/src/test/nn/moe/mxfp8_scale_mode_test.py
@@ -15,6 +15,8 @@ from olmo_core.kernels.mxfp8_utils import (
 )
 from olmo_core.mxfp8_config import get_mxfp8_default_scale_mode
 from olmo_core.nn.moe.v2.fp8 import MoERowwiseFP8Config, MoERowwiseFP8ScaleMode
+from olmo_core.testing import requires_gpu
+from olmo_core.testing.utils import requires_compute_capability
 
 
 def _one_block(value: float) -> torch.Tensor:
@@ -155,7 +157,8 @@ def test_mxfp8_te_backend_request_raises_for_cpu_input(
         quantize_rows_to_mxfp8(x, block_size=32, scale_mode="rceil")
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@requires_gpu
+@requires_compute_capability(min_cc=9)
 def test_mxfp8_te_preallocated_rceil_matches_olmo(monkeypatch: pytest.MonkeyPatch) -> None:
     if mxfp8_utils._get_te_mxfp8_state() is None:  # type: ignore[attr-defined]
         pytest.skip("TransformerEngine MXFP8 is unavailable")
@@ -179,7 +182,7 @@ def test_mxfp8_te_preallocated_rceil_matches_olmo(monkeypatch: pytest.MonkeyPatc
     assert torch.equal(s_olmo.view(torch.uint8), s_te.view(torch.uint8))
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@requires_gpu
 def test_mxfp8_te_backend_request_raises_when_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/test/nn/moe/v2/deepep_checkpoint_test.py
+++ b/src/test/nn/moe/v2/deepep_checkpoint_test.py
@@ -46,13 +46,15 @@ def test_per_block_checkpoint_uses_reentrant_only_for_deepep(
 ) -> None:
     checkpoint_kwargs = []
     forwarded_kwargs = []
+    forwarded_anchors = []
 
     def fake_checkpoint(function, *args, **kwargs):
         checkpoint_kwargs.append(kwargs)
         return function(*args)
 
-    def forward_one_block(h, _block_key, block_kwargs):
+    def forward_one_block(h, _block_key, block_kwargs, grad_anchor=None):
         forwarded_kwargs.append(block_kwargs)
+        forwarded_anchors.append(grad_anchor)
         return h + 1
 
     monkeypatch.setattr(ddp_model_module, "checkpoint", fake_checkpoint)
@@ -79,9 +81,13 @@ def test_per_block_checkpoint_uses_reentrant_only_for_deepep(
         assert "context_fn" not in checkpoint_kwargs[0]
         assert checkpoint_kwargs[0]["preserve_rng_state"] is True
         assert forwarded_kwargs[0]["deepep_reentrant_checkpoint"] is True
+        # h is detached here, so a grad-requiring anchor is passed to keep the
+        # reentrant recompute (and DeepEP expert backward) alive.
+        assert forwarded_anchors[0] is not None and forwarded_anchors[0].requires_grad
     else:
         assert "context_fn" in checkpoint_kwargs[0]
         assert "deepep_reentrant_checkpoint" not in forwarded_kwargs[0]
+        assert forwarded_anchors[0] is None
 
 
 def test_reentrant_checkpoint_supports_deepep_nested_backward_pattern() -> None:

--- a/src/test/nn/moe/v2/deepep_checkpoint_test.py
+++ b/src/test/nn/moe/v2/deepep_checkpoint_test.py
@@ -4,8 +4,8 @@ from typing import Any
 import pytest
 import torch
 
-import olmo_core.nn.ddp.block as ddp_block_module
 import olmo_core.nn.ddp.model as ddp_model_module
+import olmo_core.nn.moe.v2.ep_deepep_v2 as ep_deepep_v2_module
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 from olmo_core.nn.ddp.model import OLMoDDPModel
 from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
@@ -145,8 +145,8 @@ def test_reentrant_checkpoint_accumulates_each_deepep_metric_once(
         return x.square()
 
     monkeypatch.setattr(
-        ddp_block_module,
-        "_combined_forward_ep_deepep_v2",
+        ep_deepep_v2_module,
+        "combined_forward_ep_deepep_v2",
         fake_combined_forward,
     )
     block = _stub_block(ExpertParallelPath.deepep_v2)

--- a/src/test/nn/moe/v2/deepep_checkpoint_test.py
+++ b/src/test/nn/moe/v2/deepep_checkpoint_test.py
@@ -1,0 +1,169 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+import olmo_core.nn.ddp.block as ddp_block_module
+import olmo_core.nn.ddp.model as ddp_model_module
+from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
+from olmo_core.nn.ddp.model import OLMoDDPModel
+from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
+
+
+def _stub_block(
+    path: ExpertParallelPath,
+    *,
+    ep_enabled: bool = True,
+    training: bool = True,
+) -> OLMoDDPTransformerBlock:
+    block = object.__new__(OLMoDDPTransformerBlock)
+    torch.nn.Module.__init__(block)
+    block.routed_experts = torch.nn.Identity()
+    block._ep_enabled = ep_enabled
+    block._ep_no_sync_rowwise_static_checkpoint_state = None
+    block.ep = ExpertParallelConfig(path=path)
+    block.train(training)
+    return block
+
+
+@pytest.mark.parametrize(
+    ("path", "ep_enabled", "training", "expected_reentrant"),
+    [
+        (ExpertParallelPath.deepep_v2, True, True, True),
+        (ExpertParallelPath.sync_1d, True, True, False),
+        (ExpertParallelPath.rowwise_nvshmem, True, True, False),
+        (ExpertParallelPath.deepep_v2, False, True, False),
+        (ExpertParallelPath.deepep_v2, True, False, False),
+    ],
+)
+def test_per_block_checkpoint_uses_reentrant_only_for_deepep(
+    monkeypatch: pytest.MonkeyPatch,
+    path: ExpertParallelPath,
+    ep_enabled: bool,
+    training: bool,
+    expected_reentrant: bool,
+) -> None:
+    checkpoint_kwargs = []
+    forwarded_kwargs = []
+
+    def fake_checkpoint(function, *args, **kwargs):
+        checkpoint_kwargs.append(kwargs)
+        return function(*args)
+
+    def forward_one_block(h, _block_key, block_kwargs):
+        forwarded_kwargs.append(block_kwargs)
+        return h + 1
+
+    monkeypatch.setattr(ddp_model_module, "checkpoint", fake_checkpoint)
+    model: Any = SimpleNamespace(
+        blocks={
+            "0": _stub_block(
+                path,
+                ep_enabled=ep_enabled,
+                training=training,
+            )
+        },
+        compile_enabled=False,
+        recompute_each_block=True,
+        recompute_block_keys=None,
+        _forwrad_one_block=forward_one_block,
+    )
+
+    out = OLMoDDPModel._forward_blocks(model, torch.zeros(1), {}, {})
+
+    torch.testing.assert_close(out, torch.ones(1))
+    assert len(checkpoint_kwargs) == 1
+    assert checkpoint_kwargs[0]["use_reentrant"] is expected_reentrant
+    if expected_reentrant:
+        assert "context_fn" not in checkpoint_kwargs[0]
+        assert checkpoint_kwargs[0]["preserve_rng_state"] is True
+        assert forwarded_kwargs[0]["deepep_reentrant_checkpoint"] is True
+    else:
+        assert "context_fn" in checkpoint_kwargs[0]
+        assert "deepep_reentrant_checkpoint" not in forwarded_kwargs[0]
+
+
+def test_reentrant_checkpoint_supports_deepep_nested_backward_pattern() -> None:
+    class NestedBackward(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, source):
+            recv_x = source.detach().requires_grad_(True)
+            with torch.enable_grad():
+                expert_out = recv_x.square()
+            ctx.save_for_backward(recv_x, expert_out)
+            return expert_out.detach().clone()
+
+        @staticmethod
+        def backward(ctx, grad_out):
+            recv_x, expert_out = ctx.saved_tensors
+            torch.autograd.backward(expert_out, grad_out)
+            assert recv_x.grad is not None
+            return recv_x.grad
+
+    torch.manual_seed(1234)
+    source = torch.randn(8, requires_grad=True)
+    routes = []
+
+    def routed_expert(value: torch.Tensor) -> torch.Tensor:
+        route = torch.rand_like(value)
+        routes.append(route.detach().clone())
+        return NestedBackward.apply(value * route)
+
+    out = torch.utils.checkpoint.checkpoint(
+        routed_expert,
+        source,
+        use_reentrant=True,
+    )
+    out.sum().backward()
+
+    assert len(routes) == 2
+    torch.testing.assert_close(routes[0], routes[1])
+    torch.testing.assert_close(source.grad, 2 * source * routes[0].square())
+
+
+def test_reentrant_checkpoint_accumulates_each_deepep_metric_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def fake_combined_forward(
+        _block,
+        x,
+        *,
+        accumulate_routed_aux_loss_metrics,
+        accumulate_router_aux_loss_metrics,
+        **_kwargs,
+    ):
+        calls.append(
+            (
+                torch.is_grad_enabled(),
+                accumulate_routed_aux_loss_metrics,
+                accumulate_router_aux_loss_metrics,
+            )
+        )
+        return x.square()
+
+    monkeypatch.setattr(
+        ddp_block_module,
+        "_combined_forward_ep_deepep_v2",
+        fake_combined_forward,
+    )
+    block = _stub_block(ExpertParallelPath.deepep_v2)
+    source = torch.randn(8, requires_grad=True)
+
+    out = torch.utils.checkpoint.checkpoint(
+        lambda x: OLMoDDPTransformerBlock.combined_forward_ep_deepep_v2(
+            block,
+            x,
+            deepep_reentrant_checkpoint=True,
+        ),
+        source,
+        use_reentrant=True,
+    )
+    out.sum().backward()
+
+    assert calls == [
+        (False, True, True),
+        (True, False, True),
+    ]

--- a/src/test/nn/moe/v2/deepep_runtime_test.py
+++ b/src/test/nn/moe/v2/deepep_runtime_test.py
@@ -1,0 +1,430 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+import olmo_core.nn.moe.v2.ep_deepep_v2 as deepep_v2
+
+
+def _stub_block(
+    *,
+    ep_pg: object,
+    runtime_cache: dict,
+    fp8_enabled: bool = False,
+) -> Any:
+    deepep_config = SimpleNamespace(
+        path="/fake/deepep",
+        num_sms=8,
+        num_qps=2,
+        num_allocated_qps=2,
+        expert_alignment=1,
+        async_mode=False,
+        prefer_overlap_with_compute=True,
+        allow_hybrid_mode=True,
+        allow_multiple_reduction=True,
+    )
+    return SimpleNamespace(
+        ep_pg=ep_pg,
+        ep=SimpleNamespace(capacity_factor=1.25, deepep=deepep_config),
+        rowwise_fp8=(SimpleNamespace(enabled=True) if fp8_enabled else None),
+        routed_experts_router=SimpleNamespace(num_experts=8),
+        num_local_routed_experts=2,
+        _deepep_v2_runtime_cache=runtime_cache,
+        _deepep_v2_runtime=None,
+    )
+
+
+def test_deepep_runtime_negotiates_capacity_only_on_cache_miss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeElasticBuffer:
+        instances = []
+
+        def __init__(self, process_group, **kwargs):
+            self.process_group = process_group
+            self.kwargs = kwargs
+            self.instances.append(self)
+
+        def dispatch_expanded_into(self):
+            raise NotImplementedError
+
+        def dispatch_cached_expanded_into(self):
+            raise NotImplementedError
+
+    global_capacity_requests = []
+
+    def fake_global_capacity(_block, requested_tokens, _device):
+        global_capacity_requests.append(requested_tokens)
+        return 96
+
+    monkeypatch.setattr(
+        deepep_v2,
+        "_import_deepep",
+        lambda _path: SimpleNamespace(ElasticBuffer=FakeElasticBuffer),
+    )
+    monkeypatch.setattr(
+        deepep_v2,
+        "_global_num_max_tokens_per_rank",
+        fake_global_capacity,
+    )
+
+    ep_pg = object()
+    shared_cache: dict = {}
+    first_block = _stub_block(ep_pg=ep_pg, runtime_cache=shared_cache)
+    second_block = _stub_block(ep_pg=ep_pg, runtime_cache=shared_cache)
+
+    runtime = deepep_v2._get_deepep_v2_runtime(
+        first_block,
+        local_tokens=64,
+        hidden=256,
+        top_k=2,
+        device=torch.device("cuda"),
+    )
+    cached_runtime = deepep_v2._get_deepep_v2_runtime(
+        second_block,
+        local_tokens=64,
+        hidden=256,
+        top_k=2,
+        device=torch.device("cuda"),
+    )
+
+    assert cached_runtime is runtime
+    assert second_block._deepep_v2_runtime is runtime
+    assert global_capacity_requests == [64]
+    assert len(FakeElasticBuffer.instances) == 1
+    assert runtime.num_max_tokens_per_rank == 96
+
+
+def test_deepep_cached_runtime_rejects_local_capacity_growth_without_collective(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ep_pg = object()
+    block = _stub_block(ep_pg=ep_pg, runtime_cache={})
+    key = deepep_v2._runtime_key(block, hidden=256, top_k=2)
+    runtime: Any = SimpleNamespace(num_max_tokens_per_rank=96)
+    block._deepep_v2_runtime_cache[key] = runtime
+
+    def unexpected_collective(*_args, **_kwargs):
+        raise AssertionError("cached runtime must not renegotiate capacity")
+
+    monkeypatch.setattr(
+        deepep_v2,
+        "_global_num_max_tokens_per_rank",
+        unexpected_collective,
+    )
+
+    with pytest.raises(RuntimeError, match="local_requested=100, capacity=96"):
+        deepep_v2._get_deepep_v2_runtime(
+            block,
+            local_tokens=100,
+            hidden=256,
+            top_k=2,
+            device=torch.device("cuda"),
+        )
+
+
+def test_deepep_static_source_capacity_skips_capacity_negotiation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeElasticBuffer:
+        def __init__(self, process_group, **kwargs):
+            self.process_group = process_group
+            self.kwargs = kwargs
+
+        def dispatch_expanded_into(self):
+            raise NotImplementedError
+
+        def dispatch_cached_expanded_into(self):
+            raise NotImplementedError
+
+    def unexpected_collective(*_args, **_kwargs):
+        raise AssertionError("static DeepEP prewarm must not negotiate capacity")
+
+    process_group_warmups = []
+
+    monkeypatch.setattr(
+        deepep_v2,
+        "_import_deepep",
+        lambda _path: SimpleNamespace(ElasticBuffer=FakeElasticBuffer),
+    )
+    monkeypatch.setattr(
+        deepep_v2,
+        "_global_num_max_tokens_per_rank",
+        unexpected_collective,
+    )
+    monkeypatch.setattr(
+        deepep_v2,
+        "_warm_deepep_v2_process_group",
+        lambda block, device: process_group_warmups.append((block, device)),
+    )
+
+    block = _stub_block(ep_pg=object(), runtime_cache={})
+    runtime = deepep_v2.prewarm_deepep_v2_runtime(
+        block,
+        max_local_tokens=64,
+        hidden=256,
+        top_k=2,
+        device=torch.device("cuda"),
+    )
+
+    assert runtime.num_max_tokens_per_rank == 64
+    assert runtime.buffer.kwargs["num_max_tokens_per_rank"] == 64
+    assert block._deepep_v2_runtime is runtime
+    assert process_group_warmups == [(block, torch.device("cuda"))]
+
+
+def test_deepep_source_capacity_is_not_route_capacity() -> None:
+    assert deepep_v2._requested_num_max_tokens_per_rank(64) == 64
+    with pytest.raises(ValueError, match="positive source-token capacity"):
+        deepep_v2._requested_num_max_tokens_per_rank(0)
+
+
+def test_deepep_runtime_key_separates_fp8_dispatch() -> None:
+    ep_pg = object()
+    bf16_block = _stub_block(ep_pg=ep_pg, runtime_cache={})
+    fp8_block = _stub_block(ep_pg=ep_pg, runtime_cache={}, fp8_enabled=True)
+
+    bf16_key = deepep_v2._runtime_key(bf16_block, hidden=256, top_k=2)
+    fp8_key = deepep_v2._runtime_key(fp8_block, hidden=256, top_k=2)
+
+    assert bf16_key.use_fp8_dispatch is False
+    assert fp8_key.use_fp8_dispatch is True
+    assert fp8_key != bf16_key
+
+
+def test_deepep_mxfp8_scale_pack_round_trip() -> None:
+    scale_bits = torch.arange(16, dtype=torch.uint8).reshape(2, 8)
+    scales = scale_bits.view(torch.float8_e8m0fnu)
+
+    packed = deepep_v2._pack_deepep_mxfp8_scales(scales)
+    restored = deepep_v2._unpack_deepep_mxfp8_scales(packed)
+
+    assert packed.dtype == torch.int32
+    assert packed.shape == (2, 2)
+    assert packed.is_contiguous()
+    assert restored.dtype == torch.float8_e8m0fnu
+    assert restored.shape == scales.shape
+    torch.testing.assert_close(restored.view(torch.uint8), scale_bits)
+
+
+def test_deepep_mxfp8_scale_pack_rejects_incompatible_layout() -> None:
+    with pytest.raises(RuntimeError, match="float8_e8m0fnu"):
+        deepep_v2._pack_deepep_mxfp8_scales(torch.ones((2, 4)))
+
+    incompatible = torch.zeros((2, 6), dtype=torch.uint8).view(torch.float8_e8m0fnu)
+    with pytest.raises(RuntimeError, match="four-scale packing"):
+        deepep_v2._pack_deepep_mxfp8_scales(incompatible)
+
+
+def test_deepep_fp8_autograd_uses_prequantized_experts_and_post_weights(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hidden = 256
+    tokens = 2
+    seen = {}
+
+    class FakeHandle:
+        psum_num_recv_tokens_per_expert = torch.tensor([tokens], dtype=torch.int32)
+
+    class FakeBuffer:
+        def dispatch_expanded_into(
+            self,
+            payload,
+            *,
+            topk_idx,
+            topk_weights,
+            recv_x_out,
+            recv_sf_out,
+            recv_topk_weights_out,
+            **_kwargs,
+        ):
+            source_q, source_sf = payload
+            assert source_q.dtype == torch.float8_e4m3fn
+            assert source_sf.dtype == torch.int32
+            recv_x_out.zero_()
+            recv_sf_out.zero_()
+            recv_topk_weights_out.copy_(topk_weights.reshape(-1))
+            return (
+                (recv_x_out, recv_sf_out),
+                topk_idx,
+                recv_topk_weights_out,
+                FakeHandle(),
+                object(),
+            )
+
+        def dispatch_cached_expanded_into(self, grad, *, recv_x_out, **_kwargs):
+            recv_x_out.copy_(grad)
+            return recv_x_out, None, None, FakeHandle(), object()
+
+        def combine(self, value, **_kwargs):
+            return value, None, object()
+
+    class FakeRoutedExperts:
+        def __call__(self, value, counts, **kwargs):
+            seen["counts"] = counts.clone()
+            seen["kwargs"] = kwargs
+            return value * 3
+
+    fp8_config = SimpleNamespace(
+        enabled=True,
+        block_size=32,
+        scale_mode=SimpleNamespace(value="rceil"),
+    )
+    block: Any = SimpleNamespace(
+        rowwise_fp8=fp8_config,
+        routed_experts=FakeRoutedExperts(),
+        ep_pg=object(),
+        ep_world_size=1,
+    )
+    runtime: Any = SimpleNamespace(
+        buffer=FakeBuffer(),
+        use_fp8_dispatch=True,
+        hidden=hidden,
+        num_experts=1,
+        num_max_tokens_per_rank=tokens,
+        expert_alignment=1,
+        num_sms=4,
+        num_qps=1,
+        async_with_compute_stream=False,
+        num_topk=1,
+    )
+
+    class FakeContext:
+        needs_input_grad = (True, False, True, False, False, False)
+
+        def save_for_backward(self, *tensors):
+            self.saved_tensors = tensors
+
+    def fake_quantize(value, *, block_size, scale_mode):
+        assert block_size == 32
+        assert scale_mode == "rceil"
+        q = torch.zeros_like(value, dtype=torch.float8_e4m3fn)
+        scale_bits = torch.zeros(
+            (value.shape[0], value.shape[1] // block_size),
+            dtype=torch.uint8,
+        )
+        return q, scale_bits.view(torch.float8_e8m0fnu)
+
+    monkeypatch.setattr(deepep_v2, "quantize_rows_to_mxfp8", fake_quantize)
+    monkeypatch.setattr(
+        deepep_v2,
+        "_logical_rank2_tensor",
+        lambda shape, *, dtype, device: torch.ones(shape, dtype=dtype, device=device),
+    )
+    monkeypatch.setattr(
+        deepep_v2,
+        "_expanded_weight_grad_to_topk_grad",
+        lambda **kwargs: kwargs["expanded_weight_grad"].reshape(tokens, 1),
+    )
+
+    source = torch.randn(tokens, hidden)
+    topk_idx = torch.zeros((tokens, 1), dtype=torch.int64)
+    topk_weights = torch.tensor([[0.5], [0.25]])
+
+    ctx = FakeContext()
+    out = deepep_v2._DeepEpV2Autograd.forward(
+        ctx,
+        source,
+        topk_idx,
+        topk_weights,
+        block,
+        runtime,
+        tokens,
+    )
+    grads = deepep_v2._DeepEpV2Autograd.backward(ctx, torch.ones_like(out))
+
+    torch.testing.assert_close(out[0], torch.full((hidden,), 1.5))
+    torch.testing.assert_close(out[1], torch.full((hidden,), 0.75))
+    torch.testing.assert_close(grads[0][0], torch.full((hidden,), 1.5))
+    torch.testing.assert_close(grads[0][1], torch.full((hidden,), 0.75))
+    torch.testing.assert_close(
+        grads[2],
+        torch.full_like(topk_weights, 3.0 * hidden),
+    )
+    torch.testing.assert_close(seen["counts"], torch.tensor([tokens], dtype=torch.int32))
+    assert seen["kwargs"]["use_rowwise_fp8"] is True
+    assert "row_weights" not in seen["kwargs"]
+    assert seen["kwargs"]["rowwise_fp8_input_q"].dtype == torch.float8_e4m3fn
+    assert seen["kwargs"]["rowwise_fp8_input_scales"].dtype == torch.float8_e8m0fnu
+
+
+def test_deepep_process_group_warmup_initializes_torch_nccl_on_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list = []
+
+    class FakeScalar:
+        def zero_(self):
+            calls.append(("zero",))
+            return self
+
+    def fake_empty(shape, *, device, dtype):
+        calls.append(("empty", shape, device, dtype))
+        return FakeScalar()
+
+    def fake_all_reduce(tensor, *, group):
+        calls.append(("all_reduce", tensor, group))
+
+    def fake_synchronize(device):
+        calls.append(("synchronize", device))
+
+    monkeypatch.setenv("EP_REUSE_NCCL_COMM", "1")
+    monkeypatch.setattr(deepep_v2.torch, "empty", fake_empty)
+    monkeypatch.setattr(deepep_v2.dist, "all_reduce", fake_all_reduce)
+    monkeypatch.setattr(deepep_v2.torch.cuda, "synchronize", fake_synchronize)
+    ep_pg = object()
+    block: Any = SimpleNamespace(ep_pg=ep_pg)
+
+    deepep_v2._warm_deepep_v2_process_group(block, torch.device("cuda:3"))
+
+    assert calls[0] == ("empty", (1,), torch.device("cuda:3"), torch.int32)
+    assert calls[1] == ("zero",)
+    assert calls[2][0] == "all_reduce"
+    assert calls[2][2] is ep_pg
+    assert calls[3] == ("synchronize", torch.device("cuda:3"))
+
+
+def test_global_capacity_scalar_is_filled_on_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list = []
+
+    class FakeScalar:
+        def fill_(self, value):
+            calls.append(("fill", value))
+            return self
+
+        def item(self):
+            calls.append(("item",))
+            return 112
+
+    def fake_empty(shape, *, device, dtype):
+        calls.append(("empty", shape, device, dtype))
+        return FakeScalar()
+
+    def fail_tensor(*_args, **_kwargs):
+        raise AssertionError("must not stage the capacity scalar through CPU memory")
+
+    def fake_all_reduce(tensor, *, op, group):
+        calls.append(("all_reduce", tensor, op, group))
+
+    monkeypatch.setattr(deepep_v2.torch, "empty", fake_empty)
+    monkeypatch.setattr(deepep_v2.torch, "tensor", fail_tensor)
+    monkeypatch.setattr(deepep_v2.dist, "all_reduce", fake_all_reduce)
+    ep_pg = object()
+    block: Any = SimpleNamespace(ep_pg=ep_pg)
+
+    capacity = deepep_v2._global_num_max_tokens_per_rank(
+        block,
+        requested_tokens=80,
+        device=torch.device("cuda"),
+    )
+
+    assert capacity == 112
+    assert calls[0] == ("empty", (1,), torch.device("cuda"), torch.long)
+    assert calls[1] == ("fill", 80)
+    assert calls[2][0] == "all_reduce"
+    assert calls[2][2] is deepep_v2.dist.ReduceOp.MAX
+    assert calls[2][3] is ep_pg
+    assert calls[3] == ("item",)

--- a/src/test/nn/moe/v2/rowwise_fp8_comm_test.py
+++ b/src/test/nn/moe/v2/rowwise_fp8_comm_test.py
@@ -163,3 +163,89 @@ def test_rowwise_fp8_combine_backward_returns_grad_probs(monkeypatch):
 
     assert probs.grad is not None
     torch.testing.assert_close(probs.grad, torch.full_like(probs, 3.0))
+
+
+def test_rowwise_dispatch_put_weighted_mxfp8_uses_weighted_quantize(monkeypatch):
+    q = torch.empty(6, 64, dtype=torch.float8_e4m3fn)
+    scales = torch.empty(6, 2, dtype=torch.float8_e8m0fnu)
+    seen: dict = {"quantize": 0, "puts": []}
+
+    def _stub_weighted_quantize_rows_to_mxfp8(input_hp, probs, *, block_size):
+        seen["quantize"] += 1
+        assert input_hp.shape == (2, 64)
+        assert probs.shape == (2, 3)
+        assert block_size == 32
+        return q, scales
+
+    def _stub_rowwise_dispatch_put(
+        input_tensor,
+        out,
+        dst_ranks,
+        dst_rows,
+        group_name,
+        *,
+        nblocks,
+        pre_barrier=False,
+        post_barrier=True,
+    ):
+        seen["puts"].append(
+            {
+                "input": input_tensor,
+                "out": out,
+                "dst_ranks": dst_ranks.clone(),
+                "dst_rows": dst_rows.clone(),
+                "group_name": group_name,
+                "nblocks": nblocks,
+                "pre_barrier": pre_barrier,
+                "post_barrier": post_barrier,
+            }
+        )
+
+    monkeypatch.setattr(
+        comm,
+        "weighted_quantize_rows_to_mxfp8",
+        _stub_weighted_quantize_rows_to_mxfp8,
+    )
+    monkeypatch.setattr(
+        comm.symm_mem_vdev2d_kernels,
+        "rowwise_dispatch_put",
+        _stub_rowwise_dispatch_put,
+    )
+
+    input_hp = torch.randn(2, 64, dtype=torch.bfloat16)
+    probs = torch.rand(2, 3)
+    out_q = torch.empty(4, 64, dtype=torch.float8_e4m3fn)
+    out_scales = torch.empty(4, 2, dtype=torch.float8_e8m0fnu)
+    dst_ranks = torch.tensor([[0, 1, -1], [1, 0, 0]], dtype=torch.long)
+    dst_rows = torch.tensor([[0, 2, -1], [1, 3, 0]], dtype=torch.long)
+
+    comm._rowwise_dispatch_put_weighted_mxfp8(
+        input_hp,
+        probs,
+        out_q,
+        out_scales,
+        dst_ranks,
+        dst_rows,
+        "test_group",
+        block_size=32,
+        nblocks=128,
+    )
+
+    assert seen["quantize"] == 1
+    assert len(seen["puts"]) == 2
+    assert seen["puts"][0]["input"] is q
+    assert seen["puts"][0]["out"] is out_q
+    assert seen["puts"][0]["group_name"] == "test_group"
+    assert seen["puts"][0]["nblocks"] == 128
+    assert seen["puts"][0]["pre_barrier"] is False
+    assert seen["puts"][0]["post_barrier"] is False
+    assert seen["puts"][1]["input"] is scales
+    assert seen["puts"][1]["out"] is out_scales
+    assert seen["puts"][1]["pre_barrier"] is False
+    assert seen["puts"][1]["post_barrier"] is True
+    expected_ranks = dst_ranks.reshape(-1, 1)
+    expected_rows = dst_rows.reshape(-1, 1)
+    assert torch.equal(seen["puts"][0]["dst_ranks"], expected_ranks)
+    assert torch.equal(seen["puts"][0]["dst_rows"], expected_rows)
+    assert torch.equal(seen["puts"][1]["dst_ranks"], expected_ranks)
+    assert torch.equal(seen["puts"][1]["dst_rows"], expected_rows)

--- a/src/test/nn/moe/v2/rowwise_route_maps_test.py
+++ b/src/test/nn/moe/v2/rowwise_route_maps_test.py
@@ -110,3 +110,59 @@ def test_build_rowwise_route_maps_matches_reference(device: str):
 
     assert torch.equal(dst_ranks, expected_ranks)
     assert torch.equal(dst_rows, expected_rows)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_build_rowwise_route_maps_torch_compile_cuda():
+    ep_world_size = 3
+    num_local_experts = 2
+    block = SimpleNamespace(
+        ep_pg=object(),
+        ep_world_size=ep_world_size,
+        num_local_routed_experts=num_local_experts,
+        block_idx=0,
+    )
+    device = "cuda"
+
+    routing_map = torch.tensor(
+        [
+            [0, 1, 5],
+            [3, 0, -1],
+            [5, 4, 1],
+            [2, 3, 5],
+            [0, 1, 4],
+            [3, 2, 5],
+            [4, 0, 2],
+            [1, 5, 3],
+        ],
+        device=device,
+        dtype=torch.long,
+    )
+    keep_from_src_dest_local = torch.tensor(
+        [
+            [[2, 3], [2, 2], [2, 3]],
+            [[1, 0], [2, 1], [0, 1]],
+            [[0, 2], [1, 0], [3, 0]],
+        ],
+        device=device,
+        dtype=torch.long,
+    )
+    allowed_splits = keep_from_src_dest_local[0].reshape(-1)
+
+    compiled = torch.compile(build_rowwise_route_maps, fullgraph=False)
+    dst_ranks, dst_rows = compiled(
+        block,
+        routing_map=routing_map,
+        allowed_splits=allowed_splits,
+        keep_from_src_dest_local=keep_from_src_dest_local,
+    )
+    expected_ranks, expected_rows = _reference_rowwise_route_maps(
+        routing_map,
+        allowed_splits,
+        keep_from_src_dest_local,
+        ep_world_size=ep_world_size,
+        num_local_experts=num_local_experts,
+    )
+
+    assert torch.equal(dst_ranks, expected_ranks)
+    assert torch.equal(dst_rows, expected_rows)

--- a/src/test/nn/moe/v2/rowwise_route_maps_test.py
+++ b/src/test/nn/moe/v2/rowwise_route_maps_test.py
@@ -110,6 +110,45 @@ def test_build_rowwise_route_maps_matches_reference(device: str):
     assert torch.equal(dst_rows, expected_rows)
 
 
+@pytest.mark.parametrize("seed", [0, 1, 2, 3])
+def test_build_rowwise_route_maps_matches_reference_randomized(seed: int):
+    ep_world_size = 4
+    num_local_experts = 8
+    expert_count = ep_world_size * num_local_experts
+    block = SimpleNamespace(
+        ep_pg=object(),
+        ep_world_size=ep_world_size,
+        num_local_routed_experts=num_local_experts,
+        block_idx=0,
+    )
+
+    gen = torch.Generator().manual_seed(seed)
+    # Many routes per expert plus some dropped (-1) routes exercise stable
+    # in-bucket ordering and tail-capacity dropping.
+    routing_map = torch.randint(-1, expert_count, (96, 6), generator=gen, dtype=torch.long)
+    keep_from_src_dest_local = torch.randint(
+        0, 4, (ep_world_size, ep_world_size, num_local_experts), generator=gen, dtype=torch.long
+    )
+    allowed_splits = keep_from_src_dest_local[0].reshape(-1)
+
+    dst_ranks, dst_rows = build_rowwise_route_maps(
+        block,  # type: ignore[arg-type]
+        routing_map=routing_map,
+        allowed_splits=allowed_splits,
+        keep_from_src_dest_local=keep_from_src_dest_local,
+    )
+    expected_ranks, expected_rows = _reference_rowwise_route_maps(
+        routing_map,
+        allowed_splits,
+        keep_from_src_dest_local,
+        ep_world_size=ep_world_size,
+        num_local_experts=num_local_experts,
+    )
+
+    assert torch.equal(dst_ranks, expected_ranks)
+    assert torch.equal(dst_rows, expected_rows)
+
+
 @requires_gpu
 def test_build_rowwise_route_maps_torch_compile_cuda():
     ep_world_size = 3

--- a/src/test/nn/moe/v2/rowwise_route_maps_test.py
+++ b/src/test/nn/moe/v2/rowwise_route_maps_test.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from olmo_core.nn.moe.v2.ep_no_sync_rowwise_helpers import build_rowwise_route_maps
+from olmo_core.testing import GPU_MARKS, requires_gpu
 
 
 def _reference_rowwise_route_maps(
@@ -57,11 +58,8 @@ def _reference_rowwise_route_maps(
     return dst_ranks.to(routing_map.device), dst_rows.to(routing_map.device)
 
 
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("device", ["cpu", pytest.param("cuda", marks=GPU_MARKS)])
 def test_build_rowwise_route_maps_matches_reference(device: str):
-    if device == "cuda" and not torch.cuda.is_available():
-        pytest.skip("CUDA required")
-
     ep_world_size = 3
     num_local_experts = 2
     block = SimpleNamespace(
@@ -112,7 +110,7 @@ def test_build_rowwise_route_maps_matches_reference(device: str):
     assert torch.equal(dst_rows, expected_rows)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@requires_gpu
 def test_build_rowwise_route_maps_torch_compile_cuda():
     ep_world_size = 3
     num_local_experts = 2

--- a/src/test/nn/mxfp8_linear_test.py
+++ b/src/test/nn/mxfp8_linear_test.py
@@ -7,14 +7,14 @@ from olmo_core.testing import GPU_MARKS
 from olmo_core.testing.utils import compute_capability
 
 # Module-level equivalent of @requires_gpu (marks every test gpu + skips without a GPU); the
-# pytest.mark.gpu also routes these to the kernels GPU CI job. The MXFP8 quantize/scaled-mm kernels
-# additionally require compute capability >= 9 (they don't compile on older archs like the A100),
-# matching the other fp8 kernel suites (e.g. scaled_grouped_mm_q_test).
+# pytest.mark.gpu also routes these to the kernels GPU CI job. MXFP8Linear's forward uses the
+# blockwise (1x32) mxfp8 scaled_mm, which cuBLAS only supports on SM100/Blackwell; on SM90 (H100)
+# it raises CUBLAS_STATUS_NOT_SUPPORTED, so require compute capability >= 10.
 pytestmark = [
     *GPU_MARKS,
     pytest.mark.skipif(
-        compute_capability is None or compute_capability < 9,
-        reason=f"MXFP8 kernels require compute capability >= 9 (device has {compute_capability})",
+        compute_capability is None or compute_capability < 10,
+        reason=f"MXFP8 blockwise scaled_mm requires compute capability >= 10 (device has {compute_capability})",
     ),
 ]
 


### PR DESCRIPTION
## What this adds

Combines the DeepEP v2 MXFP8 expert-parallel training path with the MXFP8 scale-mode support it depends on.

**DeepEP v2 MXFP8 dispatch + recompute**
- `nn/moe/v2/ep_deepep_v2.py`: FP8 dispatch that quantizes routed-expert inputs to MXFP8, packs UE8M0 scales into DeepEP's `sf_pack` payload, and runs the routed experts on the received quantized activations (BF16 dispatch remains the default). Adds scale pack/unpack helpers and FP8 validation, plus a vectorized DeepEP top-k weight-gradient scatter.
- `nn/ddp/model.py`: reentrant checkpointing for DeepEP routed-expert blocks so the private expert graph and received leaf survive recompute.
- `nn/ddp/train_module`: prewarm DeepEP v2 runtimes alongside the EP no-sync symmetric-memory buffers.

**MXFP8 scale mode + fusions**
- Configurable MXFP8 scale mode (rceil/floor) resolved once from `OLMO_MXFP8_SCALE_MODE` at import time and threaded through the quantize helpers; optional TransformerEngine MXFP8 backend gate that fails loudly when requested-but-unavailable.
- Fused weighted MXFP8 quantize in the rowwise FP8 combine backward (replaces the eager `[N, K, H]` materialization).
- Vectorized rowwise route-map building (scatter/cumsum + index_select instead of a per-expert Python loop).
- Optimized FP8 weight-gradient accumulation.

## Testing

`make checks` passes. CPU-runnable tests for scale mode, DeepEP runtime/checkpoint, rowwise FP8 comm, route maps, and scaled-grouped-mm quantize all pass locally; the GPU/multi-rank paths are appropriately gated.

## Notes
- Profiling-only `*_bench.py` scripts from these changes were omitted.