### PR TITLE
Update anonymous paths in public scripts to point to data in hugging face bucket

### DIFF
--- a/src/scripts/official/OLMo3/OLMo-3-1025-32B-long-context.py
+++ b/src/scripts/official/OLMo3/OLMo-3-1025-32B-long-context.py
@@ -110,7 +110,7 @@ def build_config(opts: argparse.Namespace, overrides: List[str]) -> ExperimentCo
         TrainerConfig(
             save_folder=opts.save_folder,
             save_overwrite=True,
-            load_path="https://storage.googleapis.com/ai2-llm/checkpoints/stego32-highlr-filter3/step656000/",
+            load_path="https://huggingface.co/buckets/allenai/ai2-llm/resolve/checkpoints/stego32-highlr-filter3/step656000/",
             # "gs://ai2-llm/checkpoints/stego32-midtraining-runs-merged-step23842-resharded16",
             load_strategy=LoadStrategy.always,
             load_trainer_state=False,

--- a/src/scripts/official/OLMo3/OLMo-3-1025-32B-midtrain-ingredient-1.py
+++ b/src/scripts/official/OLMo3/OLMo-3-1025-32B-midtrain-ingredient-1.py
@@ -103,7 +103,7 @@ def build_config(opts: argparse.Namespace, overrides: List[str]) -> ExperimentCo
         TrainerConfig(
             save_folder=opts.save_folder,
             save_overwrite=True,
-            load_path="https://storage.googleapis.com/ai2-llm/checkpoints/stego32-highlr-filter3/step656000/",
+            load_path="https://huggingface.co/buckets/allenai/ai2-llm/resolve/checkpoints/stego32-highlr-filter3/step656000/",
             load_strategy=LoadStrategy.always,
             load_trainer_state=False,
             load_optim_state=True,

--- a/src/scripts/official/OLMo3/OLMo-3-1025-32B-midtrain-ingredient-2.py
+++ b/src/scripts/official/OLMo3/OLMo-3-1025-32B-midtrain-ingredient-2.py
@@ -103,7 +103,7 @@ def build_config(opts: argparse.Namespace, overrides: List[str]) -> ExperimentCo
         TrainerConfig(
             save_folder=opts.save_folder,
             save_overwrite=True,
-            load_path="https://storage.googleapis.com/ai2-llm/checkpoints/stego32-highlr-filter3/step656000/",
+            load_path="https://huggingface.co/buckets/allenai/ai2-llm/resolve/checkpoints/stego32-highlr-filter3/step656000/",
             load_strategy=LoadStrategy.always,
             load_trainer_state=False,
             load_optim_state=True,

--- a/src/scripts/official/OLMo3/OLMo-3-1025-7B-midtrain.py
+++ b/src/scripts/official/OLMo3/OLMo-3-1025-7B-midtrain.py
@@ -98,7 +98,7 @@ def build_config(opts: argparse.Namespace, overrides: List[str]) -> ExperimentCo
         TrainerConfig(
             save_folder=opts.save_folder,
             save_overwrite=True,
-            load_path="https://storage.googleapis.com/ai2-llm/checkpoints/OLMo25/step1413814/",
+            load_path="https://huggingface.co/buckets/allenai/ai2-llm/resolve/checkpoints/OLMo25/step1413814/",
             load_strategy=LoadStrategy.always,
             load_trainer_state=False,
             load_optim_state=True,

--- a/src/scripts/official/OLMo3/OLMo-3-1025-7B-pretrain-2.py
+++ b/src/scripts/official/OLMo3/OLMo-3-1025-7B-pretrain-2.py
@@ -101,7 +101,7 @@ def build_config(opts: argparse.Namespace, overrides: List[str]) -> ExperimentCo
         TrainerConfig(
             save_folder=opts.save_folder,
             save_overwrite=True,
-            load_path="https://storage.googleapis.com/ai2-llm/checkpoints/OLMo25/step596047/",
+            load_path="https://huggingface.co/buckets/allenai/ai2-llm/resolve/checkpoints/OLMo25/step596047/",
             load_strategy=LoadStrategy.always,
             load_trainer_state=True,
             load_optim_state=True,

--- a/src/test/nn/transformer/config_test.py
+++ b/src/test/nn/transformer/config_test.py
@@ -5,7 +5,9 @@ from cached_path import cached_path
 from olmo_core.nn.transformer.config import TransformerBlockConfig, TransformerConfig
 
 # OLMO3_7B_CHECKPOINT = "https://olmo-checkpoints.org/ai2-llm/Olmo-3-1025-7B/stage1/step0"
-OLMO3_7B_CHECKPOINT = "https://storage.googleapis.com/ai2-llm/checkpoints/OLMo25/step0"
+OLMO3_7B_CHECKPOINT = (
+    "https://huggingface.co/buckets/allenai/ai2-llm/resolve/checkpoints/OLMo25/step0"
+)
 
 
 def test_load_olmo3_7b_config():


### PR DESCRIPTION
<img width="1297" height="215" alt="Screenshot 2026-07-31 at 9 39 15 AM" src="https://github.com/user-attachments/assets/7fcc5b1e-bd7d-46fc-9ffb-dc6501a1507a" />

Two large checkpoint folders were copied to a Hugging Face bucket in the allenai org:
https://huggingface.co/buckets/allenai/ai2-llm/tree/checkpoints

This PR updates the public scripts to point to the new HF bucket. Paths are similar, but a "resolve" namespace is added after the bucket name in order to differentiate between bucket ui (tree) and object data (resolve). The path format is https://huggingface.co/buckets/{org name}/{bucket name}/resolve/{path prefix}

The buckets supports anonymous http, s3 api access, and also has hf specific tools to access data. 
https://huggingface.co/docs/huggingface_hub/en/guides/buckets

This pr targets anonymous access only, let me know if you want the s3 config added as an io.py schema "hfs3", with typical s3 type access. That seems simple to do, but my assumption was that internally we'll we will still be working against the gcs bucket and releasing to hf later (correct me if I am wrong). 

relates to: https://github.com/allenai/playground-issues-repo/issues/1143
closes: https://github.com/allenai/playground-issues-repo/issues/1163