### PR TITLE
Add Beaker launch presets (+ pre/post-setup CLI flags) with an olmo-ddp preset

### DIFF
--- a/src/olmo_core/kernels/symm_mem_vdev2d.py
+++ b/src/olmo_core/kernels/symm_mem_vdev2d.py
@@ -30,18 +30,36 @@ def _load_cuda_extension():
     }
     build_backend = os.getenv("OLMO_SYMM_VDEV2D_BUILD_BACKEND", "cmake")
     if auto_build:
-        try:
-            from .build_symm_mem_vdev2d_ext import build_extension
+        from olmo_core.distributed.utils import barrier, get_local_rank, is_distributed
 
-            build_extension(
-                inplace=True,
-                verbose=False,
-                force=False,
-                backend=build_backend,
-            )
-        except Exception as e:
-            _CUDA_EXTENSION_ERROR = e
-            raise RuntimeError(f"Failed to auto-build CUDA symm_mem_vdev2d extension: {e}") from e
+        from .build_symm_mem_vdev2d_ext import build_extension
+
+        # The build writes into a shared build dir and installs the .so into the (node-local)
+        # package dir, so only one process per node may build — otherwise concurrent ranks rmtree
+        # and compile in the same directory and race (getcwd()/missing-tmp CMake failures). Build on
+        # local rank 0 only; the barrier makes the other ranks wait until the .so exists before they
+        # import it below. Global barrier is fine: every node's local rank 0 builds in parallel.
+        distributed = is_distributed()
+        build_error: Optional[Exception] = None
+        if not distributed or get_local_rank() == 0:
+            try:
+                build_extension(
+                    inplace=True,
+                    verbose=False,
+                    force=False,
+                    backend=build_backend,
+                )
+            except Exception as e:  # noqa: BLE001 - re-raised after the barrier below
+                build_error = e
+        if distributed:
+            # Ensure non-builders don't race ahead to the import before the build finishes (and
+            # don't deadlock waiting on a builder that already failed).
+            barrier()
+        if build_error is not None:
+            _CUDA_EXTENSION_ERROR = build_error
+            raise RuntimeError(
+                f"Failed to auto-build CUDA symm_mem_vdev2d extension: {build_error}"
+            ) from build_error
 
     try:
         _CUDA_EXTENSION = importlib.import_module(_EXTENSION_MODULE_NAME)

--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -1027,6 +1027,15 @@ def _build_config(opts: argparse.Namespace, command: list[str]) -> BeakerLaunchC
     pre_setup = _chain(*[preset.pre_setup for preset in presets], opts.pre_setup)
     post_setup = _chain(*[preset.post_setup for preset in presets], opts.post_setup)
 
+    # Image precedence: explicit --beaker-image > preset > stable default. --beaker-image defaults
+    # to the stable image, so treat "still equal to stable" as "not explicitly set" and let a
+    # preset's image win; an explicit non-stable value always wins.
+    beaker_image = opts.beaker_image
+    if beaker_image == OLMoCoreBeakerImage.stable:
+        for preset in presets:
+            if preset.beaker_image:
+                beaker_image = preset.beaker_image
+
     return BeakerLaunchConfig(
         name=f"{opts.name}-{generate_uuid()[:8]}",
         budget=opts.budget,
@@ -1042,7 +1051,7 @@ def _build_config(opts: argparse.Namespace, command: list[str]) -> BeakerLaunchC
         num_gpus=opts.gpus,
         preemptible=opts.preemptible,
         priority=opts.priority,
-        beaker_image=opts.beaker_image,
+        beaker_image=beaker_image,
         slack_notifications=opts.slack_notifications,
         workspace=opts.workspace,
         allow_dirty=opts.allow_dirty,

--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -42,6 +42,7 @@ from ..utils import (
     prepare_cli_environment,
 )
 from ..version import VERSION
+from .beaker_presets import PRESETS, get_preset
 
 log = logging.getLogger(__name__)
 
@@ -960,6 +961,25 @@ def _parse_args():
         help="""Environment variables to add to the Beaker experiment from Beaker secrets.
         Should be in the form '{NAME}={SECRET_NAME}'. Multiple allowed, space separated.""",
     )
+    parser.add_argument(
+        "--preset",
+        type=str,
+        nargs="*",
+        choices=sorted(PRESETS),
+        help="""Named launch preset(s) to apply (env vars + setup steps). Multiple allowed;
+        later presets win on env-name conflicts and setup steps are chained. Explicit
+        --env/--pre-setup/--post-setup override the preset.""",
+    )
+    parser.add_argument(
+        "--pre-setup",
+        type=str,
+        help="""A shell command to run before the repo clone + package install.""",
+    )
+    parser.add_argument(
+        "--post-setup",
+        type=str,
+        help="""A shell command to run after the package install (e.g. build a runtime extension).""",
+    )
 
     if len(sys.argv) < 3 or "--" not in sys.argv:
         parser.print_help()
@@ -973,21 +993,40 @@ def _parse_args():
 
 
 def _build_config(opts: argparse.Namespace, command: list[str]) -> BeakerLaunchConfig:
-    env_vars: list[BeakerEnvVar] = []
+    presets = [get_preset(name) for name in (opts.preset or [])]
+
+    # Env vars: preset(s) first (later preset wins on name conflicts), then explicit --env
+    # overrides by name. The launcher's built-in default_env_vars still fill any remaining gaps.
+    env_map: dict[str, str] = {}
     if opts.debug:
-        env_vars.append(BeakerEnvVar(name="CUDA_LAUNCH_BLOCKING", value="1"))
-        env_vars.append(BeakerEnvVar(name="NCCL_DEBUG", value="INFO"))
+        env_map["CUDA_LAUNCH_BLOCKING"] = "1"
+        env_map["NCCL_DEBUG"] = "INFO"
+    for preset in presets:
+        env_map.update(dict(preset.env_vars))
     for e in opts.env or []:
         if "=" not in e:
             raise ValueError(f"Invalid env var '{e}', must be in the form NAME=VALUE")
         name, value = e.split("=", 1)
-        env_vars.append(BeakerEnvVar(name=name, value=value))
-    env_secrets: list[BeakerEnvSecret] = []
+        env_map[name] = value
+    env_vars = [BeakerEnvVar(name=name, value=value) for name, value in env_map.items()]
+
+    secret_map: dict[str, str] = {}
+    for preset in presets:
+        secret_map.update(dict(preset.env_secrets))
     for e in opts.env_secret or []:
         if "=" not in e:
             raise ValueError(f"Invalid env secret '{e}', must be in the form NAME=SECRET_NAME")
         name, secret = e.split("=", 1)
-        env_secrets.append(BeakerEnvSecret(name=name, secret=secret))
+        secret_map[name] = secret
+    env_secrets = [BeakerEnvSecret(name=name, secret=secret) for name, secret in secret_map.items()]
+
+    # Setup steps: chain preset step(s) then the explicit flag, joined with '&&'.
+    def _chain(*parts: str | None) -> str | None:
+        return " && ".join(p for p in parts if p) or None
+
+    pre_setup = _chain(*[preset.pre_setup for preset in presets], opts.pre_setup)
+    post_setup = _chain(*[preset.post_setup for preset in presets], opts.post_setup)
+
     return BeakerLaunchConfig(
         name=f"{opts.name}-{generate_uuid()[:8]}",
         budget=opts.budget,
@@ -1012,6 +1051,8 @@ def _build_config(opts: argparse.Namespace, command: list[str]) -> BeakerLaunchC
             BeakerWekaBucket(bucket=bucket, mount=f"/weka/{bucket}") for bucket in (opts.weka or [])
         ],
         torchrun=opts.torchrun,
+        pre_setup=pre_setup,
+        post_setup=post_setup,
     )
 
 

--- a/src/olmo_core/launch/beaker_presets.py
+++ b/src/olmo_core/launch/beaker_presets.py
@@ -25,8 +25,10 @@ class LaunchPreset:
     A named bundle of launch defaults layered onto a
     :class:`~olmo_core.launch.beaker.BeakerLaunchConfig`.
 
-    :param name: The preset's CLI name (e.g. ``"moe-v2"``).
+    :param name: The preset's CLI name (e.g. ``"olmo-ddp"``).
     :param description: One-line summary shown in ``--help``.
+    :param beaker_image: A default Beaker image for this preset. Overrides the launcher's
+        stable-image default, but an explicit ``--beaker-image`` still overrides this.
     :param env_vars: ``(NAME, VALUE)`` environment variables to add.
     :param env_secrets: ``(NAME, SECRET_NAME)`` env vars sourced from Beaker secrets.
     :param pre_setup: A shell command to run *before* the repo clone + package install.
@@ -37,15 +39,18 @@ class LaunchPreset:
 
     name: str
     description: str = ""
+    beaker_image: str | None = None
     env_vars: list[tuple[str, str]] = field(default_factory=list)
     env_secrets: list[tuple[str, str]] = field(default_factory=list)
     pre_setup: str | None = None
     post_setup: str | None = None
 
 
-# The MoE-v2 / OLMoDDP preset.
+# The OLMoDDP (fused MoE-v2) preset.
 #
-#  - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True: the fused MoE-v2 stack sits close to
+#  - beaker_image: the B300 image with flash-attn 4 + the symm-mem/RMA build prerequisites
+#    (nvcc + NVSHMEM), which the rowwise-EP / PP transport kernels need.
+#  - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True: the fused OLMoDDP stack sits close to
 #    device-memory capacity and fragments the caching allocator; expandable segments reclaim
 #    the stranded reserved memory that otherwise triggers spurious OOMs.
 #  - post_setup builds the symm_mem_vdev2d extension once per node (post_setup runs on each
@@ -55,9 +60,10 @@ class LaunchPreset:
 #  - OLMO_SYMM_VDEV2D_AUTO_BUILD=1 is only a fallback if the prebuilt .so is somehow missing.
 #    NOTE: the runtime auto-build is only race-safe where symm_mem_vdev2d builds on local-rank-0
 #    with a barrier; without that, prefer relying on the post_setup prebuild alone.
-MOE_V2 = LaunchPreset(
-    name="moe-v2",
-    description="MoE-v2 / OLMoDDP runs: CUDA alloc-fragmentation fix + symm_mem_vdev2d prebuild.",
+OLMO_DDP = LaunchPreset(
+    name="olmo-ddp",
+    description="OLMoDDP / fused MoE-v2 runs: B300 fa4-rma image, alloc-fragmentation fix, symm_mem_vdev2d prebuild.",
+    beaker_image="akshitab/olmo-core-tch2110cu130-fa4-rma-2026-07-24",
     env_vars=[
         ("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True"),
         ("OLMO_SYMM_VDEV2D_AUTO_BUILD", "1"),
@@ -66,7 +72,7 @@ MOE_V2 = LaunchPreset(
 )
 
 
-PRESETS: dict[str, LaunchPreset] = {p.name: p for p in (MOE_V2,)}
+PRESETS: dict[str, LaunchPreset] = {p.name: p for p in (OLMO_DDP,)}
 
 
 def get_preset(name: str) -> LaunchPreset:

--- a/src/olmo_core/launch/beaker_presets.py
+++ b/src/olmo_core/launch/beaker_presets.py
@@ -1,0 +1,83 @@
+"""
+Named launch presets for :class:`~olmo_core.launch.beaker.BeakerLaunchConfig`.
+
+A :class:`LaunchPreset` bundles a few launch defaults — environment variables, env
+secrets, and pre/post-setup shell steps — that are commonly needed together for a class
+of runs. Presets are applied *on top of* an otherwise-normal launch config; explicit
+values (e.g. CLI ``--env``/``--pre-setup``) take precedence over the preset, which in
+turn takes precedence over the launcher's built-in defaults.
+
+Presets live here (in the library) rather than in any one training script so they can be
+reused from the generic launcher CLI (``python -m olmo_core.launch.beaker --preset ...``),
+from the internal experiment launcher, or when building a ``BeakerLaunchConfig`` directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = ["LaunchPreset", "PRESETS", "get_preset"]
+
+
+@dataclass
+class LaunchPreset:
+    """
+    A named bundle of launch defaults layered onto a
+    :class:`~olmo_core.launch.beaker.BeakerLaunchConfig`.
+
+    :param name: The preset's CLI name (e.g. ``"moe-v2"``).
+    :param description: One-line summary shown in ``--help``.
+    :param env_vars: ``(NAME, VALUE)`` environment variables to add.
+    :param env_secrets: ``(NAME, SECRET_NAME)`` env vars sourced from Beaker secrets.
+    :param pre_setup: A shell command to run *before* the repo clone + package install.
+        May only touch the image/system (``olmo_core`` isn't installed yet).
+    :param post_setup: A shell command to run *after* the package install. This is where
+        steps that import ``olmo_core`` belong (e.g. building a runtime CUDA extension).
+    """
+
+    name: str
+    description: str = ""
+    env_vars: list[tuple[str, str]] = field(default_factory=list)
+    env_secrets: list[tuple[str, str]] = field(default_factory=list)
+    pre_setup: str | None = None
+    post_setup: str | None = None
+
+
+# The MoE-v2 / OLMoDDP preset.
+#
+#  - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True: the fused MoE-v2 stack sits close to
+#    device-memory capacity and fragments the caching allocator; expandable segments reclaim
+#    the stranded reserved memory that otherwise triggers spurious OOMs.
+#  - post_setup builds the symm_mem_vdev2d extension once per node (post_setup runs on each
+#    replica before torchrun spawns ranks), so the rowwise-EP path imports a ready .so with no
+#    cross-rank build race and no first-step compile stall. Requires an image with nvcc + NVSHMEM
+#    (the 'rma' images); harmless-but-wasteful for EP=1 runs that don't use the extension.
+#  - OLMO_SYMM_VDEV2D_AUTO_BUILD=1 is only a fallback if the prebuilt .so is somehow missing.
+#    NOTE: the runtime auto-build is only race-safe where symm_mem_vdev2d builds on local-rank-0
+#    with a barrier; without that, prefer relying on the post_setup prebuild alone.
+MOE_V2 = LaunchPreset(
+    name="moe-v2",
+    description="MoE-v2 / OLMoDDP runs: CUDA alloc-fragmentation fix + symm_mem_vdev2d prebuild.",
+    env_vars=[
+        ("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True"),
+        ("OLMO_SYMM_VDEV2D_AUTO_BUILD", "1"),
+    ],
+    post_setup="python -m olmo_core.kernels.build_symm_mem_vdev2d_ext --inplace --backend cmake",
+)
+
+
+PRESETS: dict[str, LaunchPreset] = {p.name: p for p in (MOE_V2,)}
+
+
+def get_preset(name: str) -> LaunchPreset:
+    """
+    Look up a launch preset by name.
+
+    :raises KeyError: If no preset with that name is registered.
+    """
+    try:
+        return PRESETS[name]
+    except KeyError:
+        raise KeyError(
+            f"Unknown launch preset '{name}'. Available presets: {sorted(PRESETS)}"
+        ) from None


### PR DESCRIPTION
Adds a small, reusable launch-preset mechanism to the generic Beaker launcher so common bundles of env vars + setup steps can be applied by name, plus the CLI flags needed to set setup steps at all.

## What's here

**`olmo_core/launch/beaker_presets.py`** (new) — a library registry of `LaunchPreset` bundles (`beaker_image`, `env_vars`, `env_secrets`, `pre_setup`, `post_setup`) that layer onto a `BeakerLaunchConfig`. Living in the library (not a training script) means it's reusable from the generic CLI, the internal launcher, or programmatic config construction.

Ships one preset, `olmo-ddp`, for fused OLMoDDP / MoE-v2 runs:
- default image `akshitab/olmo-core-tch2110cu130-fa4-rma-2026-07-24` (B300, flash-attn 4, symm-mem/RMA build prereqs),
- `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` (avoids the allocator-fragmentation OOMs the fused stack hits near memory capacity),
- `OLMO_SYMM_VDEV2D_AUTO_BUILD=1` (fallback),
- `post_setup` that prebuilds the `symm_mem_vdev2d` extension once per node (runs before torchrun spawns ranks, so no cross-rank build race and no first-step compile stall).

**`olmo_core/launch/beaker.py`** — three new flags on `python -m olmo_core.launch.beaker`:
- `--preset` (repeatable; choices from the registry),
- `--pre-setup` / `--post-setup` (shell commands).

Precedence: explicit `--env` / `--pre-setup` / `--post-setup` / `--beaker-image` > preset > launcher defaults. Multiple presets compose (later wins on env-name conflicts; setup steps chain with `&&`). Image resolution treats a `--beaker-image` left at the stable default as unset so the preset image wins, while an explicit non-stable value always wins. This also closes the prior gap where the CLI couldn't set pre/post-setup at all.

## Usage
```bash
python -m olmo_core.launch.beaker --name t002 --gpus 8 --nodes 2 \
  --preset olmo-ddp --weka oe-training-default --shared-filesystem \
  -- src/examples/olmo_ddp/OLMoE3-dev-t002.py RUN_NAME
```

## Notes
- `AUTO_BUILD=1` as a fallback is only race-safe where `symm_mem_vdev2d` builds on local-rank-0 with a barrier; the `post_setup` prebuild is the race-free primary regardless.
- Validated: ruff + mypy clean; preset registry, env/setup merge, and image precedence exercised; `--preset {olmo-ddp}` shows in `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)