### PR TITLE
Tidy vague TODO comments in ported MoE/DDP code

### DIFF
--- a/src/olmo_core/nn/ddp/model.py
+++ b/src/olmo_core/nn/ddp/model.py
@@ -231,7 +231,8 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         return True
 
     def num_flops_per_token(self, seq_len: int) -> int:
-        # TODO: check if it works with PP, does it compute one model part only? or the full model?
+        # TODO: under PP this returns full-model FLOPs/token via super(); confirm that's what the
+        # speed monitor expects rather than the per-stage count.
         return super().num_flops_per_token(seq_len)
 
     def compute_auxiliary_metrics(
@@ -619,7 +620,8 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         if target_dtype != self.dtype:
             self.to(dtype=target_dtype)
 
-        # TODO: check if this is needed
+        # TODO: decide whether the commented-out torch._dynamo optimize_ddp setting below is needed
+        # for compiled DDP; left disabled for now.
         # Adapted from
         # https://github.com/pytorch/torchtitan/blob/90c889e972b56b9faadebbb78fc985dedc537ed9/torchtitan/parallelisms/parallelize_llama.py#L328
         # if compile_enabled:
@@ -852,8 +854,10 @@ class OLMoDDPModel(olmo_core.nn.transformer.Transformer):
         )
 
     def prepare_experts_for_ddp(self, world_mesh: DeviceMesh):
+        # TODO: no-op today; confirm routed-expert blocks need no DDP-specific setup here
+        # (unlike the FSDP path, which shards the experts).
         for block in self.routed_blocks():
-            pass  # TODO: Anything to do here?
+            pass
 
     def post_batch(self, dry_run: bool = False):
         for block in self.ddp_blocks():

--- a/src/olmo_core/nn/moe/v2/router.py
+++ b/src/olmo_core/nn/moe/v2/router.py
@@ -630,8 +630,8 @@ class MoERouterV2(nn.Module):
             # shape: (batch_size, seq_len, top_k)
             expert_weights, expert_indices = self.get_top_k(scores)
 
-        # TODO: check
-        # WARN: does not work with PP
+        # TODO: verify the recompute-index cache is correct under activation checkpointing;
+        # known-broken under pipeline parallelism (the cached indices don't survive PP microbatching).
         if self.use_recompute_cache:
             if self._recompute_cache is None:  # first forward
                 if torch.is_grad_enabled():

--- a/src/olmo_core/train/train_module/transformer/ddp_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/ddp_train_module.py
@@ -1138,7 +1138,6 @@ class OLMoDDPTrainModule(TrainModule):
         # Persistent model buffers (e.g. the router's aux-loss-free score_bias) are not optimizer
         # state, so they must be added to the checkpoint explicitly; optim.load_state_dict() below
         # only round-trips the optimizer keys.
-        # TODO review
         save_dict = dict(state_dict)
         for key, buffer in self._persistent_model_buffer_state_dict().items():
             assert key not in save_dict, f"Buffer key '{key}' collides with an optimizer state key"
@@ -2580,7 +2579,6 @@ class OLMoDDPTrainModule(TrainModule):
                 f"Applied pipeline parallelism to the model with {get_device_mesh_info(self.pp_mesh)}"
             )
 
-            # TODO: chunk layers into stages (I don't understand this TODO)
             assert (
                 self.world_mesh is not None
             ), "World mesh must be built before applying expert parallelism"

--- a/src/olmo_core/train/train_module/transformer/pipeline/pipeline_stage.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline/pipeline_stage.py
@@ -347,7 +347,6 @@ class CustomPipelineStage:
             # stage_output is no longer used in the last stage for backward and only needed
             # to return to the user in merge_output_chunks, therefore
             # this should be detached to release autograd graph context and free memory earlier
-            # TODO: what?
             for t in stage_output:
                 if not t._is_view():  # views are not detachable in-place
                     t.detach_()
@@ -713,8 +712,9 @@ class CustomPipelineStage:
         return grads, param_groups
 
     def clear_runtime_states(self) -> None:
+        # TODO: no-op today; determine whether any per-step runtime state (buffers/caches) needs
+        # clearing here between steps.
         pass
-        # TODO: anything to clear?
 
     def clear_step_info(self):
         self._step_global_batch_size = None


### PR DESCRIPTION
Comment hygiene only — **no behavior change**. Cleans up eight vague TODOs left in the ported MoE-v2 / OLMoDDP code so each remaining one is self-contained (per the repo convention that TODOs state a concrete problem/why).

## Deleted (3) — stray or stale
- `pipeline_stage.py` `# TODO: what?` — sat under a comment that already fully explains the `detach_()` (release autograd graph / free memory early).
- `ddp_train_module.py` `# TODO review` — under a clear comment on the finalized persistent-buffer checkpoint save.
- `ddp_train_module.py` `# TODO: chunk layers into stages (I don't understand this TODO)` — stale: the layer→stage chunking already happens a few lines above; the code below it is unrelated EP-mesh setup.

## Rewritten (5) — casual question → self-contained note
- `router.py` `# TODO: check` + `# WARN: does not work with PP` → one note explaining the recompute-index cache needs verification under activation checkpointing and is known-broken under PP.
- `pipeline_stage.py` `# TODO: anything to clear?` → states `clear_runtime_states` is a no-op and asks whether per-step buffers/caches need clearing.
- `ddp/model.py` `num_flops_per_token` → notes it returns full-model FLOPs/token under PP via `super()`; confirm that's intended vs. per-stage.
- `ddp/model.py` `# TODO: check if this is needed` → names the commented-out `torch._dynamo.optimize_ddp` decision.
- `ddp/model.py` `prepare_experts_for_ddp` `# TODO: Anything to do here?` → notes it's a no-op and to confirm routed-expert blocks need no DDP-specific setup (unlike FSDP).

The rewrites keep the open questions tracked (they don't resolve the underlying items) but make the in-code TODOs self-contained. ruff clean; imports verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)