### PR TITLE
LatentMoE implementation

### DIFF
--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -29,6 +29,7 @@ from olmo_core.utils import get_or_init_stream
 from ..attention.base import SequenceMixerConfig
 from ..buffer_cache import BufferCache
 from ..layer_norm import LayerNormConfig
+from ..moe.moe import LatentMoEConfig
 from ..moe.v2.activation_debug import (
     EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENABLED,
     maybe_dump_ep_no_sync_saved_activations,
@@ -65,7 +66,6 @@ from ..moe.v2.fp8 import invalidate_rowwise_fp8_cache as _invalidate_rowwise_fp8
 from ..moe.v2.fp8 import normalize_rowwise_fp8_config
 from ..moe.v2.fp8 import refresh_rowwise_fp8_cache as _refresh_rowwise_fp8_cache
 from ..moe.v2.fp8 import shared_experts_forward_rowwise_fp8
-from ..moe.moe import LatentMoEConfig
 from ..moe.v2.no_ep import combined_forward_no_ep as _combined_forward_no_ep
 from ..moe.v2.routed_experts import RoutedExperts, RoutedExpertsConfig
 from ..moe.v2.router import MoERouterConfigV2, MoERouterV2
@@ -223,7 +223,10 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
                     "shared_experts.d_model must equal block d_model when latent_moe is enabled "
                     f"({self.shared_experts.d_model} != {d_model})"
                 )
-            if self.shared_experts_router is not None and self.shared_experts_router.d_model != d_model:
+            if (
+                self.shared_experts_router is not None
+                and self.shared_experts_router.d_model != d_model
+            ):
                 raise OLMoConfigurationError(
                     "shared_experts_router.d_model must equal block d_model when latent_moe is "
                     f"enabled ({self.shared_experts_router.d_model} != {d_model})"
@@ -827,17 +830,9 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
 
         # Routers can consume different widths when the routed branch is latent.
         if self.routed_experts_router is not None:
-            flops += (
-                6
-                * self.routed_experts_router.d_model
-                * self.routed_experts_router.num_experts
-            )
+            flops += 6 * self.routed_experts_router.d_model * self.routed_experts_router.num_experts
         if self.shared_experts_router is not None:
-            flops += (
-                6
-                * self.shared_experts_router.d_model
-                * self.shared_experts_router.num_experts
-            )
+            flops += 6 * self.shared_experts_router.d_model * self.shared_experts_router.num_experts
 
         # routed experts: top_k active per token; SwiGLU has 3 matmuls; fwd+bwd x3; GEMM x2.
         if self.routed_experts is not None:

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -202,21 +202,21 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
                 raise OLMoConfigurationError(
                     "latent_moe requires routed_experts and routed_experts_router"
                 )
-            routed_expert_dim = self.latent_moe.routed_expert_dim
-            if not 0 < routed_expert_dim < d_model:
+            latent_dim = self.latent_moe.latent_dim
+            if not 0 < latent_dim < d_model:
                 raise OLMoConfigurationError(
-                    "latent_moe.routed_expert_dim must be greater than 0 and less than "
-                    f"d_model ({d_model}), got {routed_expert_dim}"
+                    "latent_moe.latent_dim must be greater than 0 and less than "
+                    f"d_model ({d_model}), got {latent_dim}"
                 )
-            if self.routed_experts.d_model != routed_expert_dim:
+            if self.routed_experts.d_model != latent_dim:
                 raise OLMoConfigurationError(
-                    "latent_moe.routed_expert_dim must equal routed_experts.d_model "
-                    f"({routed_expert_dim} != {self.routed_experts.d_model})"
+                    "latent_moe.latent_dim must equal routed_experts.d_model "
+                    f"({latent_dim} != {self.routed_experts.d_model})"
                 )
-            if self.routed_experts_router.d_model != routed_expert_dim:
+            if self.routed_experts_router.d_model != d_model:
                 raise OLMoConfigurationError(
-                    "latent_moe.routed_expert_dim must equal routed_experts_router.d_model "
-                    f"({routed_expert_dim} != {self.routed_experts_router.d_model})"
+                    "routed_experts_router.d_model must equal block d_model when latent_moe is "
+                    f"enabled ({self.routed_experts_router.d_model} != {d_model})"
                 )
             if self.shared_experts is not None and self.shared_experts.d_model != d_model:
                 raise OLMoConfigurationError(
@@ -365,7 +365,7 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
             )
         if self.latent_moe is not None:
             # Both model<->latent projections are used for every routed token.
-            flops += 12 * seqlen * d_model * self.latent_moe.routed_expert_dim
+            flops += 12 * seqlen * d_model * self.latent_moe.latent_dim
 
         # shared experts
         # (seq_len, d_model) * (d_model, expert_hidden_size) * num_experts
@@ -433,35 +433,36 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
                 raise OLMoConfigurationError("latent_moe requires routed_experts")
             if routed_experts_router is None:
                 raise OLMoConfigurationError("latent_moe requires routed_experts_router")
-            if not 0 < latent_moe.routed_expert_dim < d_model:
+            if not 0 < latent_moe.latent_dim < d_model:
                 raise OLMoConfigurationError(
-                    "latent_moe.routed_expert_dim must be greater than 0 and less than "
-                    f"d_model ({d_model}), got {latent_moe.routed_expert_dim}"
+                    "latent_moe.latent_dim must be greater than 0 and less than "
+                    f"d_model ({d_model}), got {latent_moe.latent_dim}"
                 )
-            if routed_experts.d_model != latent_moe.routed_expert_dim:
+            if routed_experts.d_model != latent_moe.latent_dim:
                 raise OLMoConfigurationError(
-                    "latent_moe.routed_expert_dim must equal routed_experts.d_model"
+                    "latent_moe.latent_dim must equal routed_experts.d_model"
                 )
-            if routed_experts_router.d_model != latent_moe.routed_expert_dim:
+            if routed_experts_router.d_model != d_model:
                 raise OLMoConfigurationError(
-                    "latent_moe.routed_expert_dim must equal routed_experts_router.d_model"
+                    "routed_experts_router.d_model must equal block d_model when latent_moe is "
+                    "enabled"
                 )
             self.latent_down_proj = torch.nn.Linear(
                 d_model,
-                latent_moe.routed_expert_dim,
+                latent_moe.latent_dim,
                 bias=latent_moe.bias,
                 dtype=routed_experts.dtype.as_pt(),
                 device=init_device,
             )
             self.latent_up_proj_input_norm = (
                 latent_moe.resolved_up_proj_input_norm().build(
-                    latent_moe.routed_expert_dim, init_device=init_device
+                    latent_moe.latent_dim, init_device=init_device
                 )
                 if latent_moe.up_proj_input_norm_enabled
                 else None
             )
             self.latent_up_proj = torch.nn.Linear(
-                latent_moe.routed_expert_dim,
+                latent_moe.latent_dim,
                 d_model,
                 bias=latent_moe.bias,
                 dtype=routed_experts.dtype.as_pt(),
@@ -837,7 +838,8 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         # attention
         flops += self.attention.num_flops_per_token(seq_len)
 
-        # Routers can consume different widths when the routed branch is latent.
+        # Routers always consume model-space activations; only routed expert payloads may use a
+        # latent width.
         if self.routed_experts_router is not None:
             flops += 6 * self.routed_experts_router.d_model * self.routed_experts_router.num_experts
         if self.shared_experts_router is not None:

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -454,11 +454,11 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
                 device=init_device,
             )
             self.latent_up_proj_input_norm = (
-                None
-                if latent_moe.up_proj_input_norm is None
-                else latent_moe.up_proj_input_norm.build(
+                latent_moe.resolved_up_proj_input_norm().build(
                     latent_moe.routed_expert_dim, init_device=init_device
                 )
+                if latent_moe.up_proj_input_norm_enabled
+                else None
             )
             self.latent_up_proj = torch.nn.Linear(
                 latent_moe.routed_expert_dim,

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -28,7 +28,7 @@ from olmo_core.utils import get_or_init_stream
 
 from ..attention.base import SequenceMixerConfig
 from ..buffer_cache import BufferCache
-from ..layer_norm import LayerNormConfig
+from ..layer_norm import LayerNorm, LayerNormConfig
 from ..moe.moe import LatentMoEConfig
 from ..moe.v2.activation_debug import (
     EP_NO_SYNC_SAVED_ACTIVATIONS_DEBUG_ENABLED,
@@ -422,9 +422,11 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         self.d_model = d_model
         self.block_idx = block_idx
         self.latent_down_proj: Optional[torch.nn.Linear]
+        self.latent_up_proj_input_norm: Optional[LayerNorm]
         self.latent_up_proj: Optional[torch.nn.Linear]
         if latent_moe is None:
             self.latent_down_proj = None
+            self.latent_up_proj_input_norm = None
             self.latent_up_proj = None
         else:
             if routed_experts is None:
@@ -450,6 +452,13 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
                 bias=latent_moe.bias,
                 dtype=routed_experts.dtype.as_pt(),
                 device=init_device,
+            )
+            self.latent_up_proj_input_norm = (
+                None
+                if latent_moe.up_proj_input_norm is None
+                else latent_moe.up_proj_input_norm.build(
+                    latent_moe.routed_expert_dim, init_device=init_device
+                )
             )
             self.latent_up_proj = torch.nn.Linear(
                 latent_moe.routed_expert_dim,
@@ -1447,6 +1456,8 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
     def _restore_routed_moe_output(self, routed_output: torch.Tensor) -> torch.Tensor:
         if self.latent_up_proj is None:
             return routed_output
+        if self.latent_up_proj_input_norm is not None:
+            routed_output = self.latent_up_proj_input_norm(routed_output)
         return self.latent_up_proj(routed_output)
 
     def _merge_routed_and_shared(

--- a/src/olmo_core/nn/ddp/block.py
+++ b/src/olmo_core/nn/ddp/block.py
@@ -65,6 +65,7 @@ from ..moe.v2.fp8 import invalidate_rowwise_fp8_cache as _invalidate_rowwise_fp8
 from ..moe.v2.fp8 import normalize_rowwise_fp8_config
 from ..moe.v2.fp8 import refresh_rowwise_fp8_cache as _refresh_rowwise_fp8_cache
 from ..moe.v2.fp8 import shared_experts_forward_rowwise_fp8
+from ..moe.moe import LatentMoEConfig
 from ..moe.v2.no_ep import combined_forward_no_ep as _combined_forward_no_ep
 from ..moe.v2.routed_experts import RoutedExperts, RoutedExpertsConfig
 from ..moe.v2.router import MoERouterConfigV2, MoERouterV2
@@ -137,6 +138,9 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
     weights.
     """
 
+    latent_moe: Optional[LatentMoEConfig] = None
+    """Optional projections that run only the routed MoE branch in a latent dimension."""
+
     use_peri_norm: bool = False
     """
     Apply a "peri-norm" — an additional input (pre) norm on the attention and feed-forward
@@ -193,6 +197,37 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
             "OLMoDDPTransformerBlock does not support `feed_forward` or `feed_forward_moe`. "
             "Use `shared_experts` for dense/shared MLPs and `routed_experts` for routed MoE."
         )
+        if self.latent_moe is not None:
+            if self.routed_experts is None or self.routed_experts_router is None:
+                raise OLMoConfigurationError(
+                    "latent_moe requires routed_experts and routed_experts_router"
+                )
+            routed_expert_dim = self.latent_moe.routed_expert_dim
+            if not 0 < routed_expert_dim < d_model:
+                raise OLMoConfigurationError(
+                    "latent_moe.routed_expert_dim must be greater than 0 and less than "
+                    f"d_model ({d_model}), got {routed_expert_dim}"
+                )
+            if self.routed_experts.d_model != routed_expert_dim:
+                raise OLMoConfigurationError(
+                    "latent_moe.routed_expert_dim must equal routed_experts.d_model "
+                    f"({routed_expert_dim} != {self.routed_experts.d_model})"
+                )
+            if self.routed_experts_router.d_model != routed_expert_dim:
+                raise OLMoConfigurationError(
+                    "latent_moe.routed_expert_dim must equal routed_experts_router.d_model "
+                    f"({routed_expert_dim} != {self.routed_experts_router.d_model})"
+                )
+            if self.shared_experts is not None and self.shared_experts.d_model != d_model:
+                raise OLMoConfigurationError(
+                    "shared_experts.d_model must equal block d_model when latent_moe is enabled "
+                    f"({self.shared_experts.d_model} != {d_model})"
+                )
+            if self.shared_experts_router is not None and self.shared_experts_router.d_model != d_model:
+                raise OLMoConfigurationError(
+                    "shared_experts_router.d_model must equal block d_model when latent_moe is "
+                    f"enabled ({self.shared_experts_router.d_model} != {d_model})"
+                )
 
         kwargs = self.as_dict(exclude_none=False, recurse=False)
         kwargs.pop("name")
@@ -235,6 +270,8 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
             block_params += self.routed_experts_router.num_params()
         if self.shared_experts_router is not None:
             block_params += self.shared_experts_router.num_params()
+        if self.latent_moe is not None:
+            block_params += self.latent_moe.num_params(d_model)
         if self.layer_norm is not None:
             block_params += self.layer_norm.num_params(d_model)
         if self.use_peri_norm and self.layer_norm is not None:
@@ -259,6 +296,8 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
             block_params += self.routed_experts_router.num_params()
         if self.shared_experts_router is not None:
             block_params += self.shared_experts_router.num_params()
+        if self.latent_moe is not None:
+            block_params += self.latent_moe.num_params(d_model)
         if self.layer_norm is not None:
             block_params += self.layer_norm.num_params(d_model)
         if self.use_peri_norm and self.layer_norm is not None:
@@ -291,25 +330,21 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
                 * seqlen
             )
 
-        # router
-        # (seq_len * d_model) * (d_model * num_total_experts)
-        flops += (
-            6
-            * seqlen
-            * d_model
-            * (
-                (
-                    self.routed_experts_router.num_experts
-                    if self.routed_experts_router is not None
-                    else 0
-                )
-                + (
-                    self.shared_experts_router.num_experts
-                    if self.shared_experts_router is not None
-                    else 0
-                )
+        # routers
+        if self.routed_experts_router is not None:
+            flops += (
+                6
+                * seqlen
+                * self.routed_experts_router.d_model
+                * self.routed_experts_router.num_experts
             )
-        )
+        if self.shared_experts_router is not None:
+            flops += (
+                6
+                * seqlen
+                * self.shared_experts_router.d_model
+                * self.shared_experts_router.num_experts
+            )
 
         # routed experts
         # (seq_len, d_model) * (d_model, expert_hidden_size) * top_k
@@ -321,10 +356,13 @@ class OLMoDDPTransformerBlockConfig(TransformerBlockConfig):
             flops += (
                 (3 * 3 * 2)
                 * seqlen
-                * d_model
+                * self.routed_experts.d_model
                 * self.routed_experts.hidden_size
                 * self.routed_experts_router.top_k
             )
+        if self.latent_moe is not None:
+            # Both model<->latent projections are used for every routed token.
+            flops += 12 * seqlen * d_model * self.latent_moe.routed_expert_dim
 
         # shared experts
         # (seq_len, d_model) * (d_model, expert_hidden_size) * num_experts
@@ -371,6 +409,7 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         checkpoint_second_unpermute=False,
         ep: Optional[ExpertParallelConfig] = None,
         rowwise_fp8: Optional[MoERowwiseFP8Config] = None,
+        latent_moe: Optional[LatentMoEConfig] = None,
         init_device: str = "cpu",
         cache: Optional[BufferCache] = None,
     ):
@@ -379,6 +418,43 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         assert dropout == 0.0 or dropout is None, "OLMoDDPTransformerBlock does not support dropout"
         self.d_model = d_model
         self.block_idx = block_idx
+        self.latent_down_proj: Optional[torch.nn.Linear]
+        self.latent_up_proj: Optional[torch.nn.Linear]
+        if latent_moe is None:
+            self.latent_down_proj = None
+            self.latent_up_proj = None
+        else:
+            if routed_experts is None:
+                raise OLMoConfigurationError("latent_moe requires routed_experts")
+            if routed_experts_router is None:
+                raise OLMoConfigurationError("latent_moe requires routed_experts_router")
+            if not 0 < latent_moe.routed_expert_dim < d_model:
+                raise OLMoConfigurationError(
+                    "latent_moe.routed_expert_dim must be greater than 0 and less than "
+                    f"d_model ({d_model}), got {latent_moe.routed_expert_dim}"
+                )
+            if routed_experts.d_model != latent_moe.routed_expert_dim:
+                raise OLMoConfigurationError(
+                    "latent_moe.routed_expert_dim must equal routed_experts.d_model"
+                )
+            if routed_experts_router.d_model != latent_moe.routed_expert_dim:
+                raise OLMoConfigurationError(
+                    "latent_moe.routed_expert_dim must equal routed_experts_router.d_model"
+                )
+            self.latent_down_proj = torch.nn.Linear(
+                d_model,
+                latent_moe.routed_expert_dim,
+                bias=latent_moe.bias,
+                dtype=routed_experts.dtype.as_pt(),
+                device=init_device,
+            )
+            self.latent_up_proj = torch.nn.Linear(
+                latent_moe.routed_expert_dim,
+                d_model,
+                bias=latent_moe.bias,
+                dtype=routed_experts.dtype.as_pt(),
+                device=init_device,
+            )
 
         if attention_residual_alpha is not None:
             raise OLMoConfigurationError(
@@ -749,20 +825,26 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         # attention
         flops += self.attention.num_flops_per_token(seq_len)
 
-        # router(s): (d_model) * (num_experts) per token, x6 (fwd + bwd, GEMM x2)
-        num_router_experts = 0
+        # Routers can consume different widths when the routed branch is latent.
         if self.routed_experts_router is not None:
-            num_router_experts += self.routed_experts_router.num_experts
+            flops += (
+                6
+                * self.routed_experts_router.d_model
+                * self.routed_experts_router.num_experts
+            )
         if self.shared_experts_router is not None:
-            num_router_experts += self.shared_experts_router.num_experts
-        flops += 6 * d_model * num_router_experts
+            flops += (
+                6
+                * self.shared_experts_router.d_model
+                * self.shared_experts_router.num_experts
+            )
 
         # routed experts: top_k active per token; SwiGLU has 3 matmuls; fwd+bwd x3; GEMM x2.
         if self.routed_experts is not None:
             assert self.routed_experts_router is not None
             flops += (
                 (3 * 3 * 2)
-                * d_model
+                * self.routed_experts.d_model
                 * self.routed_experts.hidden_size
                 * self.routed_experts_router.top_k
             )
@@ -775,6 +857,10 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
                 * self.shared_experts.hidden_size
                 * self.shared_experts.num_experts
             )
+
+        for projection in (self.latent_down_proj, self.latent_up_proj):
+            if projection is not None:
+                flops += 6 * projection.weight.numel()
 
         return flops
 
@@ -1287,6 +1373,8 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
         **kwargs,
     ) -> Tuple[torch.Tensor, object]:
+        if self.latent_down_proj is not None:
+            raise NotImplementedError("LatentMoE is not supported with rowwise NVSHMEM TBO yet")
         if self.ep.path != ExpertParallelPath.rowwise_nvshmem:
             raise RuntimeError(
                 "EP TBO is only supported with "
@@ -1355,6 +1443,16 @@ class OLMoDDPTransformerBlock(olmo_core.nn.transformer.block.TransformerBlockBas
         if self.use_pre_norm:
             return self.feed_forward_norm(x)
         return x
+
+    def _prepare_routed_moe_input(self, model_input: torch.Tensor) -> torch.Tensor:
+        if self.latent_down_proj is None:
+            return model_input
+        return self.latent_down_proj(model_input)
+
+    def _restore_routed_moe_output(self, routed_output: torch.Tensor) -> torch.Tensor:
+        if self.latent_up_proj is None:
+            return routed_output
+        return self.latent_up_proj(routed_output)
 
     def _merge_routed_and_shared(
         self,

--- a/src/olmo_core/nn/moe/__init__.py
+++ b/src/olmo_core/nn/moe/__init__.py
@@ -4,7 +4,7 @@ MoE layers.
 
 from .loss import MoELoadBalancingLossGranularity
 from .mlp import DroplessMoEMLP, MoEMLP
-from .moe import DroplessMoE, MoEBase, MoEConfig, MoEType
+from .moe import DroplessMoE, LatentMoEConfig, MoEBase, MoEConfig, MoEType
 from .router import (
     MoELinearRouter,
     MoERouter,
@@ -16,6 +16,7 @@ from .router import (
 __all__ = [
     "MoEBase",
     "DroplessMoE",
+    "LatentMoEConfig",
     "MoEConfig",
     "MoEType",
     "MoEMLP",

--- a/src/olmo_core/nn/moe/moe.py
+++ b/src/olmo_core/nn/moe/moe.py
@@ -61,8 +61,8 @@ class MoEType(StrEnum):
 class LatentMoEConfig(Config):
     """Configuration for running the routed MoE branch in a latent dimension."""
 
-    routed_expert_dim: int
-    """Input and output dimension of the router and routed experts."""
+    latent_dim: int
+    """Input and output dimension of the routed expert payloads and expert MLPs."""
 
     bias: bool = False
     """Whether to use bias in the model-to-latent and latent-to-model projections."""
@@ -81,11 +81,11 @@ class LatentMoEConfig(Config):
         return self.up_proj_input_norm or LayerNormConfig(name=LayerNormType.rms, bias=False)
 
     def num_params(self, d_model: int) -> int:
-        params = 2 * d_model * self.routed_expert_dim
+        params = 2 * d_model * self.latent_dim
         if self.bias:
-            params += self.routed_expert_dim + d_model
+            params += self.latent_dim + d_model
         if self.up_proj_input_norm_enabled:
-            params += self.resolved_up_proj_input_norm().num_params(self.routed_expert_dim)
+            params += self.resolved_up_proj_input_norm().num_params(self.latent_dim)
         return params
 
 
@@ -110,12 +110,10 @@ class MoEConfig(ModuleConfig):
     dtype: DType = DType.float32
 
     def num_params(self, d_model: int) -> int:
-        routed_expert_dim = (
-            d_model if self.latent_moe is None else self.latent_moe.routed_expert_dim
-        )
+        latent_dim = d_model if self.latent_moe is None else self.latent_moe.latent_dim
         num_params = 0
-        num_params += self.router.num_params(routed_expert_dim, self.num_experts)
-        num_params += 3 * routed_expert_dim * self.hidden_size * self.num_experts
+        num_params += self.router.num_params(d_model, self.num_experts)
+        num_params += 3 * latent_dim * self.hidden_size * self.num_experts
         if self.shared_mlp is not None:
             num_params += self.shared_mlp.num_params(d_model)
         if self.latent_moe is not None:
@@ -123,13 +121,11 @@ class MoEConfig(ModuleConfig):
         return num_params
 
     def num_active_params(self, d_model: int) -> int:
-        routed_expert_dim = (
-            d_model if self.latent_moe is None else self.latent_moe.routed_expert_dim
-        )
+        latent_dim = d_model if self.latent_moe is None else self.latent_moe.latent_dim
         return (
             self.num_params(d_model)
-            - (3 * routed_expert_dim * self.hidden_size * self.num_experts)
-            + (3 * routed_expert_dim * self.hidden_size * self.router.top_k)
+            - (3 * latent_dim * self.hidden_size * self.num_experts)
+            + (3 * latent_dim * self.hidden_size * self.router.top_k)
         )
 
     def build(
@@ -140,10 +136,10 @@ class MoEConfig(ModuleConfig):
         init_device: str = "cpu",
         cache: Optional[BufferCache] = None,
     ) -> "MoEBase":
-        if self.latent_moe is not None and not (0 < self.latent_moe.routed_expert_dim < d_model):
+        if self.latent_moe is not None and not (0 < self.latent_moe.latent_dim < d_model):
             raise OLMoConfigurationError(
-                "latent_moe.routed_expert_dim must be greater than 0 and less than d_model "
-                f"({d_model}), got {self.latent_moe.routed_expert_dim}"
+                "latent_moe.latent_dim must be greater than 0 and less than d_model "
+                f"({d_model}), got {self.latent_moe.latent_dim}"
             )
         kwargs = self.as_dict(exclude_none=True, recurse=False)
         kwargs.pop("name")
@@ -199,7 +195,7 @@ class MoEBase(nn.Module):
             if z_loss_weight is not None:
                 z_loss_weight = z_loss_weight / n_layers
 
-        routed_expert_dim = d_model if latent_moe is None else latent_moe.routed_expert_dim
+        latent_dim = d_model if latent_moe is None else latent_moe.latent_dim
         self.latent_down_proj: Optional[nn.Linear]
         self.latent_up_proj_input_norm: Optional[LayerNorm]
         self.latent_up_proj: Optional[nn.Linear]
@@ -210,20 +206,20 @@ class MoEBase(nn.Module):
         else:
             self.latent_down_proj = nn.Linear(
                 d_model,
-                routed_expert_dim,
+                latent_dim,
                 bias=latent_moe.bias,
                 dtype=dtype,
                 device=init_device,
             )
             self.latent_up_proj_input_norm = (
                 latent_moe.resolved_up_proj_input_norm().build(
-                    routed_expert_dim, init_device=init_device
+                    latent_dim, init_device=init_device
                 )
                 if latent_moe.up_proj_input_norm_enabled
                 else None
             )
             self.latent_up_proj = nn.Linear(
-                routed_expert_dim,
+                latent_dim,
                 d_model,
                 bias=latent_moe.bias,
                 dtype=dtype,
@@ -231,7 +227,7 @@ class MoEBase(nn.Module):
             )
 
         self.router = router.build(
-            routed_expert_dim,
+            d_model,
             num_experts,
             lb_loss_weight=lb_loss_weight,
             lb_loss_granularity=lb_loss_granularity,
@@ -240,7 +236,7 @@ class MoEBase(nn.Module):
             init_device=init_device,
         )
         self.experts = self._init_parallel_mlp(
-            d_model=routed_expert_dim,
+            d_model=latent_dim,
             num_experts=num_experts,
             hidden_size=hidden_size,
             dtype=dtype,
@@ -311,10 +307,10 @@ class MoEBase(nn.Module):
         :returns: The output of the MoE layer, the optional load-balancing loss, and the optional
             router Z-loss.
         """
-        routed_x = self.prepare_routed_input(x)
         expert_weights, expert_indices, batch_size_per_expert, router_aux_loss = self.router(
-            routed_x, loss_div_factor=loss_div_factor
+            x, loss_div_factor=loss_div_factor
         )
+        routed_x = self.prepare_routed_input(x)
 
         if router_aux_loss is not None:
             routed_x = attach_auxiliary_loss(routed_x, router_aux_loss)

--- a/src/olmo_core/nn/moe/moe.py
+++ b/src/olmo_core/nn/moe/moe.py
@@ -13,7 +13,7 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
 )
 
-from olmo_core.config import DType, StrEnum
+from olmo_core.config import Config, DType, StrEnum
 from olmo_core.distributed.parallel import (
     flatten_mesh,
     get_pp_stage_mesh,
@@ -33,7 +33,7 @@ from .router import MoERouterConfig
 if TYPE_CHECKING:
     from olmo_core.train.common import ReduceType
 
-__all__ = ["MoEBase", "MoE", "DroplessMoE", "MoEConfig", "MoEType"]
+__all__ = ["LatentMoEConfig", "MoEBase", "MoE", "DroplessMoE", "MoEConfig", "MoEType"]
 
 
 log = logging.getLogger(__name__)
@@ -56,6 +56,23 @@ class MoEType(StrEnum):
 
 
 @dataclass
+class LatentMoEConfig(Config):
+    """Configuration for running the routed MoE branch in a latent dimension."""
+
+    routed_expert_dim: int
+    """Input and output dimension of the router and routed experts."""
+
+    bias: bool = False
+    """Whether to use bias in the model-to-latent and latent-to-model projections."""
+
+    def num_params(self, d_model: int) -> int:
+        params = 2 * d_model * self.routed_expert_dim
+        if self.bias:
+            params += self.routed_expert_dim + d_model
+        return params
+
+
+@dataclass
 class MoEConfig(ModuleConfig):
     name: MoEType = MoEType.default
     """
@@ -66,6 +83,7 @@ class MoEConfig(ModuleConfig):
     capacity_factor: Optional[float] = None
     router: MoERouterConfig = field(default_factory=MoERouterConfig)
     shared_mlp: Optional[FeedForwardConfig] = None
+    latent_moe: Optional[LatentMoEConfig] = None
     lb_loss_weight: Optional[float] = 0.01
     lb_loss_granularity: MoELoadBalancingLossGranularity = (
         MoELoadBalancingLossGranularity.local_batch
@@ -75,18 +93,26 @@ class MoEConfig(ModuleConfig):
     dtype: DType = DType.float32
 
     def num_params(self, d_model: int) -> int:
+        routed_expert_dim = (
+            d_model if self.latent_moe is None else self.latent_moe.routed_expert_dim
+        )
         num_params = 0
-        num_params += self.router.num_params(d_model, self.num_experts)
-        num_params += 3 * d_model * self.hidden_size * self.num_experts
+        num_params += self.router.num_params(routed_expert_dim, self.num_experts)
+        num_params += 3 * routed_expert_dim * self.hidden_size * self.num_experts
         if self.shared_mlp is not None:
             num_params += self.shared_mlp.num_params(d_model)
+        if self.latent_moe is not None:
+            num_params += self.latent_moe.num_params(d_model)
         return num_params
 
     def num_active_params(self, d_model: int) -> int:
+        routed_expert_dim = (
+            d_model if self.latent_moe is None else self.latent_moe.routed_expert_dim
+        )
         return (
             self.num_params(d_model)
-            - (3 * d_model * self.hidden_size * self.num_experts)
-            + (3 * d_model * self.hidden_size * self.router.top_k)
+            - (3 * routed_expert_dim * self.hidden_size * self.num_experts)
+            + (3 * routed_expert_dim * self.hidden_size * self.router.top_k)
         )
 
     def build(
@@ -97,6 +123,13 @@ class MoEConfig(ModuleConfig):
         init_device: str = "cpu",
         cache: Optional[BufferCache] = None,
     ) -> "MoEBase":
+        if self.latent_moe is not None and not (
+            0 < self.latent_moe.routed_expert_dim < d_model
+        ):
+            raise OLMoConfigurationError(
+                "latent_moe.routed_expert_dim must be greater than 0 and less than d_model "
+                f"({d_model}), got {self.latent_moe.routed_expert_dim}"
+            )
         kwargs = self.as_dict(exclude_none=True, recurse=False)
         kwargs.pop("name")
         kwargs.update(
@@ -141,6 +174,7 @@ class MoEBase(nn.Module):
         scale_loss_by_num_layers: bool = True,
         dtype: torch.dtype = torch.float32,
         cache: Optional[BufferCache] = None,
+        latent_moe: Optional[LatentMoEConfig] = None,
         **kwargs,
     ):
         super().__init__()
@@ -150,8 +184,30 @@ class MoEBase(nn.Module):
             if z_loss_weight is not None:
                 z_loss_weight = z_loss_weight / n_layers
 
+        routed_expert_dim = d_model if latent_moe is None else latent_moe.routed_expert_dim
+        self.latent_down_proj: Optional[nn.Linear]
+        self.latent_up_proj: Optional[nn.Linear]
+        if latent_moe is None:
+            self.latent_down_proj = None
+            self.latent_up_proj = None
+        else:
+            self.latent_down_proj = nn.Linear(
+                d_model,
+                routed_expert_dim,
+                bias=latent_moe.bias,
+                dtype=dtype,
+                device=init_device,
+            )
+            self.latent_up_proj = nn.Linear(
+                routed_expert_dim,
+                d_model,
+                bias=latent_moe.bias,
+                dtype=dtype,
+                device=init_device,
+            )
+
         self.router = router.build(
-            d_model,
+            routed_expert_dim,
             num_experts,
             lb_loss_weight=lb_loss_weight,
             lb_loss_granularity=lb_loss_granularity,
@@ -160,7 +216,7 @@ class MoEBase(nn.Module):
             init_device=init_device,
         )
         self.experts = self._init_parallel_mlp(
-            d_model=d_model,
+            d_model=routed_expert_dim,
             num_experts=num_experts,
             hidden_size=hidden_size,
             dtype=dtype,
@@ -231,18 +287,21 @@ class MoEBase(nn.Module):
         :returns: The output of the MoE layer, the optional load-balancing loss, and the optional
             router Z-loss.
         """
+        routed_x = x if self.latent_down_proj is None else self.latent_down_proj(x)
         expert_weights, expert_indices, batch_size_per_expert, router_aux_loss = self.router(
-            x, loss_div_factor=loss_div_factor
+            routed_x, loss_div_factor=loss_div_factor
         )
 
         if router_aux_loss is not None:
-            x = attach_auxiliary_loss(x, router_aux_loss)
+            routed_x = attach_auxiliary_loss(routed_x, router_aux_loss)
 
         shared_out: Optional[torch.Tensor] = None
         if self.shared_mlp is not None:
             shared_out = self.shared_mlp(x)
 
-        out = self.experts(x, expert_weights, expert_indices, batch_size_per_expert)
+        out = self.experts(routed_x, expert_weights, expert_indices, batch_size_per_expert)
+        if self.latent_up_proj is not None:
+            out = self.latent_up_proj(out)
 
         if shared_out is not None:
             shared_out = shared_out / (self.top_k + 1)
@@ -326,11 +385,17 @@ class MoEBase(nn.Module):
 
     def num_flops_per_token(self, seq_len: int) -> int:
         router_flops = 6 * sum(p.numel() for p in self.router.parameters())
+        latent_projection_flops = 6 * sum(
+            p.numel()
+            for projection in (self.latent_down_proj, self.latent_up_proj)
+            if projection is not None
+            for p in projection.parameters()
+        )
         shared_mlp_flops = (
             self.shared_mlp.num_flops_per_token(seq_len) if self.shared_mlp is not None else 0
         )
         expert_flops = self.experts.num_flops_per_token(seq_len)
-        return router_flops + shared_mlp_flops + expert_flops
+        return router_flops + latent_projection_flops + shared_mlp_flops + expert_flops
 
 
 class MoE(MoEBase):
@@ -355,6 +420,7 @@ class MoE(MoEBase):
         n_layers: int = 1,
         dtype: torch.dtype = torch.float32,
         cache: Optional[BufferCache] = None,
+        latent_moe: Optional[LatentMoEConfig] = None,
     ):
         super().__init__(
             d_model=d_model,
@@ -371,6 +437,7 @@ class MoE(MoEBase):
             dtype=dtype,
             capacity_factor=capacity_factor,
             cache=cache,
+            latent_moe=latent_moe,
         )
 
     def _init_parallel_mlp(  # type: ignore[override]

--- a/src/olmo_core/nn/moe/moe.py
+++ b/src/olmo_core/nn/moe/moe.py
@@ -25,6 +25,7 @@ from olmo_core.ops import attach_auxiliary_loss
 from ..buffer_cache import BufferCache
 from ..config import ModuleConfig
 from ..feed_forward import FeedForwardConfig
+from ..layer_norm import LayerNorm, LayerNormConfig, LayerNormType
 from .loss import MoELoadBalancingLossGranularity
 from .mlp import DroplessMoEMLP, MoEMLP
 from .parallel_mlp import ParallelDroplessMLP, ParallelMLP, ParallelMLPBase
@@ -65,10 +66,21 @@ class LatentMoEConfig(Config):
     bias: bool = False
     """Whether to use bias in the model-to-latent and latent-to-model projections."""
 
+    up_proj_input_norm: Optional[LayerNormConfig] = field(
+        default_factory=lambda: LayerNormConfig(name=LayerNormType.rms, bias=False)
+    )
+    """Normalization applied in latent space immediately before the up projection.
+
+    RMSNorm is used by default. Set this to another layer norm configuration to select a
+    different implementation, or to ``None`` to disable normalization.
+    """
+
     def num_params(self, d_model: int) -> int:
         params = 2 * d_model * self.routed_expert_dim
         if self.bias:
             params += self.routed_expert_dim + d_model
+        if self.up_proj_input_norm is not None:
+            params += self.up_proj_input_norm.num_params(self.routed_expert_dim)
         return params
 
 
@@ -184,9 +196,11 @@ class MoEBase(nn.Module):
 
         routed_expert_dim = d_model if latent_moe is None else latent_moe.routed_expert_dim
         self.latent_down_proj: Optional[nn.Linear]
+        self.latent_up_proj_input_norm: Optional[LayerNorm]
         self.latent_up_proj: Optional[nn.Linear]
         if latent_moe is None:
             self.latent_down_proj = None
+            self.latent_up_proj_input_norm = None
             self.latent_up_proj = None
         else:
             self.latent_down_proj = nn.Linear(
@@ -195,6 +209,11 @@ class MoEBase(nn.Module):
                 bias=latent_moe.bias,
                 dtype=dtype,
                 device=init_device,
+            )
+            self.latent_up_proj_input_norm = (
+                None
+                if latent_moe.up_proj_input_norm is None
+                else latent_moe.up_proj_input_norm.build(routed_expert_dim, init_device=init_device)
             )
             self.latent_up_proj = nn.Linear(
                 routed_expert_dim,
@@ -299,6 +318,8 @@ class MoEBase(nn.Module):
 
         out = self.experts(routed_x, expert_weights, expert_indices, batch_size_per_expert)
         if self.latent_up_proj is not None:
+            if self.latent_up_proj_input_norm is not None:
+                out = self.latent_up_proj_input_norm(out)
             out = self.latent_up_proj(out)
 
         if shared_out is not None:

--- a/src/olmo_core/nn/moe/moe.py
+++ b/src/olmo_core/nn/moe/moe.py
@@ -123,9 +123,7 @@ class MoEConfig(ModuleConfig):
         init_device: str = "cpu",
         cache: Optional[BufferCache] = None,
     ) -> "MoEBase":
-        if self.latent_moe is not None and not (
-            0 < self.latent_moe.routed_expert_dim < d_model
-        ):
+        if self.latent_moe is not None and not (0 < self.latent_moe.routed_expert_dim < d_model):
             raise OLMoConfigurationError(
                 "latent_moe.routed_expert_dim must be greater than 0 and less than d_model "
                 f"({d_model}), got {self.latent_moe.routed_expert_dim}"

--- a/src/olmo_core/nn/moe/moe.py
+++ b/src/olmo_core/nn/moe/moe.py
@@ -67,21 +67,25 @@ class LatentMoEConfig(Config):
     bias: bool = False
     """Whether to use bias in the model-to-latent and latent-to-model projections."""
 
-    up_proj_input_norm: Optional[LayerNormConfig] = field(
-        default_factory=lambda: LayerNormConfig(name=LayerNormType.rms, bias=False)
-    )
+    up_proj_input_norm: Optional[LayerNormConfig] = None
     """Normalization applied in latent space immediately before the up projection.
 
-    RMSNorm is used by default. Set this to another layer norm configuration to select a
-    different implementation, or to ``None`` to disable normalization.
+    When normalization is enabled, a bias-free RMSNorm is used if this is ``None``. Set this to
+    another layer norm configuration to select a different implementation.
     """
+
+    up_proj_input_norm_enabled: bool = False
+    """Whether to apply ``up_proj_input_norm`` before the latent up projection."""
+
+    def resolved_up_proj_input_norm(self) -> LayerNormConfig:
+        return self.up_proj_input_norm or LayerNormConfig(name=LayerNormType.rms, bias=False)
 
     def num_params(self, d_model: int) -> int:
         params = 2 * d_model * self.routed_expert_dim
         if self.bias:
             params += self.routed_expert_dim + d_model
-        if self.up_proj_input_norm is not None:
-            params += self.up_proj_input_norm.num_params(self.routed_expert_dim)
+        if self.up_proj_input_norm_enabled:
+            params += self.resolved_up_proj_input_norm().num_params(self.routed_expert_dim)
         return params
 
 
@@ -212,9 +216,11 @@ class MoEBase(nn.Module):
                 device=init_device,
             )
             self.latent_up_proj_input_norm = (
-                None
-                if latent_moe.up_proj_input_norm is None
-                else latent_moe.up_proj_input_norm.build(routed_expert_dim, init_device=init_device)
+                latent_moe.resolved_up_proj_input_norm().build(
+                    routed_expert_dim, init_device=init_device
+                )
+                if latent_moe.up_proj_input_norm_enabled
+                else None
             )
             self.latent_up_proj = nn.Linear(
                 routed_expert_dim,

--- a/src/olmo_core/nn/moe/moe.py
+++ b/src/olmo_core/nn/moe/moe.py
@@ -212,9 +212,7 @@ class MoEBase(nn.Module):
                 device=init_device,
             )
             self.latent_up_proj_input_norm = (
-                latent_moe.resolved_up_proj_input_norm().build(
-                    latent_dim, init_device=init_device
-                )
+                latent_moe.resolved_up_proj_input_norm().build(latent_dim, init_device=init_device)
                 if latent_moe.up_proj_input_norm_enabled
                 else None
             )

--- a/src/olmo_core/nn/moe/moe.py
+++ b/src/olmo_core/nn/moe/moe.py
@@ -311,7 +311,7 @@ class MoEBase(nn.Module):
         :returns: The output of the MoE layer, the optional load-balancing loss, and the optional
             router Z-loss.
         """
-        routed_x = x if self.latent_down_proj is None else self.latent_down_proj(x)
+        routed_x = self.prepare_routed_input(x)
         expert_weights, expert_indices, batch_size_per_expert, router_aux_loss = self.router(
             routed_x, loss_div_factor=loss_div_factor
         )
@@ -324,16 +324,25 @@ class MoEBase(nn.Module):
             shared_out = self.shared_mlp(x)
 
         out = self.experts(routed_x, expert_weights, expert_indices, batch_size_per_expert)
-        if self.latent_up_proj is not None:
-            if self.latent_up_proj_input_norm is not None:
-                out = self.latent_up_proj_input_norm(out)
-            out = self.latent_up_proj(out)
+        out = self.restore_routed_output(out)
 
         if shared_out is not None:
             shared_out = shared_out / (self.top_k + 1)
             out = shared_out.add(out, alpha=self.top_k / (self.top_k + 1))
 
         return out
+
+    def prepare_routed_input(self, model_input: torch.Tensor) -> torch.Tensor:
+        if self.latent_down_proj is None:
+            return model_input
+        return self.latent_down_proj(model_input)
+
+    def restore_routed_output(self, routed_output: torch.Tensor) -> torch.Tensor:
+        if self.latent_up_proj is None:
+            return routed_output
+        if self.latent_up_proj_input_norm is not None:
+            routed_output = self.latent_up_proj_input_norm(routed_output)
+        return self.latent_up_proj(routed_output)
 
     def apply_pp(self, pp_mesh: DeviceMesh):
         world_mesh = get_world_mesh()

--- a/src/olmo_core/nn/moe/moe.py
+++ b/src/olmo_core/nn/moe/moe.py
@@ -342,6 +342,9 @@ class MoEBase(nn.Module):
             return routed_output
         if self.latent_up_proj_input_norm is not None:
             routed_output = self.latent_up_proj_input_norm(routed_output)
+        # grouped-gemm experts return BF16 regardless of their parameter/input dtype. Restore the
+        # configured projection dtype before applying the dense up projection.
+        routed_output = routed_output.to(dtype=self.latent_up_proj.weight.dtype)
         return self.latent_up_proj(routed_output)
 
     def apply_pp(self, pp_mesh: DeviceMesh):

--- a/src/olmo_core/nn/moe/moe.py
+++ b/src/olmo_core/nn/moe/moe.py
@@ -19,6 +19,7 @@ from olmo_core.distributed.parallel import (
     get_pp_stage_mesh,
     get_world_mesh,
 )
+from olmo_core.distributed.parallel.tensor_parallel import SequenceParallel
 from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.ops import attach_auxiliary_loss
 
@@ -378,6 +379,20 @@ class MoEBase(nn.Module):
 
         # Sequence parallel.
         self.router.apply_tp(tp_mesh, float8_enabled=float8_enabled)
+
+        # The latent projection stack operates independently on sequence-sharded tokens. Replicate
+        # its parameters and return local tensors, matching the router and expert input contract.
+        for module in (
+            self.latent_down_proj,
+            self.latent_up_proj_input_norm,
+            self.latent_up_proj,
+        ):
+            if module is not None:
+                parallelize_module(
+                    module,
+                    device_mesh=tp_mesh,
+                    parallelize_plan=SequenceParallel(use_local_output=True),
+                )
 
         # Expert parallel.
         self.experts.apply_tp(tp_mesh, float8_enabled=float8_enabled)

--- a/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
+++ b/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
@@ -763,6 +763,7 @@ def combined_forward_ep_deepep_v2(
     kwargs.pop("max_doc_len", None)
     kwargs.pop("cu_doc_lens", None)
     moe_inp = self._prepare_moe_input(attn_res_out)
+    routed_moe_inp = self._prepare_routed_moe_input(moe_inp)
 
     (
         local_x_global_routed_expert_weights,
@@ -770,7 +771,7 @@ def combined_forward_ep_deepep_v2(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        moe_inp,
+        routed_moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )
@@ -795,7 +796,7 @@ def combined_forward_ep_deepep_v2(
         else:
             local_x_global_shared_expert_weights = None
 
-    in_shape = moe_inp.size()
+    routed_in_shape = routed_moe_inp.size()
 
     mixed_shared_out = None
     if self.shared_experts is not None:
@@ -819,7 +820,7 @@ def combined_forward_ep_deepep_v2(
                 attn_res_out.shape,
             )
 
-    moe_inp = moe_inp.view(-1, in_shape[-1])
+    routed_moe_inp = routed_moe_inp.view(-1, routed_in_shape[-1])
     top_k = self.routed_experts_router.top_k
     routing_map = local_x_global_routed_expert_indices.view(-1, top_k)
     route_weights = local_x_global_routed_expert_weights.view(-1, top_k)
@@ -858,10 +859,10 @@ def combined_forward_ep_deepep_v2(
 
     runtime = _get_deepep_v2_runtime(
         self,
-        local_tokens=moe_inp.shape[0],
-        hidden=moe_inp.shape[-1],
+        local_tokens=routed_moe_inp.shape[0],
+        hidden=routed_moe_inp.shape[-1],
         top_k=top_k,
-        device=moe_inp.device,
+        device=routed_moe_inp.device,
     )
     # Reuse rowwise's deterministic tail-drop policy, then present dropped
     # routes to DeepEP as invalid top-k slots. DeepEP ignores negative expert
@@ -897,16 +898,19 @@ def combined_forward_ep_deepep_v2(
     grad_anchor: Optional[torch.Tensor] = None
     if (
         torch.is_grad_enabled()
-        and not (moe_inp.requires_grad or topk_weights.requires_grad)
+        and not (routed_moe_inp.requires_grad or topk_weights.requires_grad)
         and _routed_experts_need_grad(self.routed_experts)
     ):
         grad_anchor = torch.zeros(
-            (), device=moe_inp.device, dtype=moe_inp.dtype, requires_grad=True
+            (),
+            device=routed_moe_inp.device,
+            dtype=routed_moe_inp.dtype,
+            requires_grad=True,
         )
 
     with nvtx.annotate("deepep_v2/routed", color="green"):
         routed_out = _DeepEpV2Autograd.apply(
-            moe_inp,
+            routed_moe_inp,
             topk_idx,
             topk_weights,
             self,
@@ -915,7 +919,8 @@ def combined_forward_ep_deepep_v2(
             grad_anchor,
         )
 
-    x_moe = routed_out.view(in_shape)
+    x_moe = routed_out.view(routed_in_shape)
+    x_moe = self._restore_routed_moe_output(x_moe)
     wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
 
     mlp_out = self._merge_routed_and_shared(x_moe, mixed_shared_out)

--- a/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
+++ b/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
@@ -775,7 +775,7 @@ def combined_forward_ep_deepep_v2(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        routed_moe_inp,
+        moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )

--- a/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
+++ b/src/olmo_core/nn/moe/v2/ep_deepep_v2.py
@@ -246,6 +246,13 @@ def _expanded_weight_grad_to_topk_grad(
     return grad_topk
 
 
+def _validate_deepep_v2_hidden_size(hidden: int) -> None:
+    if hidden % 256 != 0:
+        raise RuntimeError(
+            "deepep_v2 BF16 combine requires routed hidden size divisible by 256 " f"(got {hidden})"
+        )
+
+
 def _validate_deepep_v2_block(
     block: OLMoDDPTransformerBlock,
     x: torch.Tensor,
@@ -258,10 +265,7 @@ def _validate_deepep_v2_block(
         raise RuntimeError("deepep_v2 EP requires CUDA input")
     if x.dtype != torch.bfloat16:
         raise RuntimeError(f"deepep_v2 EP currently supports bf16 only, got {x.dtype}")
-    if x.shape[-1] % 256 != 0:
-        raise RuntimeError(
-            "deepep_v2 BF16 combine requires d_model divisible by 256 " f"(got {x.shape[-1]})"
-        )
+    _validate_deepep_v2_hidden_size(x.shape[-1])
     if block.ep_pg is None:
         raise RuntimeError("deepep_v2 EP requires block.ep_pg to be initialized")
     if block.routed_experts is None or block.routed_experts_router is None:
@@ -751,7 +755,6 @@ def combined_forward_ep_deepep_v2(
     uses DeepEP's own ElasticBuffer on the EP process group.
     """
     self = block
-    _validate_deepep_v2_block(self, x)
     assert self.routed_experts is not None
     assert self.routed_experts_router is not None
 
@@ -764,6 +767,7 @@ def combined_forward_ep_deepep_v2(
     kwargs.pop("cu_doc_lens", None)
     moe_inp = self._prepare_moe_input(attn_res_out)
     routed_moe_inp = self._prepare_routed_moe_input(moe_inp)
+    _validate_deepep_v2_block(self, routed_moe_inp)
 
     (
         local_x_global_routed_expert_weights,

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
@@ -68,7 +68,7 @@ def combined_forward_ep_no_sync_1d(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        routed_moe_inp,
+        moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_1d.py
@@ -52,8 +52,6 @@ def combined_forward_ep_no_sync_1d(
         not requires_host_side_split_sizes()
     ), "EP no-sync implementation does not support host-side split size communication"
     group_name = get_ep_no_sync_group_name(self)
-    B, S, D = x.shape
-
     block_inp = x
     del x
 
@@ -62,6 +60,7 @@ def combined_forward_ep_no_sync_1d(
     kwargs.pop("max_doc_len", None)
     kwargs.pop("cu_doc_lens", None)
     moe_inp = self._prepare_moe_input(attn_res_out)
+    routed_moe_inp = self._prepare_routed_moe_input(moe_inp)
 
     (
         local_x_global_routed_expert_weights,
@@ -69,7 +68,7 @@ def combined_forward_ep_no_sync_1d(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        moe_inp,
+        routed_moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )
@@ -94,8 +93,8 @@ def combined_forward_ep_no_sync_1d(
         else:
             local_x_global_shared_expert_weights = None
 
-    in_shape = moe_inp.size()
-    moe_inp = moe_inp.view(-1, in_shape[-1])
+    routed_in_shape = routed_moe_inp.size()
+    routed_moe_inp = routed_moe_inp.view(-1, routed_in_shape[-1])
 
     num_out_tokens = local_x_global_routed_expert_indices.numel()
 
@@ -154,15 +153,15 @@ def combined_forward_ep_no_sync_1d(
         dispatch_out_cap=dispatch_out_cap,
         combine_in_cap=combine_in_cap,
         combine_out_cap=combine_out_cap,
-        d_model=moe_inp.shape[-1],
-        dtype=moe_inp.dtype,
-        device=moe_inp.device,
+        d_model=routed_moe_inp.shape[-1],
+        dtype=routed_moe_inp.dtype,
+        device=routed_moe_inp.device,
     )
 
     routing_map = local_x_global_routed_expert_indices.view(
         -1, self.routed_experts_router.top_k
     ).int()
-    hidden_shape_before_permute = moe_inp.shape
+    hidden_shape_before_permute = routed_moe_inp.shape
 
     with torch.no_grad():
         padded_batch_size_per_local_expert = padded_local_expert_splits_for_capacity(
@@ -180,7 +179,7 @@ def combined_forward_ep_no_sync_1d(
             permutated_local_x,
             reversed_local_x_permutation_mapping,
         ) = moe_permute_1d_fused_drop_no_compile(
-            inp=moe_inp,
+            inp=routed_moe_inp,
             routing_map=routing_map,
             num_out_tokens=num_out_tokens,
             reorder_indices=local_reorder_indices,
@@ -202,7 +201,7 @@ def combined_forward_ep_no_sync_1d(
             other_stream=torch.cuda.current_stream(),
         )
         with torch.cuda.stream(self.get_dense_stream()):
-            shared_out_up, shared_out_gate = self.shared_experts.forward1(moe_inp.view(B, S, D))
+            shared_out_up, shared_out_gate = self.shared_experts.forward1(moe_inp)
     else:
         shared_out_up, shared_out_gate = None, None
 
@@ -303,7 +302,8 @@ def combined_forward_ep_no_sync_1d(
     else:
         mixed_shared_out = None
 
-    local_x = local_x.view(in_shape)
+    local_x = local_x.view(routed_in_shape)
+    local_x = self._restore_routed_moe_output(local_x)
     wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
 
     mlp_out = self._merge_routed_and_shared(local_x, mixed_shared_out)

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
@@ -128,6 +128,7 @@ def combined_forward_ep_no_sync_rowwise(
     kwargs.pop("max_doc_len", None)
     kwargs.pop("cu_doc_lens", None)
     moe_inp = self._prepare_moe_input(attn_res_out)
+    routed_moe_inp = self._prepare_routed_moe_input(moe_inp)
 
     (
         local_x_global_routed_expert_weights,
@@ -135,7 +136,7 @@ def combined_forward_ep_no_sync_rowwise(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        moe_inp,
+        routed_moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )
@@ -166,20 +167,20 @@ def combined_forward_ep_no_sync_rowwise(
         else:
             local_x_global_shared_expert_weights = None
 
-    in_shape = moe_inp.size()
-    moe_inp = moe_inp.view(-1, in_shape[-1])
+    routed_in_shape = routed_moe_inp.size()
+    routed_moe_inp = routed_moe_inp.view(-1, routed_in_shape[-1])
     rowwise_fp8_cfg = self.rowwise_fp8
     use_rowwise_fp8 = (
         rowwise_fp8_cfg is not None
         and rowwise_fp8_cfg.enabled
-        and moe_inp.device.type == "cuda"
+        and routed_moe_inp.device.type == "cuda"
         and self.ep.uses_rowwise_buffers
     )
     if not use_rowwise_fp8:
         rowwise_fp8_cfg = None
 
     num_out_tokens = local_x_global_routed_expert_indices.numel()
-    num_input_tokens = moe_inp.shape[0]
+    num_input_tokens = routed_moe_inp.shape[0]
     top_k = self.routed_experts_router.top_k
     if activation_checkpointing is None:
         (
@@ -291,9 +292,9 @@ def combined_forward_ep_no_sync_rowwise(
             combine_in_cap=combine_in_cap,
             combine_gather_cap=num_input_tokens,
             combine_gather_top_k=top_k,
-            d_model=moe_inp.shape[1],
+            d_model=routed_moe_inp.shape[1],
             block_size=rowwise_fp8_cfg.block_size,
-            device=moe_inp.device,
+            device=routed_moe_inp.device,
             need_dispatch_in=use_fp8_symm_dispatch_in,
             need_dispatch_out=not lease_lifetime_buffers,
             need_combine_gather=not fp8_lease_combine_gather,
@@ -311,9 +312,9 @@ def combined_forward_ep_no_sync_rowwise(
                 combine_in_cap=combine_in_cap,
                 combine_gather_cap=num_input_tokens,
                 combine_gather_top_k=top_k,
-                d_model=moe_inp.shape[1],
+                d_model=routed_moe_inp.shape[1],
                 block_size=rowwise_fp8_cfg.block_size,
-                device=moe_inp.device,
+                device=routed_moe_inp.device,
                 lease_dispatch_out=False,
                 lease_combine_gather=False,
                 need_dispatch_in=use_fp8_symm_dispatch_in,
@@ -332,9 +333,9 @@ def combined_forward_ep_no_sync_rowwise(
             dispatch_out_lease = acquire_ep_no_sync_fp8_dispatch_out_lease(
                 self,
                 dispatch_out_cap=dispatch_out_cap,
-                d_model=moe_inp.shape[1],
+                d_model=routed_moe_inp.shape[1],
                 block_size=rowwise_fp8_cfg.block_size,
-                device=moe_inp.device,
+                device=routed_moe_inp.device,
             )
             fp8_buffers = replace(
                 fp8_buffers,
@@ -355,9 +356,9 @@ def combined_forward_ep_no_sync_rowwise(
                     self,
                     combine_gather_cap=num_input_tokens,
                     combine_gather_top_k=top_k,
-                    d_model=moe_inp.shape[1],
+                    d_model=routed_moe_inp.shape[1],
                     block_size=rowwise_fp8_cfg.block_size,
-                    device=moe_inp.device,
+                    device=routed_moe_inp.device,
                 )
                 fp8_buffers = replace(
                     fp8_buffers,
@@ -379,7 +380,7 @@ def combined_forward_ep_no_sync_rowwise(
             block=self.block_idx,
             dispatch_out_cap=dispatch_out_cap,
             combine_in_cap=combine_in_cap,
-            d_model=moe_inp.shape[-1],
+            d_model=routed_moe_inp.shape[-1],
         )
         buffers = get_cached_ep_no_sync_buffers(
             self,
@@ -387,9 +388,9 @@ def combined_forward_ep_no_sync_rowwise(
             dispatch_out_cap=dispatch_out_cap,
             combine_in_cap=combine_in_cap,
             combine_out_cap=combine_out_cap,
-            d_model=moe_inp.shape[-1],
-            dtype=moe_inp.dtype,
-            device=moe_inp.device,
+            d_model=routed_moe_inp.shape[-1],
+            dtype=routed_moe_inp.dtype,
+            device=routed_moe_inp.device,
             need_dispatch_in=use_symm_dispatch_in,
             need_dispatch_meta=False,
             need_dispatch_out=not lease_dispatch_out,
@@ -408,9 +409,9 @@ def combined_forward_ep_no_sync_rowwise(
                 dispatch_out_cap=dispatch_out_cap,
                 combine_in_cap=combine_in_cap,
                 combine_out_cap=combine_out_cap,
-                d_model=moe_inp.shape[-1],
-                dtype=moe_inp.dtype,
-                device=moe_inp.device,
+                d_model=routed_moe_inp.shape[-1],
+                dtype=routed_moe_inp.dtype,
+                device=routed_moe_inp.device,
                 need_dispatch_in=use_symm_dispatch_in,
                 need_dispatch_meta=False,
                 need_dispatch_out=not lease_dispatch_out,
@@ -434,9 +435,9 @@ def combined_forward_ep_no_sync_rowwise(
                 combine_out_cap=combine_out_cap,
                 combine_gather_cap=num_input_tokens,
                 combine_gather_top_k=top_k,
-                d_model=moe_inp.shape[-1],
-                dtype=moe_inp.dtype,
-                device=moe_inp.device,
+                d_model=routed_moe_inp.shape[-1],
+                dtype=routed_moe_inp.dtype,
+                device=routed_moe_inp.device,
                 need_dispatch_out=lease_dispatch_out,
                 need_combine_out=lease_combine_out,
                 need_combine_gather=lease_combine_gather,
@@ -531,7 +532,7 @@ def combined_forward_ep_no_sync_rowwise(
                 name="rowwise_inverse_route_meta",
                 shape=(rank_capacity, 2),
                 dtype=torch.long,
-                device=moe_inp.device,
+                device=routed_moe_inp.device,
             )
             inverse_route_meta.fill_(-1)
             symm_mem_vdev2d_kernels.rowwise_inverse_route_meta_put_compact(
@@ -548,7 +549,7 @@ def combined_forward_ep_no_sync_rowwise(
             rowwise_combine_row_start = batch_size_per_local_expert.new_zeros(())
             rowwise_combine_num_rows = batch_size_per_local_expert.sum()
             rowwise_stage_debug_print("rowwise:combine-put-meta-exit", block=self.block_idx)
-            rowwise_stage_debug_sync("rowwise:combine-put-meta", moe_inp.device)
+            rowwise_stage_debug_sync("rowwise:combine-put-meta", routed_moe_inp.device)
 
     if self.shared_experts is not None:
         with torch.cuda.stream(self.get_dense_stream()):
@@ -605,7 +606,7 @@ def combined_forward_ep_no_sync_rowwise(
             down_anchor = down_anchor.detach()
 
         local_x = _RowwiseFP8DispatchExpertsCombineAutograd.apply(
-            moe_inp,
+            routed_moe_inp,
             dst_ranks,
             dst_rows,
             routed_expert_offsets,
@@ -651,7 +652,7 @@ def combined_forward_ep_no_sync_rowwise(
             fp8_buffers.combine_gather_scales if use_fp8_symm_combine_gather else None  # type: ignore[union-attr]
         )
         dispatch_rank_major = _DispatchRowwiseFP8Autograd.apply(
-            moe_inp,
+            routed_moe_inp,
             dst_ranks,
             dst_rows,
             dispatch_out_q,
@@ -674,7 +675,7 @@ def combined_forward_ep_no_sync_rowwise(
         grad_out_aliases_symm_out = True
         rowwise_stage_debug_print("rowwise:dispatch-enter", block=self.block_idx)
         dispatch_rank_major = _DispatchRowwiseAutograd.apply(
-            moe_inp,
+            routed_moe_inp,
             buffers.dispatch_in if use_symm_dispatch_in else None,
             dst_ranks,
             dst_rows,
@@ -690,7 +691,7 @@ def combined_forward_ep_no_sync_rowwise(
             False,
         )
         rowwise_stage_debug_print("rowwise:dispatch-exit", block=self.block_idx)
-        rowwise_stage_debug_sync("rowwise:dispatch", moe_inp.device)
+        rowwise_stage_debug_sync("rowwise:dispatch", routed_moe_inp.device)
 
     if not use_fused_rowwise_fp8:
         rowwise_stage_debug_print("rowwise:experts-enter", block=self.block_idx)
@@ -772,9 +773,9 @@ def combined_forward_ep_no_sync_rowwise(
                 post_barrier=True,
             )
             local_x = torch.empty(
-                (num_input_tokens, moe_inp.shape[-1]),
-                device=moe_inp.device,
-                dtype=moe_inp.dtype,
+                (num_input_tokens, routed_moe_inp.shape[-1]),
+                device=routed_moe_inp.device,
+                dtype=routed_moe_inp.dtype,
             )
             probs_f32 = route_probs if route_probs.dtype == torch.float32 else route_probs.float()
             symm_mem_vdev2d_kernels.rowwise_reduce_gathered_routes(
@@ -834,7 +835,8 @@ def combined_forward_ep_no_sync_rowwise(
     else:
         mixed_shared_out = None
 
-    local_x = local_x.view(in_shape)
+    local_x = local_x.view(routed_in_shape)
+    local_x = self._restore_routed_moe_output(local_x)
     wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
 
     mlp_out = self._merge_routed_and_shared(local_x, mixed_shared_out)

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise.py
@@ -136,7 +136,7 @@ def combined_forward_ep_no_sync_rowwise(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        routed_moe_inp,
+        moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
@@ -1313,9 +1313,7 @@ def combined_forward_ep_no_sync_rowwise_wave(
                 "rowwise_wave:inverse-meta-local-build-exit",
                 block=self.block_idx,
             )
-            rowwise_stage_debug_sync(
-                "rowwise_wave:inverse-meta-local-build", routed_moe_inp.device
-            )
+            rowwise_stage_debug_sync("rowwise_wave:inverse-meta-local-build", routed_moe_inp.device)
         else:
             rowwise_stage_debug_print("rowwise_wave:inverse-meta-put-enter", block=self.block_idx)
             symm_mem_vdev2d_kernels.rowwise_inverse_route_meta_put_compact(

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
@@ -1035,7 +1035,7 @@ def combined_forward_ep_no_sync_rowwise_wave(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        routed_moe_inp,
+        moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )

--- a/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
+++ b/src/olmo_core/nn/moe/v2/ep_no_sync_rowwise_wave.py
@@ -1027,6 +1027,7 @@ def combined_forward_ep_no_sync_rowwise_wave(
     kwargs.pop("max_doc_len", None)
     kwargs.pop("cu_doc_lens", None)
     moe_inp = self._prepare_moe_input(attn_res_out)
+    routed_moe_inp = self._prepare_routed_moe_input(moe_inp)
 
     (
         local_x_global_routed_expert_weights,
@@ -1034,7 +1035,7 @@ def combined_forward_ep_no_sync_rowwise_wave(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        moe_inp,
+        routed_moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )
@@ -1065,14 +1066,14 @@ def combined_forward_ep_no_sync_rowwise_wave(
         else:
             local_x_global_shared_expert_weights = None
 
-    in_shape = moe_inp.size()
-    moe_inp = moe_inp.view(-1, in_shape[-1])
+    routed_in_shape = routed_moe_inp.size()
+    routed_moe_inp = routed_moe_inp.view(-1, routed_in_shape[-1])
 
     num_out_tokens = local_x_global_routed_expert_indices.numel()
-    num_input_tokens = moe_inp.shape[0]
+    num_input_tokens = routed_moe_inp.shape[0]
     top_k = self.routed_experts_router.top_k
     rank_capacity = compute_ep_no_sync_rank_capacity(self, num_out_tokens)
-    use_fused_wave_node = moe_inp.dtype == torch.bfloat16
+    use_fused_wave_node = routed_moe_inp.dtype == torch.bfloat16
     use_symm_dispatch_in = use_ep_no_sync_rowwise_symm_dispatch_in(self)
     lease_dispatch_out = torch.is_grad_enabled()
     lease_combine_gather = torch.is_grad_enabled() and use_fused_wave_node
@@ -1128,9 +1129,9 @@ def combined_forward_ep_no_sync_rowwise_wave(
             dispatch_out_cap=rank_capacity,
             combine_in_cap=rank_capacity,
             combine_out_cap=num_input_tokens,
-            d_model=moe_inp.shape[-1],
-            dtype=moe_inp.dtype,
-            device=moe_inp.device,
+            d_model=routed_moe_inp.shape[-1],
+            dtype=routed_moe_inp.dtype,
+            device=routed_moe_inp.device,
             need_dispatch_in=use_symm_dispatch_in,
             need_dispatch_meta=False,
             need_dispatch_out=True,
@@ -1160,9 +1161,9 @@ def combined_forward_ep_no_sync_rowwise_wave(
             dispatch_out_cap=rank_capacity,
             combine_in_cap=rank_capacity,
             combine_out_cap=num_input_tokens,
-            d_model=moe_inp.shape[-1],
-            dtype=moe_inp.dtype,
-            device=moe_inp.device,
+            d_model=routed_moe_inp.shape[-1],
+            dtype=routed_moe_inp.dtype,
+            device=routed_moe_inp.device,
             need_dispatch_in=use_symm_dispatch_in,
             need_dispatch_meta=False,
             need_dispatch_out=True,
@@ -1177,14 +1178,14 @@ def combined_forward_ep_no_sync_rowwise_wave(
         )
         rowwise_stage_debug_print("rowwise_wave:get-buffers-exit", block=self.block_idx)
 
-    dispatch_input = moe_inp
+    dispatch_input = routed_moe_inp
     if use_symm_dispatch_in:
         rowwise_stage_debug_print("rowwise_wave:stage-dispatch-input-enter", block=self.block_idx)
-        dispatch_input = buffers.dispatch_in.narrow(0, 0, moe_inp.shape[0])
+        dispatch_input = buffers.dispatch_in.narrow(0, 0, routed_moe_inp.shape[0])
         if not dispatch_input.is_contiguous():
             raise RuntimeError("rowwise_wave symmetric dispatch staging view must be contiguous")
         with torch.no_grad():
-            dispatch_input.copy_(moe_inp)
+            dispatch_input.copy_(routed_moe_inp)
         rowwise_stage_debug_print("rowwise_wave:stage-dispatch-input-exit", block=self.block_idx)
         rowwise_stage_debug_sync("rowwise_wave:stage-dispatch-input", dispatch_input.device)
 
@@ -1247,14 +1248,14 @@ def combined_forward_ep_no_sync_rowwise_wave(
             nblocks=rowwise_put_nblocks,
         )
         rowwise_stage_debug_print("rowwise_wave:compact-route-exit", block=self.block_idx)
-        rowwise_stage_debug_sync("rowwise_wave:compact-route", moe_inp.device)
+        rowwise_stage_debug_sync("rowwise_wave:compact-route", routed_moe_inp.device)
         rowwise_stage_debug_print("rowwise_wave:inverse-meta-alloc-enter", block=self.block_idx)
         inverse_route_meta = get_or_init_ep_no_sync_symm_tensor(
             self,
             name="rowwise_wave_inverse_route_meta",
             shape=(rank_capacity, 2),
             dtype=torch.long,
-            device=moe_inp.device,
+            device=routed_moe_inp.device,
         )
         local_ep_rank = dist.get_rank(self.ep_pg)
         if _use_rowwise_wave_global_route_meta():
@@ -1312,7 +1313,9 @@ def combined_forward_ep_no_sync_rowwise_wave(
                 "rowwise_wave:inverse-meta-local-build-exit",
                 block=self.block_idx,
             )
-            rowwise_stage_debug_sync("rowwise_wave:inverse-meta-local-build", moe_inp.device)
+            rowwise_stage_debug_sync(
+                "rowwise_wave:inverse-meta-local-build", routed_moe_inp.device
+            )
         else:
             rowwise_stage_debug_print("rowwise_wave:inverse-meta-put-enter", block=self.block_idx)
             symm_mem_vdev2d_kernels.rowwise_inverse_route_meta_put_compact(
@@ -1327,12 +1330,12 @@ def combined_forward_ep_no_sync_rowwise_wave(
                 scalar_put=use_symm_dispatch_in,
             )
             rowwise_stage_debug_print("rowwise_wave:inverse-meta-put-exit", block=self.block_idx)
-            rowwise_stage_debug_sync("rowwise_wave:inverse-meta-put", moe_inp.device)
+            rowwise_stage_debug_sync("rowwise_wave:inverse-meta-put", routed_moe_inp.device)
 
     if use_fused_wave_node:
         assert route_out is not None
         local_x = _RowwiseWaveDispatchExpertsCombineAutograd.apply(
-            moe_inp,
+            routed_moe_inp,
             route_probs,
             self.routed_experts.w_up_gate,
             self.routed_experts.w_down,
@@ -1359,7 +1362,7 @@ def combined_forward_ep_no_sync_rowwise_wave(
         )
     else:
         dispatch_rank_major = _DispatchRowwiseAutograd.apply(
-            moe_inp,
+            routed_moe_inp,
             buffers.dispatch_in if use_symm_dispatch_in else None,
             dst_ranks_full,
             dst_rows_full,
@@ -1426,7 +1429,8 @@ def combined_forward_ep_no_sync_rowwise_wave(
     else:
         mixed_shared_out = None
 
-    local_x = local_x.view(in_shape)
+    local_x = local_x.view(routed_in_shape)
+    local_x = self._restore_routed_moe_output(local_x)
     wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
 
     mlp_out = self._merge_routed_and_shared(local_x, mixed_shared_out)

--- a/src/olmo_core/nn/moe/v2/ep_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_sync_1d.py
@@ -114,6 +114,7 @@ def combined_forward_ep_1d(
     kwargs.pop("max_doc_len", None)
     kwargs.pop("cu_doc_lens", None)
     moe_inp = self._prepare_moe_input(attn_res_out)
+    routed_moe_inp = self._prepare_routed_moe_input(moe_inp)
 
     (
         local_x_global_routed_expert_weights,
@@ -121,7 +122,7 @@ def combined_forward_ep_1d(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        moe_inp,
+        routed_moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )
@@ -159,9 +160,9 @@ def combined_forward_ep_1d(
         else:
             local_x_global_shared_expert_weights = None
 
-    in_shape = moe_inp.size()
+    routed_in_shape = routed_moe_inp.size()
 
-    moe_inp = moe_inp.view(-1, in_shape[-1])
+    routed_moe_inp = routed_moe_inp.view(-1, routed_in_shape[-1])
 
     with nvtx.annotate("Sync token count", color="green"):
         with torch.no_grad():
@@ -198,7 +199,7 @@ def combined_forward_ep_1d(
             torch.arange(
                 self.routed_experts_router.num_experts,
                 dtype=torch.int32,
-                device=moe_inp.device,
+                device=routed_moe_inp.device,
             ),
             self.num_local_routed_experts,
         )
@@ -208,9 +209,9 @@ def combined_forward_ep_1d(
             -1, self.routed_experts_router.top_k
         ).int()
         num_out_tokens = routing_map.size(0) * self.routed_experts_router.top_k
-        hidden_shape_before_permute = moe_inp.shape
+        hidden_shape_before_permute = routed_moe_inp.shape
         permutated_local_x, reversed_local_x_permutation_mapping = moe_permute_no_compile(
-            inp=moe_inp,
+            inp=routed_moe_inp,
             routing_map=routing_map,
             num_out_tokens=num_out_tokens,
             map_type="index",
@@ -330,7 +331,8 @@ def combined_forward_ep_1d(
             )
             local_x = cast(torch.Tensor, local_x)
 
-    local_x = local_x.view(in_shape)
+    local_x = local_x.view(routed_in_shape)
+    local_x = self._restore_routed_moe_output(local_x)
 
     wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
 

--- a/src/olmo_core/nn/moe/v2/ep_sync_1d.py
+++ b/src/olmo_core/nn/moe/v2/ep_sync_1d.py
@@ -122,7 +122,7 @@ def combined_forward_ep_1d(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        routed_moe_inp,
+        moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )

--- a/src/olmo_core/nn/moe/v2/no_ep.py
+++ b/src/olmo_core/nn/moe/v2/no_ep.py
@@ -46,6 +46,7 @@ def combined_forward_no_ep(
     kwargs.pop("max_doc_len", None)
     kwargs.pop("cu_doc_lens", None)
     moe_inp = self._prepare_moe_input(attn_res_out)
+    routed_moe_inp = self._prepare_routed_moe_input(moe_inp)
 
     (
         local_x_global_routed_expert_weights,
@@ -53,7 +54,7 @@ def combined_forward_no_ep(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        moe_inp,
+        routed_moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )
@@ -72,7 +73,7 @@ def combined_forward_no_ep(
     use_routed_rowwise_fp8 = (
         routed_rowwise_fp8_cfg is not None
         and routed_rowwise_fp8_cfg.enabled
-        and moe_inp.device.type == "cuda"
+        and routed_moe_inp.device.type == "cuda"
     )
 
     if requires_host_side_split_sizes() and not use_routed_rowwise_fp8:
@@ -98,7 +99,7 @@ def combined_forward_no_ep(
     else:
         local_x_global_shared_expert_weights = None
 
-    in_shape = moe_inp.size()
+    routed_in_shape = routed_moe_inp.size()
 
     mixed_shared_out = None
     if self.shared_experts is not None:
@@ -123,17 +124,17 @@ def combined_forward_no_ep(
                 attn_res_out.shape,
             )
 
-    moe_inp = moe_inp.view(-1, in_shape[-1])
+    routed_moe_inp = routed_moe_inp.view(-1, routed_in_shape[-1])
 
     routing_map = local_x_global_routed_expert_indices.view(
         -1, self.routed_experts_router.top_k
     ).int()
     num_out_tokens = routing_map.size(0) * self.routed_experts_router.top_k
-    hidden_shape_before_permute = moe_inp.shape
+    hidden_shape_before_permute = routed_moe_inp.shape
 
     with nvtx.annotate("Permute", color="green"):
         permutated_input_tokens, reversed_input_permutation_mapping = moe_permute_no_compile(
-            inp=moe_inp,
+            inp=routed_moe_inp,
             routing_map=routing_map,
             num_out_tokens=num_out_tokens,
             map_type="index",
@@ -180,7 +181,8 @@ def combined_forward_no_ep(
     if _debug_tensors_enabled() and self.block_idx == 0:
         self._debug_no_ep_combined_local_x = unpermutated_x.detach()
 
-    x_moe = unpermutated_x.view(in_shape)
+    x_moe = unpermutated_x.view(routed_in_shape)
+    x_moe = self._restore_routed_moe_output(x_moe)
 
     wait_stream_no_compile(torch.cuda.current_stream(), self.get_dense_stream())
 

--- a/src/olmo_core/nn/moe/v2/no_ep.py
+++ b/src/olmo_core/nn/moe/v2/no_ep.py
@@ -54,7 +54,7 @@ def combined_forward_no_ep(
         local_batch_size_per_global_routed_expert,
         routed_expert_router_aux_loss_info,
     ) = self.routed_experts_router(
-        routed_moe_inp,
+        moe_inp,
         False,
         loss_div_factor=loss_div_factor,
     )

--- a/src/olmo_core/nn/transformer/block.py
+++ b/src/olmo_core/nn/transformer/block.py
@@ -907,7 +907,9 @@ class MoEHybridTransformerBlock(MoEHybridTransformerBlockBase):
         # dense operations while we wait on expert parallel all-to-all comms.
         B, _, D = x.shape
 
-        x_moe = get_local_tensor(self.feed_forward_moe_norm(x))
+        model_moe_input = get_local_tensor(self.feed_forward_moe_norm(x))
+        x_moe = self.feed_forward_moe.prepare_routed_input(model_moe_input)
+        routed_dim = x_moe.shape[-1]
 
         expert_weights, expert_indices, batch_size_per_expert, router_aux_loss = self.router(
             x_moe, loss_div_factor=loss_div_factor
@@ -917,7 +919,7 @@ class MoEHybridTransformerBlock(MoEHybridTransformerBlockBase):
             x_moe = attach_auxiliary_loss(x_moe, router_aux_loss)
 
         # shape: (batch_size * seq_len, d_model)
-        x_moe = x_moe.view(-1, D)
+        x_moe = x_moe.view(-1, routed_dim)
         # shape: (batch_size * top_k,)
         expert_weights = expert_weights.flatten()
         # shape: (batch_size * top_k,)
@@ -953,7 +955,7 @@ class MoEHybridTransformerBlock(MoEHybridTransformerBlockBase):
         moe_shared_out: Optional[torch.Tensor] = None
         if self.shared_mlp is not None:
             # NOTE: -1 on seq dim in case of TP
-            moe_shared_out = self.shared_mlp(x_moe.view(B, -1, D))
+            moe_shared_out = self.shared_mlp(model_moe_input.view(B, -1, D))
 
         handle.wait()
         parallel_x = self.experts.compute_local_experts(
@@ -980,7 +982,8 @@ class MoEHybridTransformerBlock(MoEHybridTransformerBlockBase):
             indices=indices,
             bin_ids=bin_ids,
             bins=bins,
-        ).view(B, -1, D)
+        ).view(B, -1, routed_dim)
+        x_moe = self.feed_forward_moe.restore_routed_output(x_moe)
 
         if moe_shared_out is not None:
             moe_shared_out = moe_shared_out / (self.top_k + 1)
@@ -1013,7 +1016,9 @@ class MoEHybridReorderedNormTransformerBlock(MoEHybridTransformerBlockBase):
         # dense operations while we wait on expert parallel all-to-all comms.
         B, _, D = x.shape
 
-        x_moe = get_local_tensor(x)
+        model_moe_input = get_local_tensor(x)
+        x_moe = self.feed_forward_moe.prepare_routed_input(model_moe_input)
+        routed_dim = x_moe.shape[-1]
 
         expert_weights, expert_indices, batch_size_per_expert, router_aux_loss = self.router(
             x_moe, loss_div_factor=loss_div_factor
@@ -1023,7 +1028,7 @@ class MoEHybridReorderedNormTransformerBlock(MoEHybridTransformerBlockBase):
             x_moe = attach_auxiliary_loss(x_moe, router_aux_loss)
 
         # shape: (batch_size * seq_len, d_model)
-        x_moe = x_moe.view(-1, D)
+        x_moe = x_moe.view(-1, routed_dim)
         # shape: (batch_size * seq_len * top_k,)
         expert_weights = get_local_tensor(expert_weights).flatten()
         # shape: (batch_size * seq_len * top_k,)
@@ -1059,7 +1064,7 @@ class MoEHybridReorderedNormTransformerBlock(MoEHybridTransformerBlockBase):
         moe_shared_out: Optional[torch.Tensor] = None
         if self.shared_mlp is not None:
             # NOTE: -1 on seq dim in case of TP
-            moe_shared_out = self.shared_mlp(x_moe.view(B, -1, D))
+            moe_shared_out = self.shared_mlp(model_moe_input.view(B, -1, D))
 
         handle.wait()
         parallel_x = self.experts.compute_local_experts(
@@ -1086,7 +1091,8 @@ class MoEHybridReorderedNormTransformerBlock(MoEHybridTransformerBlockBase):
             indices=indices,
             bin_ids=bin_ids,
             bins=bins,
-        ).view(B, -1, D)
+        ).view(B, -1, routed_dim)
+        x_moe = self.feed_forward_moe.restore_routed_output(x_moe)
 
         if moe_shared_out is not None:
             moe_shared_out = moe_shared_out / (self.top_k + 1)

--- a/src/olmo_core/nn/transformer/block.py
+++ b/src/olmo_core/nn/transformer/block.py
@@ -912,7 +912,7 @@ class MoEHybridTransformerBlock(MoEHybridTransformerBlockBase):
         routed_dim = x_moe.shape[-1]
 
         expert_weights, expert_indices, batch_size_per_expert, router_aux_loss = self.router(
-            x_moe, loss_div_factor=loss_div_factor
+            model_moe_input, loss_div_factor=loss_div_factor
         )
 
         if router_aux_loss is not None:
@@ -1021,7 +1021,7 @@ class MoEHybridReorderedNormTransformerBlock(MoEHybridTransformerBlockBase):
         routed_dim = x_moe.shape[-1]
 
         expert_weights, expert_indices, batch_size_per_expert, router_aux_loss = self.router(
-            x_moe, loss_div_factor=loss_div_factor
+            model_moe_input, loss_div_factor=loss_div_factor
         )
 
         if router_aux_loss is not None:

--- a/src/olmo_core/nn/transformer/init.py
+++ b/src/olmo_core/nn/transformer/init.py
@@ -196,8 +196,7 @@ class InitMethod(StrEnum):
         elif self == InitMethod.llama_depth:
             std = std / (2 * (block_idx + 1)) ** 0.5
         elif self == InitMethod.fan_in:
-            # For fan_in, router weight uses the routed branch's input dimension. This differs
-            # from d_model when latent MoE is enabled.
+            # Routing decisions are always computed from model-space activations.
             std = m.router.d_model**-0.5
 
         _apply_init(

--- a/src/olmo_core/nn/transformer/init.py
+++ b/src/olmo_core/nn/transformer/init.py
@@ -196,8 +196,9 @@ class InitMethod(StrEnum):
         elif self == InitMethod.llama_depth:
             std = std / (2 * (block_idx + 1)) ** 0.5
         elif self == InitMethod.fan_in:
-            # For fan_in, router weight uses 1/√d_model
-            std = d_model**-0.5
+            # For fan_in, router weight uses the routed branch's input dimension. This differs
+            # from d_model when latent MoE is enabled.
+            std = m.router.d_model**-0.5
 
         _apply_init(
             nn.init.trunc_normal_,
@@ -208,6 +209,11 @@ class InitMethod(StrEnum):
             b=3 * std,
             generator=generator,
         )
+
+        for projection in (m.latent_down_proj, m.latent_up_proj):
+            if projection is not None:
+                projection_std = projection.in_features**-0.5 if self == InitMethod.fan_in else std
+                init_linear(projection, std=projection_std, generator=generator)
 
         mlp = cast(Union[MoEMLP, DroplessMoEMLP], m.experts.mlp)
 

--- a/src/olmo_core/nn/transformer/init.py
+++ b/src/olmo_core/nn/transformer/init.py
@@ -307,9 +307,7 @@ class InitMethod(StrEnum):
                 _apply_init(nn.init.zeros_, b.shared_experts_router.bias)
         if b.routed_experts_router:
             routed_router_std = (
-                b.routed_experts_router.d_model**-0.5
-                if self == InitMethod.fan_in
-                else std
+                b.routed_experts_router.d_model**-0.5 if self == InitMethod.fan_in else std
             )
             _apply_init(
                 nn.init.trunc_normal_,

--- a/src/olmo_core/nn/transformer/init.py
+++ b/src/olmo_core/nn/transformer/init.py
@@ -306,13 +306,18 @@ class InitMethod(StrEnum):
             if b.shared_experts_router.bias is not None:
                 _apply_init(nn.init.zeros_, b.shared_experts_router.bias)
         if b.routed_experts_router:
+            routed_router_std = (
+                b.routed_experts_router.d_model**-0.5
+                if self == InitMethod.fan_in
+                else std
+            )
             _apply_init(
                 nn.init.trunc_normal_,
                 b.routed_experts_router.weight,
                 mean=0.0,
-                std=std,
-                a=-3 * std,
-                b=3 * std,
+                std=routed_router_std,
+                a=-3 * routed_router_std,
+                b=3 * routed_router_std,
                 generator=generator,
             )
             if b.routed_experts_router.bias is not None:
@@ -328,22 +333,28 @@ class InitMethod(StrEnum):
         if b.routed_experts:
             # The routed expert weights may be sharded across the expert-parallel mesh, so use the
             # EP generator to keep initialization consistent across shards.
+            routed_up_gate_std = (
+                b.routed_experts.d_model**-0.5 if self == InitMethod.fan_in else std
+            )
             _apply_init(
                 nn.init.trunc_normal_,
                 b.routed_experts.w_up_gate,
                 mean=0.0,
-                std=std,
-                a=-3 * std,
-                b=3 * std,
+                std=routed_up_gate_std,
+                a=-3 * routed_up_gate_std,
+                b=3 * routed_up_gate_std,
                 generator=ep_generator,
+            )
+            routed_down_std = (
+                b.routed_experts.hidden_size**-0.5 if self == InitMethod.fan_in else std
             )
             _apply_init(
                 nn.init.trunc_normal_,
                 b.routed_experts.w_down,
                 mean=0.0,
-                std=std,
-                a=-3 * std,
-                b=3 * std,
+                std=routed_down_std,
+                a=-3 * routed_down_std,
+                b=3 * routed_down_std,
                 generator=ep_generator,
             )
             if b.routed_experts.b_up_gate is not None:

--- a/src/olmo_core/nn/transformer/init.py
+++ b/src/olmo_core/nn/transformer/init.py
@@ -212,7 +212,9 @@ class InitMethod(StrEnum):
 
         for projection in (m.latent_down_proj, m.latent_up_proj):
             if projection is not None:
-                projection_std = projection.in_features**-0.5 if self == InitMethod.fan_in else std
+                projection_std = (
+                    projection.in_features**-0.5 if self == InitMethod.fan_in else std
+                )
                 init_linear(projection, std=projection_std, generator=generator)
 
         mlp = cast(Union[MoEMLP, DroplessMoEMLP], m.experts.mlp)
@@ -318,7 +320,9 @@ class InitMethod(StrEnum):
 
         for projection in (b.latent_down_proj, b.latent_up_proj):
             if projection is not None:
-                projection_std = projection.in_features**-0.5 if self == InitMethod.fan_in else std
+                projection_std = (
+                    projection.in_features**-0.5 if self == InitMethod.fan_in else std
+                )
                 init_linear(projection, std=projection_std, generator=generator)
 
         if b.routed_experts:

--- a/src/olmo_core/nn/transformer/init.py
+++ b/src/olmo_core/nn/transformer/init.py
@@ -316,6 +316,11 @@ class InitMethod(StrEnum):
             if b.routed_experts_router.bias is not None:
                 _apply_init(nn.init.zeros_, b.routed_experts_router.bias)
 
+        for projection in (b.latent_down_proj, b.latent_up_proj):
+            if projection is not None:
+                projection_std = projection.in_features**-0.5 if self == InitMethod.fan_in else std
+                init_linear(projection, std=projection_std, generator=generator)
+
         if b.routed_experts:
             # The routed expert weights may be sharded across the expert-parallel mesh, so use the
             # EP generator to keep initialization consistent across shards.

--- a/src/test/nn/ddp/block_test.py
+++ b/src/test/nn/ddp/block_test.py
@@ -42,9 +42,7 @@ def _block_config(
         layer_norm=layer_norm,
         use_peri_norm=use_peri_norm,
         latent_moe=(
-            LatentMoEConfig(routed_expert_dim=routed_dim)
-            if routed_expert_dim is not None
-            else None
+            LatentMoEConfig(routed_expert_dim=routed_dim) if routed_expert_dim is not None else None
         ),
     )
 

--- a/src/test/nn/ddp/block_test.py
+++ b/src/test/nn/ddp/block_test.py
@@ -88,6 +88,38 @@ def test_latent_block_dimensions_and_param_accounting():
     assert block._restore_routed_moe_output(routed_input).shape == model_input.shape
 
 
+def test_latent_block_defaults_to_up_proj_input_rms_norm():
+    config = _block_config(routed_expert_dim=16)
+    block = _build_block(config)
+
+    assert block.latent_up_proj_input_norm is not None
+    assert config.latent_moe is not None
+    assert config.latent_moe.up_proj_input_norm is not None
+    assert config.latent_moe.up_proj_input_norm.name == LayerNormType.rms
+    assert config.num_params(D_MODEL) == sum(p.numel() for p in block.parameters())
+    routed_out = torch.randn(2, 3, 16)
+    assert block.latent_up_proj is not None
+    expected = block.latent_up_proj(block.latent_up_proj_input_norm(routed_out))
+    torch.testing.assert_close(block._restore_routed_moe_output(routed_out), expected)
+
+
+@pytest.mark.parametrize("norm_type", [LayerNormType.default, LayerNormType.l2_norm])
+def test_latent_block_accepts_configurable_up_proj_input_norm(norm_type: LayerNormType):
+    config = _block_config(routed_expert_dim=16)
+    assert config.latent_moe is not None
+    config.latent_moe.up_proj_input_norm = LayerNormConfig(name=norm_type)
+    block = _build_block(config)
+    assert block.latent_up_proj_input_norm is not None
+
+
+def test_latent_block_can_disable_up_proj_input_norm():
+    config = _block_config(routed_expert_dim=16)
+    assert config.latent_moe is not None
+    config.latent_moe.up_proj_input_norm = None
+    block = _build_block(config)
+    assert block.latent_up_proj_input_norm is None
+
+
 @pytest.mark.parametrize("routed_expert_dim", [0, D_MODEL, D_MODEL * 2])
 def test_latent_block_rejects_invalid_dimension(routed_expert_dim: int):
     config = _block_config(routed_expert_dim=routed_expert_dim)

--- a/src/test/nn/ddp/block_test.py
+++ b/src/test/nn/ddp/block_test.py
@@ -22,10 +22,10 @@ D_MODEL = 64
 
 
 def _block_config(
-    *, use_peri_norm: bool = False, routed_expert_dim: int | None = None
+    *, use_peri_norm: bool = False, latent_dim: int | None = None
 ) -> OLMoDDPTransformerBlockConfig:
     dtype = DType.float32
-    routed_dim = D_MODEL if routed_expert_dim is None else routed_expert_dim
+    routed_dim = D_MODEL if latent_dim is None else latent_dim
     layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=dtype)
     return OLMoDDPTransformerBlockConfig(
         name=TransformerBlockType.moe_fused_v2,
@@ -36,13 +36,13 @@ def _block_config(
             d_model=routed_dim, hidden_size=128, num_experts=4, bias=False, dtype=dtype
         ),
         routed_experts_router=MoERouterConfigV2(
-            d_model=routed_dim, num_experts=4, top_k=2, dtype=dtype
+            d_model=D_MODEL, num_experts=4, top_k=2, dtype=dtype
         ),
         shared_experts=None,
         layer_norm=layer_norm,
         use_peri_norm=use_peri_norm,
         latent_moe=(
-            LatentMoEConfig(routed_expert_dim=routed_dim) if routed_expert_dim is not None else None
+            LatentMoEConfig(latent_dim=routed_dim) if latent_dim is not None else None
         ),
     )
 
@@ -68,35 +68,35 @@ def test_block_num_active_params_below_total():
 
 
 def test_latent_block_dimensions_and_param_accounting():
-    routed_expert_dim = 16
-    config = _block_config(routed_expert_dim=routed_expert_dim)
+    latent_dim = 16
+    config = _block_config(latent_dim=latent_dim)
     block = _build_block(config)
 
     assert config.num_params(D_MODEL) == sum(p.numel() for p in block.parameters())
     assert block.routed_experts is not None
-    assert block.routed_experts.d_model == routed_expert_dim
+    assert block.routed_experts.d_model == latent_dim
     assert block.routed_experts_router is not None
-    assert block.routed_experts_router.d_model == routed_expert_dim
+    assert block.routed_experts_router.d_model == D_MODEL
     assert block.latent_down_proj is not None
-    assert block.latent_down_proj.weight.shape == (routed_expert_dim, D_MODEL)
+    assert block.latent_down_proj.weight.shape == (latent_dim, D_MODEL)
     assert block.latent_up_proj is not None
-    assert block.latent_up_proj.weight.shape == (D_MODEL, routed_expert_dim)
+    assert block.latent_up_proj.weight.shape == (D_MODEL, latent_dim)
 
     model_input = torch.randn(2, 3, D_MODEL)
     routed_input = block._prepare_routed_moe_input(model_input)
-    assert routed_input.shape == (2, 3, routed_expert_dim)
+    assert routed_input.shape == (2, 3, latent_dim)
     assert block._restore_routed_moe_output(routed_input).shape == model_input.shape
 
 
 def test_latent_block_norm_is_disabled_by_default():
-    config = _block_config(routed_expert_dim=16)
+    config = _block_config(latent_dim=16)
     block = _build_block(config)
 
     assert block.latent_up_proj_input_norm is None
 
 
 def test_latent_block_enabled_norm_defaults_to_rms_norm():
-    config = _block_config(routed_expert_dim=16)
+    config = _block_config(latent_dim=16)
     assert config.latent_moe is not None
     config.latent_moe.up_proj_input_norm_enabled = True
     block = _build_block(config)
@@ -118,7 +118,7 @@ def test_latent_block_enabled_norm_defaults_to_rms_norm():
 
 @pytest.mark.parametrize("norm_type", [LayerNormType.default, LayerNormType.l2_norm])
 def test_latent_block_accepts_configurable_up_proj_input_norm(norm_type: LayerNormType):
-    config = _block_config(routed_expert_dim=16)
+    config = _block_config(latent_dim=16)
     assert config.latent_moe is not None
     config.latent_moe.up_proj_input_norm_enabled = True
     config.latent_moe.up_proj_input_norm = LayerNormConfig(name=norm_type)
@@ -127,7 +127,7 @@ def test_latent_block_accepts_configurable_up_proj_input_norm(norm_type: LayerNo
 
 
 def test_latent_block_can_disable_up_proj_input_norm():
-    config = _block_config(routed_expert_dim=16)
+    config = _block_config(latent_dim=16)
     assert config.latent_moe is not None
     block = _build_block(config)
     assert block.latent_up_proj_input_norm is None
@@ -138,16 +138,16 @@ def test_latent_block_can_disable_up_proj_input_norm():
     assert restored.up_proj_input_norm_enabled is False
 
 
-@pytest.mark.parametrize("routed_expert_dim", [0, D_MODEL, D_MODEL * 2])
-def test_latent_block_rejects_invalid_dimension(routed_expert_dim: int):
-    config = _block_config(routed_expert_dim=routed_expert_dim)
-    with pytest.raises(OLMoConfigurationError, match="routed_expert_dim"):
+@pytest.mark.parametrize("latent_dim", [0, D_MODEL, D_MODEL * 2])
+def test_latent_block_rejects_invalid_dimension(latent_dim: int):
+    config = _block_config(latent_dim=latent_dim)
+    with pytest.raises(OLMoConfigurationError, match="latent_dim"):
         config.build(d_model=D_MODEL, block_idx=0, n_layers=1, init_device="cpu")
 
 
 def test_latent_block_projection_initialization():
-    routed_expert_dim = 16
-    block = _build_block(_block_config(routed_expert_dim=routed_expert_dim))
+    latent_dim = 16
+    block = _build_block(_block_config(latent_dim=latent_dim))
     InitMethod.fan_in.init_moe_v2(
         block,
         d_model=D_MODEL,
@@ -167,19 +167,19 @@ def test_latent_block_projection_initialization():
     )
     torch.testing.assert_close(
         block.latent_up_proj.weight.std(),
-        torch.tensor(routed_expert_dim**-0.5),
+        torch.tensor(latent_dim**-0.5),
         rtol=0.35,
         atol=0.0,
     )
     torch.testing.assert_close(
         block.routed_experts_router.weight.std(),
-        torch.tensor(routed_expert_dim**-0.5),
+        torch.tensor(D_MODEL**-0.5),
         rtol=0.35,
         atol=0.0,
     )
     torch.testing.assert_close(
         block.routed_experts.w_up_gate.std(),
-        torch.tensor(routed_expert_dim**-0.5),
+        torch.tensor(latent_dim**-0.5),
         rtol=0.35,
         atol=0.0,
     )
@@ -192,7 +192,7 @@ def test_latent_block_projection_initialization():
 
 
 def test_latent_block_keeps_shared_experts_in_model_space():
-    config = _block_config(routed_expert_dim=16)
+    config = _block_config(latent_dim=16)
     config.shared_experts = SharedExpertsConfig(
         d_model=D_MODEL,
         hidden_size=32,
@@ -212,10 +212,18 @@ def test_non_latent_block_preserves_state_dict_keys():
 
 
 def test_latent_block_rejects_routed_config_dimension_mismatch():
-    config = _block_config(routed_expert_dim=16)
+    config = _block_config(latent_dim=16)
     assert config.routed_experts is not None
     config.routed_experts.d_model = 8
     with pytest.raises(OLMoConfigurationError, match="routed_experts.d_model"):
+        config.build(d_model=D_MODEL, block_idx=0, n_layers=1, init_device="cpu")
+
+
+def test_latent_block_rejects_model_space_router_dimension_mismatch():
+    config = _block_config(latent_dim=16)
+    assert config.routed_experts_router is not None
+    config.routed_experts_router.d_model = 16
+    with pytest.raises(OLMoConfigurationError, match="routed_experts_router.d_model"):
         config.build(d_model=D_MODEL, block_idx=0, n_layers=1, init_device="cpu")
 
 

--- a/src/test/nn/ddp/block_test.py
+++ b/src/test/nn/ddp/block_test.py
@@ -41,9 +41,7 @@ def _block_config(
         shared_experts=None,
         layer_norm=layer_norm,
         use_peri_norm=use_peri_norm,
-        latent_moe=(
-            LatentMoEConfig(latent_dim=routed_dim) if latent_dim is not None else None
-        ),
+        latent_moe=(LatentMoEConfig(latent_dim=routed_dim) if latent_dim is not None else None),
     )
 
 

--- a/src/test/nn/ddp/block_test.py
+++ b/src/test/nn/ddp/block_test.py
@@ -88,14 +88,27 @@ def test_latent_block_dimensions_and_param_accounting():
     assert block._restore_routed_moe_output(routed_input).shape == model_input.shape
 
 
-def test_latent_block_defaults_to_up_proj_input_rms_norm():
+def test_latent_block_norm_is_disabled_by_default():
     config = _block_config(routed_expert_dim=16)
     block = _build_block(config)
 
-    assert block.latent_up_proj_input_norm is not None
+    assert block.latent_up_proj_input_norm is None
+
+
+def test_latent_block_enabled_norm_defaults_to_rms_norm():
+    config = _block_config(routed_expert_dim=16)
     assert config.latent_moe is not None
-    assert config.latent_moe.up_proj_input_norm is not None
-    assert config.latent_moe.up_proj_input_norm.name == LayerNormType.rms
+    config.latent_moe.up_proj_input_norm_enabled = True
+    block = _build_block(config)
+
+    assert block.latent_up_proj_input_norm is not None
+    assert config.latent_moe.resolved_up_proj_input_norm().name == LayerNormType.rms
+    serialized = config.latent_moe.as_config_dict()
+    assert serialized["up_proj_input_norm_enabled"] is True
+    assert "up_proj_input_norm" not in serialized
+    restored = LatentMoEConfig.from_dict(serialized)
+    assert restored.up_proj_input_norm_enabled is True
+    assert restored.resolved_up_proj_input_norm().name == LayerNormType.rms
     assert config.num_params(D_MODEL) == sum(p.numel() for p in block.parameters())
     routed_out = torch.randn(2, 3, 16)
     assert block.latent_up_proj is not None
@@ -107,6 +120,7 @@ def test_latent_block_defaults_to_up_proj_input_rms_norm():
 def test_latent_block_accepts_configurable_up_proj_input_norm(norm_type: LayerNormType):
     config = _block_config(routed_expert_dim=16)
     assert config.latent_moe is not None
+    config.latent_moe.up_proj_input_norm_enabled = True
     config.latent_moe.up_proj_input_norm = LayerNormConfig(name=norm_type)
     block = _build_block(config)
     assert block.latent_up_proj_input_norm is not None
@@ -115,9 +129,13 @@ def test_latent_block_accepts_configurable_up_proj_input_norm(norm_type: LayerNo
 def test_latent_block_can_disable_up_proj_input_norm():
     config = _block_config(routed_expert_dim=16)
     assert config.latent_moe is not None
-    config.latent_moe.up_proj_input_norm = None
     block = _build_block(config)
     assert block.latent_up_proj_input_norm is None
+
+    serialized = config.latent_moe.as_config_dict()
+    assert serialized["up_proj_input_norm_enabled"] is False
+    restored = LatentMoEConfig.from_dict(serialized)
+    assert restored.up_proj_input_norm_enabled is False
 
 
 @pytest.mark.parametrize("routed_expert_dim", [0, D_MODEL, D_MODEL * 2])
@@ -139,6 +157,8 @@ def test_latent_block_projection_initialization():
 
     assert block.latent_down_proj is not None
     assert block.latent_up_proj is not None
+    assert block.routed_experts_router is not None
+    assert block.routed_experts is not None
     torch.testing.assert_close(
         block.latent_down_proj.weight.std(),
         torch.tensor(D_MODEL**-0.5),
@@ -148,6 +168,24 @@ def test_latent_block_projection_initialization():
     torch.testing.assert_close(
         block.latent_up_proj.weight.std(),
         torch.tensor(routed_expert_dim**-0.5),
+        rtol=0.35,
+        atol=0.0,
+    )
+    torch.testing.assert_close(
+        block.routed_experts_router.weight.std(),
+        torch.tensor(routed_expert_dim**-0.5),
+        rtol=0.35,
+        atol=0.0,
+    )
+    torch.testing.assert_close(
+        block.routed_experts.w_up_gate.std(),
+        torch.tensor(routed_expert_dim**-0.5),
+        rtol=0.35,
+        atol=0.0,
+    )
+    torch.testing.assert_close(
+        block.routed_experts.w_down.std(),
+        torch.tensor(block.routed_experts.hidden_size**-0.5),
         rtol=0.35,
         atol=0.0,
     )

--- a/src/test/nn/ddp/block_test.py
+++ b/src/test/nn/ddp/block_test.py
@@ -1,23 +1,31 @@
 """Tests for ``OLMoDDPTransformerBlock`` config accounting and construction."""
 
 import pytest
+import torch
 
 from olmo_core.config import DType
+from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.attention import AttentionConfig, AttentionType
 from olmo_core.nn.ddp.block import (
     OLMoDDPTransformerBlock,
     OLMoDDPTransformerBlockConfig,
 )
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.moe import LatentMoEConfig
 from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
 from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.nn.moe.v2.shared_experts import SharedExpertsConfig
 from olmo_core.nn.transformer import TransformerBlockType
+from olmo_core.nn.transformer.init import InitMethod
 
 D_MODEL = 64
 
 
-def _block_config(*, use_peri_norm: bool = False) -> OLMoDDPTransformerBlockConfig:
+def _block_config(
+    *, use_peri_norm: bool = False, routed_expert_dim: int | None = None
+) -> OLMoDDPTransformerBlockConfig:
     dtype = DType.float32
+    routed_dim = D_MODEL if routed_expert_dim is None else routed_expert_dim
     layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=dtype)
     return OLMoDDPTransformerBlockConfig(
         name=TransformerBlockType.moe_fused_v2,
@@ -25,14 +33,19 @@ def _block_config(*, use_peri_norm: bool = False) -> OLMoDDPTransformerBlockConf
             name=AttentionType.default, n_heads=4, bias=False, use_flash=False, dtype=dtype
         ),
         routed_experts=RoutedExpertsConfig(
-            d_model=D_MODEL, hidden_size=128, num_experts=4, bias=False, dtype=dtype
+            d_model=routed_dim, hidden_size=128, num_experts=4, bias=False, dtype=dtype
         ),
         routed_experts_router=MoERouterConfigV2(
-            d_model=D_MODEL, num_experts=4, top_k=2, dtype=dtype
+            d_model=routed_dim, num_experts=4, top_k=2, dtype=dtype
         ),
         shared_experts=None,
         layer_norm=layer_norm,
         use_peri_norm=use_peri_norm,
+        latent_moe=(
+            LatentMoEConfig(routed_expert_dim=routed_dim)
+            if routed_expert_dim is not None
+            else None
+        ),
     )
 
 
@@ -54,6 +67,88 @@ def test_block_num_active_params_below_total():
     # Only top_k of num_experts routed experts are active per token, so active < total.
     config = _block_config()
     assert 0 < config.num_active_params(D_MODEL) < config.num_params(D_MODEL)
+
+
+def test_latent_block_dimensions_and_param_accounting():
+    routed_expert_dim = 16
+    config = _block_config(routed_expert_dim=routed_expert_dim)
+    block = _build_block(config)
+
+    assert config.num_params(D_MODEL) == sum(p.numel() for p in block.parameters())
+    assert block.routed_experts is not None
+    assert block.routed_experts.d_model == routed_expert_dim
+    assert block.routed_experts_router is not None
+    assert block.routed_experts_router.d_model == routed_expert_dim
+    assert block.latent_down_proj is not None
+    assert block.latent_down_proj.weight.shape == (routed_expert_dim, D_MODEL)
+    assert block.latent_up_proj is not None
+    assert block.latent_up_proj.weight.shape == (D_MODEL, routed_expert_dim)
+
+    model_input = torch.randn(2, 3, D_MODEL)
+    routed_input = block._prepare_routed_moe_input(model_input)
+    assert routed_input.shape == (2, 3, routed_expert_dim)
+    assert block._restore_routed_moe_output(routed_input).shape == model_input.shape
+
+
+@pytest.mark.parametrize("routed_expert_dim", [0, D_MODEL, D_MODEL * 2])
+def test_latent_block_rejects_invalid_dimension(routed_expert_dim: int):
+    config = _block_config(routed_expert_dim=routed_expert_dim)
+    with pytest.raises(OLMoConfigurationError, match="routed_expert_dim"):
+        config.build(d_model=D_MODEL, block_idx=0, n_layers=1, init_device="cpu")
+
+
+def test_latent_block_projection_initialization():
+    routed_expert_dim = 16
+    block = _build_block(_block_config(routed_expert_dim=routed_expert_dim))
+    InitMethod.fan_in.init_moe_v2(
+        block,
+        d_model=D_MODEL,
+        block_idx=0,
+        num_blocks=1,
+    )
+
+    assert block.latent_down_proj is not None
+    assert block.latent_up_proj is not None
+    torch.testing.assert_close(
+        block.latent_down_proj.weight.std(),
+        torch.tensor(D_MODEL**-0.5),
+        rtol=0.35,
+        atol=0.0,
+    )
+    torch.testing.assert_close(
+        block.latent_up_proj.weight.std(),
+        torch.tensor(routed_expert_dim**-0.5),
+        rtol=0.35,
+        atol=0.0,
+    )
+
+
+def test_latent_block_keeps_shared_experts_in_model_space():
+    config = _block_config(routed_expert_dim=16)
+    config.shared_experts = SharedExpertsConfig(
+        d_model=D_MODEL,
+        hidden_size=32,
+        num_experts=1,
+        bias=False,
+        dtype=DType.float32,
+    )
+    block = _build_block(config)
+    assert block.shared_experts is not None
+    assert block.shared_experts.d_model == D_MODEL
+    assert config.num_params(D_MODEL) == sum(p.numel() for p in block.parameters())
+
+
+def test_non_latent_block_preserves_state_dict_keys():
+    block = _build_block(_block_config())
+    assert not any("latent_" in key for key in block.state_dict())
+
+
+def test_latent_block_rejects_routed_config_dimension_mismatch():
+    config = _block_config(routed_expert_dim=16)
+    assert config.routed_experts is not None
+    config.routed_experts.d_model = 8
+    with pytest.raises(OLMoConfigurationError, match="routed_experts.d_model"):
+        config.build(d_model=D_MODEL, block_idx=0, n_layers=1, init_device="cpu")
 
 
 def test_block_flops_positive():

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -19,11 +19,13 @@ from olmo_core.distributed.parallel import (
 from olmo_core.distributed.utils import get_local_tensor
 from olmo_core.nn.feed_forward import FeedForwardConfig
 from olmo_core.nn.moe import (
+    LatentMoEConfig,
     MoEConfig,
     MoELoadBalancingLossGranularity,
     MoERouterConfig,
     MoEType,
 )
+from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.testing import (
     has_grouped_gemm,
     requires_gpu,
@@ -82,6 +84,70 @@ def test_moe(moe_type: MoEType, shared: bool, dtype: torch.dtype):
     # Trigger backwards pass.
     output.sum().backward()
     assert x.grad is not None
+
+
+@pytest.mark.parametrize("moe_type", [MoEType.dropless, MoEType.default])
+@pytest.mark.parametrize("shared", [False, True])
+def test_latent_moe(moe_type: MoEType, shared: bool):
+    d_model = 16
+    routed_expert_dim = 8
+    config = MoEConfig(
+        name=moe_type,
+        num_experts=4,
+        hidden_size=32,
+        router=MoERouterConfig(top_k=2),
+        shared_mlp=FeedForwardConfig(hidden_size=24) if shared else None,
+        latent_moe=LatentMoEConfig(routed_expert_dim=routed_expert_dim),
+    )
+    moe = config.build(d_model=d_model)
+
+    assert moe.router.d_model == routed_expert_dim
+    assert moe.experts.mlp.d_model == routed_expert_dim
+    assert moe.latent_down_proj is not None
+    assert moe.latent_down_proj.in_features == d_model
+    assert moe.latent_down_proj.out_features == routed_expert_dim
+    assert moe.latent_up_proj is not None
+    assert moe.latent_up_proj.in_features == routed_expert_dim
+    assert moe.latent_up_proj.out_features == d_model
+    if shared:
+        assert moe.shared_mlp is not None
+        assert moe.shared_mlp.w1.in_features == d_model
+
+    assert config.num_params(d_model) == sum(p.numel() for p in moe.parameters())
+    expected_inactive_expert_params = (
+        3 * routed_expert_dim * config.hidden_size * (config.num_experts - config.router.top_k)
+    )
+    assert config.num_active_params(d_model) == (
+        config.num_params(d_model) - expected_inactive_expert_params
+    )
+
+    class IdentityExperts(torch.nn.Module):
+        def forward(self, x, expert_weights, expert_indices, batch_size_per_expert):
+            del expert_weights, expert_indices, batch_size_per_expert
+            return x
+
+    # The production expert kernels require CUDA. Replacing only their computation keeps this
+    # unit test focused on the latent/model-space branch boundaries and their gradients.
+    moe.experts = IdentityExperts()
+    x = torch.randn(2, 3, d_model, requires_grad=True)
+    output = moe(x)
+    assert output.shape == x.shape
+    output.sum().backward()
+    assert x.grad is not None
+    assert moe.latent_down_proj.weight.grad is not None
+    assert moe.latent_up_proj.weight.grad is not None
+
+
+@pytest.mark.parametrize("routed_expert_dim", [0, 16, 32])
+def test_latent_moe_rejects_invalid_routed_expert_dim(routed_expert_dim: int):
+    config = MoEConfig(latent_moe=LatentMoEConfig(routed_expert_dim=routed_expert_dim))
+    with pytest.raises(OLMoConfigurationError, match="routed_expert_dim"):
+        config.build(d_model=16)
+
+
+def test_moe_without_latent_config_preserves_state_dict_keys():
+    moe = MoEConfig().build(d_model=16)
+    assert not any("latent_" in key for key in moe.state_dict())
 
 
 def run_moe_with_expert_parallelism(

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -91,24 +91,24 @@ def test_moe(moe_type: MoEType, shared: bool, dtype: torch.dtype):
 @pytest.mark.parametrize("shared", [False, True])
 def test_latent_moe(moe_type: MoEType, shared: bool):
     d_model = 16
-    routed_expert_dim = 8
+    latent_dim = 8
     config = MoEConfig(
         name=moe_type,
         num_experts=4,
         hidden_size=32,
         router=MoERouterConfig(top_k=2),
         shared_mlp=FeedForwardConfig(hidden_size=24) if shared else None,
-        latent_moe=LatentMoEConfig(routed_expert_dim=routed_expert_dim),
+        latent_moe=LatentMoEConfig(latent_dim=latent_dim),
     )
     moe = config.build(d_model=d_model)
 
-    assert moe.router.d_model == routed_expert_dim
-    assert moe.experts.mlp.d_model == routed_expert_dim
+    assert moe.router.d_model == d_model
+    assert moe.experts.mlp.d_model == latent_dim
     assert moe.latent_down_proj is not None
     assert moe.latent_down_proj.in_features == d_model
-    assert moe.latent_down_proj.out_features == routed_expert_dim
+    assert moe.latent_down_proj.out_features == latent_dim
     assert moe.latent_up_proj is not None
-    assert moe.latent_up_proj.in_features == routed_expert_dim
+    assert moe.latent_up_proj.in_features == latent_dim
     assert moe.latent_up_proj.out_features == d_model
     if shared:
         assert moe.shared_mlp is not None
@@ -116,7 +116,7 @@ def test_latent_moe(moe_type: MoEType, shared: bool):
 
     assert config.num_params(d_model) == sum(p.numel() for p in moe.parameters())
     expected_inactive_expert_params = (
-        3 * routed_expert_dim * config.hidden_size * (config.num_experts - config.router.top_k)
+        3 * latent_dim * config.hidden_size * (config.num_experts - config.router.top_k)
     )
     assert config.num_active_params(d_model) == (
         config.num_params(d_model) - expected_inactive_expert_params
@@ -131,24 +131,28 @@ def test_latent_moe(moe_type: MoEType, shared: bool):
     # unit test focused on the latent/model-space branch boundaries and their gradients.
     moe.experts = IdentityExperts()
     x = torch.randn(2, 3, d_model, requires_grad=True)
+    routed_inputs = []
+    moe.router.register_forward_pre_hook(lambda _module, args: routed_inputs.append(args[0]))
     output = moe(x)
     assert output.shape == x.shape
+    assert routed_inputs[0] is x
+    assert routed_inputs[0].shape[-1] == d_model
     output.sum().backward()
     assert x.grad is not None
     assert moe.latent_down_proj.weight.grad is not None
     assert moe.latent_up_proj.weight.grad is not None
 
 
-@pytest.mark.parametrize("routed_expert_dim", [0, 16, 32])
-def test_latent_moe_rejects_invalid_routed_expert_dim(routed_expert_dim: int):
-    config = MoEConfig(latent_moe=LatentMoEConfig(routed_expert_dim=routed_expert_dim))
-    with pytest.raises(OLMoConfigurationError, match="routed_expert_dim"):
+@pytest.mark.parametrize("latent_dim", [0, 16, 32])
+def test_latent_moe_rejects_invalid_latent_dim(latent_dim: int):
+    config = MoEConfig(latent_moe=LatentMoEConfig(latent_dim=latent_dim))
+    with pytest.raises(OLMoConfigurationError, match="latent_dim"):
         config.build(d_model=16)
 
 
 def test_latent_moe_enabled_norm_defaults_to_up_proj_input_rms_norm():
     config = MoEConfig(
-        latent_moe=LatentMoEConfig(routed_expert_dim=8, up_proj_input_norm_enabled=True)
+        latent_moe=LatentMoEConfig(latent_dim=8, up_proj_input_norm_enabled=True)
     )
     moe = config.build(d_model=16)
 
@@ -161,7 +165,7 @@ def test_latent_moe_enabled_norm_defaults_to_up_proj_input_rms_norm():
 def test_latent_moe_accepts_non_rms_up_proj_input_norm():
     config = MoEConfig(
         latent_moe=LatentMoEConfig(
-            routed_expert_dim=8,
+            latent_dim=8,
             up_proj_input_norm_enabled=True,
             up_proj_input_norm=LayerNormConfig(name=LayerNormType.default),
         )
@@ -171,7 +175,7 @@ def test_latent_moe_accepts_non_rms_up_proj_input_norm():
 
 
 def test_latent_moe_up_projection_accepts_bf16_expert_output():
-    moe = MoEConfig(latent_moe=LatentMoEConfig(routed_expert_dim=8)).build(d_model=16)
+    moe = MoEConfig(latent_moe=LatentMoEConfig(latent_dim=8)).build(d_model=16)
     assert moe.latent_up_proj is not None
 
     routed_output = torch.randn(2, 3, 8, dtype=torch.bfloat16)
@@ -185,7 +189,7 @@ def test_latent_moe_tensor_parallelizes_projection_stack(
     monkeypatch: pytest.MonkeyPatch,
 ):
     config = MoEConfig(
-        latent_moe=LatentMoEConfig(routed_expert_dim=8, up_proj_input_norm_enabled=True)
+        latent_moe=LatentMoEConfig(latent_dim=8, up_proj_input_norm_enabled=True)
     )
     moe = config.build(d_model=16)
     parallelized = {}

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -146,14 +146,17 @@ def test_latent_moe_rejects_invalid_routed_expert_dim(routed_expert_dim: int):
         config.build(d_model=16)
 
 
-def test_latent_moe_defaults_to_up_proj_input_rms_norm():
-    config = MoEConfig(latent_moe=LatentMoEConfig(routed_expert_dim=8))
+def test_latent_moe_enabled_norm_defaults_to_up_proj_input_rms_norm():
+    config = MoEConfig(
+        latent_moe=LatentMoEConfig(
+            routed_expert_dim=8, up_proj_input_norm_enabled=True
+        )
+    )
     moe = config.build(d_model=16)
 
     assert moe.latent_up_proj_input_norm is not None
     assert config.latent_moe is not None
-    assert config.latent_moe.up_proj_input_norm is not None
-    assert config.latent_moe.up_proj_input_norm.name == LayerNormType.rms
+    assert config.latent_moe.resolved_up_proj_input_norm().name == LayerNormType.rms
     assert config.num_params(16) == sum(p.numel() for p in moe.parameters())
 
 
@@ -161,6 +164,7 @@ def test_latent_moe_accepts_non_rms_up_proj_input_norm():
     config = MoEConfig(
         latent_moe=LatentMoEConfig(
             routed_expert_dim=8,
+            up_proj_input_norm_enabled=True,
             up_proj_input_norm=LayerNormConfig(name=LayerNormType.default),
         )
     )
@@ -171,7 +175,11 @@ def test_latent_moe_accepts_non_rms_up_proj_input_norm():
 def test_latent_moe_tensor_parallelizes_projection_stack(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    config = MoEConfig(latent_moe=LatentMoEConfig(routed_expert_dim=8))
+    config = MoEConfig(
+        latent_moe=LatentMoEConfig(
+            routed_expert_dim=8, up_proj_input_norm_enabled=True
+        )
+    )
     moe = config.build(d_model=16)
     parallelized = {}
 

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -151,9 +151,7 @@ def test_latent_moe_rejects_invalid_latent_dim(latent_dim: int):
 
 
 def test_latent_moe_enabled_norm_defaults_to_up_proj_input_rms_norm():
-    config = MoEConfig(
-        latent_moe=LatentMoEConfig(latent_dim=8, up_proj_input_norm_enabled=True)
-    )
+    config = MoEConfig(latent_moe=LatentMoEConfig(latent_dim=8, up_proj_input_norm_enabled=True))
     moe = config.build(d_model=16)
 
     assert moe.latent_up_proj_input_norm is not None
@@ -188,9 +186,7 @@ def test_latent_moe_up_projection_accepts_bf16_expert_output():
 def test_latent_moe_tensor_parallelizes_projection_stack(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    config = MoEConfig(
-        latent_moe=LatentMoEConfig(latent_dim=8, up_proj_input_norm_enabled=True)
-    )
+    config = MoEConfig(latent_moe=LatentMoEConfig(latent_dim=8, up_proj_input_norm_enabled=True))
     moe = config.build(d_model=16)
     parallelized = {}
 

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -168,6 +168,34 @@ def test_latent_moe_accepts_non_rms_up_proj_input_norm():
     assert moe.latent_up_proj_input_norm is not None
 
 
+def test_latent_moe_tensor_parallelizes_projection_stack(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config = MoEConfig(latent_moe=LatentMoEConfig(routed_expert_dim=8))
+    moe = config.build(d_model=16)
+    parallelized = {}
+
+    def record_parallelize(module, *, device_mesh, parallelize_plan):
+        del device_mesh
+        parallelized[module] = parallelize_plan
+        return module
+
+    monkeypatch.setattr("olmo_core.nn.moe.moe.parallelize_module", record_parallelize)
+    monkeypatch.setattr(moe.router, "apply_tp", lambda *args, **kwargs: None)
+    monkeypatch.setattr(moe.experts, "apply_tp", lambda *args, **kwargs: None)
+    moe.apply_tp(object())  # type: ignore[arg-type]
+
+    for module in (
+        moe.latent_down_proj,
+        moe.latent_up_proj_input_norm,
+        moe.latent_up_proj,
+    ):
+        assert module is not None
+        plan = parallelized[module]
+        assert plan.__class__.__name__ == "SequenceParallel"
+        assert plan.use_local_output is True
+
+
 def test_moe_without_latent_config_preserves_state_dict_keys():
     moe = MoEConfig().build(d_model=16)
     assert not any("latent_" in key for key in moe.state_dict())

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -17,6 +17,7 @@ from olmo_core.distributed.parallel import (
     get_ep_mesh,
 )
 from olmo_core.distributed.utils import get_local_tensor
+from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.feed_forward import FeedForwardConfig
 from olmo_core.nn.moe import (
     LatentMoEConfig,
@@ -25,7 +26,6 @@ from olmo_core.nn.moe import (
     MoERouterConfig,
     MoEType,
 )
-from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.testing import (
     has_grouped_gemm,
     requires_gpu,

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -19,6 +19,7 @@ from olmo_core.distributed.parallel import (
 from olmo_core.distributed.utils import get_local_tensor
 from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.feed_forward import FeedForwardConfig
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.moe import (
     LatentMoEConfig,
     MoEConfig,
@@ -143,6 +144,30 @@ def test_latent_moe_rejects_invalid_routed_expert_dim(routed_expert_dim: int):
     config = MoEConfig(latent_moe=LatentMoEConfig(routed_expert_dim=routed_expert_dim))
     with pytest.raises(OLMoConfigurationError, match="routed_expert_dim"):
         config.build(d_model=16)
+
+
+def test_latent_moe_defaults_to_up_proj_input_rms_norm():
+    config = MoEConfig(
+        latent_moe=LatentMoEConfig(routed_expert_dim=8)
+    )
+    moe = config.build(d_model=16)
+
+    assert moe.latent_up_proj_input_norm is not None
+    assert config.latent_moe is not None
+    assert config.latent_moe.up_proj_input_norm is not None
+    assert config.latent_moe.up_proj_input_norm.name == LayerNormType.rms
+    assert config.num_params(16) == sum(p.numel() for p in moe.parameters())
+
+
+def test_latent_moe_accepts_non_rms_up_proj_input_norm():
+    config = MoEConfig(
+        latent_moe=LatentMoEConfig(
+            routed_expert_dim=8,
+            up_proj_input_norm=LayerNormConfig(name=LayerNormType.default),
+        )
+    )
+    moe = config.build(d_model=16)
+    assert moe.latent_up_proj_input_norm is not None
 
 
 def test_moe_without_latent_config_preserves_state_dict_keys():

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -147,9 +147,7 @@ def test_latent_moe_rejects_invalid_routed_expert_dim(routed_expert_dim: int):
 
 
 def test_latent_moe_defaults_to_up_proj_input_rms_norm():
-    config = MoEConfig(
-        latent_moe=LatentMoEConfig(routed_expert_dim=8)
-    )
+    config = MoEConfig(latent_moe=LatentMoEConfig(routed_expert_dim=8))
     moe = config.build(d_model=16)
 
     assert moe.latent_up_proj_input_norm is not None

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -170,6 +170,17 @@ def test_latent_moe_accepts_non_rms_up_proj_input_norm():
     assert moe.latent_up_proj_input_norm is not None
 
 
+def test_latent_moe_up_projection_accepts_bf16_expert_output():
+    moe = MoEConfig(latent_moe=LatentMoEConfig(routed_expert_dim=8)).build(d_model=16)
+    assert moe.latent_up_proj is not None
+
+    routed_output = torch.randn(2, 3, 8, dtype=torch.bfloat16)
+    output = moe.restore_routed_output(routed_output)
+
+    assert output.shape == (2, 3, 16)
+    assert output.dtype == moe.latent_up_proj.weight.dtype
+
+
 def test_latent_moe_tensor_parallelizes_projection_stack(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/src/test/nn/moe/moe_test.py
+++ b/src/test/nn/moe/moe_test.py
@@ -148,9 +148,7 @@ def test_latent_moe_rejects_invalid_routed_expert_dim(routed_expert_dim: int):
 
 def test_latent_moe_enabled_norm_defaults_to_up_proj_input_rms_norm():
     config = MoEConfig(
-        latent_moe=LatentMoEConfig(
-            routed_expert_dim=8, up_proj_input_norm_enabled=True
-        )
+        latent_moe=LatentMoEConfig(routed_expert_dim=8, up_proj_input_norm_enabled=True)
     )
     moe = config.build(d_model=16)
 
@@ -176,9 +174,7 @@ def test_latent_moe_tensor_parallelizes_projection_stack(
     monkeypatch: pytest.MonkeyPatch,
 ):
     config = MoEConfig(
-        latent_moe=LatentMoEConfig(
-            routed_expert_dim=8, up_proj_input_norm_enabled=True
-        )
+        latent_moe=LatentMoEConfig(routed_expert_dim=8, up_proj_input_norm_enabled=True)
     )
     moe = config.build(d_model=16)
     parallelized = {}

--- a/src/test/nn/moe/v2/deepep_runtime_test.py
+++ b/src/test/nn/moe/v2/deepep_runtime_test.py
@@ -180,6 +180,15 @@ def test_deepep_source_capacity_is_not_route_capacity() -> None:
         deepep_v2._requested_num_max_tokens_per_rank(0)
 
 
+@pytest.mark.parametrize("hidden", [128, 256, 384, 1024])
+def test_deepep_validates_routed_hidden_size(hidden: int) -> None:
+    if hidden % 256 == 0:
+        deepep_v2._validate_deepep_v2_hidden_size(hidden)
+    else:
+        with pytest.raises(RuntimeError, match=f"routed hidden size.*got {hidden}"):
+            deepep_v2._validate_deepep_v2_hidden_size(hidden)
+
+
 def test_deepep_runtime_key_separates_fp8_dispatch() -> None:
     ep_pg = object()
     bf16_block = _stub_block(ep_pg=ep_pg, runtime_cache={})

--- a/src/test/nn/transformer/init_test.py
+++ b/src/test/nn/transformer/init_test.py
@@ -141,7 +141,7 @@ def test_fan_in_init_moe(d_model, init_device, device):
 
 def test_fan_in_init_latent_moe():
     d_model = 256
-    routed_expert_dim = 64
+    latent_dim = 64
     config = TransformerConfig(
         name=TransformerType.moe,
         d_model=d_model,
@@ -154,7 +154,7 @@ def test_fan_in_init_latent_moe():
             feed_forward_moe=MoEConfig(
                 num_experts=4,
                 hidden_size=128,
-                latent_moe=LatentMoEConfig(routed_expert_dim=routed_expert_dim),
+                latent_moe=LatentMoEConfig(latent_dim=latent_dim),
             ),
             layer_norm=LayerNormConfig(name=LayerNormType.rms, bias=False),
         ),
@@ -169,7 +169,7 @@ def test_fan_in_init_latent_moe():
     assert moe.latent_up_proj is not None
     torch.testing.assert_close(
         moe.router.weight.std(),
-        torch.tensor(routed_expert_dim**-0.5),
+        torch.tensor(d_model**-0.5),
         rtol=0.3,
         atol=0.0,
     )
@@ -181,7 +181,7 @@ def test_fan_in_init_latent_moe():
     )
     torch.testing.assert_close(
         moe.latent_up_proj.weight.std(),
-        torch.tensor(routed_expert_dim**-0.5),
+        torch.tensor(latent_dim**-0.5),
         rtol=0.3,
         atol=0.0,
     )

--- a/src/test/nn/transformer/init_test.py
+++ b/src/test/nn/transformer/init_test.py
@@ -13,7 +13,7 @@ from olmo_core.nn.attention.recurrent import GatedDeltaNetConfig
 from olmo_core.nn.feed_forward import FeedForwardConfig
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.lm_head import LMHeadConfig
-from olmo_core.nn.moe import MoEConfig
+from olmo_core.nn.moe import LatentMoEConfig, MoEConfig
 from olmo_core.nn.transformer import (
     TransformerBlockConfig,
     TransformerBlockType,
@@ -137,6 +137,54 @@ def test_fan_in_init_moe(d_model, init_device, device):
         assert (
             abs(actual - expected) < tolerance
         ), f"MoE {name} std: expected ~{expected:.5f}, got {actual:.5f}"
+
+
+def test_fan_in_init_latent_moe():
+    d_model = 256
+    routed_expert_dim = 64
+    config = TransformerConfig(
+        name=TransformerType.moe,
+        d_model=d_model,
+        n_layers=1,
+        vocab_size=1000,
+        init_method=InitMethod.fan_in,
+        block=TransformerBlockConfig(
+            name=TransformerBlockType.moe,
+            sequence_mixer=AttentionConfig(n_heads=4),
+            feed_forward_moe=MoEConfig(
+                num_experts=4,
+                hidden_size=128,
+                latent_moe=LatentMoEConfig(routed_expert_dim=routed_expert_dim),
+            ),
+            layer_norm=LayerNormConfig(name=LayerNormType.rms, bias=False),
+        ),
+        lm_head=LMHeadConfig(bias=False),
+    )
+
+    model = config.build(init_device="cpu")
+    model.init_weights(device=torch.device("cpu"))
+    moe = model.blocks["0"].feed_forward_moe
+
+    assert moe.latent_down_proj is not None
+    assert moe.latent_up_proj is not None
+    torch.testing.assert_close(
+        moe.router.weight.std(),
+        torch.tensor(routed_expert_dim**-0.5),
+        rtol=0.3,
+        atol=0.0,
+    )
+    torch.testing.assert_close(
+        moe.latent_down_proj.weight.std(),
+        torch.tensor(d_model**-0.5),
+        rtol=0.3,
+        atol=0.0,
+    )
+    torch.testing.assert_close(
+        moe.latent_up_proj.weight.std(),
+        torch.tensor(routed_expert_dim**-0.5),
+        rtol=0.3,
+        atol=0.0,
+    )
 
 
 @pytest.mark.parametrize("d_model", [256, 512])

--- a/src/test/nn/transformer/model_test.py
+++ b/src/test/nn/transformer/model_test.py
@@ -471,7 +471,7 @@ def run_moe_hybrid_combined_forward(
                     FeedForwardConfig(hidden_size=512, bias=False) if shared_experts else None
                 ),
                 router=MoERouterConfig(uniform_expert_assignment=True),
-                latent_moe=LatentMoEConfig(routed_expert_dim=256) if latent_moe else None,
+                latent_moe=LatentMoEConfig(latent_dim=256) if latent_moe else None,
             ),
         ),
         lm_head=LMHeadConfig(layer_norm=layer_norm, bias=False),

--- a/src/test/nn/transformer/model_test.py
+++ b/src/test/nn/transformer/model_test.py
@@ -35,7 +35,7 @@ from olmo_core.nn.attention.ring import (
 from olmo_core.nn.feed_forward import ActivationFunction, FeedForwardConfig
 from olmo_core.nn.layer_norm import LayerNorm, LayerNormConfig, LayerNormType
 from olmo_core.nn.lm_head import LMHeadConfig
-from olmo_core.nn.moe import MoEConfig, MoERouterConfig, MoEType
+from olmo_core.nn.moe import LatentMoEConfig, MoEConfig, MoERouterConfig, MoEType
 from olmo_core.nn.rope import RoPEConfig
 from olmo_core.nn.transformer import (
     MoEHybridTransformerBlockBase,
@@ -442,7 +442,11 @@ def test_init_with_hsdp(architecture: str):
 
 
 def run_moe_hybrid_combined_forward(
-    dropless: bool, shared_experts: bool, reordered_norm: bool, tp: bool
+    dropless: bool,
+    shared_experts: bool,
+    reordered_norm: bool,
+    tp: bool,
+    latent_moe: bool = False,
 ):
     layer_norm = LayerNormConfig(name=LayerNormType.rms, bias=False)
     config = TransformerConfig(
@@ -467,6 +471,7 @@ def run_moe_hybrid_combined_forward(
                     FeedForwardConfig(hidden_size=512, bias=False) if shared_experts else None
                 ),
                 router=MoERouterConfig(uniform_expert_assignment=True),
+                latent_moe=LatentMoEConfig(routed_expert_dim=256) if latent_moe else None,
             ),
         ),
         lm_head=LMHeadConfig(layer_norm=layer_norm, bias=False),
@@ -525,6 +530,21 @@ def test_moe_hybrid_combined_forward(
             reordered_norm,
             tp,
         ),
+    )
+
+
+@requires_multi_gpu
+@pytest.mark.parametrize(
+    "reordered_norm",
+    [pytest.param(True, id="reordered-norm"), pytest.param(False, id="default-block")],
+)
+@pytest.mark.parametrize("tp", [pytest.param(True, id="TP"), pytest.param(False, id="EP")])
+def test_latent_moe_hybrid_combined_forward(reordered_norm: bool, tp: bool):
+    run_distributed_test(
+        run_moe_hybrid_combined_forward,
+        backend="nccl",
+        start_method="spawn",
+        func_args=(True, True, reordered_norm, tp, True),
     )
 
 


### PR DESCRIPTION
## Summary

  This PR adds LatentMoE support to the original MoE and MoE v2 implementations.

  Instead of running routed experts on the model’s hidden representation, LatentMoE wraps the routed expert path with two shared linear projections:

  1. Project routed token payloads into a smaller latent representation: d → ℓ
  2. Perform expert dispatch, expert computation, and combine in latent space
  3. Project the combined routed output back into model space: ℓ → d

  The router continues to compute gating decisions from the original model-space representation. Only the routed payload and routed expert computation use
  the latent dimension.

  Shared experts, transformer norms, and residual operations remain in model space.

  ## Configuration

  ### Original MoE

  For the original MoE implementation, add latent_moe to MoEConfig:
```
  from olmo_core.nn.moe import LatentMoEConfig, MoEConfig

  moe = MoEConfig(
      ...,
      latent_moe=LatentMoEConfig(
          latent_dim=1024,
      ),
  )
```
  The router remains model-width, while the routed experts are built automatically with latent_dim.

  ### MoE v2

  For MoE v2, configure the router with the model dimension and the routed experts with the latent dimension:

```
  from olmo_core.nn.moe import LatentMoEConfig
  from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
  from olmo_core.nn.moe.v2.router import MoERouterConfigV2

  d_model = 4096
  latent_dim = 1024

  block = OLMoDDPTransformerBlockConfig(
      ...,
      latent_moe=LatentMoEConfig(
          latent_dim=latent_dim,
      ),
      routed_experts_router=MoERouterConfigV2(
          d_model=d_model,
          ...,
      ),
      routed_experts=RoutedExpertsConfig(
          d_model=latent_dim,
          ...,
      ),
  )
```

  The following dimensional constraints are enforced:

  - 0 < latent_dim < d_model
  - routed_experts_router.d_model == d_model
  - routed_experts.d_model == latent_dim
  - Shared expert and shared router dimensions remain equal to d_model

  Leave latent_moe=None to use the standard MoE architecture.

  ## Optional pre-up-projection normalization

  Normalization before the ℓ → d projection is disabled by default.

  Enable it with:
```
  latent_moe=LatentMoEConfig(
      latent_dim=1024,
      up_proj_input_norm_enabled=True,
  )
```

  When enabled without an explicit configuration, a bias-free RMSNorm is used.

  A different normalization can be configured explicitly:

```
  from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType

  latent_moe=LatentMoEConfig(
      latent_dim=1024,
      up_proj_input_norm_enabled=True,
      up_proj_input_norm=LayerNormConfig(
          name=LayerNormType.rms,
          eps=1e-6,
          bias=False,
      ),
  )
```

  Projection biases are disabled by default and can be enabled with bias=True.

  ## Supported execution paths

  LatentMoE is integrated with:

  - Original MoE and dropless MoE
  - MoE v2 without expert parallelism
  - Synchronous and asynchronous expert parallelism
  - Rowwise, rowwise-wave, and DeepEP v2 backends
  - Hybrid MoE combined-forward paths
  - Tensor, expert, context, data, and pipeline parallel execution

  Routing remains model-width in every path, while routed communication and expert computation use latent_dim.