### PR TITLE
Rowwise-FP8 / IBGDA expert-parallel transport with per-collective block-count controls

### DIFF
--- a/src/olmo_core/kernels/cuda/olmo_symm_mem_bindings.cpp
+++ b/src/olmo_core/kernels/cuda/olmo_symm_mem_bindings.cpp
@@ -29,7 +29,10 @@ bool olmo_symm_has_group(const std::string& group_name);
 
 void olmo_symm_world_barrier();
 
-void preflight_rowwise_collective_launches(int64_t nblocks);
+void preflight_rowwise_collective_launches(
+    int64_t get_nblocks,
+    int64_t put_nblocks,
+    int64_t weighted_put_nblocks);
 
 void rowwise_signal_peers_on_stream(
     torch::Tensor& signals,
@@ -226,7 +229,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       "preflight_rowwise_collective_launches",
       &preflight_rowwise_collective_launches,
       "Validate OLMo rowwise NVSHMEM collective-launch grids once before runtime",
-      py::arg("nblocks"));
+      py::arg("get_nblocks"),
+      py::arg("put_nblocks"),
+      py::arg("weighted_put_nblocks"));
   m.def(
       "rowwise_signal_peers_on_stream",
       &rowwise_signal_peers_on_stream,

--- a/src/olmo_core/kernels/cuda/olmo_symm_mem_runtime.cuh
+++ b/src/olmo_core/kernels/cuda/olmo_symm_mem_runtime.cuh
@@ -1,21 +1,35 @@
-void preflight_rowwise_collective_launches(int64_t nblocks) {
-  TORCH_CHECK(
-      nblocks > 0,
-      "strict NVSHMEM rowwise collective preflight requires explicit "
-      "rowwise_nblocks > 0 (0 means auto and cannot be validated before "
-      "runtime)");
-  TORCH_CHECK(
-      nblocks <= std::numeric_limits<int>::max(),
-      "rowwise_nblocks is too large: ",
-      nblocks);
-  int requested_blocks = static_cast<int>(nblocks);
+void preflight_rowwise_collective_launches(
+    int64_t get_nblocks,
+    int64_t put_nblocks,
+    int64_t weighted_put_nblocks) {
+  auto validate_nblocks = [](const char* setting_name, int64_t setting_value) {
+    TORCH_CHECK(
+        setting_value > 0,
+        "strict NVSHMEM rowwise collective preflight requires explicit ep.",
+        setting_name,
+        " > 0 (0 means auto and cannot be validated before runtime)");
+    TORCH_CHECK(
+        setting_value <= std::numeric_limits<int>::max(),
+        setting_name,
+        " is too large: ",
+        setting_value);
+  };
+  validate_nblocks("rowwise_get_nblocks", get_nblocks);
+  validate_nblocks("rowwise_put_nblocks", put_nblocks);
+  validate_nblocks("rowwise_weighted_put_nblocks", weighted_put_nblocks);
 
-  auto preflight = [requested_blocks](
-                       const char* kernel_name,
-                       const void* kernel,
-                       dim3 block_dims,
-                       void** args,
-                       size_t shared_mem) {
+  const int requested_get_blocks = static_cast<int>(get_nblocks);
+  const int requested_put_blocks = static_cast<int>(put_nblocks);
+  const int requested_weighted_put_blocks =
+      static_cast<int>(weighted_put_nblocks);
+
+  auto preflight = [](const char* kernel_name,
+                      const char* setting_name,
+                      int requested_blocks,
+                      const void* kernel,
+                      dim3 block_dims,
+                      void** args,
+                      size_t shared_mem) {
     maybe_init_nvshmem_cumodule(kernel);
     int max_grid =
         query_collective_launch_max_grid(kernel_name, kernel, block_dims, args, shared_mem);
@@ -23,7 +37,9 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         requested_blocks <= max_grid,
         "NVSHMEM rowwise collective launch preflight failed for ",
         kernel_name,
-        ": requested rowwise_nblocks=",
+        ": requested ",
+        setting_name,
+        "=",
         requested_blocks,
         " exceeds max_grid=",
         max_grid,
@@ -33,9 +49,9 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         block_dims.y,
         ",",
         block_dims.z,
-        "). Lower ep.rowwise_nblocks / ROWWISE_A2A_NBLOCKS "
-        "(for the OLMoE3 testrun script, set "
-        "OLMOE3_TESTRUN_ROWWISE_NBLOCKS).");
+        "). Lower ep.",
+        setting_name,
+        ".");
   };
 
   const void* const_data_ptr = nullptr;
@@ -44,18 +60,26 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
   int64_t* i64_ptr = nullptr;
   const int* rank_to_pe_dev = nullptr;
   const float* probs_ptr = nullptr;
+  const float* float_input_ptr = nullptr;
   const at::Half* half_input_ptr = nullptr;
   at::Half* half_out_ptr = nullptr;
   const at::BFloat16* bf16_input_ptr = nullptr;
   at::BFloat16* bf16_out_ptr = nullptr;
+  uint8_t* q_out_ptr = nullptr;
+  uint8_t* scales_out_ptr = nullptr;
   nvshmem_team_t team = NVSHMEM_TEAM_WORLD;
   size_t row_bytes = 0;
+  size_t q_row_bytes = 0;
+  size_t scales_row_bytes = 0;
   int64_t num_input_rows = 0;
   int64_t num_out_rows = 0;
   int64_t top_k = 0;
   int64_t dim = 0;
+  int64_t scale_dim = 0;
   int64_t input_row_stride = 0;
   int64_t out_row_stride = 0;
+  int64_t out_q_row_stride = 0;
+  int64_t out_scales_row_stride = 0;
   int64_t out_capacity_rows = 0;
   int64_t wave_idx = 0;
   int64_t num_waves = 0;
@@ -80,7 +104,35 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "dispatchRowsPut",
+        "rowwise_put_nblocks",
+        requested_put_blocks,
         (const void*)dispatchRowsPut,
+        dim3(ROWWISE_THREADS_PER_BLOCK),
+        args,
+        0);
+  }
+
+  {
+    void* args[] = {
+        &const_data_ptr,
+        &const_data_ptr,
+        &data_ptr,
+        &data_ptr,
+        &const_i64_ptr,
+        &const_i64_ptr,
+        &q_row_bytes,
+        &scales_row_bytes,
+        &num_input_rows,
+        &top_k,
+        &out_capacity_rows,
+        &team,
+        &rank_to_pe_dev,
+        &group_size};
+    preflight(
+        "dispatchRowsPutPair",
+        "rowwise_put_nblocks",
+        requested_put_blocks,
+        (const void*)dispatchRowsPutPair,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
         0);
@@ -104,7 +156,96 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "dispatchRowsPutWeighted<Half>",
+        "rowwise_weighted_put_nblocks",
+        requested_weighted_put_blocks,
         (const void*)dispatchRowsPutWeighted<at::Half>,
+        dim3(ROWWISE_THREADS_PER_BLOCK),
+        args,
+        0);
+  }
+
+  {
+    void* args[] = {
+        &float_input_ptr,
+        &q_out_ptr,
+        &scales_out_ptr,
+        &const_i64_ptr,
+        &const_i64_ptr,
+        &probs_ptr,
+        &num_input_rows,
+        &top_k,
+        &dim,
+        &scale_dim,
+        &input_row_stride,
+        &out_q_row_stride,
+        &out_scales_row_stride,
+        &out_capacity_rows,
+        &team,
+        &rank_to_pe_dev,
+        &group_size};
+    preflight(
+        "dispatchRowsPutScaledWeighted<Float>",
+        "rowwise_weighted_put_nblocks",
+        requested_weighted_put_blocks,
+        (const void*)dispatchRowsPutScaledWeighted<float>,
+        dim3(ROWWISE_THREADS_PER_BLOCK),
+        args,
+        0);
+  }
+
+  {
+    void* args[] = {
+        &half_input_ptr,
+        &q_out_ptr,
+        &scales_out_ptr,
+        &const_i64_ptr,
+        &const_i64_ptr,
+        &probs_ptr,
+        &num_input_rows,
+        &top_k,
+        &dim,
+        &scale_dim,
+        &input_row_stride,
+        &out_q_row_stride,
+        &out_scales_row_stride,
+        &out_capacity_rows,
+        &team,
+        &rank_to_pe_dev,
+        &group_size};
+    preflight(
+        "dispatchRowsPutScaledWeighted<Half>",
+        "rowwise_weighted_put_nblocks",
+        requested_weighted_put_blocks,
+        (const void*)dispatchRowsPutScaledWeighted<at::Half>,
+        dim3(ROWWISE_THREADS_PER_BLOCK),
+        args,
+        0);
+  }
+
+  {
+    void* args[] = {
+        &bf16_input_ptr,
+        &q_out_ptr,
+        &scales_out_ptr,
+        &const_i64_ptr,
+        &const_i64_ptr,
+        &probs_ptr,
+        &num_input_rows,
+        &top_k,
+        &dim,
+        &scale_dim,
+        &input_row_stride,
+        &out_q_row_stride,
+        &out_scales_row_stride,
+        &out_capacity_rows,
+        &team,
+        &rank_to_pe_dev,
+        &group_size};
+    preflight(
+        "dispatchRowsPutScaledWeighted<BFloat16>",
+        "rowwise_weighted_put_nblocks",
+        requested_weighted_put_blocks,
+        (const void*)dispatchRowsPutScaledWeighted<at::BFloat16>,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
         0);
@@ -128,6 +269,8 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "dispatchRowsPutWeighted<BFloat16>",
+        "rowwise_weighted_put_nblocks",
+        requested_weighted_put_blocks,
         (const void*)dispatchRowsPutWeighted<at::BFloat16>,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
@@ -149,6 +292,8 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "dispatchRowsPutCompact",
+        "rowwise_put_nblocks",
+        requested_put_blocks,
         (const void*)dispatchRowsPutCompact,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
@@ -174,6 +319,8 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "dispatchRowsPutCompactWeighted<Half>",
+        "rowwise_weighted_put_nblocks",
+        requested_weighted_put_blocks,
         (const void*)dispatchRowsPutCompactWeighted<at::Half>,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
@@ -199,6 +346,8 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "dispatchRowsPutCompactWeighted<BFloat16>",
+        "rowwise_weighted_put_nblocks",
+        requested_weighted_put_blocks,
         (const void*)dispatchRowsPutCompactWeighted<at::BFloat16>,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
@@ -218,6 +367,8 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "inverseRouteMetaPutCompact",
+        "rowwise_put_nblocks",
+        requested_put_blocks,
         (const void*)inverseRouteMetaPutCompact,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
@@ -237,6 +388,8 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "inverseRouteMetaPutCompactScalar",
+        "rowwise_put_nblocks",
+        requested_put_blocks,
         (const void*)inverseRouteMetaPutCompactScalar,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
@@ -258,6 +411,8 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "gatherRowsGet<true>",
+        "rowwise_get_nblocks",
+        requested_get_blocks,
         (const void*)gatherRowsGet<true>,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
@@ -281,6 +436,8 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "combineRowsPutRange",
+        "rowwise_put_nblocks",
+        requested_put_blocks,
         (const void*)combineRowsPutRange,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
@@ -302,7 +459,35 @@ void preflight_rowwise_collective_launches(int64_t nblocks) {
         &group_size};
     preflight(
         "gatherRowsGet<false>",
+        "rowwise_get_nblocks",
+        requested_get_blocks,
         (const void*)gatherRowsGet<false>,
+        dim3(ROWWISE_THREADS_PER_BLOCK),
+        args,
+        0);
+  }
+
+  {
+    void* args[] = {
+        &const_data_ptr,
+        &const_data_ptr,
+        &data_ptr,
+        &data_ptr,
+        &const_i64_ptr,
+        &const_i64_ptr,
+        &q_row_bytes,
+        &scales_row_bytes,
+        &num_out_rows,
+        &top_k,
+        &expert_capacity_rows,
+        &team,
+        &rank_to_pe_dev,
+        &group_size};
+    preflight(
+        "gatherRowsGetPair<false>",
+        "rowwise_get_nblocks",
+        requested_get_blocks,
+        (const void*)gatherRowsGetPair<false>,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
         0);

--- a/src/olmo_core/kernels/cuda/olmo_symm_mem_runtime.cuh
+++ b/src/olmo_core/kernels/cuda/olmo_symm_mem_runtime.cuh
@@ -60,26 +60,18 @@ void preflight_rowwise_collective_launches(
   int64_t* i64_ptr = nullptr;
   const int* rank_to_pe_dev = nullptr;
   const float* probs_ptr = nullptr;
-  const float* float_input_ptr = nullptr;
   const at::Half* half_input_ptr = nullptr;
   at::Half* half_out_ptr = nullptr;
   const at::BFloat16* bf16_input_ptr = nullptr;
   at::BFloat16* bf16_out_ptr = nullptr;
-  uint8_t* q_out_ptr = nullptr;
-  uint8_t* scales_out_ptr = nullptr;
   nvshmem_team_t team = NVSHMEM_TEAM_WORLD;
   size_t row_bytes = 0;
-  size_t q_row_bytes = 0;
-  size_t scales_row_bytes = 0;
   int64_t num_input_rows = 0;
   int64_t num_out_rows = 0;
   int64_t top_k = 0;
   int64_t dim = 0;
-  int64_t scale_dim = 0;
   int64_t input_row_stride = 0;
   int64_t out_row_stride = 0;
-  int64_t out_q_row_stride = 0;
-  int64_t out_scales_row_stride = 0;
   int64_t out_capacity_rows = 0;
   int64_t wave_idx = 0;
   int64_t num_waves = 0;
@@ -114,32 +106,6 @@ void preflight_rowwise_collective_launches(
 
   {
     void* args[] = {
-        &const_data_ptr,
-        &const_data_ptr,
-        &data_ptr,
-        &data_ptr,
-        &const_i64_ptr,
-        &const_i64_ptr,
-        &q_row_bytes,
-        &scales_row_bytes,
-        &num_input_rows,
-        &top_k,
-        &out_capacity_rows,
-        &team,
-        &rank_to_pe_dev,
-        &group_size};
-    preflight(
-        "dispatchRowsPutPair",
-        "rowwise_put_nblocks",
-        requested_put_blocks,
-        (const void*)dispatchRowsPutPair,
-        dim3(ROWWISE_THREADS_PER_BLOCK),
-        args,
-        0);
-  }
-
-  {
-    void* args[] = {
         &half_input_ptr,
         &half_out_ptr,
         &const_i64_ptr,
@@ -159,93 +125,6 @@ void preflight_rowwise_collective_launches(
         "rowwise_weighted_put_nblocks",
         requested_weighted_put_blocks,
         (const void*)dispatchRowsPutWeighted<at::Half>,
-        dim3(ROWWISE_THREADS_PER_BLOCK),
-        args,
-        0);
-  }
-
-  {
-    void* args[] = {
-        &float_input_ptr,
-        &q_out_ptr,
-        &scales_out_ptr,
-        &const_i64_ptr,
-        &const_i64_ptr,
-        &probs_ptr,
-        &num_input_rows,
-        &top_k,
-        &dim,
-        &scale_dim,
-        &input_row_stride,
-        &out_q_row_stride,
-        &out_scales_row_stride,
-        &out_capacity_rows,
-        &team,
-        &rank_to_pe_dev,
-        &group_size};
-    preflight(
-        "dispatchRowsPutScaledWeighted<Float>",
-        "rowwise_weighted_put_nblocks",
-        requested_weighted_put_blocks,
-        (const void*)dispatchRowsPutScaledWeighted<float>,
-        dim3(ROWWISE_THREADS_PER_BLOCK),
-        args,
-        0);
-  }
-
-  {
-    void* args[] = {
-        &half_input_ptr,
-        &q_out_ptr,
-        &scales_out_ptr,
-        &const_i64_ptr,
-        &const_i64_ptr,
-        &probs_ptr,
-        &num_input_rows,
-        &top_k,
-        &dim,
-        &scale_dim,
-        &input_row_stride,
-        &out_q_row_stride,
-        &out_scales_row_stride,
-        &out_capacity_rows,
-        &team,
-        &rank_to_pe_dev,
-        &group_size};
-    preflight(
-        "dispatchRowsPutScaledWeighted<Half>",
-        "rowwise_weighted_put_nblocks",
-        requested_weighted_put_blocks,
-        (const void*)dispatchRowsPutScaledWeighted<at::Half>,
-        dim3(ROWWISE_THREADS_PER_BLOCK),
-        args,
-        0);
-  }
-
-  {
-    void* args[] = {
-        &bf16_input_ptr,
-        &q_out_ptr,
-        &scales_out_ptr,
-        &const_i64_ptr,
-        &const_i64_ptr,
-        &probs_ptr,
-        &num_input_rows,
-        &top_k,
-        &dim,
-        &scale_dim,
-        &input_row_stride,
-        &out_q_row_stride,
-        &out_scales_row_stride,
-        &out_capacity_rows,
-        &team,
-        &rank_to_pe_dev,
-        &group_size};
-    preflight(
-        "dispatchRowsPutScaledWeighted<BFloat16>",
-        "rowwise_weighted_put_nblocks",
-        requested_weighted_put_blocks,
-        (const void*)dispatchRowsPutScaledWeighted<at::BFloat16>,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
         0);
@@ -462,32 +341,6 @@ void preflight_rowwise_collective_launches(
         "rowwise_get_nblocks",
         requested_get_blocks,
         (const void*)gatherRowsGet<false>,
-        dim3(ROWWISE_THREADS_PER_BLOCK),
-        args,
-        0);
-  }
-
-  {
-    void* args[] = {
-        &const_data_ptr,
-        &const_data_ptr,
-        &data_ptr,
-        &data_ptr,
-        &const_i64_ptr,
-        &const_i64_ptr,
-        &q_row_bytes,
-        &scales_row_bytes,
-        &num_out_rows,
-        &top_k,
-        &expert_capacity_rows,
-        &team,
-        &rank_to_pe_dev,
-        &group_size};
-    preflight(
-        "gatherRowsGetPair<false>",
-        "rowwise_get_nblocks",
-        requested_get_blocks,
-        (const void*)gatherRowsGetPair<false>,
         dim3(ROWWISE_THREADS_PER_BLOCK),
         args,
         0);

--- a/src/olmo_core/kernels/symm_mem_vdev2d.py
+++ b/src/olmo_core/kernels/symm_mem_vdev2d.py
@@ -13,7 +13,7 @@ from .mxfp8_utils import quantize_rows_to_mxfp8, reduce_gathered_rows_from_mxfp8
 _EXTENSION_MODULE_NAME = "olmo_core.kernels._symm_mem_vdev2d_ext_gpu"
 _CUDA_EXTENSION = None
 _CUDA_EXTENSION_ERROR: Optional[Exception] = None
-_PREFLIGHTED_ROWWISE_COLLECTIVE_LAUNCHES: set[tuple[int, int]] = set()
+_PREFLIGHTED_ROWWISE_COLLECTIVE_LAUNCHES: set[tuple[int, int, int, int]] = set()
 
 
 def _load_cuda_extension():
@@ -64,20 +64,36 @@ def nvshmem_world_barrier() -> None:
 
 
 @torch.compiler.disable
-def preflight_rowwise_collective_launches(nblocks: int) -> None:
+def preflight_rowwise_collective_launches(
+    get_nblocks: int,
+    put_nblocks: int,
+    weighted_put_nblocks: int,
+) -> None:
     """Validate rowwise NVSHMEM collective launch grids before compiled runtime."""
-    nblocks = int(nblocks)
-    if nblocks <= 0:
-        raise ValueError(
-            "strict NVSHMEM rowwise collective preflight requires rowwise_nblocks > 0 "
-            "(0 means auto and cannot be validated before runtime)"
-        )
+    get_nblocks = int(get_nblocks)
+    put_nblocks = int(put_nblocks)
+    weighted_put_nblocks = int(weighted_put_nblocks)
+    for setting_name, setting_value in (
+        ("rowwise_get_nblocks", get_nblocks),
+        ("rowwise_put_nblocks", put_nblocks),
+        ("rowwise_weighted_put_nblocks", weighted_put_nblocks),
+    ):
+        if setting_value <= 0:
+            raise ValueError(
+                "strict NVSHMEM rowwise collective preflight requires "
+                f"{setting_name} > 0 (0 means auto and cannot be validated "
+                "before runtime)"
+            )
     device_idx = torch.cuda.current_device()
-    key = (device_idx, nblocks)
+    key = (device_idx, get_nblocks, put_nblocks, weighted_put_nblocks)
     if key in _PREFLIGHTED_ROWWISE_COLLECTIVE_LAUNCHES:
         return
     ext = _load_cuda_extension()
-    ext.preflight_rowwise_collective_launches(nblocks)
+    ext.preflight_rowwise_collective_launches(
+        get_nblocks,
+        put_nblocks,
+        weighted_put_nblocks,
+    )
     _PREFLIGHTED_ROWWISE_COLLECTIVE_LAUNCHES.add(key)
 
 

--- a/src/olmo_core/kernels/symm_mem_vdev2d.py
+++ b/src/olmo_core/kernels/symm_mem_vdev2d.py
@@ -349,6 +349,8 @@ def rowwise_dispatch_put_scaled(
     pre_barrier: bool = False,
     post_barrier: bool = True,
     zero_unwritten: bool = False,
+    input_q: Optional[torch.Tensor] = None,
+    input_scales: Optional[torch.Tensor] = None,
 ) -> None:
     # The rowwise dispatch kernel only writes rows referenced by valid route
     # maps. Keep an opt-in safety init for diagnostics or callers that knowingly
@@ -357,7 +359,12 @@ def rowwise_dispatch_put_scaled(
         out_q.zero_()
         out_scales.fill_(1.0)
 
-    qdata, scales = quantize_rows_to_mxfp8(input_hp, block_size=block_size)
+    qdata, scales = quantize_rows_to_mxfp8(
+        input_hp,
+        block_size=block_size,
+        out=input_q,
+        scales_out=input_scales,
+    )
     rowwise_dispatch_put(
         qdata,
         out_q,

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -395,7 +395,8 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         self.shared_experts_router: Optional[MoERouterV2]
         self.rowwise_fp8 = normalize_rowwise_fp8_config(rowwise_fp8)
         if self.rowwise_fp8 is not None and self.rowwise_fp8.enabled:
-            self.rowwise_fp8.assert_runtime_supported()
+            # Config-only check here; runtime CUDA support is asserted at FP8 buffer build.
+            self.rowwise_fp8.validate()
         self._shared_rowwise_fp8_up_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
         self._shared_rowwise_fp8_down_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
         self._shared_rowwise_fp8_up_prequant_t: Optional[ScaledGroupedMMPrequantizedRHS] = None

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -394,7 +394,8 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         self.shared_experts: Optional[SharedExperts]
         self.shared_experts_router: Optional[MoERouterV2]
         self.rowwise_fp8 = normalize_rowwise_fp8_config(rowwise_fp8)
-        self._rowwise_fp8_checked = False
+        if self.rowwise_fp8 is not None and self.rowwise_fp8.enabled:
+            self.rowwise_fp8.assert_runtime_supported()
         self._shared_rowwise_fp8_up_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
         self._shared_rowwise_fp8_down_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
         self._shared_rowwise_fp8_up_prequant_t: Optional[ScaledGroupedMMPrequantizedRHS] = None
@@ -1154,10 +1155,6 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
             and rowwise_fp8_cfg.enabled
             and mlp_inp.device.type == "cuda"
         )
-        if use_rowwise_fp8 and not self._rowwise_fp8_checked:
-            assert rowwise_fp8_cfg is not None
-            rowwise_fp8_cfg.assert_runtime_supported()
-            self._rowwise_fp8_checked = True
 
         if use_rowwise_fp8:
             assert rowwise_fp8_cfg is not None

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -1041,7 +1041,9 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
                 resolve_ep_no_sync_rowwise_symm_options(self)
                 if self.ep.rowwise_transport == "nvshmem":
                     symm_mem_vdev2d_kernels.preflight_rowwise_collective_launches(
-                        self.ep.rowwise_nblocks
+                        self.ep.rowwise_get_nblocks,
+                        self.ep.rowwise_put_nblocks,
+                        self.ep.rowwise_weighted_put_nblocks,
                     )
             self._ep_no_sync_symm_cache.clear()
             self._ep_no_sync_static_buffer_cache.clear()

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -32,10 +32,12 @@ from ..lm_head import LMOutputWithLoss
 from ..moe.v2.checkpointing import checkpoint_recompute_context_fn
 from ..moe.v2.ep_config import ExpertParallelPath
 from ..moe.v2.ep_no_sync_buffers import (
+    EpNoSyncSymmTensorInfo,
     _NoSyncSymmSharedPool,
     compute_ep_no_sync_rank_capacity,
     get_ep_no_sync_buffers,
     get_ep_no_sync_rowwise_fp8_buffers,
+    iter_ep_no_sync_symm_tensor_infos,
     prewarm_ep_no_sync_rowwise_lifetime_leases,
     use_ep_no_sync_rowwise_symm_combine_gather,
     use_ep_no_sync_rowwise_symm_combine_out,
@@ -270,6 +272,10 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
 
     def count_ep_no_sync_blocks(self) -> int:
         return sum(1 for _ in self.ep_no_sync_blocks())
+
+    def iter_ep_no_sync_symm_tensor_infos(self) -> Iterator[EpNoSyncSymmTensorInfo]:
+        for block in self.ep_no_sync_blocks():
+            yield from iter_ep_no_sync_symm_tensor_infos(block)
 
     def count_non_rowwise_ep_no_sync_blocks(self) -> int:
         return sum(1 for block in self.ep_no_sync_blocks() if not block.ep.uses_rowwise_buffers)
@@ -515,7 +521,7 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                 )
                 if use_rowwise_fp8:
                     assert rowwise_fp8_cfg is not None
-                    rowwise_fp8_cfg.assert_runtime_supported()
+                    # Runtime support is asserted once inside get_ep_no_sync_rowwise_fp8_buffers.
                     get_ep_no_sync_rowwise_fp8_buffers(
                         block,
                         dispatch_in_cap=prewarm_local_microbatch_size,

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -421,6 +421,12 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                 use_symm_combine_gather = (
                     not use_rowwise_fp8
                 ) and use_ep_no_sync_rowwise_symm_combine_gather(block)
+                use_fp8_symm_dispatch_in = (
+                    use_rowwise_fp8 and use_ep_no_sync_rowwise_symm_dispatch_in(block)
+                )
+                use_fp8_symm_combine_gather = (
+                    use_rowwise_fp8 and use_ep_no_sync_rowwise_symm_combine_gather(block)
+                )
                 block_is_checkpointed = (
                     self.recompute_all_blocks_by_chunk
                     or self.recompute_each_block
@@ -464,7 +470,9 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                     use_symm_combine_gather = False
                 lease_dispatch_out = runtime_uses_lifetime_leases
                 lease_combine_out = use_symm_combine_out and runtime_uses_lifetime_leases
-                lease_combine_gather = use_symm_combine_gather and runtime_uses_lifetime_leases
+                lease_combine_gather = (
+                    use_symm_combine_gather or use_fp8_symm_combine_gather
+                ) and runtime_uses_lifetime_leases
                 slot_indices = range(block.ep.shared_slots) if self.tbo else (None,)
                 for slot_idx in slot_indices:
                     get_ep_no_sync_buffers(
@@ -508,12 +516,18 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
                     rowwise_fp8_cfg.assert_runtime_supported()
                     get_ep_no_sync_rowwise_fp8_buffers(
                         block,
+                        dispatch_in_cap=prewarm_local_microbatch_size,
                         dispatch_out_cap=rank_capacity,
                         combine_in_cap=rank_capacity,
+                        combine_gather_cap=prewarm_local_microbatch_size,
+                        combine_gather_top_k=top_k,
                         d_model=d_model,
                         block_size=rowwise_fp8_cfg.block_size,
                         device=device,
+                        lease_combine_gather=False,
+                        need_dispatch_in=use_fp8_symm_dispatch_in,
                         need_dispatch_out=not lease_dispatch_out,
+                        need_combine_gather=not lease_combine_gather,
                     )
             else:
                 get_ep_no_sync_buffers(

--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -404,7 +404,9 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
             if block.ep.uses_rowwise_buffers:
                 if block.ep.rowwise_transport == "nvshmem" and device.type == "cuda":
                     symm_mem_vdev2d_kernels.preflight_rowwise_collective_launches(
-                        block.ep.rowwise_nblocks
+                        block.ep.rowwise_get_nblocks,
+                        block.ep.rowwise_put_nblocks,
+                        block.ep.rowwise_weighted_put_nblocks,
                     )
                 rowwise_fp8_cfg = block.rowwise_fp8
                 use_rowwise_fp8 = (

--- a/src/olmo_core/nn/moe/v2/comm.py
+++ b/src/olmo_core/nn/moe/v2/comm.py
@@ -103,6 +103,26 @@ def _rowwise_debug_sync(label: str, device: torch.device) -> None:
     torch.cuda.synchronize(device)
 
 
+def _rowwise_debug_op_enter(
+    label: str,
+    group_name: str,
+    device: torch.device,
+    **tensors: Optional[torch.Tensor],
+) -> None:
+    _rowwise_debug_print(label, "enter", group_name, **tensors)
+    _rowwise_debug_sync(f"{label}:enter", device)
+
+
+def _rowwise_debug_op_exit(
+    label: str,
+    group_name: str,
+    device: torch.device,
+    **tensors: Optional[torch.Tensor],
+) -> None:
+    _rowwise_debug_sync(f"{label}:exit", device)
+    _rowwise_debug_print(label, "exit", group_name, **tensors)
+
+
 def _logical_rank2_tensor(
     shape: Tuple[int, ...], *, dtype: torch.dtype, device: torch.device
 ) -> torch.Tensor:
@@ -138,14 +158,43 @@ def _rowwise_dispatch_put_weighted_mxfp8(
     *,
     block_size: int,
     nblocks: int,
+    input_q: Optional[torch.Tensor] = None,
+    input_scales: Optional[torch.Tensor] = None,
 ) -> None:
+    _rowwise_debug_op_enter(
+        "rowwise_fp8_weighted_dispatch_quantize",
+        group_name,
+        input_hp.device,
+        input=input_hp,
+        probs=probs,
+        input_q=input_q,
+        input_scales=input_scales,
+    )
     qdata, scales = weighted_quantize_rows_to_mxfp8(
         input_hp,
         probs,
         block_size=block_size,
+        out=input_q,
+        scales_out=input_scales,
+    )
+    _rowwise_debug_op_exit(
+        "rowwise_fp8_weighted_dispatch_quantize",
+        group_name,
+        input_hp.device,
+        qdata=qdata,
+        scales=scales,
     )
     flat_ranks = dst_ranks.reshape(-1, 1).contiguous()
     flat_rows = dst_rows.reshape(-1, 1).contiguous()
+    _rowwise_debug_op_enter(
+        "rowwise_fp8_weighted_dispatch_put_q",
+        group_name,
+        out_q.device,
+        qdata=qdata,
+        out_q=out_q,
+        dst_ranks=flat_ranks,
+        dst_rows=flat_rows,
+    )
     symm_mem_vdev2d_kernels.rowwise_dispatch_put(
         qdata,
         out_q,
@@ -155,6 +204,21 @@ def _rowwise_dispatch_put_weighted_mxfp8(
         nblocks=nblocks,
         post_barrier=False,
     )
+    _rowwise_debug_op_exit(
+        "rowwise_fp8_weighted_dispatch_put_q",
+        group_name,
+        out_q.device,
+        out_q=out_q,
+    )
+    _rowwise_debug_op_enter(
+        "rowwise_fp8_weighted_dispatch_put_scales",
+        group_name,
+        out_scales.device,
+        scales=scales,
+        out_scales=out_scales,
+        dst_ranks=flat_ranks,
+        dst_rows=flat_rows,
+    )
     symm_mem_vdev2d_kernels.rowwise_dispatch_put(
         scales,
         out_scales,
@@ -163,6 +227,12 @@ def _rowwise_dispatch_put_weighted_mxfp8(
         group_name,
         nblocks=nblocks,
         pre_barrier=False,
+    )
+    _rowwise_debug_op_exit(
+        "rowwise_fp8_weighted_dispatch_put_scales",
+        group_name,
+        out_scales.device,
+        out_scales=out_scales,
     )
 
 
@@ -295,6 +365,11 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
         down_prequant,
         down_prequant_t,
         dispatch_out_lease,
+        combine_gather_lease,
+        dispatch_in_q: Optional[torch.Tensor],
+        dispatch_in_scales: Optional[torch.Tensor],
+        combine_gather_q: Optional[torch.Tensor],
+        combine_gather_scales: Optional[torch.Tensor],
         block_size: int,
         use_fast_accum: bool,
         recompute_swiglu: bool,
@@ -353,6 +428,18 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
         # MXFP8 rowwise comm format. The high-precision logical tensor below is
         # only an autograd/API placeholder; grouped mm reads the q/scales via
         # the prequantized_lhs object.
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_forward_dispatch_put_scaled",
+            group_name,
+            source_input_contig.device,
+            input=source_input_contig,
+            dispatch_in_q=dispatch_in_q,
+            dispatch_in_scales=dispatch_in_scales,
+            out_q=dispatch_out_q,
+            out_scales=dispatch_out_scales,
+            dst_ranks=dst_ranks_i64,
+            dst_rows=dst_rows_i64,
+        )
         symm_mem_vdev2d_kernels.rowwise_dispatch_put_scaled(
             source_input_contig,
             dispatch_out_q,
@@ -362,6 +449,15 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             group_name,
             block_size=int(block_size),
             nblocks=int(nblocks),
+            input_q=dispatch_in_q,
+            input_scales=dispatch_in_scales,
+        )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_forward_dispatch_put_scaled",
+            group_name,
+            dispatch_out_q.device,
+            out_q=dispatch_out_q,
+            out_scales=dispatch_out_scales,
         )
 
         dispatch_shape = tuple(dispatch_out_q.shape)
@@ -375,12 +471,25 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             dispatch_out_scales,
             shape=dispatch_shape,
         )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_forward_up_gate_gemm",
+            group_name,
+            source_input.device,
+            dispatch_out_q=dispatch_out_q,
+            dispatch_out_scales=dispatch_out_scales,
+        )
         up_gate = _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
             dispatch_logical,
             up_gate_prequant,
             offs_i32,
             use_fast_accum=bool(use_fast_accum),
             prequantized_lhs=dispatch_prequantized_lhs,
+        )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_forward_up_gate_gemm",
+            group_name,
+            source_input.device,
+            up_gate=up_gate,
         )
 
         if bool(recompute_swiglu):
@@ -431,6 +540,14 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             h_scales,
             shape=h_shape,
         )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_forward_down_gemm",
+            group_name,
+            h.device,
+            h=h,
+            h_q=h_q,
+            h_scales=h_scales,
+        )
         expert_out = _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
             h,
             down_prequant,
@@ -438,13 +555,34 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             use_fast_accum=bool(use_fast_accum),
             prequantized_lhs=h_prequantized_lhs,
         )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_forward_down_gemm",
+            group_name,
+            expert_out.device,
+            expert_out=expert_out,
+        )
 
         expert_out_contig = expert_out if expert_out.is_contiguous() else expert_out.contiguous()
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_forward_expert_quantize",
+            group_name,
+            expert_out_contig.device,
+            expert_out=expert_out_contig,
+            combine_in_q=combine_in_q,
+            combine_in_scales=combine_in_scales,
+        )
         quantize_rows_to_mxfp8(
             expert_out_contig,
             block_size=int(block_size),
             out=combine_in_q,
             scales_out=combine_in_scales,
+        )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_forward_expert_quantize",
+            group_name,
+            expert_out_contig.device,
+            combine_in_q=combine_in_q,
+            combine_in_scales=combine_in_scales,
         )
 
         combine_out = torch.empty(
@@ -453,7 +591,53 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             dtype=expert_out.dtype,
         )
         need_grad_probs = ctx.needs_input_grad[4]
-        if need_grad_probs:
+        if combine_gather_q is not None:
+            expected_gather_q_shape = (
+                dst_ranks_i64.shape[0],
+                dst_ranks_i64.shape[1],
+                combine_in_q.shape[1],
+            )
+            if tuple(combine_gather_q.shape) != expected_gather_q_shape:
+                raise RuntimeError(
+                    "combine_gather_q shape mismatch: "
+                    f"expected {expected_gather_q_shape}, got {tuple(combine_gather_q.shape)}"
+                )
+            if (
+                combine_gather_q.dtype != combine_in_q.dtype
+                or combine_gather_q.device != combine_in_q.device
+            ):
+                raise RuntimeError("combine_gather_q dtype/device must match combine_in_q")
+            if not combine_gather_q.is_contiguous():
+                raise RuntimeError("combine_gather_q must be contiguous")
+        if combine_gather_scales is not None:
+            expected_gather_scales_shape = (
+                dst_ranks_i64.shape[0],
+                dst_ranks_i64.shape[1],
+                combine_in_scales.shape[1],
+            )
+            if tuple(combine_gather_scales.shape) != expected_gather_scales_shape:
+                raise RuntimeError(
+                    "combine_gather_scales shape mismatch: "
+                    f"expected {expected_gather_scales_shape}, got {tuple(combine_gather_scales.shape)}"
+                )
+            if (
+                combine_gather_scales.dtype != combine_in_scales.dtype
+                or combine_gather_scales.device != combine_in_scales.device
+            ):
+                raise RuntimeError(
+                    "combine_gather_scales dtype/device must match combine_in_scales"
+                )
+            if not combine_gather_scales.is_contiguous():
+                raise RuntimeError("combine_gather_scales must be contiguous")
+        if (combine_gather_q is None) != (combine_gather_scales is None):
+            raise RuntimeError(
+                "combine_gather_q and combine_gather_scales must be provided together"
+            )
+
+        if need_grad_probs and combine_gather_q is not None:
+            gathered_q_saved = combine_gather_q
+            gathered_scales_saved = combine_gather_scales
+        elif need_grad_probs:
             gathered_q_saved = torch.empty(
                 (dst_ranks_i64.shape[0], dst_ranks_i64.shape[1], combine_in_q.shape[1]),
                 device=combine_in_q.device,
@@ -475,10 +659,32 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
                 device=combine_in_scales.device,
                 dtype=combine_in_scales.dtype,
             )
+        gathered_q_for_get = (
+            combine_gather_q
+            if combine_gather_q is not None
+            else (gathered_q_saved if need_grad_probs else None)
+        )
+        gathered_scales_for_get = (
+            combine_gather_scales
+            if combine_gather_scales is not None
+            else (gathered_scales_saved if need_grad_probs else None)
+        )
 
         # Combine ends the fused node back in bf16. If probs need grad, the
         # kernel also gathers the routed FP8 rows used to form grad_probs in
         # backward; otherwise we avoid saving that large [N, top_k, D] payload.
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_forward_combine_get_scaled",
+            group_name,
+            combine_in_q.device,
+            combine_in_q=combine_in_q,
+            combine_in_scales=combine_in_scales,
+            combine_out=combine_out,
+            dst_ranks=dst_ranks_i64,
+            dst_rows=dst_rows_i64,
+            gathered_q_out=gathered_q_for_get,
+            gathered_scales_out=gathered_scales_for_get,
+        )
         symm_mem_vdev2d_kernels.rowwise_combine_get_scaled(
             combine_in_q,
             combine_in_scales,
@@ -489,8 +695,16 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             probs=probs_f32,
             block_size=int(block_size),
             nblocks=int(nblocks),
-            gathered_q_out=(gathered_q_saved if need_grad_probs else None),
-            gathered_scales_out=(gathered_scales_saved if need_grad_probs else None),
+            gathered_q_out=gathered_q_for_get,
+            gathered_scales_out=gathered_scales_for_get,
+        )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_forward_combine_get_scaled",
+            group_name,
+            combine_in_q.device,
+            combine_out=combine_out,
+            gathered_q_out=gathered_q_for_get,
+            gathered_scales_out=gathered_scales_for_get,
         )
 
         ctx.group = group
@@ -508,6 +722,9 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
         ctx.up_gate_prequant_t = up_gate_prequant_t
         ctx.down_prequant_t = down_prequant_t
         ctx.dispatch_out_lease = dispatch_out_lease
+        ctx.combine_gather_lease = combine_gather_lease
+        ctx.combine_gather_q = combine_gather_q
+        ctx.combine_gather_scales = combine_gather_scales
         ctx.combine_in_q = combine_in_q
         ctx.combine_in_scales = combine_in_scales
         ctx.up_wgrad_sink = up_wgrad_sink
@@ -559,9 +776,23 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
         ) = ctx.saved_tensors
         grad_out_contig = grad_out if grad_out.is_contiguous() else grad_out.contiguous()
 
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward",
+            ctx.group_name,
+            grad_out_contig.device,
+            grad_out=grad_out_contig,
+        )
         grad_probs = None
         valid_mask = (dst_ranks >= 0) & (dst_rows >= 0) & (dst_rows < ctx.expert_out_shape[0])
         if ctx.needs_input_grad[4]:
+            _rowwise_debug_op_enter(
+                "rowwise_fp8_fused_backward_grad_probs",
+                ctx.group_name,
+                grad_out_contig.device,
+                gathered_q=gathered_q_saved,
+                gathered_scales=gathered_scales_saved,
+                grad_out=grad_out_contig,
+            )
             grad_probs = dot_gathered_rows_mxfp8_with_grad(
                 gathered_q_saved,
                 gathered_scales_saved,
@@ -570,9 +801,25 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
                 block_size=ctx.block_size,
                 out_dtype=ctx.probs_input_dtype,
             )
+            _rowwise_debug_op_exit(
+                "rowwise_fp8_fused_backward_grad_probs",
+                ctx.group_name,
+                grad_out_contig.device,
+                grad_probs=grad_probs,
+            )
 
         # Combine backward first weights each route by its router probability,
         # then dispatches the weighted token grads into combine_in_q/scales.
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_weighted_dispatch",
+            ctx.group_name,
+            grad_out_contig.device,
+            grad_out=grad_out_contig,
+            combine_in_q=ctx.combine_in_q,
+            combine_in_scales=ctx.combine_in_scales,
+            combine_gather_q=ctx.combine_gather_q,
+            combine_gather_scales=ctx.combine_gather_scales,
+        )
         _rowwise_dispatch_put_weighted_mxfp8(
             grad_out_contig,
             probs,
@@ -583,6 +830,23 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             ctx.group_name,
             block_size=ctx.block_size,
             nblocks=ctx.nblocks,
+            input_q=(
+                ctx.combine_gather_q.view(-1, ctx.combine_gather_q.shape[-1])
+                if ctx.combine_gather_q is not None
+                else None
+            ),
+            input_scales=(
+                ctx.combine_gather_scales.view(-1, ctx.combine_gather_scales.shape[-1])
+                if ctx.combine_gather_scales is not None
+                else None
+            ),
+        )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_weighted_dispatch",
+            ctx.group_name,
+            ctx.combine_in_q.device,
+            combine_in_q=ctx.combine_in_q,
+            combine_in_scales=ctx.combine_in_scales,
         )
 
         # Down dgrad consumes the just-written combine_in_q/scales. Do this
@@ -598,12 +862,25 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             ctx.combine_in_scales,
             shape=ctx.expert_out_shape,
         )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_down_dgrad_gemm",
+            ctx.group_name,
+            grad_out.device,
+            combine_in_q=ctx.combine_in_q,
+            combine_in_scales=ctx.combine_in_scales,
+        )
         grad_h = _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
             grad_expert_logical,
             ctx.down_prequant_t,
             offs,
             use_fast_accum=True,
             prequantized_lhs=grad_expert_prequantized_lhs,
+        )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_down_dgrad_gemm",
+            ctx.group_name,
+            grad_h.device,
+            grad_h=grad_h,
         )
 
         # Wgrad paths need bf16 operands. In recompute mode we restore the
@@ -619,19 +896,58 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             h = _rowwise_fp8_swiglu_forward(up_gate)
         else:
             up_gate = up_gate_saved
+            _rowwise_debug_op_enter(
+                "rowwise_fp8_fused_backward_dequant_h",
+                ctx.group_name,
+                h_q.device,
+                h_q=h_q,
+                h_scales=h_scales,
+            )
             h = dequantize_rows_from_mxfp8(
                 h_q,
                 h_scales,
                 block_size=ctx.block_size,
                 out_dtype=grad_h.dtype,
             )
+            _rowwise_debug_op_exit(
+                "rowwise_fp8_fused_backward_dequant_h",
+                ctx.group_name,
+                h.device,
+                h=h,
+            )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_dequant_grad_expert",
+            ctx.group_name,
+            ctx.combine_in_q.device,
+            combine_in_q=ctx.combine_in_q,
+            combine_in_scales=ctx.combine_in_scales,
+        )
         grad_expert_hp = dequantize_rows_from_mxfp8(
             ctx.combine_in_q,
             ctx.combine_in_scales,
             block_size=ctx.block_size,
             out_dtype=h.dtype,
         )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_dequant_grad_expert",
+            ctx.group_name,
+            grad_expert_hp.device,
+            grad_expert_hp=grad_expert_hp,
+        )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_down_wgrad",
+            ctx.group_name,
+            grad_expert_hp.device,
+            grad_expert_hp=grad_expert_hp,
+            h=h,
+        )
         grad_down_anchor = _rowwise_fp8_grouped_wgrad(grad_expert_hp, h, offs)
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_down_wgrad",
+            ctx.group_name,
+            grad_down_anchor.device,
+            grad_down_anchor=grad_down_anchor,
+        )
         _rowwise_fp8_accumulate_wgrad_sink(
             ctx.down_wgrad_sink,
             grad_down_anchor,
@@ -645,12 +961,38 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
         # SwiGLU gradient directly. The old split autograd path returned an
         # OlmoMXFP8Tensor here and dequantized it for wgrad; the fused node can
         # avoid that extra Q->DQ round trip.
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_swiglu_backward",
+            ctx.group_name,
+            up_gate.device,
+            up_gate=up_gate,
+            grad_h=grad_h,
+        )
         grad_up_gate = _rowwise_fp8_swiglu_backward(up_gate, grad_h)
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_swiglu_backward",
+            ctx.group_name,
+            grad_up_gate.device,
+            grad_up_gate=grad_up_gate,
+        )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_quantize_grad_up_gate",
+            ctx.group_name,
+            grad_up_gate.device,
+            grad_up_gate=grad_up_gate,
+        )
         grad_up_gate_q, grad_up_gate_scales_blocked = quantize_grouped_2d_to_mxfp8_blocked_fused(
             grad_up_gate,
             offs,
             block_size=ctx.block_size,
             zero_unwritten_tail=False,
+        )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_quantize_grad_up_gate",
+            ctx.group_name,
+            grad_up_gate.device,
+            grad_up_gate_q=grad_up_gate_q,
+            grad_up_gate_scales=grad_up_gate_scales_blocked,
         )
         grad_up_gate_logical = _logical_rank2_tensor(
             tuple(grad_up_gate.shape),
@@ -663,6 +1005,13 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             shape=tuple(grad_up_gate.shape),
             scales_are_blocked=True,
         )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_up_dgrad_gemm",
+            ctx.group_name,
+            grad_up_gate.device,
+            grad_up_gate_q=grad_up_gate_q,
+            grad_up_gate_scales=grad_up_gate_scales_blocked,
+        )
         grad_dispatch = _forward_scaled_grouped_mm_mxfp8_prequantized_rhs(
             grad_up_gate_logical,
             ctx.up_gate_prequant_t,
@@ -670,17 +1019,49 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             use_fast_accum=True,
             prequantized_lhs=grad_up_gate_prequantized_lhs,
         )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_up_dgrad_gemm",
+            ctx.group_name,
+            grad_dispatch.device,
+            grad_dispatch=grad_dispatch,
+        )
 
         # Read dispatch_out_q/scales for up/gate wgrad before overwriting them
         # with grad_dispatch below. This is the main buffer-lifetime invariant
         # that motivated fusing the region into one autograd node.
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_dequant_dispatch",
+            ctx.group_name,
+            dispatch_out_q.device,
+            dispatch_out_q=dispatch_out_q,
+            dispatch_out_scales=dispatch_out_scales,
+        )
         dispatch_hp = dequantize_rows_from_mxfp8(
             dispatch_out_q,
             dispatch_out_scales,
             block_size=ctx.block_size,
             out_dtype=grad_up_gate.dtype,
         )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_dequant_dispatch",
+            ctx.group_name,
+            dispatch_hp.device,
+            dispatch_hp=dispatch_hp,
+        )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_up_wgrad",
+            ctx.group_name,
+            grad_up_gate.device,
+            grad_up_gate=grad_up_gate,
+            dispatch_hp=dispatch_hp,
+        )
         grad_up_anchor = _rowwise_fp8_grouped_wgrad(grad_up_gate, dispatch_hp, offs)
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_up_wgrad",
+            ctx.group_name,
+            grad_up_anchor.device,
+            grad_up_anchor=grad_up_anchor,
+        )
         _rowwise_fp8_accumulate_wgrad_sink(
             ctx.up_wgrad_sink,
             grad_up_anchor,
@@ -696,16 +1077,43 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
         grad_dispatch_contig = (
             grad_dispatch if grad_dispatch.is_contiguous() else grad_dispatch.contiguous()
         )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_quantize_grad_dispatch",
+            ctx.group_name,
+            grad_dispatch_contig.device,
+            grad_dispatch=grad_dispatch_contig,
+            dispatch_out_q=dispatch_out_q,
+            dispatch_out_scales=dispatch_out_scales,
+        )
         quantize_rows_to_mxfp8(
             grad_dispatch_contig,
             block_size=ctx.block_size,
             out=dispatch_out_q,
             scales_out=dispatch_out_scales,
         )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_quantize_grad_dispatch",
+            ctx.group_name,
+            grad_dispatch_contig.device,
+            dispatch_out_q=dispatch_out_q,
+            dispatch_out_scales=dispatch_out_scales,
+        )
         grad_source = torch.empty(
             ctx.source_input_shape,
             device=grad_out.device,
             dtype=ctx.source_input_dtype,
+        )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_fused_backward_dispatch_combine_get_scaled",
+            ctx.group_name,
+            dispatch_out_q.device,
+            dispatch_out_q=dispatch_out_q,
+            dispatch_out_scales=dispatch_out_scales,
+            grad_source=grad_source,
+            dst_ranks=dst_ranks,
+            dst_rows=dst_rows,
+            gathered_q_out=ctx.combine_gather_q,
+            gathered_scales_out=ctx.combine_gather_scales,
         )
         symm_mem_vdev2d_kernels.rowwise_combine_get_scaled(
             dispatch_out_q,
@@ -716,41 +1124,67 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             ctx.group_name,
             block_size=ctx.block_size,
             nblocks=ctx.nblocks,
+            gathered_q_out=ctx.combine_gather_q,
+            gathered_scales_out=ctx.combine_gather_scales,
+        )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward_dispatch_combine_get_scaled",
+            ctx.group_name,
+            dispatch_out_q.device,
+            grad_source=grad_source,
+            gathered_q_out=ctx.combine_gather_q,
+            gathered_scales_out=ctx.combine_gather_scales,
         )
 
         if ctx.dispatch_out_lease is not None:
             ctx.dispatch_out_lease.release()
         ctx.dispatch_out_lease = None
+        if ctx.combine_gather_lease is not None:
+            ctx.combine_gather_lease.release()
+        ctx.combine_gather_lease = None
+        ctx.combine_gather_q = None
+        ctx.combine_gather_scales = None
         ctx.group = None
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_fused_backward",
+            ctx.group_name,
+            grad_source.device,
+            grad_source=grad_source,
+        )
         grads = (
             grad_source,
-            None,
-            None,
-            None,
+            None,  # dst_ranks
+            None,  # dst_rows
+            None,  # offs
             grad_probs,
-            None,
-            None,
-            None,
-            None,
+            None,  # dispatch_out_q
+            None,  # dispatch_out_scales
+            None,  # combine_in_q
+            None,  # combine_in_scales
             grad_up_anchor,
             grad_down_anchor,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
+            None,  # up_gate_prequant
+            None,  # up_gate_prequant_t
+            None,  # down_prequant
+            None,  # down_prequant_t
+            None,  # dispatch_out_lease
+            None,  # combine_gather_lease
+            None,  # dispatch_in_q
+            None,  # dispatch_in_scales
+            None,  # combine_gather_q
+            None,  # combine_gather_scales
+            None,  # block_size
+            None,  # use_fast_accum
+            None,  # recompute_swiglu
+            None,  # group_name
+            None,  # group
+            None,  # nblocks
+            None,  # up_wgrad_sink
+            None,  # up_wgrad_sink_transpose_last2
+            None,  # up_wgrad_sink_squeeze_first_dim
+            None,  # down_wgrad_sink
+            None,  # down_wgrad_sink_transpose_last2
+            None,  # down_wgrad_sink_squeeze_first_dim
         )
         return _check_input_grads(grads, ctx.needs_input_grad)
 
@@ -1269,6 +1703,11 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
         symm_out_q: torch.Tensor,
         symm_out_scales: torch.Tensor,
         symm_out_lease,
+        dispatch_in_q: Optional[torch.Tensor],
+        dispatch_in_scales: Optional[torch.Tensor],
+        combine_gather_q: Optional[torch.Tensor],
+        combine_gather_scales: Optional[torch.Tensor],
+        combine_gather_lease,
         block_size: int,
         group_name: str,
         group: dist.ProcessGroup,
@@ -1323,17 +1762,88 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
             dst_ranks_i64 = dst_ranks_i64.contiguous()
         if not dst_rows_i64.is_contiguous():
             dst_rows_i64 = dst_rows_i64.contiguous()
+        if (dispatch_in_q is None) != (dispatch_in_scales is None):
+            raise RuntimeError("dispatch_in_q and dispatch_in_scales must be provided together")
+        if dispatch_in_q is not None:
+            expected_dispatch_in_scales_shape = (
+                source_input.shape[0],
+                source_input.shape[1] // int(block_size),
+            )
+            if tuple(dispatch_in_q.shape) != tuple(source_input.shape):
+                raise RuntimeError(
+                    "dispatch_in_q shape mismatch: "
+                    f"expected {tuple(source_input.shape)}, got {tuple(dispatch_in_q.shape)}"
+                )
+            if tuple(dispatch_in_scales.shape) != expected_dispatch_in_scales_shape:  # type: ignore[union-attr]
+                raise RuntimeError(
+                    "dispatch_in_scales shape mismatch: "
+                    f"expected {expected_dispatch_in_scales_shape}, got {tuple(dispatch_in_scales.shape)}"  # type: ignore[union-attr]
+                )
+            if dispatch_in_q.dtype != torch.float8_e4m3fn:
+                raise RuntimeError(
+                    f"dispatch_in_q must be float8_e4m3fn, got {dispatch_in_q.dtype}"
+                )
+            if dispatch_in_scales.dtype != torch.float8_e8m0fnu:  # type: ignore[union-attr]
+                raise RuntimeError(
+                    f"dispatch_in_scales must be float8_e8m0fnu, got {dispatch_in_scales.dtype}"  # type: ignore[union-attr]
+                )
+            if (
+                dispatch_in_q.device != source_input.device
+                or dispatch_in_scales.device != source_input.device  # type: ignore[union-attr]
+            ):
+                raise RuntimeError("dispatch_in_q/scales device must match source_input")
+            if not dispatch_in_q.is_contiguous() or not dispatch_in_scales.is_contiguous():  # type: ignore[union-attr]
+                raise RuntimeError("dispatch_in_q/scales must be contiguous")
+        if (combine_gather_q is None) != (combine_gather_scales is None):
+            raise RuntimeError(
+                "combine_gather_q and combine_gather_scales must be provided together"
+            )
+        if combine_gather_q is not None:
+            expected_gather_q_shape = (
+                dst_ranks_i64.shape[0],
+                dst_ranks_i64.shape[1],
+                symm_out_q.shape[1],
+            )
+            expected_gather_scales_shape = (
+                dst_ranks_i64.shape[0],
+                dst_ranks_i64.shape[1],
+                symm_out_scales.shape[1],
+            )
+            if tuple(combine_gather_q.shape) != expected_gather_q_shape:
+                raise RuntimeError(
+                    "combine_gather_q shape mismatch: "
+                    f"expected {expected_gather_q_shape}, got {tuple(combine_gather_q.shape)}"
+                )
+            if tuple(combine_gather_scales.shape) != expected_gather_scales_shape:  # type: ignore[union-attr]
+                raise RuntimeError(
+                    "combine_gather_scales shape mismatch: "
+                    f"expected {expected_gather_scales_shape}, got {tuple(combine_gather_scales.shape)}"  # type: ignore[union-attr]
+                )
+            if (
+                combine_gather_q.dtype != symm_out_q.dtype
+                or combine_gather_q.device != symm_out_q.device
+            ):
+                raise RuntimeError("combine_gather_q dtype/device must match symm_out_q")
+            if (
+                combine_gather_scales.dtype != symm_out_scales.dtype  # type: ignore[union-attr]
+                or combine_gather_scales.device != symm_out_scales.device  # type: ignore[union-attr]
+            ):
+                raise RuntimeError("combine_gather_scales dtype/device must match symm_out_scales")
+            if not combine_gather_q.is_contiguous() or not combine_gather_scales.is_contiguous():  # type: ignore[union-attr]
+                raise RuntimeError("combine_gather_q/scales must be contiguous")
 
-        # _rowwise_debug_print(
-        #     "rowwise_fp8_dispatch_forward_put_scaled",
-        #     "enter",
-        #     group_name,
-        #     input=source_input_contig,
-        #     out_q=symm_out_q,
-        #     out_scales=symm_out_scales,
-        #     dst_ranks=dst_ranks_i64,
-        #     dst_rows=dst_rows_i64,
-        # )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_dispatch_forward_put_scaled",
+            group_name,
+            source_input_contig.device,
+            input=source_input_contig,
+            dispatch_in_q=dispatch_in_q,
+            dispatch_in_scales=dispatch_in_scales,
+            out_q=symm_out_q,
+            out_scales=symm_out_scales,
+            dst_ranks=dst_ranks_i64,
+            dst_rows=dst_rows_i64,
+        )
         symm_mem_vdev2d_kernels.rowwise_dispatch_put_scaled(
             source_input_contig,
             symm_out_q,
@@ -1343,16 +1853,16 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
             group_name,
             block_size=int(block_size),
             nblocks=nblocks,
+            input_q=dispatch_in_q,
+            input_scales=dispatch_in_scales,
         )
-        # _rowwise_debug_sync("rowwise_fp8_dispatch_forward_put_scaled", symm_out_q.device)
-        # _rowwise_debug_print(
-        #     "rowwise_fp8_dispatch_forward_put_scaled",
-        #     "exit",
-        #     group_name,
-        #     input=source_input_contig,
-        #     out_q=symm_out_q,
-        #     out_scales=symm_out_scales,
-        # )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_dispatch_forward_put_scaled",
+            group_name,
+            symm_out_q.device,
+            out_q=symm_out_q,
+            out_scales=symm_out_scales,
+        )
         # Keep dispatch payload fully FP8 through expert compute.
 
         ctx.group_name = group_name
@@ -1365,6 +1875,9 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
         ctx.symm_out_q = symm_out_q
         ctx.symm_out_scales = symm_out_scales
         ctx.symm_out_lease = symm_out_lease
+        ctx.combine_gather_q = combine_gather_q
+        ctx.combine_gather_scales = combine_gather_scales
+        ctx.combine_gather_lease = combine_gather_lease
         ctx.save_for_backward(dst_ranks_i64, dst_rows_i64)
         return _logical_rank2_tensor(
             ctx.logical_out_shape,
@@ -1393,16 +1906,18 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
             device=grad_out_hp.device,
             dtype=ctx.logical_out_dtype,
         )
-        # _rowwise_debug_print(
-        #     "rowwise_fp8_dispatch_backward_combine_get_scaled",
-        #     "enter",
-        #     ctx.group_name,
-        #     expert_out_q=ctx.symm_out_q,
-        #     expert_out_scales=ctx.symm_out_scales,
-        #     out=grad_input,
-        #     src_ranks=dst_ranks,
-        #     src_rows=dst_rows,
-        # )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_dispatch_backward_combine_get_scaled",
+            ctx.group_name,
+            ctx.symm_out_q.device,
+            expert_out_q=ctx.symm_out_q,
+            expert_out_scales=ctx.symm_out_scales,
+            out=grad_input,
+            src_ranks=dst_ranks,
+            src_rows=dst_rows,
+            gathered_q_out=ctx.combine_gather_q,
+            gathered_scales_out=ctx.combine_gather_scales,
+        )
         symm_mem_vdev2d_kernels.rowwise_combine_get_scaled(
             ctx.symm_out_q,
             ctx.symm_out_scales,
@@ -1412,22 +1927,45 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
             ctx.group_name,
             block_size=ctx.block_size,
             nblocks=ctx.nblocks,
+            gathered_q_out=ctx.combine_gather_q,
+            gathered_scales_out=ctx.combine_gather_scales,
         )
-        # _rowwise_debug_sync("rowwise_fp8_dispatch_backward_combine_get_scaled", ctx.symm_out_q.device)
-        # _rowwise_debug_print(
-        #     "rowwise_fp8_dispatch_backward_combine_get_scaled",
-        #     "exit",
-        #     ctx.group_name,
-        #     expert_out_q=ctx.symm_out_q,
-        #     expert_out_scales=ctx.symm_out_scales,
-        #     out=grad_input,
-        # )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_dispatch_backward_combine_get_scaled",
+            ctx.group_name,
+            ctx.symm_out_q.device,
+            out=grad_input,
+            gathered_q_out=ctx.combine_gather_q,
+            gathered_scales_out=ctx.combine_gather_scales,
+        )
         if ctx.symm_out_lease is not None:
             ctx.symm_out_lease.release()
         ctx.symm_out_lease = None
+        if ctx.combine_gather_lease is not None:
+            ctx.combine_gather_lease.release()
+        ctx.combine_gather_lease = None
+        ctx.combine_gather_q = None
+        ctx.combine_gather_scales = None
         ctx.group = None
         return _check_input_grads(
-            (grad_input, None, None, None, None, None, None, None, None, None), ctx.needs_input_grad
+            (
+                grad_input,
+                None,  # dst_ranks
+                None,  # dst_rows
+                None,  # symm_out_q
+                None,  # symm_out_scales
+                None,  # symm_out_lease
+                None,  # dispatch_in_q
+                None,  # dispatch_in_scales
+                None,  # combine_gather_q
+                None,  # combine_gather_scales
+                None,  # combine_gather_lease
+                None,  # block_size
+                None,  # group_name
+                None,  # group
+                None,  # nblocks
+            ),
+            ctx.needs_input_grad,
         )
 
 
@@ -1441,6 +1979,8 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
         probs: torch.Tensor,
         symm_expert_out_q: torch.Tensor,
         symm_expert_out_scales: torch.Tensor,
+        combine_gather_q: Optional[torch.Tensor],
+        combine_gather_scales: Optional[torch.Tensor],
         block_size: int,
         group_name: str,
         group: dist.ProcessGroup,
@@ -1526,7 +2066,49 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
         )
 
         need_grad_probs = ctx.needs_input_grad[3]
-        if need_grad_probs:
+        if (combine_gather_q is None) != (combine_gather_scales is None):
+            raise RuntimeError(
+                "combine_gather_q and combine_gather_scales must be provided together"
+            )
+        if combine_gather_q is not None:
+            expected_gather_q_shape = (
+                src_ranks_i64.shape[0],
+                src_ranks_i64.shape[1],
+                symm_expert_out_q.shape[1],
+            )
+            expected_gather_scales_shape = (
+                src_ranks_i64.shape[0],
+                src_ranks_i64.shape[1],
+                symm_expert_out_scales.shape[1],
+            )
+            if tuple(combine_gather_q.shape) != expected_gather_q_shape:
+                raise RuntimeError(
+                    "combine_gather_q shape mismatch: "
+                    f"expected {expected_gather_q_shape}, got {tuple(combine_gather_q.shape)}"
+                )
+            if tuple(combine_gather_scales.shape) != expected_gather_scales_shape:  # type: ignore[union-attr]
+                raise RuntimeError(
+                    "combine_gather_scales shape mismatch: "
+                    f"expected {expected_gather_scales_shape}, got {tuple(combine_gather_scales.shape)}"  # type: ignore[union-attr]
+                )
+            if (
+                combine_gather_q.dtype != symm_expert_out_q.dtype
+                or combine_gather_q.device != symm_expert_out_q.device
+            ):
+                raise RuntimeError("combine_gather_q dtype/device must match symm_expert_out_q")
+            if (
+                combine_gather_scales.dtype != symm_expert_out_scales.dtype  # type: ignore[union-attr]
+                or combine_gather_scales.device != symm_expert_out_scales.device  # type: ignore[union-attr]
+            ):
+                raise RuntimeError(
+                    "combine_gather_scales dtype/device must match symm_expert_out_scales"
+                )
+            if not combine_gather_q.is_contiguous() or not combine_gather_scales.is_contiguous():  # type: ignore[union-attr]
+                raise RuntimeError("combine_gather_q/scales must be contiguous")
+        if need_grad_probs and combine_gather_q is not None:
+            gathered_q_saved = combine_gather_q
+            gathered_scales_saved = combine_gather_scales
+        elif need_grad_probs:
             gathered_q_saved = torch.empty(
                 (src_ranks_i64.shape[0], src_ranks_i64.shape[1], symm_expert_out_q.shape[1]),
                 device=symm_expert_out_q.device,
@@ -1553,19 +2135,27 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
                 dtype=symm_expert_out_scales.dtype,
             )
 
-        # _rowwise_debug_print(
-        #     "rowwise_fp8_combine_forward_get_scaled",
-        #     "enter",
-        #     group_name,
-        #     expert_out_q=symm_expert_out_q,
-        #     expert_out_scales=symm_expert_out_scales,
-        #     out=combine_out,
-        #     src_ranks=src_ranks_i64,
-        #     src_rows=src_rows_i64,
-        #     probs=probs_f32,
-        #     gathered_q_out=(gathered_q_saved if need_grad_probs else None),
-        #     gathered_scales_out=(gathered_scales_saved if need_grad_probs else None),
-        # )
+        _rowwise_debug_op_enter(
+            "rowwise_fp8_combine_forward_get_scaled",
+            group_name,
+            symm_expert_out_q.device,
+            expert_out_q=symm_expert_out_q,
+            expert_out_scales=symm_expert_out_scales,
+            out=combine_out,
+            src_ranks=src_ranks_i64,
+            src_rows=src_rows_i64,
+            probs=probs_f32,
+            gathered_q_out=(
+                combine_gather_q
+                if combine_gather_q is not None
+                else (gathered_q_saved if need_grad_probs else None)
+            ),
+            gathered_scales_out=(
+                combine_gather_scales
+                if combine_gather_scales is not None
+                else (gathered_scales_saved if need_grad_probs else None)
+            ),
+        )
         symm_mem_vdev2d_kernels.rowwise_combine_get_scaled(
             symm_expert_out_q,
             symm_expert_out_scales,
@@ -1576,18 +2166,33 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
             probs=probs_f32,
             block_size=int(block_size),
             nblocks=nblocks,
-            gathered_q_out=(gathered_q_saved if need_grad_probs else None),
-            gathered_scales_out=(gathered_scales_saved if need_grad_probs else None),
+            gathered_q_out=(
+                combine_gather_q
+                if combine_gather_q is not None
+                else (gathered_q_saved if need_grad_probs else None)
+            ),
+            gathered_scales_out=(
+                combine_gather_scales
+                if combine_gather_scales is not None
+                else (gathered_scales_saved if need_grad_probs else None)
+            ),
         )
-        # _rowwise_debug_sync("rowwise_fp8_combine_forward_get_scaled", symm_expert_out_q.device)
-        # _rowwise_debug_print(
-        #     "rowwise_fp8_combine_forward_get_scaled",
-        #     "exit",
-        #     group_name,
-        #     expert_out_q=symm_expert_out_q,
-        #     expert_out_scales=symm_expert_out_scales,
-        #     out=combine_out,
-        # )
+        _rowwise_debug_op_exit(
+            "rowwise_fp8_combine_forward_get_scaled",
+            group_name,
+            symm_expert_out_q.device,
+            out=combine_out,
+            gathered_q_out=(
+                combine_gather_q
+                if combine_gather_q is not None
+                else (gathered_q_saved if need_grad_probs else None)
+            ),
+            gathered_scales_out=(
+                combine_gather_scales
+                if combine_gather_scales is not None
+                else (gathered_scales_saved if need_grad_probs else None)
+            ),
+        )
 
         ctx.group = group
         ctx.group_name = group_name
@@ -1598,6 +2203,8 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
         ctx.expert_out_dtype = expert_out.dtype
         ctx.symm_expert_out_q = symm_expert_out_q
         ctx.symm_expert_out_scales = symm_expert_out_scales
+        ctx.combine_gather_q = combine_gather_q
+        ctx.combine_gather_scales = combine_gather_scales
         ctx.save_for_backward(
             src_ranks_i64, src_rows_i64, probs_f32, gathered_q_saved, gathered_scales_saved
         )
@@ -1632,16 +2239,18 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
 
         grad_expert_out = None
         if ctx.needs_input_grad[0]:
-            # _rowwise_debug_print(
-            #     "rowwise_fp8_combine_backward_dispatch_put_scaled",
-            #     "enter",
-            #     ctx.group_name,
-            #     input=grad_out_contig,
-            #     out_q=ctx.symm_expert_out_q,
-            #     out_scales=ctx.symm_expert_out_scales,
-            #     dst_ranks=src_ranks,
-            #     dst_rows=src_rows,
-            # )
+            _rowwise_debug_op_enter(
+                "rowwise_fp8_combine_backward_dispatch_put_scaled",
+                ctx.group_name,
+                grad_out_contig.device,
+                input=grad_out_contig,
+                out_q=ctx.symm_expert_out_q,
+                out_scales=ctx.symm_expert_out_scales,
+                dst_ranks=src_ranks,
+                dst_rows=src_rows,
+                combine_gather_q=ctx.combine_gather_q,
+                combine_gather_scales=ctx.combine_gather_scales,
+            )
             _rowwise_dispatch_put_weighted_mxfp8(
                 grad_out_contig,
                 probs,
@@ -1652,16 +2261,24 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
                 ctx.group_name,
                 block_size=ctx.block_size,
                 nblocks=ctx.nblocks,
+                input_q=(
+                    ctx.combine_gather_q.view(-1, ctx.combine_gather_q.shape[-1])
+                    if ctx.combine_gather_q is not None
+                    else None
+                ),
+                input_scales=(
+                    ctx.combine_gather_scales.view(-1, ctx.combine_gather_scales.shape[-1])
+                    if ctx.combine_gather_scales is not None
+                    else None
+                ),
             )
-            # _rowwise_debug_sync("rowwise_fp8_combine_backward_dispatch_put_scaled", ctx.symm_expert_out_q.device)
-            # _rowwise_debug_print(
-            #     "rowwise_fp8_combine_backward_dispatch_put_scaled",
-            #     "exit",
-            #     ctx.group_name,
-            #     input=grad_out_contig,
-            #     out_q=ctx.symm_expert_out_q,
-            #     out_scales=ctx.symm_expert_out_scales,
-            # )
+            _rowwise_debug_op_exit(
+                "rowwise_fp8_combine_backward_dispatch_put_scaled",
+                ctx.group_name,
+                ctx.symm_expert_out_q.device,
+                out_q=ctx.symm_expert_out_q,
+                out_scales=ctx.symm_expert_out_scales,
+            )
             grad_expert_out = OlmoMXFP8Tensor.from_qdata_scales(
                 ctx.symm_expert_out_q,
                 ctx.symm_expert_out_scales,
@@ -1669,8 +2286,24 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
                 orig_dtype=ctx.expert_out_dtype,
             )
 
+        ctx.combine_gather_q = None
+        ctx.combine_gather_scales = None
+        ctx.group = None
         return _check_input_grads(
-            (grad_expert_out, None, None, grad_probs, None, None, None, None, None, None),
+            (
+                grad_expert_out,
+                None,  # src_ranks
+                None,  # src_rows
+                grad_probs,
+                None,  # symm_expert_out_q
+                None,  # symm_expert_out_scales
+                None,  # combine_gather_q
+                None,  # combine_gather_scales
+                None,  # block_size
+                None,  # group_name
+                None,  # group
+                None,  # nblocks
+            ),
             ctx.needs_input_grad,
         )
 

--- a/src/olmo_core/nn/moe/v2/comm.py
+++ b/src/olmo_core/nn/moe/v2/comm.py
@@ -65,6 +65,22 @@ def _rowwise_debug_sync_enabled() -> bool:
     }
 
 
+def _rowwise_bool_env_enabled(name: str) -> bool:
+    return os.getenv(name, "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "y",
+        "on",
+    }
+
+
+def _rowwise_ibgda_enabled() -> bool:
+    return _rowwise_bool_env_enabled("NVSHMEM_IB_ENABLE_IBGDA") and not _rowwise_bool_env_enabled(
+        "NVSHMEM_DISABLE_IBGDA"
+    )
+
+
 def _rowwise_rank_tag() -> str:
     if not dist.is_available() or not dist.is_initialized():
         return "rank=? local_rank=?"
@@ -1596,6 +1612,12 @@ class _DispatchRowwiseAutograd(torch.autograd.Function):
             if not source_input_aliases_symm_input:
                 symm_input_view.copy_(source_input_contig)
             dispatch_source = symm_input_view
+        elif _rowwise_ibgda_enabled():
+            raise RuntimeError(
+                "rowwise NVSHMEM/IBGDA dispatch requires a symmetric source "
+                "staging buffer. Enable OLMO_MOE_ROWWISE_SYMM_DISPATCH_IN=1 "
+                "or leave it on auto for inter-node EP."
+            )
 
         # _rowwise_debug_print(
         #     "rowwise_dispatch_forward_put",

--- a/src/olmo_core/nn/moe/v2/comm.py
+++ b/src/olmo_core/nn/moe/v2/comm.py
@@ -375,7 +375,8 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
         recompute_swiglu: bool,
         group_name: str,
         group: dist.ProcessGroup,
-        nblocks: int,
+        get_nblocks: int,
+        put_nblocks: int,
         up_wgrad_sink,
         up_wgrad_sink_transpose_last2: bool,
         up_wgrad_sink_squeeze_first_dim: bool,
@@ -401,8 +402,10 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             raise RuntimeError(
                 f"Invalid block_size={block_size} for hidden dim {source_input.shape[1]}"
             )
-        if nblocks < 0:
-            raise RuntimeError(f"nblocks must be >= 0 (got {nblocks})")
+        if get_nblocks < 0:
+            raise RuntimeError(f"get_nblocks must be >= 0 (got {get_nblocks})")
+        if put_nblocks < 0:
+            raise RuntimeError(f"put_nblocks must be >= 0 (got {put_nblocks})")
 
         source_input_contig = (
             source_input if source_input.is_contiguous() else source_input.contiguous()
@@ -448,7 +451,7 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             dst_rows_i64,
             group_name,
             block_size=int(block_size),
-            nblocks=int(nblocks),
+            nblocks=int(put_nblocks),
             input_q=dispatch_in_q,
             input_scales=dispatch_in_scales,
         )
@@ -694,7 +697,7 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             group_name,
             probs=probs_f32,
             block_size=int(block_size),
-            nblocks=int(nblocks),
+            nblocks=int(get_nblocks),
             gathered_q_out=gathered_q_for_get,
             gathered_scales_out=gathered_scales_for_get,
         )
@@ -709,7 +712,8 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
 
         ctx.group = group
         ctx.group_name = group_name
-        ctx.nblocks = int(nblocks)
+        ctx.get_nblocks = int(get_nblocks)
+        ctx.put_nblocks = int(put_nblocks)
         ctx.block_size = int(block_size)
         ctx.use_fast_accum = bool(use_fast_accum)
         ctx.recompute_swiglu = bool(recompute_swiglu)
@@ -829,7 +833,7 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             dst_rows,
             ctx.group_name,
             block_size=ctx.block_size,
-            nblocks=ctx.nblocks,
+            nblocks=ctx.put_nblocks,
             input_q=(
                 ctx.combine_gather_q.view(-1, ctx.combine_gather_q.shape[-1])
                 if ctx.combine_gather_q is not None
@@ -1123,7 +1127,7 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             dst_rows,
             ctx.group_name,
             block_size=ctx.block_size,
-            nblocks=ctx.nblocks,
+            nblocks=ctx.get_nblocks,
             gathered_q_out=ctx.combine_gather_q,
             gathered_scales_out=ctx.combine_gather_scales,
         )
@@ -1178,7 +1182,8 @@ class _RowwiseFP8DispatchExpertsCombineAutograd(torch.autograd.Function):
             None,  # recompute_swiglu
             None,  # group_name
             None,  # group
-            None,  # nblocks
+            None,  # get_nblocks
+            None,  # put_nblocks
             None,  # up_wgrad_sink
             None,  # up_wgrad_sink_transpose_last2
             None,  # up_wgrad_sink_squeeze_first_dim
@@ -1204,7 +1209,9 @@ class _RowwiseCombineWeightedAutograd(torch.autograd.Function):
         probs: torch.Tensor,
         group_name: str,
         group: dist.ProcessGroup,
-        nblocks: int,
+        get_nblocks: int,
+        put_nblocks: int,
+        weighted_put_nblocks: int,
         expert_out_aliases_symm_expert_out: bool,
         pre_barrier: bool,
         post_barrier: bool,
@@ -1231,8 +1238,12 @@ class _RowwiseCombineWeightedAutograd(torch.autograd.Function):
                 "probs shape mismatch with src_ranks/src_rows: "
                 f"{tuple(probs.shape)} vs {tuple(src_ranks.shape)}"
             )
-        if nblocks < 0:
-            raise RuntimeError(f"nblocks must be >= 0 (got {nblocks})")
+        if get_nblocks < 0:
+            raise RuntimeError(f"get_nblocks must be >= 0 (got {get_nblocks})")
+        if put_nblocks < 0:
+            raise RuntimeError(f"put_nblocks must be >= 0 (got {put_nblocks})")
+        if weighted_put_nblocks < 0:
+            raise RuntimeError(f"weighted_put_nblocks must be >= 0 (got {weighted_put_nblocks})")
 
         src_ranks_i64 = (
             src_ranks if src_ranks.dtype == torch.long else src_ranks.to(dtype=torch.long)
@@ -1346,7 +1357,7 @@ class _RowwiseCombineWeightedAutograd(torch.autograd.Function):
             src_rows_i64,
             group_name,
             probs=probs_f32,
-            nblocks=nblocks,
+            nblocks=get_nblocks,
             gathered_out=gathered_routes_for_kernel,
             pre_barrier=pre_barrier,
             post_barrier=post_barrier,
@@ -1362,7 +1373,8 @@ class _RowwiseCombineWeightedAutograd(torch.autograd.Function):
         # )
         ctx.group = group
         ctx.group_name = group_name
-        ctx.nblocks = int(nblocks)
+        ctx.put_nblocks = int(put_nblocks)
+        ctx.weighted_put_nblocks = int(weighted_put_nblocks)
         ctx.probs_input_dtype = probs.dtype
         ctx.symm_expert_out = symm_expert_out
         ctx.symm_combine_out_lease = symm_combine_out_lease
@@ -1442,7 +1454,7 @@ class _RowwiseCombineWeightedAutograd(torch.autograd.Function):
                     flat_ranks,
                     flat_rows,
                     ctx.group_name,
-                    nblocks=ctx.nblocks,
+                    nblocks=ctx.put_nblocks,
                 )
                 # _rowwise_debug_sync("rowwise_combine_backward_dispatch_put_unweighted", symm_grad_expert_out.device)
                 # _rowwise_debug_print(
@@ -1470,7 +1482,7 @@ class _RowwiseCombineWeightedAutograd(torch.autograd.Function):
                     src_rows,
                     ctx.group_name,
                     probs=probs,
-                    nblocks=ctx.nblocks,
+                    nblocks=ctx.weighted_put_nblocks,
                 )
                 # _rowwise_debug_sync("rowwise_combine_backward_dispatch_put", symm_grad_expert_out.device)
                 # _rowwise_debug_print(
@@ -1493,20 +1505,22 @@ class _RowwiseCombineWeightedAutograd(torch.autograd.Function):
         ctx.group = None
         grads = (
             grad_expert_out,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
+            None,  # symm_expert_out
+            None,  # symm_combine_out
+            None,  # symm_combine_out_lease
+            None,  # symm_gathered_routes
+            None,  # symm_gathered_routes_lease
+            None,  # src_ranks
+            None,  # src_rows
             grad_probs,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
+            None,  # group_name
+            None,  # group
+            None,  # get_nblocks
+            None,  # put_nblocks
+            None,  # weighted_put_nblocks
+            None,  # expert_out_aliases_symm_expert_out
+            None,  # pre_barrier
+            None,  # post_barrier
         )
         return _check_input_grads(grads, ctx.needs_input_grad)
 
@@ -1524,7 +1538,8 @@ class _DispatchRowwiseAutograd(torch.autograd.Function):
         symm_out_lease,
         group_name: str,
         group: dist.ProcessGroup,
-        nblocks: int,
+        get_nblocks: int,
+        put_nblocks: int,
         source_input_aliases_symm_input: bool,
         grad_out_aliases_symm_out: bool,
         get_pre_barrier: bool,
@@ -1540,8 +1555,10 @@ class _DispatchRowwiseAutograd(torch.autograd.Function):
             raise RuntimeError("dst_ranks/dst_rows must be [N, K] and match source_input first dim")
         if symm_out.ndim != 2 or symm_out.shape[1] != source_input.shape[1]:
             raise RuntimeError("symm_out must be [C, D] with matching hidden dim to source_input")
-        if nblocks < 0:
-            raise RuntimeError(f"nblocks must be >= 0 (got {nblocks})")
+        if get_nblocks < 0:
+            raise RuntimeError(f"get_nblocks must be >= 0 (got {get_nblocks})")
+        if put_nblocks < 0:
+            raise RuntimeError(f"put_nblocks must be >= 0 (got {put_nblocks})")
 
         source_input_contig = source_input
         if not source_input_contig.is_contiguous():
@@ -1595,7 +1612,7 @@ class _DispatchRowwiseAutograd(torch.autograd.Function):
             dst_ranks_i64,
             dst_rows_i64,
             group_name,
-            nblocks=nblocks,
+            nblocks=put_nblocks,
         )
         # _rowwise_debug_sync("rowwise_dispatch_forward_put", symm_out.device)
         # _rowwise_debug_print(
@@ -1608,7 +1625,7 @@ class _DispatchRowwiseAutograd(torch.autograd.Function):
 
         ctx.group_name = group_name
         ctx.group = group
-        ctx.nblocks = int(nblocks)
+        ctx.get_nblocks = int(get_nblocks)
         ctx.get_pre_barrier = bool(get_pre_barrier)
         ctx.get_post_barrier = bool(get_post_barrier)
         ctx.grad_out_aliases_symm_out = bool(grad_out_aliases_symm_out)
@@ -1667,7 +1684,7 @@ class _DispatchRowwiseAutograd(torch.autograd.Function):
             dst_ranks,
             dst_rows,
             ctx.group_name,
-            nblocks=ctx.nblocks,
+            nblocks=ctx.get_nblocks,
             gathered_out=gathered_grad_out,
             pre_barrier=ctx.get_pre_barrier,
             post_barrier=ctx.get_post_barrier,
@@ -1688,7 +1705,22 @@ class _DispatchRowwiseAutograd(torch.autograd.Function):
         ctx.symm_out_lease = None
         ctx.group = None
         return _check_input_grads(
-            (grad_input, None, None, None, None, None, None, None, None, None, None, None, None),
+            (
+                grad_input,
+                None,  # symm_input
+                None,  # dst_ranks
+                None,  # dst_rows
+                None,  # symm_out
+                None,  # symm_out_lease
+                None,  # group_name
+                None,  # group
+                None,  # get_nblocks
+                None,  # put_nblocks
+                None,  # source_input_aliases_symm_input
+                None,  # grad_out_aliases_symm_out
+                None,  # get_pre_barrier
+                None,  # get_post_barrier
+            ),
             ctx.needs_input_grad,
         )
 
@@ -1711,7 +1743,8 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
         block_size: int,
         group_name: str,
         group: dist.ProcessGroup,
-        nblocks: int,
+        get_nblocks: int,
+        put_nblocks: int,
     ) -> torch.Tensor:
         if source_input.ndim != 2:
             raise RuntimeError(
@@ -1748,8 +1781,10 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
             raise RuntimeError(
                 f"symm_out_scales must be float8_e8m0fnu, got {symm_out_scales.dtype}"
             )
-        if nblocks < 0:
-            raise RuntimeError(f"nblocks must be >= 0 (got {nblocks})")
+        if get_nblocks < 0:
+            raise RuntimeError(f"get_nblocks must be >= 0 (got {get_nblocks})")
+        if put_nblocks < 0:
+            raise RuntimeError(f"put_nblocks must be >= 0 (got {put_nblocks})")
 
         source_input_contig = (
             source_input if source_input.is_contiguous() else source_input.contiguous()
@@ -1852,7 +1887,7 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
             dst_rows_i64,
             group_name,
             block_size=int(block_size),
-            nblocks=nblocks,
+            nblocks=put_nblocks,
             input_q=dispatch_in_q,
             input_scales=dispatch_in_scales,
         )
@@ -1867,7 +1902,7 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
 
         ctx.group_name = group_name
         ctx.group = group
-        ctx.nblocks = int(nblocks)
+        ctx.get_nblocks = int(get_nblocks)
         ctx.block_size = int(block_size)
         ctx.logical_out_shape = tuple(symm_out_q.shape)
         ctx.logical_out_dtype = source_input.dtype
@@ -1926,7 +1961,7 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
             dst_rows,
             ctx.group_name,
             block_size=ctx.block_size,
-            nblocks=ctx.nblocks,
+            nblocks=ctx.get_nblocks,
             gathered_q_out=ctx.combine_gather_q,
             gathered_scales_out=ctx.combine_gather_scales,
         )
@@ -1963,7 +1998,8 @@ class _DispatchRowwiseFP8Autograd(torch.autograd.Function):
                 None,  # block_size
                 None,  # group_name
                 None,  # group
-                None,  # nblocks
+                None,  # get_nblocks
+                None,  # put_nblocks
             ),
             ctx.needs_input_grad,
         )
@@ -1984,7 +2020,8 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
         block_size: int,
         group_name: str,
         group: dist.ProcessGroup,
-        nblocks: int,
+        get_nblocks: int,
+        put_nblocks: int,
     ) -> torch.Tensor:
         if expert_out.ndim != 2:
             raise RuntimeError("expert_out must be rank-2 [R, D]")
@@ -2035,8 +2072,10 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
             raise RuntimeError(
                 f"symm_expert_out_scales must be float8_e8m0fnu, got {symm_expert_out_scales.dtype}"
             )
-        if nblocks < 0:
-            raise RuntimeError(f"nblocks must be >= 0 (got {nblocks})")
+        if get_nblocks < 0:
+            raise RuntimeError(f"get_nblocks must be >= 0 (got {get_nblocks})")
+        if put_nblocks < 0:
+            raise RuntimeError(f"put_nblocks must be >= 0 (got {put_nblocks})")
 
         src_ranks_i64 = (
             src_ranks if src_ranks.dtype == torch.long else src_ranks.to(dtype=torch.long)
@@ -2165,7 +2204,7 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
             group_name,
             probs=probs_f32,
             block_size=int(block_size),
-            nblocks=nblocks,
+            nblocks=get_nblocks,
             gathered_q_out=(
                 combine_gather_q
                 if combine_gather_q is not None
@@ -2196,7 +2235,7 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
 
         ctx.group = group
         ctx.group_name = group_name
-        ctx.nblocks = int(nblocks)
+        ctx.put_nblocks = int(put_nblocks)
         ctx.block_size = int(block_size)
         ctx.probs_input_dtype = probs.dtype
         ctx.expert_out_shape = tuple(expert_out.shape)
@@ -2260,7 +2299,7 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
                 src_rows,
                 ctx.group_name,
                 block_size=ctx.block_size,
-                nblocks=ctx.nblocks,
+                nblocks=ctx.put_nblocks,
                 input_q=(
                     ctx.combine_gather_q.view(-1, ctx.combine_gather_q.shape[-1])
                     if ctx.combine_gather_q is not None
@@ -2302,7 +2341,8 @@ class _RowwiseCombineWeightedFP8Autograd(torch.autograd.Function):
                 None,  # block_size
                 None,  # group_name
                 None,  # group
-                None,  # nblocks
+                None,  # get_nblocks
+                None,  # put_nblocks
             ),
             ctx.needs_input_grad,
         )

--- a/src/olmo_core/nn/moe/v2/ep_config.py
+++ b/src/olmo_core/nn/moe/v2/ep_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -93,6 +94,9 @@ class ExpertParallelConfig(Config):
     rowwise_get_nblocks: int = 256
     rowwise_put_nblocks: int = 256
     rowwise_weighted_put_nblocks: int = 128
+    # Deprecated: rowwise_nblocks was split into the three per-collective settings above. When set,
+    # its value is applied to any of those still left at their default (see validate()).
+    rowwise_nblocks: Optional[int] = None
     share_dispatch_out: bool = False
     share_combine_out: bool = False
     restore_unpermute_backend: str = "te_fused"
@@ -108,12 +112,38 @@ class ExpertParallelConfig(Config):
 
     deepep: DeepEPConfig = field(default_factory=DeepEPConfig)
 
+    def _migrate_rowwise_nblocks(self) -> None:
+        if self.rowwise_nblocks is None:
+            return
+        warnings.warn(
+            "ExpertParallelConfig.rowwise_nblocks is deprecated; use rowwise_get_nblocks / "
+            "rowwise_put_nblocks / rowwise_weighted_put_nblocks instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        for setting_name, default in (
+            ("rowwise_get_nblocks", 256),
+            ("rowwise_put_nblocks", 256),
+            ("rowwise_weighted_put_nblocks", 128),
+        ):
+            current = getattr(self, setting_name)
+            if current == default:
+                setattr(self, setting_name, self.rowwise_nblocks)
+            elif current != self.rowwise_nblocks:
+                raise OLMoConfigurationError(
+                    f"EP rowwise_nblocks={self.rowwise_nblocks} conflicts with explicit "
+                    f"{setting_name}={current}; set only the per-collective fields."
+                )
+        self.rowwise_nblocks = None
+
     def validate(self) -> None:
         self.path = ExpertParallelPath(self.path)
         self.schedule = ExpertParallelSchedule(self.schedule)
         self.restore_unpermute_backend = self.restore_unpermute_backend.lower()
         self.rowwise_wave_mode = self.rowwise_wave_mode.lower()
         self.deepep.validate()
+
+        self._migrate_rowwise_nblocks()
 
         # The tbo schedule is declared but not yet wired into block/train dispatch, so a config
         # selecting it would silently run a different path. Fail loudly until it lands.

--- a/src/olmo_core/nn/moe/v2/ep_config.py
+++ b/src/olmo_core/nn/moe/v2/ep_config.py
@@ -90,7 +90,9 @@ class ExpertParallelConfig(Config):
     shared_slots: int = 1
     major_align: int = 1
 
-    rowwise_nblocks: int = 32
+    rowwise_get_nblocks: int = 256
+    rowwise_put_nblocks: int = 256
+    rowwise_weighted_put_nblocks: int = 128
     share_dispatch_out: bool = False
     share_combine_out: bool = False
     restore_unpermute_backend: str = "te_fused"
@@ -126,10 +128,16 @@ class ExpertParallelConfig(Config):
             raise OLMoConfigurationError(f"EP shared_slots must be >= 1 (got {self.shared_slots})")
         if self.major_align < 1:
             raise OLMoConfigurationError(f"EP major_align must be >= 1 (got {self.major_align})")
-        if self.rowwise_nblocks < 0:
-            raise OLMoConfigurationError(
-                f"EP rowwise_nblocks must be >= 0 (got {self.rowwise_nblocks})"
-            )
+        for setting_name in (
+            "rowwise_get_nblocks",
+            "rowwise_put_nblocks",
+            "rowwise_weighted_put_nblocks",
+        ):
+            setting_value = getattr(self, setting_name)
+            if setting_value < 0:
+                raise OLMoConfigurationError(
+                    f"EP {setting_name} must be >= 0 (got {setting_value})"
+                )
         if self.rowwise_wave_num_waves < 1:
             raise OLMoConfigurationError(
                 "EP rowwise_wave_num_waves must be >= 1 " f"(got {self.rowwise_wave_num_waves})"

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_buffers.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_buffers.py
@@ -150,6 +150,38 @@ class _NoSyncSymmLeaseTensorSpec:
     device: torch.device
 
 
+@dataclass(frozen=True)
+class EpNoSyncSymmTensorInfo:
+    owner: str
+    name: str
+    shape: Tuple[int, ...]
+    dtype: torch.dtype
+    device: torch.device
+    nbytes: int
+    data_ptr: int
+
+
+def _symm_tensor_info(
+    *,
+    owner: str,
+    name: str,
+    tensor: torch.Tensor,
+) -> EpNoSyncSymmTensorInfo:
+    nbytes = int(tensor.numel() * tensor.element_size())
+    data_ptr = 0
+    if nbytes > 0:
+        data_ptr = int(tensor.untyped_storage().data_ptr())
+    return EpNoSyncSymmTensorInfo(
+        owner=owner,
+        name=name,
+        shape=tuple(int(dim) for dim in tensor.shape),
+        dtype=tensor.dtype,
+        device=tensor.device,
+        nbytes=nbytes,
+        data_ptr=data_ptr,
+    )
+
+
 class _NoSyncSymmLease:
     def __init__(
         self,
@@ -395,6 +427,15 @@ class _NoSyncSymmLeasePool:
         for slot in self._slots:
             for tensor in slot.values():
                 yield tensor
+
+    def iter_tensor_infos(self, *, owner: str) -> Iterator[EpNoSyncSymmTensorInfo]:
+        for slot_idx, slot in enumerate(self._slots):
+            for name, tensor in slot.items():
+                yield _symm_tensor_info(
+                    owner=owner,
+                    name=f"slot{slot_idx}.{name}",
+                    tensor=tensor,
+                )
 
 
 @dataclass
@@ -765,10 +806,19 @@ class _NoSyncSymmSharedPool:
         )
         return combine_gather_q, combine_gather_scales
 
-    def iter_tensors(self):
+    def iter_tensors(self) -> Iterator[torch.Tensor]:
         for slot_cache in self._slot_caches:
             for tensor in slot_cache.values():
                 yield tensor
+
+    def iter_tensor_infos(self, *, owner: str) -> Iterator[EpNoSyncSymmTensorInfo]:
+        for slot_idx, slot_cache in enumerate(self._slot_caches):
+            for name, tensor in slot_cache.items():
+                yield _symm_tensor_info(
+                    owner=owner,
+                    name=f"slot{slot_idx}.{name}",
+                    tensor=tensor,
+                )
 
 
 def get_ep_no_sync_group_name(block: "OLMoDDPTransformerBlock") -> str:
@@ -1231,6 +1281,10 @@ def get_ep_no_sync_rowwise_fp8_buffers(
     need_dispatch_out: bool = True,
     need_combine_gather: bool = True,
 ) -> _NoSyncRowwiseFP8SymmBuffers:
+    # One-time compile-disabled path: assert CUDA runtime support here, not in the traced forward.
+    if block.rowwise_fp8 is not None and block.rowwise_fp8.enabled:
+        block.rowwise_fp8.assert_runtime_supported()
+
     if d_model % block_size != 0:
         raise RuntimeError(
             "Rowwise FP8 requires hidden dim divisible by block_size: "
@@ -1438,6 +1492,16 @@ def _parse_bool_env(value: str, *, env_name: str) -> Optional[bool]:
     raise RuntimeError(
         f"{env_name} must be one of auto|0|1|true|false|yes|no|on|off, got {value!r}"
     )
+
+
+def _rowwise_ibgda_enabled() -> bool:
+    disabled = os.getenv("NVSHMEM_DISABLE_IBGDA")
+    if disabled is not None and _parse_bool_env(disabled, env_name="NVSHMEM_DISABLE_IBGDA"):
+        return False
+    enabled = os.getenv("NVSHMEM_IB_ENABLE_IBGDA")
+    if enabled is None:
+        return False
+    return bool(_parse_bool_env(enabled, env_name="NVSHMEM_IB_ENABLE_IBGDA"))
 
 
 def _rowwise_symm_auto_enabled(block: "OLMoDDPTransformerBlock") -> bool:
@@ -1664,6 +1728,8 @@ def get_cached_ep_no_sync_rowwise_fp8_buffers(
 
 
 def use_ep_no_sync_rowwise_symm_dispatch_in(block: "OLMoDDPTransformerBlock") -> bool:
+    if _rowwise_ibgda_enabled():
+        return True
     return _resolve_rowwise_symm_option(
         block,
         attr_name="ep.rowwise_symm_dispatch_in",
@@ -2079,6 +2145,25 @@ def iter_ep_no_sync_symm_tensors(block: "OLMoDDPTransformerBlock") -> Iterator[t
             yield from pool.iter_tensors()
     if block._ep_no_sync_shared_pool is not None:
         yield from block._ep_no_sync_shared_pool.iter_tensors()
+
+
+def iter_ep_no_sync_symm_tensor_infos(
+    block: "OLMoDDPTransformerBlock",
+) -> Iterator[EpNoSyncSymmTensorInfo]:
+    for name, tensor in block._ep_no_sync_symm_cache.items():
+        if isinstance(tensor, torch.Tensor):
+            yield _symm_tensor_info(
+                owner=f"block{block.block_idx}:cache",
+                name=name,
+                tensor=tensor,
+            )
+    for pool_name, pool in getattr(block, "_ep_no_sync_symm_lease_pools", {}).items():
+        if isinstance(pool, _NoSyncSymmLeasePool):
+            yield from pool.iter_tensor_infos(
+                owner=f"block{block.block_idx}:lease_pool:{pool_name}"
+            )
+    if block._ep_no_sync_shared_pool is not None:
+        yield from block._ep_no_sync_shared_pool.iter_tensor_infos(owner="shared_pool")
 
 
 def compute_ep_no_sync_rank_capacity(block: "OLMoDDPTransformerBlock", num_out_tokens: int) -> int:

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_buffers.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_buffers.py
@@ -123,11 +123,16 @@ class _NoSyncSymmBuffers:
 
 @dataclass
 class _NoSyncRowwiseFP8SymmBuffers:
+    dispatch_in_q: torch.Tensor
+    dispatch_in_scales: torch.Tensor
     dispatch_out_q: torch.Tensor
     dispatch_out_scales: torch.Tensor
     combine_in_q: torch.Tensor
     combine_in_scales: torch.Tensor
+    combine_gather_q: torch.Tensor
+    combine_gather_scales: torch.Tensor
     dispatch_out_lease: Optional["_NoSyncSymmLease"] = None
+    combine_gather_lease: Optional["_NoSyncSymmLease"] = None
 
 
 @dataclass
@@ -361,11 +366,11 @@ class _NoSyncSymmLeasePool:
         self._ensure_slot(slot_idx, specs)
         self._in_use_slots.add(slot_idx)
         self.high_water = max(self.high_water, len(self._in_use_slots))
-        # self._debug_print(
-        #     f"acquire owner={owner} slot={slot_idx} "
-        #     f"in_use={len(self._in_use_slots)} high_water={self.high_water} "
-        #     f"slots={len(self._slots)} free={len(self._free_slots)}"
-        # )
+        self._debug_print(
+            f"acquire owner={owner} slot={slot_idx} "
+            f"in_use={len(self._in_use_slots)} high_water={self.high_water} "
+            f"slots={len(self._slots)} free={len(self._free_slots)}"
+        )
         slot = self._slots[slot_idx]
         tensors = {
             spec.name: _view_cached_symm_tensor(slot[spec.name], spec.shape) for spec in specs
@@ -380,11 +385,11 @@ class _NoSyncSymmLeasePool:
             )
         self._in_use_slots.remove(slot_idx)
         self._free_slots.append(slot_idx)
-        # self._debug_print(
-        #     f"release slot={slot_idx} in_use={len(self._in_use_slots)} "
-        #     f"high_water={self.high_water} slots={len(self._slots)} "
-        #     f"free={len(self._free_slots)}"
-        # )
+        self._debug_print(
+            f"release slot={slot_idx} in_use={len(self._in_use_slots)} "
+            f"high_water={self.high_water} slots={len(self._slots)} "
+            f"free={len(self._free_slots)}"
+        )
 
     def iter_tensors(self) -> Iterator[torch.Tensor]:
         for slot in self._slots:
@@ -658,6 +663,38 @@ class _NoSyncSymmSharedPool:
         )
         return dispatch_out_q, dispatch_out_scales
 
+    def get_rowwise_fp8_dispatch_in_slot(
+        self,
+        *,
+        slot_idx: int,
+        dispatch_in_cap: int,
+        d_model: int,
+        block_size: int,
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if slot_idx < 0 or slot_idx >= self.num_slots:
+            raise ValueError(f"slot_idx must be in [0, {self.num_slots - 1}] (got {slot_idx})")
+        if d_model % block_size != 0:
+            raise RuntimeError(
+                "Rowwise FP8 requires hidden dim divisible by block_size: "
+                f"hidden={d_model} block_size={block_size}"
+            )
+        dispatch_in_q = self._get_or_init_slot_tensor(
+            slot_idx=slot_idx,
+            name="dispatch_in_rowwise_fp8_q",
+            shape=(dispatch_in_cap, d_model),
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        )
+        dispatch_in_scales = self._get_or_init_slot_tensor(
+            slot_idx=slot_idx,
+            name="dispatch_in_rowwise_fp8_scales",
+            shape=(dispatch_in_cap, d_model // block_size),
+            dtype=torch.float8_e8m0fnu,
+            device=device,
+        )
+        return dispatch_in_q, dispatch_in_scales
+
     def get_rowwise_fp8_combine_in_slot(
         self,
         *,
@@ -689,6 +726,44 @@ class _NoSyncSymmSharedPool:
             device=device,
         )
         return combine_in_q, combine_in_scales
+
+    def get_rowwise_fp8_combine_gather_slot(
+        self,
+        *,
+        slot_idx: int,
+        combine_gather_cap: int,
+        combine_gather_top_k: int,
+        d_model: int,
+        block_size: int,
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if slot_idx < 0 or slot_idx >= self.num_slots:
+            raise ValueError(f"slot_idx must be in [0, {self.num_slots - 1}] (got {slot_idx})")
+        if combine_gather_cap <= 0 or combine_gather_top_k <= 0:
+            raise RuntimeError(
+                "combine_gather_cap and combine_gather_top_k must be positive "
+                "when using rowwise FP8 combine gather staging"
+            )
+        if d_model % block_size != 0:
+            raise RuntimeError(
+                "Rowwise FP8 requires hidden dim divisible by block_size: "
+                f"hidden={d_model} block_size={block_size}"
+            )
+        combine_gather_q = self._get_or_init_slot_tensor(
+            slot_idx=slot_idx,
+            name="combine_gather_rowwise_fp8_q",
+            shape=(combine_gather_cap, combine_gather_top_k, d_model),
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        )
+        combine_gather_scales = self._get_or_init_slot_tensor(
+            slot_idx=slot_idx,
+            name="combine_gather_rowwise_fp8_scales",
+            shape=(combine_gather_cap, combine_gather_top_k, d_model // block_size),
+            dtype=torch.float8_e8m0fnu,
+            device=device,
+        )
+        return combine_gather_q, combine_gather_scales
 
     def iter_tensors(self):
         for slot_cache in self._slot_caches:
@@ -886,6 +961,40 @@ def _fp8_dispatch_out_specs(
     )
 
 
+def _fp8_combine_gather_specs(
+    *,
+    combine_gather_cap: int,
+    combine_gather_top_k: int,
+    d_model: int,
+    block_size: int,
+    device: torch.device,
+) -> Tuple[_NoSyncSymmLeaseTensorSpec, ...]:
+    if combine_gather_cap <= 0 or combine_gather_top_k <= 0:
+        raise RuntimeError(
+            "combine_gather_cap and combine_gather_top_k must be positive "
+            "when leasing rowwise FP8 combine_gather"
+        )
+    if d_model % block_size != 0:
+        raise RuntimeError(
+            "Rowwise FP8 requires hidden dim divisible by block_size: "
+            f"hidden={d_model} block_size={block_size}"
+        )
+    return (
+        _NoSyncSymmLeaseTensorSpec(
+            name="combine_gather_q",
+            shape=(combine_gather_cap, combine_gather_top_k, d_model),
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        ),
+        _NoSyncSymmLeaseTensorSpec(
+            name="combine_gather_scales",
+            shape=(combine_gather_cap, combine_gather_top_k, d_model // block_size),
+            dtype=torch.float8_e8m0fnu,
+            device=device,
+        ),
+    )
+
+
 @torch.compiler.disable
 def acquire_ep_no_sync_dispatch_out_lease(
     block: "OLMoDDPTransformerBlock",
@@ -973,6 +1082,29 @@ def acquire_ep_no_sync_combine_gather_lease(
 
 
 @torch.compiler.disable
+def acquire_ep_no_sync_fp8_combine_gather_lease(
+    block: "OLMoDDPTransformerBlock",
+    *,
+    combine_gather_cap: int,
+    combine_gather_top_k: int,
+    d_model: int,
+    block_size: int,
+    device: torch.device,
+) -> _NoSyncSymmLease:
+    pool = _get_or_init_ep_no_sync_lease_pool(block, name="combine_gather_rowwise_fp8")
+    return pool.acquire(
+        specs=_fp8_combine_gather_specs(
+            combine_gather_cap=combine_gather_cap,
+            combine_gather_top_k=combine_gather_top_k,
+            d_model=d_model,
+            block_size=block_size,
+            device=device,
+        ),
+        owner="rowwise_fp8_combine_gather",
+    )
+
+
+@torch.compiler.disable
 def prewarm_ep_no_sync_rowwise_dispatch_out_leases(
     block: "OLMoDDPTransformerBlock",
     *,
@@ -1055,30 +1187,49 @@ def prewarm_ep_no_sync_rowwise_lifetime_leases(
             ),
         )
     if need_combine_gather:
-        pool = _get_or_init_ep_no_sync_lease_pool(block, name="combine_gather")
-        pool.prewarm(
-            num_slots=num_slots,
-            specs=_bf16_combine_gather_specs(
-                combine_gather_cap=combine_gather_cap,
-                combine_gather_top_k=combine_gather_top_k,
-                d_model=d_model,
-                dtype=dtype,
-                device=device,
-            ),
-        )
+        if use_rowwise_fp8:
+            pool = _get_or_init_ep_no_sync_lease_pool(block, name="combine_gather_rowwise_fp8")
+            pool.prewarm(
+                num_slots=num_slots,
+                specs=_fp8_combine_gather_specs(
+                    combine_gather_cap=combine_gather_cap,
+                    combine_gather_top_k=combine_gather_top_k,
+                    d_model=d_model,
+                    block_size=block_size,
+                    device=device,
+                ),
+            )
+        else:
+            pool = _get_or_init_ep_no_sync_lease_pool(block, name="combine_gather")
+            pool.prewarm(
+                num_slots=num_slots,
+                specs=_bf16_combine_gather_specs(
+                    combine_gather_cap=combine_gather_cap,
+                    combine_gather_top_k=combine_gather_top_k,
+                    d_model=d_model,
+                    dtype=dtype,
+                    device=device,
+                ),
+            )
 
 
 @torch.compiler.disable
 def get_ep_no_sync_rowwise_fp8_buffers(
     block: "OLMoDDPTransformerBlock",
     *,
+    dispatch_in_cap: int,
     dispatch_out_cap: int,
     combine_in_cap: int,
+    combine_gather_cap: int,
+    combine_gather_top_k: int,
     d_model: int,
     block_size: int,
     device: torch.device,
     lease_dispatch_out: bool = False,
+    lease_combine_gather: bool = False,
+    need_dispatch_in: bool = True,
     need_dispatch_out: bool = True,
+    need_combine_gather: bool = True,
 ) -> _NoSyncRowwiseFP8SymmBuffers:
     if d_model % block_size != 0:
         raise RuntimeError(
@@ -1087,11 +1238,45 @@ def get_ep_no_sync_rowwise_fp8_buffers(
         )
 
     scale_cols = d_model // block_size
+    empty_q = torch.empty((0,), dtype=torch.float8_e4m3fn, device=device)
+    empty_scales = torch.empty((0,), dtype=torch.float8_e8m0fnu, device=device)
+
+    if need_dispatch_in:
+        if block._ep_no_sync_shared_pool is not None:
+            (
+                dispatch_in_q,
+                dispatch_in_scales,
+            ) = block._ep_no_sync_shared_pool.get_rowwise_fp8_dispatch_in_slot(
+                slot_idx=block._ep_no_sync_shared_slot,
+                dispatch_in_cap=dispatch_in_cap,
+                d_model=d_model,
+                block_size=block_size,
+                device=device,
+            )
+        else:
+            dispatch_in_q = get_or_init_ep_no_sync_symm_tensor(
+                block,
+                name="dispatch_in_rowwise_fp8_q",
+                shape=(dispatch_in_cap, d_model),
+                dtype=torch.float8_e4m3fn,
+                device=device,
+            )
+            dispatch_in_scales = get_or_init_ep_no_sync_symm_tensor(
+                block,
+                name="dispatch_in_rowwise_fp8_scales",
+                shape=(dispatch_in_cap, scale_cols),
+                dtype=torch.float8_e8m0fnu,
+                device=device,
+            )
+    else:
+        dispatch_in_q = empty_q
+        dispatch_in_scales = empty_scales
+
     dispatch_out_lease: Optional[_NoSyncSymmLease]
     if not need_dispatch_out:
         dispatch_out_lease = None
-        dispatch_out_q = torch.empty((0,), dtype=torch.float8_e4m3fn, device=device)
-        dispatch_out_scales = torch.empty((0,), dtype=torch.float8_e8m0fnu, device=device)
+        dispatch_out_q = empty_q
+        dispatch_out_scales = empty_scales
     elif lease_dispatch_out:
         dispatch_out_lease = acquire_ep_no_sync_fp8_dispatch_out_lease(
             block,
@@ -1159,24 +1344,84 @@ def get_ep_no_sync_rowwise_fp8_buffers(
             dtype=torch.float8_e8m0fnu,
             device=device,
         )
+    combine_gather_lease: Optional[_NoSyncSymmLease]
+    if not need_combine_gather and not lease_combine_gather:
+        combine_gather_lease = None
+        combine_gather_q = empty_q
+        combine_gather_scales = empty_scales
+    elif lease_combine_gather:
+        combine_gather_lease = acquire_ep_no_sync_fp8_combine_gather_lease(
+            block,
+            combine_gather_cap=combine_gather_cap,
+            combine_gather_top_k=combine_gather_top_k,
+            d_model=d_model,
+            block_size=block_size,
+            device=device,
+        )
+        combine_gather_q = combine_gather_lease.tensor("combine_gather_q")  # type: ignore[union-attr]
+        combine_gather_scales = combine_gather_lease.tensor("combine_gather_scales")  # type: ignore[union-attr]
+    elif block._ep_no_sync_shared_pool is not None:
+        combine_gather_lease = None
+        (
+            combine_gather_q,
+            combine_gather_scales,
+        ) = block._ep_no_sync_shared_pool.get_rowwise_fp8_combine_gather_slot(
+            slot_idx=block._ep_no_sync_shared_slot,
+            combine_gather_cap=combine_gather_cap,
+            combine_gather_top_k=combine_gather_top_k,
+            d_model=d_model,
+            block_size=block_size,
+            device=device,
+        )
+    else:
+        combine_gather_lease = None
+        combine_gather_q = get_or_init_ep_no_sync_symm_tensor(
+            block,
+            name="combine_gather_rowwise_fp8_q",
+            shape=(combine_gather_cap, combine_gather_top_k, d_model),
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        )
+        combine_gather_scales = get_or_init_ep_no_sync_symm_tensor(
+            block,
+            name="combine_gather_rowwise_fp8_scales",
+            shape=(combine_gather_cap, combine_gather_top_k, scale_cols),
+            dtype=torch.float8_e8m0fnu,
+            device=device,
+        )
+
     buffers = _NoSyncRowwiseFP8SymmBuffers(
+        dispatch_in_q=dispatch_in_q,
+        dispatch_in_scales=dispatch_in_scales,
         dispatch_out_q=dispatch_out_q,
         dispatch_out_scales=dispatch_out_scales,
         combine_in_q=combine_in_q,
         combine_in_scales=combine_in_scales,
+        combine_gather_q=combine_gather_q,
+        combine_gather_scales=combine_gather_scales,
         dispatch_out_lease=dispatch_out_lease,
+        combine_gather_lease=combine_gather_lease,
     )
-    if dispatch_out_lease is None and block._ep_no_sync_shared_pool is None:
+    if (
+        dispatch_out_lease is None
+        and combine_gather_lease is None
+        and block._ep_no_sync_shared_pool is None
+    ):
         cache = getattr(block, "_ep_no_sync_rowwise_fp8_static_buffer_cache", None)
         if cache is not None:
             cache[
                 _ep_no_sync_fp8_buffers_cache_key(
+                    dispatch_in_cap=dispatch_in_cap,
                     dispatch_out_cap=dispatch_out_cap,
                     combine_in_cap=combine_in_cap,
+                    combine_gather_cap=combine_gather_cap,
+                    combine_gather_top_k=combine_gather_top_k,
                     d_model=d_model,
                     block_size=block_size,
                     device=device,
+                    need_dispatch_in=need_dispatch_in,
                     need_dispatch_out=need_dispatch_out,
+                    need_combine_gather=need_combine_gather,
                 )
             ] = buffers
     return buffers
@@ -1304,20 +1549,30 @@ def _ep_no_sync_buffers_cache_slot(
 
 def _ep_no_sync_fp8_buffers_cache_key(
     *,
+    dispatch_in_cap: int,
     dispatch_out_cap: int,
     combine_in_cap: int,
+    combine_gather_cap: int,
+    combine_gather_top_k: int,
     d_model: int,
     block_size: int,
     device: torch.device,
+    need_dispatch_in: bool,
     need_dispatch_out: bool,
+    need_combine_gather: bool,
 ) -> Tuple[object, ...]:
     return (
+        int(dispatch_in_cap),
         int(dispatch_out_cap),
         int(combine_in_cap),
+        int(combine_gather_cap),
+        int(combine_gather_top_k),
         int(d_model),
         int(block_size),
         device,
+        bool(need_dispatch_in),
         bool(need_dispatch_out),
+        bool(need_combine_gather),
     )
 
 
@@ -1371,12 +1626,17 @@ def get_cached_ep_no_sync_buffers(
 def get_cached_ep_no_sync_rowwise_fp8_buffers(
     block: "OLMoDDPTransformerBlock",
     *,
+    dispatch_in_cap: int,
     dispatch_out_cap: int,
     combine_in_cap: int,
+    combine_gather_cap: int,
+    combine_gather_top_k: int,
     d_model: int,
     block_size: int,
     device: torch.device,
+    need_dispatch_in: bool = True,
     need_dispatch_out: bool = True,
+    need_combine_gather: bool = True,
 ) -> Optional[_NoSyncRowwiseFP8SymmBuffers]:
     if getattr(block, "_ep_no_sync_shared_pool", None) is not None:
         # Shared-pool combine_in tensors can be resized by another block sharing
@@ -1388,12 +1648,17 @@ def get_cached_ep_no_sync_rowwise_fp8_buffers(
         return None
     return cache.get(
         _ep_no_sync_fp8_buffers_cache_key(
+            dispatch_in_cap=dispatch_in_cap,
             dispatch_out_cap=dispatch_out_cap,
             combine_in_cap=combine_in_cap,
+            combine_gather_cap=combine_gather_cap,
+            combine_gather_top_k=combine_gather_top_k,
             d_model=d_model,
             block_size=block_size,
             device=device,
+            need_dispatch_in=need_dispatch_in,
             need_dispatch_out=need_dispatch_out,
+            need_combine_gather=need_combine_gather,
         )
     )
 

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
@@ -500,11 +500,15 @@ def combined_forward_ep_no_sync_rowwise(
             allowed_splits=allowed_splits,
             keep_from_src_dest_local=keep_from_src_dest_local,
         )
-        rowwise_nblocks = self.ep.rowwise_nblocks
+        rowwise_get_nblocks = self.ep.rowwise_get_nblocks
+        rowwise_put_nblocks = self.ep.rowwise_put_nblocks
+        rowwise_weighted_put_nblocks = self.ep.rowwise_weighted_put_nblocks
         rowwise_stage_debug_print(
             "rowwise:build-route-exit",
             block=self.block_idx,
-            nblocks=rowwise_nblocks,
+            get_nblocks=rowwise_get_nblocks,
+            put_nblocks=rowwise_put_nblocks,
+            weighted_put_nblocks=rowwise_weighted_put_nblocks,
         )
         inverse_route_meta = None
         rowwise_combine_row_start = None
@@ -520,7 +524,7 @@ def combined_forward_ep_no_sync_rowwise(
                 routing_map,
                 num_local_experts=self.num_local_routed_experts,
                 num_waves=1,
-                nblocks=rowwise_nblocks,
+                nblocks=rowwise_put_nblocks,
             )
             inverse_route_meta = get_or_init_ep_no_sync_symm_tensor(
                 self,
@@ -536,7 +540,7 @@ def combined_forward_ep_no_sync_rowwise(
                 compact_wave_offsets,
                 src_rank=torch.distributed.get_rank(self.ep_pg),
                 group_name=group_name,
-                nblocks=rowwise_nblocks,
+                nblocks=rowwise_put_nblocks,
                 pre_barrier=True,
                 post_barrier=True,
                 scalar_put=use_symm_dispatch_in,
@@ -627,7 +631,8 @@ def combined_forward_ep_no_sync_rowwise(
             rowwise_fp8_cfg.fused_autograd_recompute_swiglu,
             group_name,
             self.ep_pg,
-            rowwise_nblocks,
+            rowwise_get_nblocks,
+            rowwise_put_nblocks,
             up_wgrad_sink,
             up_wgrad_sink_transpose_last2,
             False,
@@ -660,7 +665,8 @@ def combined_forward_ep_no_sync_rowwise(
             rowwise_fp8_cfg.block_size,
             group_name,
             self.ep_pg,
-            rowwise_nblocks,
+            rowwise_get_nblocks,
+            rowwise_put_nblocks,
         )
     else:
         assert buffers is not None
@@ -676,7 +682,8 @@ def combined_forward_ep_no_sync_rowwise(
             buffers.dispatch_out_lease,
             group_name,
             self.ep_pg,
-            rowwise_nblocks,
+            rowwise_get_nblocks,
+            rowwise_put_nblocks,
             source_input_aliases_symm_input,
             grad_out_aliases_symm_out,
             True,
@@ -736,7 +743,8 @@ def combined_forward_ep_no_sync_rowwise(
             rowwise_fp8_cfg.block_size,
             group_name,
             self.ep_pg,
-            self.ep.rowwise_nblocks,
+            rowwise_get_nblocks,
+            rowwise_put_nblocks,
         )
     else:
         assert buffers is not None
@@ -759,7 +767,7 @@ def combined_forward_ep_no_sync_rowwise(
                 rowwise_combine_row_start,
                 rowwise_combine_num_rows,
                 group_name,
-                nblocks=self.ep.rowwise_nblocks,
+                nblocks=rowwise_put_nblocks,
                 pre_barrier=True,
                 post_barrier=True,
             )
@@ -788,7 +796,9 @@ def combined_forward_ep_no_sync_rowwise(
                 route_probs,
                 group_name,
                 self.ep_pg,
-                self.ep.rowwise_nblocks,
+                rowwise_get_nblocks,
+                rowwise_put_nblocks,
+                rowwise_weighted_put_nblocks,
                 expert_out_aliases_symm_expert_out,
                 True,
                 False,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
@@ -175,12 +175,7 @@ def combined_forward_ep_no_sync_rowwise(
         and moe_inp.device.type == "cuda"
         and self.ep.uses_rowwise_buffers
     )
-    if use_rowwise_fp8:
-        assert rowwise_fp8_cfg is not None
-        if not self._rowwise_fp8_checked:
-            rowwise_fp8_cfg.assert_runtime_supported()
-            self._rowwise_fp8_checked = True
-    else:
+    if not use_rowwise_fp8:
         rowwise_fp8_cfg = None
 
     num_out_tokens = local_x_global_routed_expert_indices.numel()

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
@@ -18,6 +18,7 @@ from .comm import (
     _RowwiseFP8DispatchExpertsCombineAutograd,
 )
 from .ep_no_sync_buffers import (
+    acquire_ep_no_sync_fp8_combine_gather_lease,
     acquire_ep_no_sync_fp8_dispatch_out_lease,
     acquire_ep_no_sync_rowwise_lifetime_leases,
     compute_ep_no_sync_rank_capacity,
@@ -276,27 +277,63 @@ def combined_forward_ep_no_sync_rowwise(
     combine_in_scales: Optional[torch.Tensor] = None
     if use_rowwise_fp8:
         assert rowwise_fp8_cfg is not None
-        fp8_buffers = get_cached_ep_no_sync_rowwise_fp8_buffers(
-            self,
+        use_fp8_symm_dispatch_in = use_ep_no_sync_rowwise_symm_dispatch_in(self)
+        use_fp8_symm_combine_gather = use_ep_no_sync_rowwise_symm_combine_gather(self)
+        fp8_lease_combine_gather = use_fp8_symm_combine_gather and lease_lifetime_buffers
+        rowwise_stage_debug_print(
+            "rowwise:fp8-get-buffers-enter",
+            block=self.block_idx,
             dispatch_out_cap=dispatch_out_cap,
             combine_in_cap=combine_in_cap,
+            use_symm_dispatch_in=use_fp8_symm_dispatch_in,
+            use_symm_combine_gather=use_fp8_symm_combine_gather,
+            lease_lifetime=lease_lifetime_buffers,
+        )
+        fp8_buffers = get_cached_ep_no_sync_rowwise_fp8_buffers(
+            self,
+            dispatch_in_cap=num_input_tokens,
+            dispatch_out_cap=dispatch_out_cap,
+            combine_in_cap=combine_in_cap,
+            combine_gather_cap=num_input_tokens,
+            combine_gather_top_k=top_k,
             d_model=moe_inp.shape[1],
             block_size=rowwise_fp8_cfg.block_size,
             device=moe_inp.device,
+            need_dispatch_in=use_fp8_symm_dispatch_in,
             need_dispatch_out=not lease_lifetime_buffers,
+            need_combine_gather=not fp8_lease_combine_gather,
+        )
+        rowwise_stage_debug_print(
+            "rowwise:fp8-get-buffers-cache",
+            block=self.block_idx,
+            cached=fp8_buffers is not None,
         )
         if fp8_buffers is None:
             fp8_buffers = get_ep_no_sync_rowwise_fp8_buffers(
                 self,
+                dispatch_in_cap=num_input_tokens,
                 dispatch_out_cap=dispatch_out_cap,
                 combine_in_cap=combine_in_cap,
+                combine_gather_cap=num_input_tokens,
+                combine_gather_top_k=top_k,
                 d_model=moe_inp.shape[1],
                 block_size=rowwise_fp8_cfg.block_size,
                 device=moe_inp.device,
                 lease_dispatch_out=False,
+                lease_combine_gather=False,
+                need_dispatch_in=use_fp8_symm_dispatch_in,
                 need_dispatch_out=not lease_lifetime_buffers,
+                need_combine_gather=not fp8_lease_combine_gather,
             )
+        rowwise_stage_debug_print(
+            "rowwise:fp8-get-buffers-exit",
+            block=self.block_idx,
+        )
         if lease_lifetime_buffers:
+            rowwise_stage_debug_print(
+                "rowwise:fp8-dispatch-out-lease-enter",
+                block=self.block_idx,
+            )
             dispatch_out_lease = acquire_ep_no_sync_fp8_dispatch_out_lease(
                 self,
                 dispatch_out_cap=dispatch_out_cap,
@@ -310,6 +347,33 @@ def combined_forward_ep_no_sync_rowwise(
                 dispatch_out_scales=dispatch_out_lease.tensor("dispatch_out_scales"),
                 dispatch_out_lease=dispatch_out_lease,
             )
+            rowwise_stage_debug_print(
+                "rowwise:fp8-dispatch-out-lease-exit",
+                block=self.block_idx,
+            )
+            if fp8_lease_combine_gather:
+                rowwise_stage_debug_print(
+                    "rowwise:fp8-combine-gather-lease-enter",
+                    block=self.block_idx,
+                )
+                combine_gather_lease = acquire_ep_no_sync_fp8_combine_gather_lease(
+                    self,
+                    combine_gather_cap=num_input_tokens,
+                    combine_gather_top_k=top_k,
+                    d_model=moe_inp.shape[1],
+                    block_size=rowwise_fp8_cfg.block_size,
+                    device=moe_inp.device,
+                )
+                fp8_buffers = replace(
+                    fp8_buffers,
+                    combine_gather_q=combine_gather_lease.tensor("combine_gather_q"),
+                    combine_gather_scales=combine_gather_lease.tensor("combine_gather_scales"),
+                    combine_gather_lease=combine_gather_lease,
+                )
+                rowwise_stage_debug_print(
+                    "rowwise:fp8-combine-gather-lease-exit",
+                    block=self.block_idx,
+                )
         dispatch_out_q = fp8_buffers.dispatch_out_q
         dispatch_out_scales = fp8_buffers.dispatch_out_scales
         combine_in_q = fp8_buffers.combine_in_q
@@ -509,6 +573,12 @@ def combined_forward_ep_no_sync_rowwise(
         assert dispatch_out_scales is not None
         assert combine_in_q is not None
         assert combine_in_scales is not None
+        dispatch_in_q = fp8_buffers.dispatch_in_q if use_fp8_symm_dispatch_in else None  # type: ignore[union-attr]
+        dispatch_in_scales = fp8_buffers.dispatch_in_scales if use_fp8_symm_dispatch_in else None  # type: ignore[union-attr]
+        combine_gather_q = fp8_buffers.combine_gather_q if use_fp8_symm_combine_gather else None  # type: ignore[union-attr]
+        combine_gather_scales = (
+            fp8_buffers.combine_gather_scales if use_fp8_symm_combine_gather else None  # type: ignore[union-attr]
+        )
         routed_experts = self.routed_experts
         routed_fp8_cfg = routed_experts.rowwise_fp8
         if routed_fp8_cfg is None or not routed_fp8_cfg.enabled:
@@ -552,6 +622,11 @@ def combined_forward_ep_no_sync_rowwise(
             down_prequant,
             down_prequant_t,
             fp8_buffers.dispatch_out_lease,  # type: ignore[union-attr]
+            fp8_buffers.combine_gather_lease,  # type: ignore[union-attr]
+            dispatch_in_q,
+            dispatch_in_scales,
+            combine_gather_q,
+            combine_gather_scales,
             rowwise_fp8_cfg.block_size,
             rowwise_fp8_cfg.use_fast_accum,
             rowwise_fp8_cfg.fused_autograd_recompute_swiglu,
@@ -569,6 +644,12 @@ def combined_forward_ep_no_sync_rowwise(
         assert rowwise_fp8_cfg is not None
         assert dispatch_out_q is not None
         assert dispatch_out_scales is not None
+        dispatch_in_q = fp8_buffers.dispatch_in_q if use_fp8_symm_dispatch_in else None  # type: ignore[union-attr]
+        dispatch_in_scales = fp8_buffers.dispatch_in_scales if use_fp8_symm_dispatch_in else None  # type: ignore[union-attr]
+        combine_gather_q = fp8_buffers.combine_gather_q if use_fp8_symm_combine_gather else None  # type: ignore[union-attr]
+        combine_gather_scales = (
+            fp8_buffers.combine_gather_scales if use_fp8_symm_combine_gather else None  # type: ignore[union-attr]
+        )
         dispatch_rank_major = _DispatchRowwiseFP8Autograd.apply(
             moe_inp,
             dst_ranks,
@@ -576,6 +657,11 @@ def combined_forward_ep_no_sync_rowwise(
             dispatch_out_q,
             dispatch_out_scales,
             fp8_buffers.dispatch_out_lease,  # type: ignore[union-attr]
+            dispatch_in_q,
+            dispatch_in_scales,
+            combine_gather_q,
+            combine_gather_scales,
+            fp8_buffers.combine_gather_lease,  # type: ignore[union-attr]
             rowwise_fp8_cfg.block_size,
             group_name,
             self.ep_pg,
@@ -639,6 +725,10 @@ def combined_forward_ep_no_sync_rowwise(
         assert rowwise_fp8_cfg is not None
         assert combine_in_q is not None
         assert combine_in_scales is not None
+        combine_gather_q = fp8_buffers.combine_gather_q if use_fp8_symm_combine_gather else None  # type: ignore[union-attr]
+        combine_gather_scales = (
+            fp8_buffers.combine_gather_scales if use_fp8_symm_combine_gather else None  # type: ignore[union-attr]
+        )
         local_x = _RowwiseCombineWeightedFP8Autograd.apply(
             dispatch_rank_major,
             dst_ranks,
@@ -646,6 +736,8 @@ def combined_forward_ep_no_sync_rowwise(
             route_probs,
             combine_in_q,
             combine_in_scales,
+            combine_gather_q,
+            combine_gather_scales,
             rowwise_fp8_cfg.block_size,
             group_name,
             self.ep_pg,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
@@ -131,7 +131,8 @@ class _RowwiseGatherSlotsAutograd(torch.autograd.Function):
         src_rows: torch.Tensor,
         group_name: str,
         group: dist.ProcessGroup,
-        nblocks: int,
+        get_nblocks: int,
+        put_nblocks: int,
         expert_out_aliases_symm_expert_out: bool,
         pre_barrier: bool,
         post_barrier: bool,
@@ -150,8 +151,10 @@ class _RowwiseGatherSlotsAutograd(torch.autograd.Function):
             )
         if src_ranks.shape != src_rows.shape:
             raise RuntimeError("src_ranks/src_rows shape mismatch")
-        if nblocks < 0:
-            raise RuntimeError(f"nblocks must be >= 0 (got {nblocks})")
+        if get_nblocks < 0:
+            raise RuntimeError(f"get_nblocks must be >= 0 (got {get_nblocks})")
+        if put_nblocks < 0:
+            raise RuntimeError(f"put_nblocks must be >= 0 (got {put_nblocks})")
 
         src_ranks_i64 = (
             src_ranks if src_ranks.dtype == torch.long else src_ranks.to(dtype=torch.long)
@@ -182,14 +185,14 @@ class _RowwiseGatherSlotsAutograd(torch.autograd.Function):
             flat_ranks,
             flat_rows,
             group_name,
-            nblocks=nblocks,
+            nblocks=get_nblocks,
             pre_barrier=pre_barrier,
             post_barrier=post_barrier,
         )
 
         ctx.group = group
         ctx.group_name = group_name
-        ctx.nblocks = int(nblocks)
+        ctx.put_nblocks = int(put_nblocks)
         ctx.symm_expert_out = symm_expert_out
         ctx.save_for_backward(src_ranks_i64, src_rows_i64)
         return gathered_routes
@@ -223,13 +226,13 @@ class _RowwiseGatherSlotsAutograd(torch.autograd.Function):
                 flat_ranks,
                 flat_rows,
                 ctx.group_name,
-                nblocks=ctx.nblocks,
+                nblocks=ctx.put_nblocks,
             )
             grad_expert_out = ctx.symm_expert_out
 
         ctx.symm_expert_out = None
         ctx.group = None
-        return grad_expert_out, None, None, None, None, None, None, None, None, None
+        return grad_expert_out, None, None, None, None, None, None, None, None, None, None
 
 
 def _rowwise_wave_grouped_wgrad(
@@ -268,7 +271,8 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
         local_expert_base_rows: torch.Tensor,
         group_name: str,
         group: dist.ProcessGroup,
-        nblocks: int,
+        put_nblocks: int,
+        weighted_put_nblocks: int,
         wave_groups: Tuple[Tuple[int, int], ...],
         recompute_linear1: bool,
         recompute_act: bool,
@@ -325,8 +329,10 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
             raise RuntimeError("batch_size_per_local_expert must be rank-1")
         if local_expert_base_rows.ndim != 1:
             raise RuntimeError("local_expert_base_rows must be rank-1")
-        if nblocks < 0:
-            raise RuntimeError(f"nblocks must be >= 0 (got {nblocks})")
+        if put_nblocks < 0:
+            raise RuntimeError(f"put_nblocks must be >= 0 (got {put_nblocks})")
+        if weighted_put_nblocks < 0:
+            raise RuntimeError("weighted_put_nblocks must be >= 0 " f"(got {weighted_put_nblocks})")
         recompute_linear1 = bool(recompute_linear1)
         recompute_act = bool(recompute_act)
 
@@ -405,7 +411,8 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
             rows=source_input.shape[0],
             d_model=source_input.shape[1],
             waves=num_waves,
-            nblocks=nblocks,
+            put_nblocks=put_nblocks,
+            weighted_put_nblocks=weighted_put_nblocks,
         )
         for wave_idx, (start, end) in enumerate(wave_groups):
             wave_label = f"rowwise_wave/wave_{wave_idx}/experts_{int(start)}_{int(end)}"
@@ -428,7 +435,7 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
                         compact_wave_offsets,
                         wave_idx,
                         group_name,
-                        nblocks=int(nblocks),
+                        nblocks=int(put_nblocks),
                         pre_barrier=False,
                         post_barrier=True,
                     )
@@ -513,7 +520,7 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
                         wave_row_start,
                         wave_num_rows,
                         group_name,
-                        nblocks=int(nblocks),
+                        nblocks=int(put_nblocks),
                         pre_barrier=False,
                         post_barrier=True,
                     )
@@ -545,7 +552,8 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
         if needs_backward:
             ctx.group = group
             ctx.group_name = group_name
-            ctx.nblocks = int(nblocks)
+            ctx.put_nblocks = int(put_nblocks)
+            ctx.weighted_put_nblocks = int(weighted_put_nblocks)
             ctx.recompute_linear1 = recompute_linear1
             ctx.recompute_act = recompute_act
             ctx.probs_input_dtype = probs.dtype
@@ -685,7 +693,8 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
             rowwise_stage_debug_print(
                 "rowwise_wave:fused-backward-enter",
                 waves=len(ctx.wave_groups),
-                nblocks=ctx.nblocks,
+                put_nblocks=ctx.put_nblocks,
+                weighted_put_nblocks=ctx.weighted_put_nblocks,
             )
 
             wave_infos = []
@@ -723,7 +732,7 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
                             wave_idx,
                             probs,
                             ctx.group_name,
-                            nblocks=ctx.nblocks,
+                            nblocks=ctx.weighted_put_nblocks,
                             pre_barrier=False,
                             post_barrier=True,
                         )
@@ -850,7 +859,7 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
                                 wave_row_start,
                                 wave_num_rows,
                                 ctx.group_name,
-                                nblocks=ctx.nblocks,
+                                nblocks=ctx.put_nblocks,
                                 pre_barrier=False,
                                 post_barrier=True,
                             )
@@ -922,6 +931,7 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
             grad_probs,
             grad_w_up_gate,
             grad_w_down,
+            None,
             None,
             None,
             None,
@@ -1164,7 +1174,9 @@ def combined_forward_ep_no_sync_rowwise_wave(
 
     routing_map = local_x_global_routed_expert_indices.view(-1, top_k).int()
     route_probs = local_x_global_routed_expert_weights.view(-1, top_k)
-    rowwise_nblocks = self.ep.rowwise_nblocks
+    rowwise_get_nblocks = self.ep.rowwise_get_nblocks
+    rowwise_put_nblocks = self.ep.rowwise_put_nblocks
+    rowwise_weighted_put_nblocks = self.ep.rowwise_weighted_put_nblocks
 
     if self.shared_experts is not None:
         with torch.cuda.stream(self.get_dense_stream()):
@@ -1216,7 +1228,7 @@ def combined_forward_ep_no_sync_rowwise_wave(
             routing_map,
             num_local_experts=self.num_local_routed_experts,
             num_waves=len(wave_groups),
-            nblocks=rowwise_nblocks,
+            nblocks=rowwise_put_nblocks,
         )
         rowwise_stage_debug_print("rowwise_wave:compact-route-exit", block=self.block_idx)
         rowwise_stage_debug_sync("rowwise_wave:compact-route", moe_inp.device)
@@ -1278,7 +1290,7 @@ def combined_forward_ep_no_sync_rowwise_wave(
                     global_route_records,
                     global_wave_offsets,
                     local_rank=local_ep_rank,
-                    nblocks=rowwise_nblocks,
+                    nblocks=rowwise_put_nblocks,
                 )
             rowwise_stage_debug_print(
                 "rowwise_wave:inverse-meta-local-build-exit",
@@ -1293,7 +1305,7 @@ def combined_forward_ep_no_sync_rowwise_wave(
                 compact_wave_offsets,
                 src_rank=local_ep_rank,
                 group_name=group_name,
-                nblocks=rowwise_nblocks,
+                nblocks=rowwise_put_nblocks,
                 pre_barrier=False,
                 post_barrier=True,
                 scalar_put=use_symm_dispatch_in,
@@ -1321,7 +1333,8 @@ def combined_forward_ep_no_sync_rowwise_wave(
             local_expert_base_rows_full,
             group_name,
             self.ep_pg,
-            rowwise_nblocks,
+            rowwise_put_nblocks,
+            rowwise_weighted_put_nblocks,
             wave_groups,
             self.ep.rowwise_wave_recompute_linear1,
             self.ep.rowwise_wave_recompute_act,
@@ -1338,7 +1351,8 @@ def combined_forward_ep_no_sync_rowwise_wave(
             buffers.dispatch_out_lease,
             group_name,
             self.ep_pg,
-            rowwise_nblocks,
+            rowwise_get_nblocks,
+            rowwise_put_nblocks,
             False,
             True,
             True,
@@ -1367,7 +1381,9 @@ def combined_forward_ep_no_sync_rowwise_wave(
             route_probs,
             group_name,
             self.ep_pg,
-            rowwise_nblocks,
+            rowwise_get_nblocks,
+            rowwise_put_nblocks,
+            rowwise_weighted_put_nblocks,
             expert_out_aliases_symm_expert_out,
             True,
             False,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
@@ -21,7 +21,11 @@ from ...moe.utils import (
     wait_stream_no_compile,
 )
 from .checkpointing import get_rowwise_checkpoint_state
-from .comm import _DispatchRowwiseAutograd, _RowwiseCombineWeightedAutograd
+from .comm import (
+    _DispatchRowwiseAutograd,
+    _rowwise_ibgda_enabled,
+    _RowwiseCombineWeightedAutograd,
+)
 from .ep_config import ExpertParallelPath
 from .ep_no_sync_buffers import (
     compute_ep_no_sync_rank_capacity,
@@ -342,6 +346,18 @@ class _RowwiseWaveDispatchExpertsCombineAutograd(torch.autograd.Function):
         dispatch_input_contig = (
             dispatch_input if dispatch_input.is_contiguous() else dispatch_input.contiguous()
         )
+        dispatch_input_aliases_source = (
+            dispatch_input.untyped_storage().data_ptr() == source_input.untyped_storage().data_ptr()
+            and dispatch_input.storage_offset() == source_input.storage_offset()
+            and tuple(dispatch_input.shape) == tuple(source_input.shape)
+            and tuple(dispatch_input.stride()) == tuple(source_input.stride())
+        )
+        if _rowwise_ibgda_enabled() and dispatch_input_aliases_source:
+            raise RuntimeError(
+                "rowwise_wave NVSHMEM/IBGDA dispatch requires a symmetric "
+                "source staging buffer. Enable OLMO_MOE_ROWWISE_SYMM_DISPATCH_IN=1 "
+                "or leave it on auto for inter-node EP."
+            )
         probs_f32 = probs if probs.dtype == torch.float32 else probs.to(dtype=torch.float32)
         if not probs_f32.is_contiguous():
             probs_f32 = probs_f32.contiguous()

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_tbo_rowwise.py
@@ -120,7 +120,9 @@ class _NoSyncRowwiseStageAState:
     padded_batch_size_per_local_expert: torch.Tensor
     dst_ranks: torch.Tensor
     dst_rows: torch.Tensor
-    rowwise_nblocks: int
+    rowwise_get_nblocks: int
+    rowwise_put_nblocks: int
+    rowwise_weighted_put_nblocks: int
     use_symm_dispatch_in: bool
     use_symm_combine_out: bool
     use_symm_combine_gather: bool
@@ -324,10 +326,16 @@ def ep_no_sync_rowwise_tbo_stage_a(
             allowed_splits=allowed_splits,
             keep_from_src_dest_local=keep_from_src_dest_local,
         )
-        rowwise_nblocks = self.ep.rowwise_nblocks
+        rowwise_get_nblocks = self.ep.rowwise_get_nblocks
+        rowwise_put_nblocks = self.ep.rowwise_put_nblocks
+        rowwise_weighted_put_nblocks = self.ep.rowwise_weighted_put_nblocks
         # _tbo_debug_print(
         #     self,
-        #     f"A{lane_id}:route-maps-exit nblocks={rowwise_nblocks}",
+        #     (
+        #         f"A{lane_id}:route-maps-exit get_nblocks={rowwise_get_nblocks} "
+        #         f"put_nblocks={rowwise_put_nblocks} "
+        #         f"weighted_put_nblocks={rowwise_weighted_put_nblocks}"
+        #     ),
         #     routing_map=routing_map,
         #     dst_ranks=dst_ranks,
         #     dst_rows=dst_rows,
@@ -353,7 +361,9 @@ def ep_no_sync_rowwise_tbo_stage_a(
         padded_batch_size_per_local_expert=padded_batch_size_per_local_expert,
         dst_ranks=dst_ranks,
         dst_rows=dst_rows,
-        rowwise_nblocks=rowwise_nblocks,
+        rowwise_get_nblocks=rowwise_get_nblocks,
+        rowwise_put_nblocks=rowwise_put_nblocks,
+        rowwise_weighted_put_nblocks=rowwise_weighted_put_nblocks,
         use_symm_dispatch_in=use_symm_dispatch_in,
         use_symm_combine_out=use_symm_combine_out,
         use_symm_combine_gather=use_symm_combine_gather,
@@ -397,7 +407,8 @@ def ep_no_sync_rowwise_tbo_stage_d_launch(
             getattr(a_state.buffers, "dispatch_out_lease", None),
             a_state.group_name,
             self.ep_pg,
-            a_state.rowwise_nblocks,
+            a_state.rowwise_get_nblocks,
+            a_state.rowwise_put_nblocks,
             source_input_aliases_symm_input,
             grad_out_aliases_symm_out,
             True,
@@ -546,7 +557,9 @@ def ep_no_sync_rowwise_tbo_stage_c_launch(
             route_probs,
             a_state.group_name,
             block.ep_pg,
-            a_state.rowwise_nblocks,
+            a_state.rowwise_get_nblocks,
+            a_state.rowwise_put_nblocks,
+            a_state.rowwise_weighted_put_nblocks,
             expert_out_aliases_symm_expert_out,
             True,
             True,

--- a/src/olmo_core/nn/moe/v2/routed_experts.py
+++ b/src/olmo_core/nn/moe/v2/routed_experts.py
@@ -537,7 +537,8 @@ class RoutedExperts(nn.Module):
         self.ep_rank: int = 0
         self.rowwise_fp8 = normalize_rowwise_fp8_config(rowwise_fp8)
         if self.rowwise_fp8 is not None and self.rowwise_fp8.enabled:
-            self.rowwise_fp8.assert_runtime_supported()
+            # Config-only check here; runtime CUDA support is asserted at FP8 buffer build.
+            self.rowwise_fp8.validate()
         self._rowwise_fp8_up_gate_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
         self._rowwise_fp8_down_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
         self._rowwise_fp8_up_gate_prequant_t: Optional[ScaledGroupedMMPrequantizedRHS] = None

--- a/src/olmo_core/nn/moe/v2/routed_experts.py
+++ b/src/olmo_core/nn/moe/v2/routed_experts.py
@@ -536,7 +536,8 @@ class RoutedExperts(nn.Module):
         self.ep_dim: int = 1
         self.ep_rank: int = 0
         self.rowwise_fp8 = normalize_rowwise_fp8_config(rowwise_fp8)
-        self._rowwise_fp8_checked = False
+        if self.rowwise_fp8 is not None and self.rowwise_fp8.enabled:
+            self.rowwise_fp8.assert_runtime_supported()
         self._rowwise_fp8_up_gate_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
         self._rowwise_fp8_down_prequant: Optional[ScaledGroupedMMPrequantizedRHS] = None
         self._rowwise_fp8_up_gate_prequant_t: Optional[ScaledGroupedMMPrequantizedRHS] = None
@@ -751,9 +752,6 @@ class RoutedExperts(nn.Module):
             return False
         if x.dtype not in (torch.bfloat16, torch.float16, torch.float32):
             return False
-        if not self._rowwise_fp8_checked:
-            cfg.assert_runtime_supported()
-            self._rowwise_fp8_checked = True
         return True
 
     def _forward_rowwise_fp8(

--- a/src/olmo_core/train/train_module/transformer/ddp_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/ddp_train_module.py
@@ -3,6 +3,7 @@ import logging
 import math
 import os
 import time
+from collections import OrderedDict
 from functools import cached_property, lru_cache
 from itertools import product
 from typing import (
@@ -2885,6 +2886,160 @@ class OLMoDDPTrainModule(TrainModule):
                 max_local_microbatch_size=prewarm_rank_microbatch_size,
             )
 
+    @staticmethod
+    def _ep_no_sync_symm_summary_enabled() -> bool:
+        raw = os.getenv("OLMO_EP_NO_SYNC_SYMM_BUFFER_SUMMARY", "1")
+        return raw.strip().lower() not in {"", "0", "false", "no", "off"}
+
+    @staticmethod
+    def _ep_no_sync_symm_prewarm_summary_enabled() -> bool:
+        raw = os.getenv("OLMO_EP_NO_SYNC_SYMM_BUFFER_SUMMARY_PREWARM", "0")
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _should_log_ep_no_sync_symm_summary_rank() -> bool:
+        if not dist.is_available() or not dist.is_initialized():
+            return True
+        ranks = (
+            os.getenv("OLMO_EP_NO_SYNC_SYMM_BUFFER_SUMMARY_RANKS")
+            or os.getenv("OLMO_ROWWISE_DEBUG_RANKS")
+            or os.getenv("OLMO_TBO_DEBUG_RANKS")
+        )
+        if ranks is None:
+            return dist.get_rank() == 0
+        normalized = ranks.strip().lower()
+        if normalized in {"all", "*"}:
+            return True
+        if normalized in {"", "none", "off", "0-only"}:
+            return dist.get_rank() == 0
+        selected_ranks = {part.strip() for part in ranks.split(",") if part.strip()}
+        return str(dist.get_rank()) in selected_ranks
+
+    @staticmethod
+    def _gib(nbytes: int) -> float:
+        return float(nbytes) / float(1024**3)
+
+    def _log_ep_no_sync_symm_buffer_summary(
+        self,
+        *,
+        model_parts,
+        context: str,
+    ) -> None:
+        if not self._ep_no_sync_symm_summary_enabled():
+            return
+
+        typed_parts = [cast(OLMoDDPModel, m) for m in model_parts]
+        unique_infos: "OrderedDict[Tuple[str, int], Tuple[int, Any]]" = OrderedDict()
+        duplicate_refs = 0
+        for model_part_idx, model_part in enumerate(typed_parts):
+            for info in model_part.iter_ep_no_sync_symm_tensor_infos():
+                if info.nbytes <= 0:
+                    continue
+                storage_key = (str(info.device), int(info.data_ptr))
+                if storage_key in unique_infos:
+                    duplicate_refs += 1
+                    continue
+                unique_infos[storage_key] = (model_part_idx, info)
+
+        if not self._should_log_ep_no_sync_symm_summary_rank():
+            return
+
+        rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+        local_rank = os.getenv("LOCAL_RANK", "?")
+        total_bytes = sum(info.nbytes for _, info in unique_infos.values())
+        lines = [
+            (
+                f"EP no-sync symmetric buffer summary ({context}) "
+                f"rank={rank} local_rank={local_rank}: "
+                f"unique_tensors={len(unique_infos)}, duplicate_refs={duplicate_refs}, "
+                f"requested={self._gib(total_bytes):.4f} GiB"
+            )
+        ]
+
+        if torch.cuda.is_available():
+            device = torch.device(self.device)
+            if device.type != "cuda":
+                device = torch.device("cuda")
+            cuda_stats = torch.cuda.memory_stats(device)
+
+            def stat(name: str) -> int:
+                return int(cuda_stats.get(name, 0))
+
+            free_bytes, total_device_bytes = torch.cuda.mem_get_info(device)
+            reserved_bytes = torch.cuda.memory_reserved(device)
+            allocated_bytes = torch.cuda.memory_allocated(device)
+            used_bytes = total_device_bytes - free_bytes
+            non_torch_bytes = max(0, used_bytes - reserved_bytes)
+            lines.append(
+                "  CUDA now: "
+                f"allocated={self._gib(allocated_bytes):.4f} GiB, "
+                f"reserved={self._gib(reserved_bytes):.4f} GiB, "
+                f"device_used={self._gib(used_bytes):.4f} GiB, "
+                f"non_torch~={self._gib(non_torch_bytes):.4f} GiB"
+            )
+            lines.append(
+                "  PyTorch stats: "
+                f"allocated_peak={self._gib(stat('allocated_bytes.all.peak')):.4f} GiB, "
+                f"reserved_peak={self._gib(stat('reserved_bytes.all.peak')):.4f} GiB, "
+                f"active_current={self._gib(stat('active_bytes.all.current')):.4f} GiB, "
+                f"active_peak={self._gib(stat('active_bytes.all.peak')):.4f} GiB"
+            )
+            lines.append(
+                "  PyTorch fragmentation/cache: "
+                f"inactive_split_current={self._gib(stat('inactive_split_bytes.all.current')):.4f} GiB, "
+                f"inactive_split_peak={self._gib(stat('inactive_split_bytes.all.peak')):.4f} GiB, "
+                f"segment_current={self._gib(stat('segment_bytes.all.current')):.4f} GiB, "
+                f"segment_peak={self._gib(stat('segment_bytes.all.peak')):.4f} GiB, "
+                f"alloc_retries={stat('num_alloc_retries')}, "
+                f"ooms={stat('num_ooms')}"
+            )
+
+        if unique_infos:
+            owner_totals: Dict[str, int] = {}
+            owner_counts: Dict[str, int] = {}
+            detail_rows = []
+            for model_part_idx, info in unique_infos.values():
+                owner = (
+                    info.owner
+                    if info.owner == "shared_pool"
+                    else f"part{model_part_idx}:{info.owner}"
+                )
+                owner_totals[owner] = owner_totals.get(owner, 0) + info.nbytes
+                owner_counts[owner] = owner_counts.get(owner, 0) + 1
+                detail_rows.append((info.nbytes, model_part_idx, info))
+
+            lines.append("  by owner:")
+            for owner, nbytes in sorted(
+                owner_totals.items(), key=lambda item: item[1], reverse=True
+            ):
+                lines.append(
+                    f"    {owner}: {self._gib(nbytes):.4f} GiB " f"({owner_counts[owner]} tensors)"
+                )
+
+            try:
+                detail_limit = int(os.getenv("OLMO_EP_NO_SYNC_SYMM_BUFFER_SUMMARY_LIMIT", "64"))
+            except ValueError:
+                detail_limit = 64
+            if detail_limit != 0:
+                detail_rows.sort(key=lambda row: row[0], reverse=True)
+                shown_rows = detail_rows if detail_limit < 0 else detail_rows[:detail_limit]
+                lines.append(f"  largest buffers: showing {len(shown_rows)}/{len(detail_rows)}")
+                for nbytes, model_part_idx, info in shown_rows:
+                    dtype = str(info.dtype).replace("torch.", "")
+                    lines.append(
+                        f"    {self._gib(nbytes):.4f} GiB "
+                        f"part={model_part_idx} {info.owner}.{info.name} "
+                        f"shape={info.shape} dtype={dtype} device={info.device}"
+                    )
+
+        log.info("\n".join(lines))
+
+    def log_ep_no_sync_symm_buffer_summary(self, *, context: str) -> None:
+        self._log_ep_no_sync_symm_buffer_summary(
+            model_parts=self.model_parts,
+            context=context,
+        )
+
     def _prewarm_ep_no_sync_symm_buffers(
         self,
         *,
@@ -2945,6 +3100,16 @@ class OLMoDDPTrainModule(TrainModule):
                 max_local_microbatch_size=prewarm_rank_microbatch_size,
                 pad_to_block_count=max_count,
                 rowwise_lifetime_lease_slots=rowwise_slots_by_part[model_part_idx],
+            )
+
+        if self._ep_no_sync_symm_prewarm_summary_enabled():
+            self._log_ep_no_sync_symm_buffer_summary(
+                model_parts=typed_parts,
+                context=(
+                    "after prewarm, "
+                    f"rank_microbatch_size={prewarm_rank_microbatch_size}, "
+                    f"rowwise_lifetime_lease_slots={rowwise_lifetime_lease_slots}"
+                ),
             )
 
     def compile_model(self):

--- a/src/olmo_core/train/train_module/transformer/ddp_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/ddp_train_module.py
@@ -2888,8 +2888,10 @@ class OLMoDDPTrainModule(TrainModule):
 
     @staticmethod
     def _ep_no_sync_symm_summary_enabled() -> bool:
-        raw = os.getenv("OLMO_EP_NO_SYNC_SYMM_BUFFER_SUMMARY", "1")
-        return raw.strip().lower() not in {"", "0", "false", "no", "off"}
+        # Opt-in: this walks every symmetric tensor and queries CUDA allocator stats, so keep it off
+        # for normal runs and enable it explicitly in IBGDA/debug recipes.
+        raw = os.getenv("OLMO_EP_NO_SYNC_SYMM_BUFFER_SUMMARY", "0")
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
 
     @staticmethod
     def _ep_no_sync_symm_prewarm_summary_enabled() -> bool:

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -1666,6 +1666,16 @@ class Trainer:
         log.info("Starting forward/backward dry-run batch...")
         self.train_module.train_batch(batch, dry_run=True)
         log.info("Dry-run complete")
+        self._log_ep_no_sync_symm_buffer_summary(context="after dry-run")
+
+    def _log_ep_no_sync_symm_buffer_summary(self, *, context: str) -> None:
+        log_summary = getattr(
+            self.train_module,
+            "log_ep_no_sync_symm_buffer_summary",
+            None,
+        )
+        if callable(log_summary):
+            log_summary(context=context)
 
     def _fit_epoch(self):
         self.data_loader.reshuffle(self.epoch)
@@ -1702,12 +1712,20 @@ class Trainer:
                 log.warning(f"Skipping training on step {self.global_step:,d} intentionally...")
             else:
                 self.train_module.train_batch(batch)
+                if self.global_step == 1:
+                    self._log_ep_no_sync_symm_buffer_summary(
+                        context="after train step 1 backward before optim"
+                    )
 
                 for callback in self._iter_callbacks():
                     callback.pre_optim_step()
 
                 self.train_module.optim_step()
                 self.train_module.zero_grads()
+                if self.global_step == 1:
+                    self._log_ep_no_sync_symm_buffer_summary(
+                        context="after train step 1 optim+zero_grad before callbacks"
+                    )
 
             for callback in self._iter_callbacks():
                 callback.post_train_batch()

--- a/src/test/nn/ddp/block_no_ep_parity_test.py
+++ b/src/test/nn/ddp/block_no_ep_parity_test.py
@@ -99,7 +99,9 @@ def _run_dropless_path_matches_no_ep(
     _install_deterministic_topk_router(ep_block)
 
     if rowwise:
-        ep_block.ep.rowwise_nblocks = 128
+        ep_block.ep.rowwise_get_nblocks = 128
+        ep_block.ep.rowwise_put_nblocks = 128
+        ep_block.ep.rowwise_weighted_put_nblocks = 128
         ep_block.ep.validate()
 
     no_ep_block.train()

--- a/src/test/nn/ddp/block_no_sync_test.py
+++ b/src/test/nn/ddp/block_no_sync_test.py
@@ -6,6 +6,7 @@ import torch.distributed as dist
 from torch.distributed.device_mesh import DeviceMesh
 
 from olmo_core.config import DType
+from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import MoERouterGatingFunction
@@ -22,6 +23,29 @@ from olmo_core.testing import (
     requires_triton,
     run_distributed_test,
 )
+
+
+def test_v2_extracted_forward_module_names_importable():
+    from olmo_core.nn.moe.v2 import (
+        activation_debug,
+        checkpointing,
+        ep_no_sync_1d,
+        ep_no_sync_buffers,
+        ep_no_sync_rowwise,
+        ep_no_sync_rowwise_wave,
+        ep_sync_1d,
+        no_ep,
+    )
+
+    assert hasattr(activation_debug, "maybe_dump_ep_no_sync_saved_activations")
+    assert hasattr(ep_sync_1d, "combined_forward_ep_1d")
+    assert hasattr(no_ep, "combined_forward_no_ep")
+    assert hasattr(checkpointing, "checkpoint_recompute_context_fn")
+    assert hasattr(ep_no_sync_buffers, "get_ep_no_sync_buffers")
+    assert hasattr(ep_no_sync_buffers, "_NoSyncSymmBuffers")
+    assert hasattr(ep_no_sync_1d, "combined_forward_ep_no_sync_1d")
+    assert hasattr(ep_no_sync_rowwise, "combined_forward_ep_no_sync_rowwise")
+    assert hasattr(ep_no_sync_rowwise_wave, "combined_forward_ep_no_sync_rowwise_wave")
 
 
 def _build_ep_mesh() -> DeviceMesh:
@@ -46,10 +70,16 @@ def _build_block(
     num_shared_experts: int = 0,
     shared_hidden_size: int = 512,
     uniform_expert_assignment: bool = True,
-    ep_no_sync_use_rowwise_all_to_all: bool = False,
     init_device: str = "cuda",
+    checkpoint_combined_ep_tbo: bool = False,
+    rowwise_fp8=None,
+    ep_no_sync_use_rowwise_all_to_all: bool = False,
+    ep_no_sync_rowwise_backend: str = "nvshmem",
 ) -> OLMoDDPTransformerBlock:
     if ep is None:
+        rowwise_backend = ep_no_sync_rowwise_backend.lower()
+        if rowwise_backend != "nvshmem":
+            raise OLMoConfigurationError("ep_no_sync_rowwise_backend must be 'nvshmem'")
         if not ep_no_sync:
             path = ExpertParallelPath.sync_1d
         elif ep_no_sync_use_rowwise_all_to_all:
@@ -59,8 +89,10 @@ def _build_block(
         ep = ExpertParallelConfig(
             path=path,
             capacity_factor=ep_no_sync_capacity_factor,
-            rowwise_nblocks=256,
-            major_align=1,
+            rowwise_get_nblocks=256,
+            rowwise_put_nblocks=256,
+            rowwise_weighted_put_nblocks=128,
+            checkpoint_tbo=checkpoint_combined_ep_tbo,
         )
 
     layer_norm = LayerNormConfig(
@@ -94,7 +126,13 @@ def _build_block(
             z_loss_weight=None,
             dtype=DType.float32,
         ),
-        shared_experts_router=None,
+        routed_experts=RoutedExpertsConfig(
+            d_model=d_model,
+            hidden_size=hidden_size,
+            num_experts=num_experts,
+            bias=False,
+            dtype=DType.float32,
+        ),
         shared_experts=(
             SharedExpertsConfig(
                 d_model=d_model,
@@ -106,17 +144,160 @@ def _build_block(
             if num_shared_experts > 0
             else None
         ),
-        routed_experts=RoutedExpertsConfig(
-            d_model=d_model,
-            hidden_size=hidden_size,
-            num_experts=num_experts,
-            bias=False,
-            dtype=DType.float32,
-        ),
+        shared_experts_router=None,
         feed_forward_norm=layer_norm,
         ep=ep,
+        rowwise_fp8=rowwise_fp8,
         init_device=init_device,
     )
+
+
+def _set_rowwise_block_counts(block: OLMoDDPTransformerBlock, value: int) -> None:
+    block.ep.rowwise_get_nblocks = value
+    block.ep.rowwise_put_nblocks = value
+    block.ep.rowwise_weighted_put_nblocks = value
+
+
+def test_v2_ep_config_selects_rowwise_wave_path():
+    block = _build_block(
+        ep_no_sync=False,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.rowwise_wave,
+            rowwise_wave_num_waves=4,
+            rowwise_wave_mode="EXPERT",
+        ),
+        init_device="cpu",
+    )
+    assert block.ep.path == ExpertParallelPath.rowwise_wave
+    assert block.ep.no_sync is True
+    assert block.ep.is_rowwise is True
+    assert block.ep.uses_rowwise_buffers is True
+    assert block.ep.rowwise_transport == "nvshmem"
+    assert block.ep.rowwise_wave_num_waves == 4
+    assert block.ep.rowwise_wave_mode == "expert"
+
+
+def test_v2_ep_config_rowwise_nblock_defaults():
+    ep = ExpertParallelConfig()
+
+    assert ep.rowwise_get_nblocks == 256
+    assert ep.rowwise_put_nblocks == 256
+    assert ep.rowwise_weighted_put_nblocks == 128
+
+
+@pytest.mark.parametrize(
+    "setting_name",
+    [
+        "rowwise_get_nblocks",
+        "rowwise_put_nblocks",
+        "rowwise_weighted_put_nblocks",
+    ],
+)
+def test_v2_ep_config_rejects_negative_rowwise_nblock_setting(setting_name):
+    ep = ExpertParallelConfig()
+    setattr(ep, setting_name, -1)
+
+    with pytest.raises(OLMoConfigurationError, match=setting_name):
+        ep.validate()
+
+
+def test_v2_rowwise_nvshmem_tbo_forward_method_is_available():
+    block = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_use_rowwise_all_to_all=True,
+        init_device="cpu",
+    )
+    assert block.ep.path == ExpertParallelPath.rowwise_nvshmem
+    assert callable(block.combined_forward_rowwise_nvshmem_tbo)
+
+
+def test_v2_rowwise_wave_num_waves_requires_rowwise_wave_path():
+    with pytest.raises(OLMoConfigurationError, match="rowwise_wave_num_waves"):
+        ExpertParallelConfig(
+            path=ExpertParallelPath.rowwise_nvshmem,
+            rowwise_wave_num_waves=2,
+        ).validate()
+
+
+def test_v2_rowwise_wave_rejects_invalid_mode_and_num_waves():
+    with pytest.raises(OLMoConfigurationError, match="rowwise_wave_num_waves"):
+        ExpertParallelConfig(
+            path=ExpertParallelPath.rowwise_wave,
+            rowwise_wave_num_waves=0,
+        ).validate()
+
+    with pytest.raises(OLMoConfigurationError, match="rowwise_wave_mode"):
+        ExpertParallelConfig(
+            path=ExpertParallelPath.rowwise_wave,
+            rowwise_wave_mode="token",
+        ).validate()
+
+
+def test_v2_rowwise_backend_rejects_unknown_backend():
+    with pytest.raises(OLMoConfigurationError, match="ep_no_sync_rowwise_backend"):
+        _build_block(
+            ep_no_sync=True,
+            ep_no_sync_use_rowwise_all_to_all=True,
+            ep_no_sync_rowwise_backend="unknown",
+            init_device="cpu",
+        )
+
+
+def test_v2_rowwise_wave_forward_method_is_available():
+    block = _build_block(
+        ep_no_sync=False,
+        ep=ExpertParallelConfig(
+            path=ExpertParallelPath.rowwise_wave,
+            rowwise_wave_num_waves=2,
+        ),
+        init_device="cpu",
+    )
+    assert callable(block.combined_forward_ep_no_sync_rowwise_wave)
+
+
+def _reference_rowwise_dispatch_bf16(
+    source_input: torch.Tensor,
+    dst_ranks: torch.Tensor,
+    dst_rows: torch.Tensor,
+    *,
+    ep_world_size: int,
+    rank_capacity: int,
+) -> torch.Tensor:
+    output = torch.zeros(
+        (ep_world_size, rank_capacity, source_input.shape[1]),
+        dtype=source_input.dtype,
+        device=source_input.device,
+    )
+    for token_idx in range(dst_ranks.shape[0]):
+        for topk_idx in range(dst_ranks.shape[1]):
+            rank = int(dst_ranks[token_idx, topk_idx].item())
+            row = int(dst_rows[token_idx, topk_idx].item())
+            if rank >= 0 and row >= 0:
+                output[rank, row] = source_input[token_idx]
+    return output
+
+
+def _reference_rowwise_combine_bf16(
+    expert_out_by_rank: torch.Tensor,
+    src_ranks: torch.Tensor,
+    src_rows: torch.Tensor,
+    *,
+    probs: torch.Tensor,
+) -> torch.Tensor:
+    output = torch.zeros(
+        (src_ranks.shape[0], expert_out_by_rank.shape[2]),
+        dtype=torch.float32,
+        device=expert_out_by_rank.device,
+    )
+    for token_idx in range(src_ranks.shape[0]):
+        for topk_idx in range(src_ranks.shape[1]):
+            rank = int(src_ranks[token_idx, topk_idx].item())
+            row = int(src_rows[token_idx, topk_idx].item())
+            if rank >= 0 and row >= 0:
+                output[token_idx] += (
+                    expert_out_by_rank[rank, row].float() * probs[token_idx, topk_idx]
+                )
+    return output.to(dtype=torch.bfloat16)
 
 
 def _init_block_params(block: OLMoDDPTransformerBlock):
@@ -223,370 +404,6 @@ def _install_deterministic_topk_router(block: OLMoDDPTransformerBlock):
         )
 
 
-@requires_gpu
-@requires_grouped_gemm
-def test_v2_no_ep_forward_backward_smoke():
-    block = _build_block(ep_no_sync=False, init_device="cuda")
-    _init_block_params(block)
-    _install_forced_router(block)
-    block.train()
-
-    x = torch.randn(1, 8, block.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
-    y = block(x)
-
-    assert y.shape == x.shape
-    assert torch.isfinite(y).all()
-
-    y.square().mean().backward()
-
-    assert x.grad is not None
-    assert torch.isfinite(x.grad).all()
-    for p in block.parameters():
-        if p.grad is not None:
-            assert torch.isfinite(p.grad).all()
-
-
-@requires_gpu
-@requires_grouped_gemm
-def test_v2_no_ep_apply_compile_forward_smoke():
-    block = _build_block(
-        ep_no_sync=False,
-        d_model=128,
-        hidden_size=256,
-        num_experts=4,
-        top_k=1,
-        init_device="cuda",
-    )
-    _init_block_params(block)
-    block.to(dtype=torch.bfloat16)
-    _install_forced_router(block)
-    block.train()
-    block.apply_compile()
-
-    x = torch.randn(1, 4, block.d_model, device="cuda", dtype=torch.bfloat16)
-    y = block(x)
-
-    assert y.shape == x.shape
-    assert torch.isfinite(y).all()
-
-
-def _run_ep_no_sync_matches_synced():
-    # VDev-1d no-sync EP uses the legacy torch symm-mem backend; OLMo-owned symm-mem
-    # (default on) supports only the rowwise no-sync path.
-    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"
-    ep_mesh = _build_ep_mesh()
-
-    block_ep = _build_block(ep_no_sync=False, uniform_expert_assignment=True)
-    block_no_sync = _build_block(ep_no_sync=True, uniform_expert_assignment=True)
-    block_ep.apply_ep(ep_mesh)
-    block_no_sync.apply_ep(ep_mesh)
-
-    _init_block_params(block_ep)
-    block_no_sync.load_state_dict(block_ep.state_dict())
-    block_ep.train()
-    block_no_sync.train()
-
-    x = torch.randn(1, 8, block_ep.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
-    x_ref = x.detach().clone().requires_grad_(True)
-
-    y_ep = block_ep(x)
-    y_no_sync = block_no_sync(x_ref)
-    torch.testing.assert_close(y_no_sync, y_ep, atol=2e-4, rtol=2e-4)
-
-    y_ep.sum().backward()
-    y_no_sync.sum().backward()
-    torch.testing.assert_close(x_ref.grad, x.grad, atol=3e-4, rtol=3e-4)
-
-    ep_params = dict(block_ep.named_parameters())
-    no_sync_params = dict(block_no_sync.named_parameters())
-    for name, p_ep in ep_params.items():
-        p_no_sync = no_sync_params[name]
-        if p_ep.grad is None or p_no_sync.grad is None:
-            continue
-        torch.testing.assert_close(p_no_sync.grad, p_ep.grad, atol=8e-4, rtol=8e-4)
-
-
-def _run_ep_no_sync_drop_behavior():
-    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # non-rowwise EP → legacy symm-mem backend
-    ep_mesh = _build_ep_mesh()
-
-    block_no_sync = _build_block(
-        ep_no_sync=True,
-        ep_no_sync_capacity_factor=0.25,
-        uniform_expert_assignment=False,
-    )
-    block_no_sync.apply_ep(ep_mesh)
-    _init_block_params(block_no_sync)
-    _install_forced_router(block_no_sync)
-    block_no_sync.train()
-
-    x = torch.randn(
-        1, 8, block_no_sync.d_model, device="cuda", dtype=torch.float32, requires_grad=True
-    )
-    y = block_no_sync(x)
-    assert torch.isfinite(y).all()
-    y.sum().backward()
-    assert x.grad is not None
-
-    dbg = block_no_sync._ep_no_sync_last_debug
-    assert dbg["num_dropped"].item() > 0
-    assert dbg["received_tokens_after_drop"].item() <= dbg["rank_capacity"].item()
-    assert dbg["allowed_splits"].sum().item() == dbg["local_kept_tokens"].item()
-    assert dbg["combined_tokens"].item() == dbg["local_kept_tokens"].item()
-    assert dbg["zero_rows_after_local_unpermute"].item() >= dbg["num_dropped"].item()
-
-
-def _run_ep_no_sync_quota_invariants():
-    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # non-rowwise EP → legacy symm-mem backend
-    ep_mesh = _build_ep_mesh()
-
-    block_no_sync = _build_block(
-        ep_no_sync=True,
-        ep_no_sync_capacity_factor=0.5,
-        uniform_expert_assignment=False,
-    )
-    block_no_sync.apply_ep(ep_mesh)
-    _init_block_params(block_no_sync)
-    _install_forced_router(block_no_sync)
-    block_no_sync.train()
-
-    x = torch.randn(
-        1, 8, block_no_sync.d_model, device="cuda", dtype=torch.float32, requires_grad=True
-    )
-    y = block_no_sync(x)
-    y.sum().backward()
-
-    dbg = block_no_sync._ep_no_sync_last_debug
-    assert dbg["allowed_splits"].sum().item() == dbg["local_kept_tokens"].item()
-    assert dbg["received_tokens_after_drop"].item() <= dbg["rank_capacity"].item()
-    assert dbg["combined_tokens"].item() == dbg["local_kept_tokens"].item()
-
-
-def _run_ep_no_sync_hard_fail_setup():
-    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # non-rowwise EP → legacy symm-mem backend
-    import olmo_core.nn.ddp.block as block_module
-
-    ep_mesh = _build_ep_mesh()
-    old_symm = block_module._symm_mem
-    block_module._symm_mem = None
-    try:
-        block = _build_block(ep_no_sync=True)
-        try:
-            block.apply_ep(ep_mesh)
-        except RuntimeError:
-            pass
-        else:
-            raise AssertionError("Expected RuntimeError when symmetric memory is unavailable")
-    finally:
-        block_module._symm_mem = old_symm
-
-
-def _run_ep_no_sync_rowwise_matches_synced():
-    ep_mesh = _build_ep_mesh()
-
-    block_ep = _build_block(
-        ep_no_sync=False,
-        d_model=512,
-        hidden_size=1024,
-        num_experts=8,
-        top_k=2,
-        uniform_expert_assignment=False,
-    )
-    block_rowwise = _build_block(
-        ep_no_sync=True,
-        d_model=512,
-        hidden_size=1024,
-        num_experts=8,
-        top_k=2,
-        uniform_expert_assignment=False,
-    )
-    block_ep.apply_ep(ep_mesh)
-    block_rowwise.apply_ep(ep_mesh)
-
-    _init_block_params(block_ep)
-    block_rowwise.load_state_dict(block_ep.state_dict())
-    _install_deterministic_topk_router(block_ep)
-    _install_deterministic_topk_router(block_rowwise)
-
-    block_rowwise.ep.path = ExpertParallelPath.rowwise_nvshmem
-    block_rowwise.ep.rowwise_nblocks = 128
-
-    block_ep.train()
-    block_rowwise.train()
-
-    x = torch.randn(1, 8, block_ep.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
-    x_rowwise = x.detach().clone().requires_grad_(True)
-
-    y_ep = block_ep(x)
-    y_rowwise = block_rowwise(x_rowwise)
-    torch.testing.assert_close(y_rowwise, y_ep, atol=5e-4, rtol=5e-4)
-
-    loss_ep = y_ep.square().mean() + (0.1 * y_ep.sum())
-    loss_rowwise = y_rowwise.square().mean() + (0.1 * y_rowwise.sum())
-    loss_ep.backward()
-    loss_rowwise.backward()
-
-    torch.testing.assert_close(x_rowwise.grad, x.grad, atol=5e-4, rtol=5e-4)
-
-    ep_params = dict(block_ep.named_parameters())
-    rowwise_params = dict(block_rowwise.named_parameters())
-    for name, p_ep in ep_params.items():
-        p_rowwise = rowwise_params[name]
-        if p_ep.grad is None or p_rowwise.grad is None:
-            continue
-        torch.testing.assert_close(p_rowwise.grad, p_ep.grad, atol=1e-3, rtol=1e-3)
-
-
-def _run_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
-    ep_mesh = _build_ep_mesh()
-
-    block_a = _build_block(
-        ep_no_sync=True,
-        ep_no_sync_capacity_factor=0.5,
-        d_model=512,
-        hidden_size=1024,
-        num_experts=8,
-        top_k=4,
-        uniform_expert_assignment=False,
-    )
-    block_b = _build_block(
-        ep_no_sync=True,
-        ep_no_sync_capacity_factor=0.5,
-        d_model=512,
-        hidden_size=1024,
-        num_experts=8,
-        top_k=4,
-        uniform_expert_assignment=False,
-    )
-    block_a.apply_ep(ep_mesh)
-    block_b.apply_ep(ep_mesh)
-
-    _init_block_params(block_a)
-    block_b.load_state_dict(block_a.state_dict())
-    _install_deterministic_topk_router(block_a)
-    _install_deterministic_topk_router(block_b)
-
-    block_a.ep.path = ExpertParallelPath.rowwise_nvshmem
-    block_a.ep.rowwise_nblocks = 128
-
-    block_b.ep.path = ExpertParallelPath.rowwise_nvshmem
-    block_b.ep.rowwise_nblocks = 128
-
-    block_a.train()
-    block_b.train()
-
-    x = torch.randn(2, 64, block_a.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
-    x_b = x.detach().clone().requires_grad_(True)
-
-    y_a = block_a(x)
-    y_b = block_b(x_b)
-    assert torch.isfinite(y_a).all()
-    assert torch.isfinite(y_b).all()
-    torch.testing.assert_close(y_b, y_a, atol=8e-4, rtol=8e-4)
-
-    loss_a = y_a.square().mean() + (0.1 * y_a.sum())
-    loss_b = y_b.square().mean() + (0.1 * y_b.sum())
-    loss_a.backward()
-    loss_b.backward()
-
-    assert torch.isfinite(x.grad).all()
-    assert torch.isfinite(x_b.grad).all()
-    torch.testing.assert_close(x_b.grad, x.grad, atol=2e-3, rtol=2e-3)
-
-    params_a = dict(block_a.named_parameters())
-    params_b = dict(block_b.named_parameters())
-    for name, p_a in params_a.items():
-        p_b = params_b[name]
-        if p_a.grad is None or p_b.grad is None:
-            continue
-        assert torch.isfinite(p_a.grad).all()
-        assert torch.isfinite(p_b.grad).all()
-        torch.testing.assert_close(p_b.grad, p_a.grad, atol=3e-3, rtol=3e-3)
-
-
-@requires_multi_gpu
-def test_v2_ep_no_sync_matches_synced():
-    run_distributed_test(_run_ep_no_sync_matches_synced, backend="nccl", start_method="spawn")
-
-
-@requires_multi_gpu
-def test_v2_ep_no_sync_drop_behavior():
-    run_distributed_test(_run_ep_no_sync_drop_behavior, backend="nccl", start_method="spawn")
-
-
-@requires_multi_gpu
-def test_v2_ep_no_sync_quota_invariants():
-    run_distributed_test(_run_ep_no_sync_quota_invariants, backend="nccl", start_method="spawn")
-
-
-@requires_multi_gpu
-def test_v2_ep_no_sync_hard_fail_setup():
-    run_distributed_test(_run_ep_no_sync_hard_fail_setup, backend="nccl", start_method="spawn")
-
-
-@requires_multi_gpu
-@requires_symm_mem_vdev2d
-def test_v2_ep_no_sync_rowwise_matches_synced():
-    run_distributed_test(
-        _run_ep_no_sync_rowwise_matches_synced, backend="nccl", start_method="spawn"
-    )
-
-
-@requires_multi_gpu
-@requires_symm_mem_vdev2d
-def test_v2_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
-    run_distributed_test(
-        _run_ep_no_sync_rowwise_drop_matches_independent_rowwise_block,
-        backend="nccl",
-        start_method="spawn",
-    )
-
-
-def test_v2_extracted_forward_module_names_importable():
-    from olmo_core.nn.moe.v2 import (
-        activation_debug,
-        checkpointing,
-        ep_no_sync_1d,
-        ep_no_sync_buffers,
-        ep_no_sync_rowwise,
-        ep_no_sync_rowwise_wave,
-        ep_sync_1d,
-        no_ep,
-    )
-
-    assert hasattr(activation_debug, "maybe_dump_ep_no_sync_saved_activations")
-    assert hasattr(ep_sync_1d, "combined_forward_ep_1d")
-    assert hasattr(no_ep, "combined_forward_no_ep")
-    assert hasattr(checkpointing, "checkpoint_recompute_context_fn")
-    assert hasattr(ep_no_sync_buffers, "get_ep_no_sync_buffers")
-    assert hasattr(ep_no_sync_buffers, "_NoSyncSymmBuffers")
-    assert hasattr(ep_no_sync_1d, "combined_forward_ep_no_sync_1d")
-    assert hasattr(ep_no_sync_rowwise, "combined_forward_ep_no_sync_rowwise")
-    assert hasattr(ep_no_sync_rowwise_wave, "combined_forward_ep_no_sync_rowwise_wave")
-
-
-def test_v2_rowwise_nvshmem_tbo_forward_method_is_available():
-    block = _build_block(
-        ep_no_sync=True,
-        ep_no_sync_use_rowwise_all_to_all=True,
-        init_device="cpu",
-    )
-    assert block.ep.path == ExpertParallelPath.rowwise_nvshmem
-    assert callable(block.combined_forward_rowwise_nvshmem_tbo)
-
-
-def test_v2_rowwise_wave_forward_method_is_available():
-    block = _build_block(
-        ep_no_sync=False,
-        ep=ExpertParallelConfig(
-            path=ExpertParallelPath.rowwise_wave,
-            rowwise_wave_num_waves=2,
-        ),
-        init_device="cpu",
-    )
-    assert callable(block.combined_forward_ep_no_sync_rowwise_wave)
-
-
 def _install_local_deterministic_topk_router(block: OLMoDDPTransformerBlock):
     """Deterministic router for single-process tests that do not initialize dist."""
 
@@ -624,161 +441,258 @@ def _install_local_deterministic_topk_router(block: OLMoDDPTransformerBlock):
         )
 
 
-def _poison_rowwise_capacity_tails(block: OLMoDDPTransformerBlock, *, value: float) -> int:
-    recv_splits = getattr(block, "_debug_rowwise_recv_splits_by_src_local", None)
-    if recv_splits is None:
-        raise RuntimeError("rowwise debug tensors were not captured")
-    valid_rows = int(recv_splits.sum().item())
-    poisoned_rows = 0
+@requires_gpu
+@requires_grouped_gemm
+def test_v2_no_ep_forward_backward_smoke():
+    block = _build_block(ep_no_sync=False, init_device="cuda")
+    _init_block_params(block)
+    _install_forced_router(block)
+    block.train()
 
-    def poison_tensor(tensor: torch.Tensor | None) -> None:
-        nonlocal poisoned_rows
-        if tensor is None or tensor.ndim != 2 or not tensor.is_floating_point():
-            return
-        tail_rows = int(tensor.shape[0]) - valid_rows
-        if tail_rows <= 0:
-            return
-        tensor.narrow(0, valid_rows, tail_rows).fill_(value)
-        poisoned_rows += tail_rows
+    x = torch.randn(1, 8, block.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    y = block(x)
 
-    with torch.no_grad():
-        pools = getattr(block, "_ep_no_sync_symm_lease_pools", {})
-        dispatch_pool = pools.get("dispatch_out")
-        if dispatch_pool is not None:
-            for slot in dispatch_pool._slots:
-                poison_tensor(slot.get("dispatch_out"))
+    assert y.shape == x.shape
+    assert torch.isfinite(y).all()
 
-        for buffers in getattr(block, "_ep_no_sync_static_buffer_cache", {}).values():
-            poison_tensor(getattr(buffers, "combine_in", None))
+    y.square().mean().backward()
 
-    return poisoned_rows
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+    for p in block.parameters():
+        if p.grad is not None:
+            assert torch.isfinite(p.grad).all()
 
 
-def _reference_rowwise_dispatch_bf16(
-    source_input: torch.Tensor,
-    dst_ranks: torch.Tensor,
-    dst_rows: torch.Tensor,
-    *,
-    ep_world_size: int,
-    rank_capacity: int,
-) -> torch.Tensor:
-    output = torch.zeros(
-        (ep_world_size, rank_capacity, source_input.shape[1]),
-        dtype=source_input.dtype,
-        device=source_input.device,
+@requires_gpu
+@requires_grouped_gemm
+def test_v2_no_ep_repeated_forward_backward_is_stable():
+    block = _build_block(
+        ep_no_sync=False,
+        d_model=256,
+        hidden_size=512,
+        num_experts=8,
+        top_k=4,
+        num_shared_experts=1,
+        shared_hidden_size=256,
+        uniform_expert_assignment=False,
+        init_device="cuda",
     )
-    for token_idx in range(dst_ranks.shape[0]):
-        for topk_idx in range(dst_ranks.shape[1]):
-            rank = int(dst_ranks[token_idx, topk_idx].item())
-            row = int(dst_rows[token_idx, topk_idx].item())
-            if rank >= 0 and row >= 0:
-                output[rank, row] = source_input[token_idx]
-    return output
+    _init_block_params(block)
+    _install_local_deterministic_topk_router(block)
+    block.train()
 
+    torch.manual_seed(1234)
+    x0 = torch.randn(2, 256, block.d_model, device="cuda", dtype=torch.float32)
 
-def _reference_rowwise_combine_bf16(
-    expert_out_by_rank: torch.Tensor,
-    src_ranks: torch.Tensor,
-    src_rows: torch.Tensor,
-    *,
-    probs: torch.Tensor,
-) -> torch.Tensor:
-    output = torch.zeros(
-        (src_ranks.shape[0], expert_out_by_rank.shape[2]),
-        dtype=torch.float32,
-        device=expert_out_by_rank.device,
-    )
-    for token_idx in range(src_ranks.shape[0]):
-        for topk_idx in range(src_ranks.shape[1]):
-            rank = int(src_ranks[token_idx, topk_idx].item())
-            row = int(src_rows[token_idx, topk_idx].item())
-            if rank >= 0 and row >= 0:
-                output[token_idx] += (
-                    expert_out_by_rank[rank, row].float() * probs[token_idx, topk_idx]
-                )
-    return output.to(dtype=torch.bfloat16)
-
-
-def _run_ep_no_sync_rowwise_capacity_tail_poison_does_not_change_backward():
-    old_debug = os.environ.get("OLMO_MOE_ROWWISE_DEBUG_TENSORS")
-    os.environ["OLMO_MOE_ROWWISE_DEBUG_TENSORS"] = "1"
-    try:
-        ep_mesh = _build_ep_mesh()
-
-        block_a = _build_block(
-            ep_no_sync=True,
-            ep_no_sync_use_rowwise_all_to_all=True,
-            ep_no_sync_capacity_factor=8.0,
-            d_model=512,
-            hidden_size=1024,
-            num_experts=8,
-            top_k=4,
-            uniform_expert_assignment=False,
-        )
-        block_b = _build_block(
-            ep_no_sync=True,
-            ep_no_sync_use_rowwise_all_to_all=True,
-            ep_no_sync_capacity_factor=8.0,
-            d_model=512,
-            hidden_size=1024,
-            num_experts=8,
-            top_k=4,
-            uniform_expert_assignment=False,
-        )
-        block_a.apply_ep(ep_mesh)
-        block_b.apply_ep(ep_mesh)
-
-        _init_block_params(block_a)
-        block_b.load_state_dict(block_a.state_dict())
-        _install_deterministic_topk_router(block_a)
-        _install_deterministic_topk_router(block_b)
-
-        block_a.ep.rowwise_nblocks = 128
-        block_b.ep.rowwise_nblocks = 128
-        block_a.ep.validate()
-        block_b.ep.validate()
-        block_a.train()
-        block_b.train()
-
-        x = torch.randn(
-            2, 64, block_a.d_model, device="cuda", dtype=torch.float32, requires_grad=True
-        )
-        x_b = x.detach().clone().requires_grad_(True)
-
-        y_a = block_a(x)
-        y_b = block_b(x_b)
-        torch.testing.assert_close(y_b, y_a, atol=8e-4, rtol=8e-4)
-
-        poisoned_rows = _poison_rowwise_capacity_tails(block_b, value=2048.0)
-        assert poisoned_rows > 0
-
-        loss_a = y_a.square().mean() + (0.1 * y_a.sum())
-        loss_b = y_b.square().mean() + (0.1 * y_b.sum())
-        loss_a.backward()
-        loss_b.backward()
-
+    def run_once():
+        block.zero_grad(set_to_none=True)
+        x = x0.detach().clone().requires_grad_(True)
+        y = block(x)
+        loss = y.float().square().mean() + 0.03125 * y.float().sum()
+        loss.backward()
+        torch.cuda.synchronize()
+        grads = {
+            name: p.grad.detach().clone()
+            for name, p in block.named_parameters()
+            if p.grad is not None
+        }
         assert x.grad is not None
-        assert x_b.grad is not None
-        torch.testing.assert_close(x_b.grad, x.grad, atol=2e-3, rtol=2e-3)
+        return y.detach().clone(), x.grad.detach().clone(), grads
 
-        params_a = dict(block_a.named_parameters())
-        params_b = dict(block_b.named_parameters())
-        for name, p_a in params_a.items():
-            p_b = params_b[name]
-            if p_a.grad is None or p_b.grad is None:
-                continue
-            torch.testing.assert_close(
-                p_b.grad,
-                p_a.grad,
-                atol=3e-3,
-                rtol=3e-3,
-                msg=f"capacity tail poison changed gradient for {name}",
-            )
-    finally:
-        if old_debug is None:
-            os.environ.pop("OLMO_MOE_ROWWISE_DEBUG_TENSORS", None)
+    ref_y, ref_x_grad, ref_grads = run_once()
+    for _ in range(3):
+        y, x_grad, grads = run_once()
+        torch.testing.assert_close(y, ref_y, atol=0.0, rtol=0.0)
+        torch.testing.assert_close(x_grad, ref_x_grad, atol=2e-8, rtol=0.0)
+        for name, ref_grad in ref_grads.items():
+            torch.testing.assert_close(grads[name], ref_grad, atol=1e-6, rtol=0.0)
+
+
+@requires_gpu
+@requires_grouped_gemm
+def test_v2_no_ep_apply_compile_forward_smoke():
+    block = _build_block(
+        ep_no_sync=False,
+        d_model=128,
+        hidden_size=256,
+        num_experts=4,
+        top_k=1,
+        init_device="cuda",
+    )
+    _init_block_params(block)
+    block.to(dtype=torch.bfloat16)
+    _install_forced_router(block)
+    block.train()
+    block.apply_compile()
+
+    x = torch.randn(1, 4, block.d_model, device="cuda", dtype=torch.bfloat16)
+    y = block(x)
+
+    assert y.shape == x.shape
+    assert torch.isfinite(y).all()
+
+
+def _run_ep_no_sync_matches_synced():
+    ep_mesh = _build_ep_mesh()
+
+    block_ep = _build_block(ep_no_sync=False, uniform_expert_assignment=True)
+    block_no_sync = _build_block(ep_no_sync=True, uniform_expert_assignment=True)
+    block_ep.apply_ep(ep_mesh)
+    block_no_sync.apply_ep(ep_mesh)
+
+    _init_block_params(block_ep)
+    block_no_sync.load_state_dict(block_ep.state_dict())
+    block_ep.train()
+    block_no_sync.train()
+
+    x = torch.randn(1, 8, block_ep.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_(True)
+
+    y_ep = block_ep(x)
+    y_no_sync = block_no_sync(x_ref)
+    torch.testing.assert_close(y_no_sync, y_ep, atol=2e-4, rtol=2e-4)
+
+    y_ep.sum().backward()
+    y_no_sync.sum().backward()
+    torch.testing.assert_close(x_ref.grad, x.grad, atol=3e-4, rtol=3e-4)
+
+    ep_params = dict(block_ep.named_parameters())
+    no_sync_params = dict(block_no_sync.named_parameters())
+    for name, p_ep in ep_params.items():
+        p_no_sync = no_sync_params[name]
+        if p_ep.grad is None or p_no_sync.grad is None:
+            continue
+        torch.testing.assert_close(p_no_sync.grad, p_ep.grad, atol=8e-4, rtol=8e-4)
+
+
+def _run_ep_no_sync_drop_behavior():
+    ep_mesh = _build_ep_mesh()
+
+    block_no_sync = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_capacity_factor=0.25,
+        uniform_expert_assignment=False,
+    )
+    block_no_sync.apply_ep(ep_mesh)
+    _init_block_params(block_no_sync)
+    _install_forced_router(block_no_sync)
+    block_no_sync.train()
+
+    x = torch.randn(
+        1, 8, block_no_sync.d_model, device="cuda", dtype=torch.float32, requires_grad=True
+    )
+    y = block_no_sync(x)
+    assert torch.isfinite(y).all()
+    y.sum().backward()
+    assert x.grad is not None
+
+    dbg = block_no_sync._ep_no_sync_last_debug
+    assert dbg["num_dropped"].item() > 0
+    assert dbg["received_tokens_after_drop"].item() <= dbg["rank_capacity"].item()
+    assert dbg["allowed_splits"].sum().item() == dbg["local_kept_tokens"].item()
+    assert dbg["combined_tokens"].item() == dbg["local_kept_tokens"].item()
+    assert dbg["zero_rows_after_local_unpermute"].item() >= dbg["num_dropped"].item()
+
+
+def _run_ep_no_sync_quota_invariants():
+    ep_mesh = _build_ep_mesh()
+
+    block_no_sync = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_capacity_factor=0.5,
+        uniform_expert_assignment=False,
+    )
+    block_no_sync.apply_ep(ep_mesh)
+    _init_block_params(block_no_sync)
+    _install_forced_router(block_no_sync)
+    block_no_sync.train()
+
+    x = torch.randn(
+        1, 8, block_no_sync.d_model, device="cuda", dtype=torch.float32, requires_grad=True
+    )
+    y = block_no_sync(x)
+    y.sum().backward()
+
+    dbg = block_no_sync._ep_no_sync_last_debug
+    assert dbg["allowed_splits"].sum().item() == dbg["local_kept_tokens"].item()
+    assert dbg["received_tokens_after_drop"].item() <= dbg["rank_capacity"].item()
+    assert dbg["combined_tokens"].item() == dbg["local_kept_tokens"].item()
+
+
+def _run_ep_no_sync_hard_fail_setup():
+    import olmo_core.nn.ddp.block as block_module
+
+    ep_mesh = _build_ep_mesh()
+    old_symm = block_module._symm_mem
+    block_module._symm_mem = None
+    try:
+        block = _build_block(ep_no_sync=True)
+        try:
+            block.apply_ep(ep_mesh)
+        except RuntimeError:
+            pass
         else:
-            os.environ["OLMO_MOE_ROWWISE_DEBUG_TENSORS"] = old_debug
+            raise AssertionError("Expected RuntimeError when symmetric memory is unavailable")
+    finally:
+        block_module._symm_mem = old_symm
+
+
+def _run_ep_no_sync_rowwise_matches_synced():
+    ep_mesh = _build_ep_mesh()
+
+    block_ep = _build_block(
+        ep_no_sync=False,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=2,
+        uniform_expert_assignment=False,
+    )
+    block_rowwise = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_use_rowwise_all_to_all=True,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=2,
+        uniform_expert_assignment=False,
+    )
+    block_ep.apply_ep(ep_mesh)
+    block_rowwise.apply_ep(ep_mesh)
+
+    _init_block_params(block_ep)
+    block_rowwise.load_state_dict(block_ep.state_dict())
+    _install_deterministic_topk_router(block_ep)
+    _install_deterministic_topk_router(block_rowwise)
+
+    _set_rowwise_block_counts(block_rowwise, 128)
+    block_rowwise.ep.validate()
+
+    block_ep.train()
+    block_rowwise.train()
+
+    x = torch.randn(1, 8, block_ep.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    x_rowwise = x.detach().clone().requires_grad_(True)
+
+    y_ep = block_ep(x)
+    y_rowwise = block_rowwise(x_rowwise)
+    torch.testing.assert_close(y_rowwise, y_ep, atol=5e-4, rtol=5e-4)
+
+    loss_ep = y_ep.square().mean() + (0.1 * y_ep.sum())
+    loss_rowwise = y_rowwise.square().mean() + (0.1 * y_rowwise.sum())
+    loss_ep.backward()
+    loss_rowwise.backward()
+
+    torch.testing.assert_close(x_rowwise.grad, x.grad, atol=5e-4, rtol=5e-4)
+
+    ep_params = dict(block_ep.named_parameters())
+    rowwise_params = dict(block_rowwise.named_parameters())
+    for name, p_ep in ep_params.items():
+        p_rowwise = rowwise_params[name]
+        if p_ep.grad is None or p_rowwise.grad is None:
+            continue
+        torch.testing.assert_close(p_rowwise.grad, p_ep.grad, atol=1e-3, rtol=1e-3)
 
 
 def _run_ep_no_sync_rowwise_wave_matches_rowwise():
@@ -798,7 +712,9 @@ def _run_ep_no_sync_rowwise_wave_matches_rowwise():
         ep=ExpertParallelConfig(
             path=ExpertParallelPath.rowwise_wave,
             capacity_factor=2.0,
-            rowwise_nblocks=128,
+            rowwise_get_nblocks=128,
+            rowwise_put_nblocks=128,
+            rowwise_weighted_put_nblocks=128,
             rowwise_wave_num_waves=2,
         ),
         d_model=128,
@@ -815,8 +731,8 @@ def _run_ep_no_sync_rowwise_wave_matches_rowwise():
     _install_deterministic_topk_router(block_rowwise)
     _install_deterministic_topk_router(block_wave)
 
-    block_rowwise.ep.rowwise_nblocks = 128
-    block_wave.ep.rowwise_nblocks = 128
+    _set_rowwise_block_counts(block_rowwise, 128)
+    _set_rowwise_block_counts(block_wave, 128)
     block_rowwise.ep.validate()
     block_wave.ep.validate()
     block_rowwise.train()
@@ -871,7 +787,9 @@ def _run_ep_no_sync_rowwise_wave_matches_rowwise():
         ep=ExpertParallelConfig(
             path=ExpertParallelPath.rowwise_wave,
             capacity_factor=2.0,
-            rowwise_nblocks=32,
+            rowwise_get_nblocks=32,
+            rowwise_put_nblocks=32,
+            rowwise_weighted_put_nblocks=32,
             rowwise_wave_num_waves=2,
         ),
         d_model=128,
@@ -890,8 +808,8 @@ def _run_ep_no_sync_rowwise_wave_matches_rowwise():
 
     block_rowwise_bf16.to(dtype=torch.bfloat16)
     block_wave_bf16.to(dtype=torch.bfloat16)
-    block_rowwise_bf16.ep.rowwise_nblocks = 32
-    block_wave_bf16.ep.rowwise_nblocks = 32
+    _set_rowwise_block_counts(block_rowwise_bf16, 32)
+    _set_rowwise_block_counts(block_wave_bf16, 32)
     block_rowwise_bf16.ep.validate()
     block_wave_bf16.ep.validate()
     block_rowwise_bf16.train()
@@ -946,7 +864,9 @@ def _run_ep_no_sync_rowwise_wave_matches_rowwise():
         ep=ExpertParallelConfig(
             path=ExpertParallelPath.rowwise_wave,
             capacity_factor=2.0,
-            rowwise_nblocks=32,
+            rowwise_get_nblocks=32,
+            rowwise_put_nblocks=32,
+            rowwise_weighted_put_nblocks=32,
             rowwise_wave_num_waves=4,
         ),
         d_model=128,
@@ -965,8 +885,8 @@ def _run_ep_no_sync_rowwise_wave_matches_rowwise():
 
     block_rowwise_eval.to(dtype=torch.bfloat16)
     block_wave_eval.to(dtype=torch.bfloat16)
-    block_rowwise_eval.ep.rowwise_nblocks = 32
-    block_wave_eval.ep.rowwise_nblocks = 32
+    _set_rowwise_block_counts(block_rowwise_eval, 32)
+    _set_rowwise_block_counts(block_wave_eval, 32)
     block_rowwise_eval.ep.validate()
     block_wave_eval.ep.validate()
     block_rowwise_eval.eval()
@@ -981,6 +901,215 @@ def _run_ep_no_sync_rowwise_wave_matches_rowwise():
     assert y_wave_eval.shape == y_rowwise_eval.shape
     assert torch.isfinite(y_wave_eval).all()
     torch.testing.assert_close(y_wave_eval, y_rowwise_eval, atol=2e-2, rtol=2e-2)
+
+
+def _run_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
+    ep_mesh = _build_ep_mesh()
+
+    block_a = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_use_rowwise_all_to_all=True,
+        ep_no_sync_capacity_factor=0.5,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_b = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_use_rowwise_all_to_all=True,
+        ep_no_sync_capacity_factor=0.5,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=4,
+        uniform_expert_assignment=False,
+    )
+    block_a.apply_ep(ep_mesh)
+    block_b.apply_ep(ep_mesh)
+
+    _init_block_params(block_a)
+    block_b.load_state_dict(block_a.state_dict())
+    _install_deterministic_topk_router(block_a)
+    _install_deterministic_topk_router(block_b)
+
+    _set_rowwise_block_counts(block_a, 128)
+    block_a.ep.validate()
+
+    _set_rowwise_block_counts(block_b, 128)
+    block_b.ep.validate()
+
+    block_a.train()
+    block_b.train()
+
+    x = torch.randn(2, 64, block_a.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+    x_b = x.detach().clone().requires_grad_(True)
+
+    y_a = block_a(x)
+    y_b = block_b(x_b)
+    assert torch.isfinite(y_a).all()
+    assert torch.isfinite(y_b).all()
+    torch.testing.assert_close(y_b, y_a, atol=8e-4, rtol=8e-4)
+
+    loss_a = y_a.square().mean() + (0.1 * y_a.sum())
+    loss_b = y_b.square().mean() + (0.1 * y_b.sum())
+    loss_a.backward()
+    loss_b.backward()
+
+    assert torch.isfinite(x.grad).all()
+    assert torch.isfinite(x_b.grad).all()
+    torch.testing.assert_close(x_b.grad, x.grad, atol=2e-3, rtol=2e-3)
+
+    params_a = dict(block_a.named_parameters())
+    params_b = dict(block_b.named_parameters())
+    for name, p_a in params_a.items():
+        p_b = params_b[name]
+        if p_a.grad is None or p_b.grad is None:
+            continue
+        assert torch.isfinite(p_a.grad).all()
+        assert torch.isfinite(p_b.grad).all()
+        torch.testing.assert_close(p_b.grad, p_a.grad, atol=3e-3, rtol=3e-3)
+
+
+def _poison_rowwise_capacity_tails(block: OLMoDDPTransformerBlock, *, value: float) -> int:
+    recv_splits = getattr(block, "_debug_rowwise_recv_splits_by_src_local", None)
+    if recv_splits is None:
+        raise RuntimeError("rowwise debug tensors were not captured")
+    valid_rows = int(recv_splits.sum().item())
+    poisoned_rows = 0
+
+    def poison_tensor(tensor: torch.Tensor | None) -> None:
+        nonlocal poisoned_rows
+        if tensor is None or tensor.ndim != 2 or not tensor.is_floating_point():
+            return
+        tail_rows = int(tensor.shape[0]) - valid_rows
+        if tail_rows <= 0:
+            return
+        tensor.narrow(0, valid_rows, tail_rows).fill_(value)
+        poisoned_rows += tail_rows
+
+    with torch.no_grad():
+        pools = getattr(block, "_ep_no_sync_symm_lease_pools", {})
+        dispatch_pool = pools.get("dispatch_out")
+        if dispatch_pool is not None:
+            for slot in dispatch_pool._slots:
+                poison_tensor(slot.get("dispatch_out"))
+
+        for buffers in getattr(block, "_ep_no_sync_static_buffer_cache", {}).values():
+            poison_tensor(getattr(buffers, "combine_in", None))
+
+    return poisoned_rows
+
+
+def _run_ep_no_sync_rowwise_capacity_tail_poison_does_not_change_backward():
+    old_debug = os.environ.get("OLMO_MOE_ROWWISE_DEBUG_TENSORS")
+    os.environ["OLMO_MOE_ROWWISE_DEBUG_TENSORS"] = "1"
+    try:
+        ep_mesh = _build_ep_mesh()
+
+        block_a = _build_block(
+            ep_no_sync=True,
+            ep_no_sync_use_rowwise_all_to_all=True,
+            ep_no_sync_capacity_factor=8.0,
+            d_model=512,
+            hidden_size=1024,
+            num_experts=8,
+            top_k=4,
+            uniform_expert_assignment=False,
+        )
+        block_b = _build_block(
+            ep_no_sync=True,
+            ep_no_sync_use_rowwise_all_to_all=True,
+            ep_no_sync_capacity_factor=8.0,
+            d_model=512,
+            hidden_size=1024,
+            num_experts=8,
+            top_k=4,
+            uniform_expert_assignment=False,
+        )
+        block_a.apply_ep(ep_mesh)
+        block_b.apply_ep(ep_mesh)
+
+        _init_block_params(block_a)
+        block_b.load_state_dict(block_a.state_dict())
+        _install_deterministic_topk_router(block_a)
+        _install_deterministic_topk_router(block_b)
+
+        _set_rowwise_block_counts(block_a, 128)
+        _set_rowwise_block_counts(block_b, 128)
+        block_a.ep.validate()
+        block_b.ep.validate()
+        block_a.train()
+        block_b.train()
+
+        x = torch.randn(
+            2, 64, block_a.d_model, device="cuda", dtype=torch.float32, requires_grad=True
+        )
+        x_b = x.detach().clone().requires_grad_(True)
+
+        y_a = block_a(x)
+        y_b = block_b(x_b)
+        torch.testing.assert_close(y_b, y_a, atol=8e-4, rtol=8e-4)
+
+        poisoned_rows = _poison_rowwise_capacity_tails(block_b, value=2048.0)
+        assert poisoned_rows > 0
+
+        loss_a = y_a.square().mean() + (0.1 * y_a.sum())
+        loss_b = y_b.square().mean() + (0.1 * y_b.sum())
+        loss_a.backward()
+        loss_b.backward()
+
+        assert x.grad is not None
+        assert x_b.grad is not None
+        torch.testing.assert_close(x_b.grad, x.grad, atol=2e-3, rtol=2e-3)
+
+        params_a = dict(block_a.named_parameters())
+        params_b = dict(block_b.named_parameters())
+        for name, p_a in params_a.items():
+            p_b = params_b[name]
+            if p_a.grad is None or p_b.grad is None:
+                continue
+            torch.testing.assert_close(
+                p_b.grad,
+                p_a.grad,
+                atol=3e-3,
+                rtol=3e-3,
+                msg=f"capacity tail poison changed gradient for {name}",
+            )
+    finally:
+        if old_debug is None:
+            os.environ.pop("OLMO_MOE_ROWWISE_DEBUG_TENSORS", None)
+        else:
+            os.environ["OLMO_MOE_ROWWISE_DEBUG_TENSORS"] = old_debug
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_matches_synced():
+    run_distributed_test(_run_ep_no_sync_matches_synced, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_drop_behavior():
+    run_distributed_test(_run_ep_no_sync_drop_behavior, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_quota_invariants():
+    run_distributed_test(_run_ep_no_sync_quota_invariants, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+def test_v2_ep_no_sync_hard_fail_setup():
+    run_distributed_test(_run_ep_no_sync_hard_fail_setup, backend="nccl", start_method="spawn")
+
+
+@requires_multi_gpu
+@requires_symm_mem_vdev2d
+def test_v2_ep_no_sync_rowwise_matches_synced():
+    run_distributed_test(
+        _run_ep_no_sync_rowwise_matches_synced, backend="nccl", start_method="spawn"
+    )
 
 
 @requires_multi_gpu
@@ -998,54 +1127,19 @@ def test_v2_ep_no_sync_rowwise_wave_matches_rowwise():
 
 @requires_multi_gpu
 @requires_symm_mem_vdev2d
+def test_v2_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
+    run_distributed_test(
+        _run_ep_no_sync_rowwise_drop_matches_independent_rowwise_block,
+        backend="nccl",
+        start_method="spawn",
+    )
+
+
+@requires_multi_gpu
+@requires_symm_mem_vdev2d
 def test_v2_ep_no_sync_rowwise_capacity_tail_poison_does_not_change_backward():
     run_distributed_test(
         _run_ep_no_sync_rowwise_capacity_tail_poison_does_not_change_backward,
         backend="nccl",
         start_method="spawn",
     )
-
-
-@requires_gpu
-@requires_grouped_gemm
-def test_v2_no_ep_repeated_forward_backward_is_stable():
-    block = _build_block(
-        ep_no_sync=False,
-        d_model=256,
-        hidden_size=512,
-        num_experts=8,
-        top_k=4,
-        num_shared_experts=1,
-        shared_hidden_size=256,
-        uniform_expert_assignment=False,
-        init_device="cuda",
-    )
-    _init_block_params(block)
-    _install_local_deterministic_topk_router(block)
-    block.train()
-
-    torch.manual_seed(1234)
-    x0 = torch.randn(2, 256, block.d_model, device="cuda", dtype=torch.float32)
-
-    def run_once():
-        block.zero_grad(set_to_none=True)
-        x = x0.detach().clone().requires_grad_(True)
-        y = block(x)
-        loss = y.float().square().mean() + 0.03125 * y.float().sum()
-        loss.backward()
-        torch.cuda.synchronize()
-        grads = {
-            name: p.grad.detach().clone()
-            for name, p in block.named_parameters()
-            if p.grad is not None
-        }
-        assert x.grad is not None
-        return y.detach().clone(), x.grad.detach().clone(), grads
-
-    ref_y, ref_x_grad, ref_grads = run_once()
-    for _ in range(3):
-        y, x_grad, grads = run_once()
-        torch.testing.assert_close(y, ref_y, atol=0.0, rtol=0.0)
-        torch.testing.assert_close(x_grad, ref_x_grad, atol=2e-8, rtol=0.0)
-        for name, ref_grad in ref_grads.items():
-            torch.testing.assert_close(grads[name], ref_grad, atol=1e-6, rtol=0.0)

--- a/src/test/nn/ddp/block_no_sync_test.py
+++ b/src/test/nn/ddp/block_no_sync_test.py
@@ -536,6 +536,9 @@ def test_v2_no_ep_apply_compile_forward_smoke():
 
 
 def _run_ep_no_sync_matches_synced():
+    # VDev-1d no-sync EP uses the legacy torch symm-mem backend; OLMo-owned symm-mem
+    # (default on) supports only the rowwise no-sync path.
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"
     ep_mesh = _build_ep_mesh()
 
     block_ep = _build_block(ep_no_sync=False, uniform_expert_assignment=True)
@@ -569,6 +572,7 @@ def _run_ep_no_sync_matches_synced():
 
 
 def _run_ep_no_sync_drop_behavior():
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # non-rowwise EP → legacy symm-mem backend
     ep_mesh = _build_ep_mesh()
 
     block_no_sync = _build_block(
@@ -598,6 +602,7 @@ def _run_ep_no_sync_drop_behavior():
 
 
 def _run_ep_no_sync_quota_invariants():
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # non-rowwise EP → legacy symm-mem backend
     ep_mesh = _build_ep_mesh()
 
     block_no_sync = _build_block(
@@ -623,6 +628,7 @@ def _run_ep_no_sync_quota_invariants():
 
 
 def _run_ep_no_sync_hard_fail_setup():
+    os.environ["OLMO_USE_OWN_SYMM_MEM"] = "0"  # non-rowwise EP → legacy symm-mem backend
     import olmo_core.nn.ddp.block as block_module
 
     ep_mesh = _build_ep_mesh()

--- a/src/test/nn/ddp/block_no_sync_test.py
+++ b/src/test/nn/ddp/block_no_sync_test.py
@@ -11,6 +11,7 @@ from olmo_core.nn.ddp.block import OLMoDDPTransformerBlock
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import MoERouterGatingFunction
 from olmo_core.nn.moe.v2.ep_config import ExpertParallelConfig, ExpertParallelPath
+from olmo_core.nn.moe.v2.fp8 import MoERowwiseFP8Config
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
 from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
@@ -23,6 +24,7 @@ from olmo_core.testing import (
     requires_triton,
     run_distributed_test,
 )
+from olmo_core.testing.utils import requires_compute_capability
 
 
 def test_v2_extracted_forward_module_names_importable():
@@ -1140,6 +1142,52 @@ def test_v2_ep_no_sync_rowwise_drop_matches_independent_rowwise_block():
 def test_v2_ep_no_sync_rowwise_capacity_tail_poison_does_not_change_backward():
     run_distributed_test(
         _run_ep_no_sync_rowwise_capacity_tail_poison_does_not_change_backward,
+        backend="nccl",
+        start_method="spawn",
+    )
+
+
+def _run_ep_no_sync_rowwise_fp8_combine_gather_lease_released():
+    ep_mesh = _build_ep_mesh()
+    block = _build_block(
+        ep_no_sync=True,
+        ep_no_sync_use_rowwise_all_to_all=True,
+        d_model=512,
+        hidden_size=1024,
+        num_experts=8,
+        top_k=2,
+        uniform_expert_assignment=False,
+        # fused_autograd=False takes the separate dispatch/experts/combine path, where the
+        # dispatch autograd (not the combine autograd) owns the combine-gather lease release.
+        rowwise_fp8=MoERowwiseFP8Config(fused_autograd=False),
+    )
+    block.apply_ep(ep_mesh)
+
+    _init_block_params(block)
+    _install_deterministic_topk_router(block)
+    _set_rowwise_block_counts(block, 128)
+    # Force the leased symmetric combine-gather staging buffer so this path is exercised.
+    block.ep.rowwise_symm_combine_gather = True
+    block.ep.validate()
+    block.train()
+
+    for _ in range(3):
+        x = torch.randn(1, 8, block.d_model, device="cuda", dtype=torch.float32, requires_grad=True)
+        block(x).square().mean().backward()
+
+    pool = block._ep_no_sync_symm_lease_pools.get("combine_gather_rowwise_fp8")
+    assert pool is not None, "combine-gather lease pool was never created"
+    # Every leased combine-gather slot must return to the free list after each backward;
+    # otherwise repeated steps leak pool slots and eventually fail with "no free slot".
+    assert len(pool._in_use_slots) == 0  # type: ignore[attr-defined]
+
+
+@requires_multi_gpu
+@requires_symm_mem_vdev2d
+@requires_compute_capability(min_cc=10)
+def test_v2_ep_no_sync_rowwise_fp8_combine_gather_lease_released():
+    run_distributed_test(
+        _run_ep_no_sync_rowwise_fp8_combine_gather_lease_released,
         backend="nccl",
         start_method="spawn",
     )

--- a/src/test/nn/moe/v2/ep_experimental_backends_test.py
+++ b/src/test/nn/moe/v2/ep_experimental_backends_test.py
@@ -60,3 +60,20 @@ def test_experimental_backend_entry_points_exist():
     assert hasattr(ep_no_sync_rowwise_wave, "combined_forward_ep_no_sync_rowwise_wave")
     # DeepEP availability probe must be import-safe even without the optional package installed.
     assert ep_deepep_v2.is_deepep_available("/nonexistent-deepep-path") is False
+
+
+def test_ep_config_deprecated_rowwise_nblocks_populates_split_fields():
+    # Configs from before the get/put/weighted_put split still deserialize and migrate.
+    config = ExpertParallelConfig.from_dict({"rowwise_nblocks": 128})
+    with pytest.warns(DeprecationWarning, match="rowwise_nblocks"):
+        config.validate()
+    assert config.rowwise_get_nblocks == 128
+    assert config.rowwise_put_nblocks == 128
+    assert config.rowwise_weighted_put_nblocks == 128
+    assert config.rowwise_nblocks is None
+
+
+def test_ep_config_deprecated_rowwise_nblocks_rejects_conflict():
+    config = ExpertParallelConfig(rowwise_nblocks=128, rowwise_put_nblocks=64)
+    with pytest.raises(OLMoConfigurationError, match="rowwise_nblocks"):
+        config.validate()

--- a/src/test/nn/moe/v2/ep_no_sync_rowwise_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_rowwise_test.py
@@ -142,7 +142,9 @@ def _run_rowwise_ep_dropless_matches_no_ep():
     # Select the rowwise path before apply_ep: apply_ep configures the rowwise symmetric-memory
     # buffers and rejects the non-rowwise (VDev) path under the default OLMo-owned symm-mem backend.
     ep_block.ep.path = ExpertParallelPath.rowwise_nvshmem
-    ep_block.ep.rowwise_nblocks = 128
+    ep_block.ep.rowwise_get_nblocks = 128
+    ep_block.ep.rowwise_put_nblocks = 128
+    ep_block.ep.rowwise_weighted_put_nblocks = 128
     ep_block.apply_ep(ep_mesh)
 
     _init_block_params(no_ep_block)

--- a/src/test/nn/moe/v2/ep_no_sync_tbo_rowwise_test.py
+++ b/src/test/nn/moe/v2/ep_no_sync_tbo_rowwise_test.py
@@ -120,7 +120,9 @@ def test_rowwise_stage_d_launch_uses_comm_stream_and_dispatch(monkeypatch):
         dst_rows=torch.arange(2).view(2, 1),
         buffers=buffers,
         group_name="ep_group",
-        rowwise_nblocks=64,
+        rowwise_get_nblocks=61,
+        rowwise_put_nblocks=62,
+        rowwise_weighted_put_nblocks=63,
     )
     block = SimpleNamespace(block_idx=4, ep_pg="pg")
 
@@ -138,5 +140,5 @@ def test_rowwise_stage_d_launch_uses_comm_stream_and_dispatch(monkeypatch):
     assert torch.equal(dispatch_args[2], a_state.dst_ranks)
     assert torch.equal(dispatch_args[3], a_state.dst_rows)
     assert dispatch_args[4] is buffers.dispatch_out
-    assert dispatch_args[5:] == (None, "ep_group", "pg", 64, False, True, True, True)
+    assert dispatch_args[5:] == (None, "ep_group", "pg", 61, 62, False, True, True, True)
     assert calls[2] == ("record_event", comm_stream)

--- a/src/test/nn/moe/v2/olmo_symm_mem_test.py
+++ b/src/test/nn/moe/v2/olmo_symm_mem_test.py
@@ -20,6 +20,74 @@ def test_nvshmem_world_barrier_calls_extension(monkeypatch):
     assert ext.called
 
 
+def test_rowwise_collective_preflight_forwards_and_caches_all_settings(monkeypatch):
+    class _Ext:
+        def __init__(self):
+            self.calls = []
+
+        def preflight_rowwise_collective_launches(
+            self,
+            get_nblocks,
+            put_nblocks,
+            weighted_put_nblocks,
+        ):
+            self.calls.append((get_nblocks, put_nblocks, weighted_put_nblocks))
+
+    ext = _Ext()
+    current_device = 0
+    monkeypatch.setattr(symm_mod, "_load_cuda_extension", lambda: ext)
+    monkeypatch.setattr(symm_mod.torch.cuda, "current_device", lambda: current_device)
+    monkeypatch.setattr(symm_mod, "_PREFLIGHTED_ROWWISE_COLLECTIVE_LAUNCHES", set())
+
+    symm_mod.preflight_rowwise_collective_launches(256, 256, 128)
+    symm_mod.preflight_rowwise_collective_launches(256, 256, 128)
+    symm_mod.preflight_rowwise_collective_launches(257, 256, 128)
+    symm_mod.preflight_rowwise_collective_launches(256, 257, 128)
+    symm_mod.preflight_rowwise_collective_launches(256, 256, 129)
+    current_device = 1
+    symm_mod.preflight_rowwise_collective_launches(256, 256, 128)
+
+    assert ext.calls == [
+        (256, 256, 128),
+        (257, 256, 128),
+        (256, 257, 128),
+        (256, 256, 129),
+        (256, 256, 128),
+    ]
+    assert symm_mod._PREFLIGHTED_ROWWISE_COLLECTIVE_LAUNCHES == {
+        (0, 256, 256, 128),
+        (0, 257, 256, 128),
+        (0, 256, 257, 128),
+        (0, 256, 256, 129),
+        (1, 256, 256, 128),
+    }
+
+
+@pytest.mark.parametrize(
+    ("nblocks", "invalid_setting"),
+    [
+        ((0, 256, 128), "rowwise_get_nblocks"),
+        ((-1, 256, 128), "rowwise_get_nblocks"),
+        ((256, 0, 128), "rowwise_put_nblocks"),
+        ((256, -1, 128), "rowwise_put_nblocks"),
+        ((256, 256, 0), "rowwise_weighted_put_nblocks"),
+        ((256, 256, -1), "rowwise_weighted_put_nblocks"),
+    ],
+)
+def test_rowwise_collective_preflight_rejects_nonpositive_settings(
+    monkeypatch,
+    nblocks,
+    invalid_setting,
+):
+    def _unexpected_cuda_call():
+        raise AssertionError("invalid settings should fail before accessing CUDA")
+
+    monkeypatch.setattr(symm_mod.torch.cuda, "current_device", _unexpected_cuda_call)
+
+    with pytest.raises(ValueError, match=invalid_setting):
+        symm_mod.preflight_rowwise_collective_launches(*nblocks)
+
+
 def test_bootstrap_world_barrier_calls_extension_for_bootstrap_group(monkeypatch):
     class _Ext:
         called = False

--- a/src/test/nn/moe/v2/rowwise_fp8_comm_test.py
+++ b/src/test/nn/moe/v2/rowwise_fp8_comm_test.py
@@ -77,6 +77,8 @@ def test_rowwise_bf16_combine_releases_lifetime_leases_and_grads_probs(monkeypat
         "test_group",
         None,
         1,
+        1,
+        1,
         False,
         False,
         False,
@@ -170,6 +172,7 @@ def test_rowwise_fp8_combine_backward_returns_grad_probs(monkeypatch):
         32,
         "test_group",
         None,
+        1,
         1,
     )
     out.sum().backward()

--- a/src/test/nn/moe/v2/rowwise_fp8_comm_test.py
+++ b/src/test/nn/moe/v2/rowwise_fp8_comm_test.py
@@ -108,8 +108,19 @@ def test_rowwise_fp8_combine_backward_returns_grad_probs(monkeypatch):
         nblocks,
         gathered_q_out=None,
         gathered_scales_out=None,
+        post_barrier=False,
     ):
-        del expert_q, expert_scales, src_ranks, src_rows, group_name, probs, block_size, nblocks
+        del (
+            expert_q,
+            expert_scales,
+            src_ranks,
+            src_rows,
+            group_name,
+            probs,
+            block_size,
+            nblocks,
+            post_barrier,
+        )
         combine_out.zero_()
         if gathered_q_out is not None:
             gathered_q_out.zero_()
@@ -154,6 +165,8 @@ def test_rowwise_fp8_combine_backward_returns_grad_probs(monkeypatch):
         probs,
         q,
         scales,
+        None,
+        None,
         32,
         "test_group",
         None,
@@ -170,11 +183,15 @@ def test_rowwise_dispatch_put_weighted_mxfp8_uses_weighted_quantize(monkeypatch)
     scales = torch.empty(6, 2, dtype=torch.float8_e8m0fnu)
     seen: dict = {"quantize": 0, "puts": []}
 
-    def _stub_weighted_quantize_rows_to_mxfp8(input_hp, probs, *, block_size):
+    def _stub_weighted_quantize_rows_to_mxfp8(
+        input_hp, probs, *, block_size, out=None, scales_out=None
+    ):
         seen["quantize"] += 1
         assert input_hp.shape == (2, 64)
         assert probs.shape == (2, 3)
         assert block_size == 32
+        assert out is None
+        assert scales_out is None
         return q, scales
 
     def _stub_rowwise_dispatch_put(

--- a/src/test/nn/moe/v2/rowwise_fp8_config_test.py
+++ b/src/test/nn/moe/v2/rowwise_fp8_config_test.py
@@ -1,3 +1,5 @@
+import ast
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -47,6 +49,25 @@ def test_rowwise_fp8_config_requires_scaled_grouped_mm(monkeypatch):
 
     with pytest.raises(RuntimeError, match="scaled_grouped_mm"):
         cfg.assert_runtime_supported()
+
+
+def test_rowwise_fp8_cache_miss_does_not_acquire_static_combine_gather_lease():
+    path = Path(__file__).resolve().parents[4] / "olmo_core/nn/moe/v2/ep_no_sync_rowwise.py"
+    tree = ast.parse(path.read_text())
+
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "get_ep_no_sync_rowwise_fp8_buffers"
+    ]
+
+    assert len(calls) == 1
+    lease_kw = next((kw for kw in calls[0].keywords if kw.arg == "lease_combine_gather"), None)
+    assert lease_kw is not None
+    assert isinstance(lease_kw.value, ast.Constant)
+    assert lease_kw.value.value is False
 
 
 def test_rowwise_fp8_normalize_from_dict():

--- a/src/test/nn/moe/v2/symm_mem_vdev2d_scaled_test.py
+++ b/src/test/nn/moe/v2/symm_mem_vdev2d_scaled_test.py
@@ -264,8 +264,8 @@ def test_rowwise_dispatch_put_scaled_applies_outer_barriers_once(monkeypatch):
     qdata = torch.empty((1, 512), dtype=torch.float32)
     scales = torch.empty((1, 16), dtype=torch.float32)
 
-    def _fake_quantize(input_hp, *, block_size=32):
-        del input_hp, block_size
+    def _fake_quantize(input_hp, *, block_size=32, out=None, scales_out=None):
+        del input_hp, block_size, out, scales_out
         return qdata, scales
 
     calls = []


### PR DESCRIPTION
Adds inter-node support and tuning knobs for the row-wise NVSHMEM expert-parallel transport, plus symmetric-buffer diagnostics.

## Changes
- **IBGDA symmetric staging.** Route row-wise FP8 dispatch/combine through symmetric source-staging buffers so the NVSHMEM/IBGDA transport works inter-node. The row-wise wave path now rejects an aliased (non-symmetric) source buffer when IBGDA is enabled.
- **Per-collective block counts.** Replace the single `rowwise_nblocks` setting with independently tunable `rowwise_get_nblocks` / `rowwise_put_nblocks` / `rowwise_weighted_put_nblocks` (defaults 256 / 256 / 128), threaded through `ExpertParallelConfig`, the comm/forward paths, the `symm_mem_vdev2d` wrapper, and the CUDA `preflight_rowwise_collective_launches` (which now validates each collective's launch grid against its own kernel and reports the failing setting by name).
- **Row-wise FP8 runtime validation.** Validate the FP8 config at module construction (device-independent) and assert full CUDA/SM100 runtime support once in the compile-disabled buffer-build path, so CPU/meta construction and unit tests no longer require a GPU.
- **Symmetric-buffer diagnostics.** Env-gated logging of EP no-sync symmetric-buffer usage (unique tensors, duplicate refs, per-owner totals, largest buffers) alongside CUDA memory stats, emitted after the dry-run and the first train step.

## Testing
- `pytest src/test/nn/ddp/ src/test/nn/moe/v2/` (CPU): 131 passed, 44 skipped.
- Multi-GPU row-wise / IBGDA paths are covered by GPU-gated tests.