### PR TITLE
add partial ScaledSoftmax support

### DIFF
--- a/src/olmo_core/nn/attention/__init__.py
+++ b/src/olmo_core/nn/attention/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from torch.distributed import DeviceMesh
-from torch.distributed.tensor import Placement, Replicate, Shard
+from torch.distributed.tensor import DTensor, Placement, Replicate, Shard, distribute_tensor
 from torch.distributed.tensor.parallel import parallelize_module
 
 from olmo_core.config import Config, DType, StrEnum
@@ -201,6 +201,7 @@ class AttentionConfig(SequenceMixerConfig["SequenceMixer"]):
     dtype: DType = DType.float32
     sliding_window: Optional[SlidingWindowAttentionConfig] = None
     use_head_qk_norm: Optional[bool] = None
+    scalable_softmax: bool = False
 
     def num_params(self, d_model: int) -> int:
         """
@@ -254,6 +255,9 @@ class AttentionConfig(SequenceMixerConfig["SequenceMixer"]):
             params += n_heads * head_dim
             params += n_kv_heads * head_dim
 
+        if self.scalable_softmax:
+            params += n_heads
+
         return params
 
     def build(
@@ -280,6 +284,10 @@ class AttentionConfig(SequenceMixerConfig["SequenceMixer"]):
         if sliding_window_config is not None and sliding_window_config.should_use_swa(
             layer_idx, n_layers
         ):
+            if self.scalable_softmax:
+                raise OLMoConfigurationError(
+                    "'scalable_softmax' is not supported with sliding window attention"
+                )
             kwargs["window_size"] = sliding_window_config.get_window_size(layer_idx, n_layers)
         else:  # global (non-SWA) layer
             rope_config: Optional[RoPEConfig] = kwargs.get("rope")
@@ -340,6 +348,7 @@ class Attention(SequenceMixer):
     :param dropout: Dropout probability.
     :param use_flash: Deprecated, use ``backend="flash_2"`` instead.
     :param backend: The attention backend to use. If not set, it will be chosen automatically.
+    :param scalable_softmax: Use Scalable-Softmax with a learned scale for each query head.
     :param dtype: The default data type to use for parameters.
     :param init_device: The device to initialize weights on.
     """
@@ -365,6 +374,7 @@ class Attention(SequenceMixer):
         init_device: str = "cpu",
         cache: Optional[BufferCache] = None,
         use_head_qk_norm: bool = False,
+        scalable_softmax: bool = False,
     ):
         super().__init__()
 
@@ -407,6 +417,14 @@ class Attention(SequenceMixer):
 
         self.clip_qkv = clip_qkv
         self.use_head_qk_norm = use_head_qk_norm
+        self.scalable_softmax = scalable_softmax
+        self.ssmax_scale: Optional[nn.Parameter] = None
+        if scalable_softmax:
+            if window_size is not None:
+                raise OLMoConfigurationError(
+                    "'scalable_softmax' is not supported with sliding window attention"
+                )
+            self.ssmax_scale = nn.Parameter(torch.ones(n_heads, dtype=dtype, device=init_device))
 
         self.q_norm: Optional[LayerNorm] = None
         self.k_norm: Optional[LayerNorm] = None
@@ -516,6 +534,38 @@ class Attention(SequenceMixer):
             self.kv_cache_manager.update_seqlen(q.shape[1])
         return att
 
+    def _apply_scalable_softmax(
+        self,
+        q: torch.Tensor,
+        cu_doc_lens: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if not self.scalable_softmax:
+            return q
+        if self.cp_enabled:
+            raise NotImplementedError("Scalable-Softmax is not supported with context parallelism")
+        if self.kv_cache_manager is not None:
+            raise NotImplementedError("Scalable-Softmax is not supported with KV caching")
+
+        if cu_doc_lens is None:
+            visible_lengths = torch.arange(1, q.shape[1] + 1, device=q.device)
+            visible_lengths = visible_lengths.unsqueeze(0).expand(q.shape[0], -1)
+        else:
+            boundaries = cu_doc_lens.to(device=q.device)
+            token_indices = torch.arange(
+                q.shape[0] * q.shape[1], device=q.device, dtype=boundaries.dtype
+            )
+            document_indices = torch.searchsorted(boundaries[1:], token_indices, right=True)
+            document_starts = boundaries[document_indices]
+            visible_lengths = (token_indices - document_starts + 1).view(q.shape[0], q.shape[1])
+
+        assert self.ssmax_scale is not None
+        ssmax_scale = self.ssmax_scale
+        if isinstance(ssmax_scale, DTensor):
+            ssmax_scale = ssmax_scale.to_local()
+        scale = visible_lengths.log().to(q.dtype).unsqueeze(-1)
+        scale = scale * ssmax_scale.to(q.dtype).view(1, 1, -1)
+        return q * scale.unsqueeze(-1)
+
     def _apply_rope(
         self,
         q: torch.Tensor,
@@ -618,6 +668,8 @@ class Attention(SequenceMixer):
             start_pos = self.kv_cache_manager.current_position() if self.kv_cache_manager else None
             q, k = self._apply_rope(q, k, start_pos, pos_sin, pos_cos, freqs_cis, cu_doc_lens)
 
+        q = self._apply_scalable_softmax(q, cu_doc_lens)
+
         # shape: (batch_size, seq_len, n_heads, head_dim)
         att = self.sdpa(
             q,
@@ -697,6 +749,12 @@ class Attention(SequenceMixer):
             #    which will be reshaped into (B, T, H [sharded], D)
             # if head-wise norm: output is sharded on the head dimension (B, T, H [sharded], D)
             plan["q_norm"] = SequenceParallel(use_local_output=True, output_layouts=Shard(2))
+
+        if self.ssmax_scale is not None:
+            self.register_parameter(
+                "ssmax_scale",
+                nn.Parameter(distribute_tensor(self.ssmax_scale, tp_mesh, [Shard(0)])),
+            )
         if self.k_norm is not None:
             plan["k_norm"] = SequenceParallel(use_local_output=True, output_layouts=Shard(2))
 
@@ -735,6 +793,9 @@ class Attention(SequenceMixer):
         generator: Optional[torch.Generator] = None,
     ) -> None:
         from olmo_core.nn.transformer.init import InitMethod, init_linear
+
+        if self.ssmax_scale is not None:
+            nn.init.ones_(self.ssmax_scale)
 
         # Compute std for Q/K/V initialization
         if init_method == InitMethod.fan_in:

--- a/src/test/nn/attention/attention_test.py
+++ b/src/test/nn/attention/attention_test.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import pytest
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed.tensor import Shard, init_device_mesh
 
@@ -30,6 +31,7 @@ from olmo_core.nn.attention.ring import (
 )
 from olmo_core.nn.layer_norm import LayerNormConfig
 from olmo_core.nn.rope import RoPEConfig, RoPEType
+from olmo_core.nn.transformer.init import InitMethod
 from olmo_core.testing import (
     BACKENDS,
     DEVICES,
@@ -882,6 +884,15 @@ def test_attention_leftpad_shift_equivalence(use_rope):
             ),
             id="headwise-gating",
         ),
+        pytest.param(
+            AttentionConfig(
+                name=AttentionType.default,
+                n_heads=8,
+                bias=False,
+                scalable_softmax=True,
+            ),
+            id="scalable-softmax",
+        ),
     ],
 )
 def test_attention_builder_config(attn_config: AttentionConfig):
@@ -893,6 +904,141 @@ def test_attention_builder_config(attn_config: AttentionConfig):
     # Make sure the estimated number of params matches the actual number of params.
     n_params = sum(p.numel() for p in attn.parameters())
     assert attn_config.num_params(d_model) == n_params
+
+
+@pytest.mark.parametrize(
+    "cu_doc_lens,expected_lengths",
+    [
+        pytest.param(None, [[1, 2, 3, 4], [1, 2, 3, 4]], id="causal"),
+        pytest.param(
+            torch.tensor([0, 2, 4, 7, 8], dtype=torch.int32),
+            [[1, 2, 1, 2], [1, 2, 3, 1]],
+            id="packed-documents",
+        ),
+    ],
+)
+def test_scalable_softmax_query_scaling(cu_doc_lens, expected_lengths):
+    attention = Attention(
+        d_model=8,
+        n_heads=2,
+        head_dim=4,
+        bias=False,
+        scalable_softmax=True,
+    )
+    assert attention.ssmax_scale is not None
+    with torch.no_grad():
+        attention.ssmax_scale.copy_(torch.tensor([0.5, 2.0]))
+
+    q = torch.ones(2, 4, 2, 4)
+    scaled_q = attention._apply_scalable_softmax(q, cu_doc_lens)
+    expected = torch.tensor(expected_lengths, dtype=q.dtype).log()
+    expected = expected[:, :, None, None] * torch.tensor([0.5, 2.0])[None, None, :, None]
+
+    torch.testing.assert_close(scaled_q, expected.expand_as(q))
+    scaled_q.sum().backward()
+    assert attention.ssmax_scale.grad is not None
+    assert torch.all(attention.ssmax_scale.grad > 0)
+
+
+def test_scalable_softmax_disabled_is_identity():
+    attention = Attention(d_model=8, n_heads=2, head_dim=4, bias=False)
+    q = torch.randn(2, 4, 2, 4)
+
+    assert attention.ssmax_scale is None
+    assert attention._apply_scalable_softmax(q, None) is q
+
+
+def test_scalable_softmax_scale_is_initialized_to_one():
+    attention = Attention(
+        d_model=8,
+        n_heads=2,
+        head_dim=4,
+        bias=False,
+        scalable_softmax=True,
+    )
+    assert attention.ssmax_scale is not None
+    with torch.no_grad():
+        attention.ssmax_scale.fill_(float("nan"))
+
+    attention.init_weights(
+        init_method=InitMethod.normal,
+        d_model=8,
+        block_idx=0,
+        num_blocks=1,
+    )
+
+    torch.testing.assert_close(attention.ssmax_scale, torch.ones(2))
+
+
+def test_scalable_softmax_is_applied_after_qk_norm():
+    class ConstantNorm(nn.Module):
+        def forward(self, x):
+            return torch.full_like(x, 3.0)
+
+    attention = Attention(
+        d_model=8,
+        n_heads=2,
+        head_dim=4,
+        bias=False,
+        qk_norm=LayerNormConfig(),
+        use_head_qk_norm=True,
+        scalable_softmax=True,
+    )
+    attention.q_norm = ConstantNorm()
+    attention.k_norm = ConstantNorm()
+    assert attention.ssmax_scale is not None
+    with torch.no_grad():
+        attention.ssmax_scale.fill_(2.0)
+
+    captured_q = None
+
+    def capture_sdpa(q, k, v, **kwargs):
+        nonlocal captured_q
+        captured_q = q
+        return torch.zeros_like(q)
+
+    attention.sdpa = capture_sdpa
+    attention(torch.randn(1, 3, 8))
+
+    assert captured_q is not None
+    expected = 6.0 * torch.arange(1, 4, dtype=captured_q.dtype).log()
+    expected = expected.view(1, 3, 1, 1).expand_as(captured_q)
+    torch.testing.assert_close(captured_q, expected)
+
+
+@pytest.mark.parametrize("unsupported_mode", ["kv-cache", "context-parallel"])
+def test_scalable_softmax_rejects_unsupported_runtime_modes(unsupported_mode):
+    attention = Attention(
+        d_model=8,
+        n_heads=2,
+        head_dim=4,
+        bias=False,
+        scalable_softmax=True,
+    )
+    if unsupported_mode == "kv-cache":
+        attention.kv_cache_manager = nn.Identity()
+        match = "KV caching"
+    else:
+        attention.backend.cp_enabled = True
+        match = "context parallelism"
+
+    with pytest.raises(NotImplementedError, match=match):
+        attention._apply_scalable_softmax(torch.ones(1, 2, 2, 4), None)
+
+
+def test_scalable_softmax_rejects_sliding_window_attention():
+    config = AttentionConfig(
+        n_heads=2,
+        scalable_softmax=True,
+        sliding_window=SlidingWindowAttentionConfig(
+            pattern=[128],
+            force_full_attention_on_first_layer=False,
+            force_full_attention_on_last_layer=False,
+        ),
+    )
+
+    with pytest.raises(OLMoConfigurationError, match="scalable_softmax"):
+        config.build(d_model=8, layer_idx=0, n_layers=2)
 
 
 @pytest.mark.parametrize(
@@ -1108,6 +1254,14 @@ def _run_tensor_parallel_attention(
         pytest.param(
             {"gate": GateConfig(granularity=GateGranularity.headwise)},
             id="headwise-gating",
+        ),
+        pytest.param(
+            {
+                "qk_norm": LayerNormConfig(),
+                "use_head_qk_norm": True,
+                "scalable_softmax": True,
+            },
+            id="scalable-softmax",
         ),
     ],
 )


### PR DESCRIPTION
Adds an optional Scalable-Softmax (SSMax) path to `Attention`, behind
`AttentionConfig.scalable_softmax`.

## What it does

Standard attention computes `softmax(q·kᵀ/√d)`. As the number of visible keys grows the logit
distribution flattens and attention fades toward uniform, which is one of the mechanisms behind
degradation at long context. SSMax ("Scalable-Softmax Is Superior for Attention", Nakanishi 2025)
counteracts it by scaling the logits with the visible-context size:

    softmax(s · log(n) · q·kᵀ/√d)

where `n` is the number of keys the query can see and `s` is learned.

It is implemented as a scale applied to `q`, not to the logits. That is algebraically identical and
keeps the change entirely outside the attention kernel, so every backend (flash_2, flash_3, torch
SDPA) picks it up without a custom path.

`ssmax_scale` is one learnable scalar per query head — `n_heads` extra parameters per layer, which
`AttentionConfig.num_params` now accounts for — initialised to ones in `init_weights`.

## `n` is per-position and document-aware

`n` is the number of tokens a given query actually attends to, not the sequence length:

- causal, unpacked: `n = position + 1`;
- packed sequences (`cu_doc_lens` set): `n` restarts at each document boundary, so intra-document
  masking is respected. A token three positions into the second packed document gets `n = 3`, not
  its offset into the flattened batch.

The first token of each document has `log(1) = 0` and therefore a zeroed query. That is a no-op: it
attends to exactly one key, and softmax over a single logit is 1 regardless of its value.

The scale is applied after QK-norm and RoPE, immediately before `sdpa`.

## What is and isn't supported

This is deliberately partial. Three configurations are rejected rather than silently computing the
wrong `n`:

- **Sliding-window attention** — `OLMoConfigurationError`, raised both from `AttentionConfig.build`
  and from the `Attention` constructor. Under SWA a query sees at most `window` keys, so the
  position-based count computed here is simply not the visible count.
- **Context parallelism** — `NotImplementedError`. Under CP the local `q` shard does not carry
  global position offsets, so `arange` over the local sequence gives the wrong `n`. This is the
  remaining work.
- **KV caching** — `NotImplementedError`. During incremental decode `q.shape[1]` is 1, so the
  position count would collapse to `n = 1` instead of the true cached length.

Tensor parallelism is supported: `apply_tp` re-registers `ssmax_scale` as a DTensor sharded on the
head dimension, matching the head-sharded `q`, and the forward pass converts back to local before
the multiply.

## Tests

Six new test functions (eight cases with parametrisation) in `src/test/nn/attention/attention_test.py`:

- `test_scalable_softmax_query_scaling` — exact per-head scaling for both the plain causal case and
  a packed-document case with `cu_doc_lens=[0, 2, 4, 7, 8]`, plus that gradients reach `ssmax_scale`;
- `test_scalable_softmax_disabled_is_identity` — the disabled path returns the input tensor itself;
- `test_scalable_softmax_scale_is_initialized_to_one` — `init_weights` resets the scale;
- `test_scalable_softmax_is_applied_after_qk_norm` — captures `q` at the `sdpa` boundary to pin
  the ordering against QK-norm;
- `test_scalable_softmax_rejects_unsupported_runtime_modes` — KV cache and CP;
- `test_scalable_softmax_rejects_sliding_window_attention` — config-build rejection.

`test_attention_builder_config` gains a `scalable-softmax` case, which pins the `num_params`
accounting, and `test_tensor_parallel_attention` gains one combining `scalable_softmax` with
head-wise QK-norm.