### PR TITLE
Fix Muon attention grouping and gradient clipping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
 ]
 beaker = ["beaker-py>=2.5.4,<3.0", "beaker-gantry>=3.4.3,<4.0", "GitPython>=3.0,<4.0", "google-cloud-compute"]
 comet = ["comet_ml"]
-dion = ["dion @ git+https://github.com/microsoft/dion.git@7452a5823cf9655b93c3f1d8020b4ebb2535239b ; sys_platform == 'linux'"]
+dion = ["dion @ git+https://github.com/microsoft/dion.git@27318de168a2487c4edc0adf36200556d713d871 ; sys_platform == 'linux'"]
 eval = ["ai2-olmo-eval==0.9.0"]
 fa4 = ["flash-attn-4>=4.0.0b4 ; sys_platform == 'linux'"]
 fla = ["flash-linear-attention==0.5.2"]

--- a/src/olmo_core/optim/muon.py
+++ b/src/olmo_core/optim/muon.py
@@ -125,6 +125,9 @@ class MuonConfig(MatrixAwareOptimConfig):
                 add_attention_param(module_name, "w_q.weight", module.n_heads)
                 add_attention_param(module_name, "w_k.weight", module.n_kv_heads)
                 add_attention_param(module_name, "w_v.weight", module.n_kv_heads)
+                add_attention_param(module_name, "w_q_b.weight", module.n_heads)
+                add_attention_param(module_name, "w_k_b.weight", module.n_kv_heads)
+                add_attention_param(module_name, "w_v_b.weight", module.n_kv_heads)
             elif isinstance(module, FusedAttention):
                 add_attention_param(module_name, "w_qkv.weight", 3 * module.n_heads)
 

--- a/src/olmo_core/optim/muon.py
+++ b/src/olmo_core/optim/muon.py
@@ -14,6 +14,7 @@ from olmo_core.distributed.parallel import (
     get_dp_shard_mesh,
     get_world_mesh,
 )
+from olmo_core.nn.attention import Attention, FusedAttention
 from olmo_core.nn.transformer import Transformer
 
 from .config import MatrixAwareOptimConfig, OptimConfig, OptimGroupOverride
@@ -99,13 +100,42 @@ class MuonConfig(MatrixAwareOptimConfig):
     def default_group_overrides(self, model: torch.nn.Module) -> list[OptimGroupOverride]:
         """
         Split the model parameters into Adam and Muon groups.
-        Only >=2d, internal parameters are meant to be optimized with Muon.
+
+        Only >=2d, internal parameters are meant to be optimized with Muon. Query, key, and
+        value projection matrices are further grouped by their number of attention heads so that
+        Dion applies Newton-Schulz independently to each head.
         """
         assert isinstance(model, Transformer)
         params = self.categorize_parameters(model)
 
-        # Matrix parameters are optimized with Muon.
-        matrix_override = OptimGroupOverride(params=params["matrix"], opts=dict())
+        # Attention projection matrices are optimized independently per head. Dion splits a 2D
+        # parameter evenly along dim 0 according to the group's `num_heads` option. A fused Wqkv
+        # contains Q, K, and V heads consecutively, hence 3 * n_heads splits.
+        attention_params_by_num_heads: dict[int, list[str]] = {}
+        matrix_params = set(params["matrix"])
+
+        def add_attention_param(module_name: str, param_name: str, num_heads: int) -> None:
+            fqn = f"blocks.{module_name}.{param_name}"
+            if num_heads > 1 and fqn in matrix_params:
+                attention_params_by_num_heads.setdefault(num_heads, []).append(fqn)
+                matrix_params.remove(fqn)
+
+        for module_name, module in model.blocks.named_modules():
+            if isinstance(module, Attention):
+                add_attention_param(module_name, "w_q.weight", module.n_heads)
+                add_attention_param(module_name, "w_k.weight", module.n_kv_heads)
+                add_attention_param(module_name, "w_v.weight", module.n_kv_heads)
+            elif isinstance(module, FusedAttention):
+                add_attention_param(module_name, "w_qkv.weight", 3 * module.n_heads)
+
+        # All other matrix parameters are optimized as whole matrices with Muon.
+        matrix_override = OptimGroupOverride(
+            params=[name for name in params["matrix"] if name in matrix_params], opts=dict()
+        )
+        attention_overrides = [
+            OptimGroupOverride(params=head_params, opts=dict(num_heads=num_heads))
+            for num_heads, head_params in attention_params_by_num_heads.items()
+        ]
 
         # Vector, embedding, and lm_head parameters are optimized with AdamW.
         embed_override = OptimGroupOverride(
@@ -116,7 +146,13 @@ class MuonConfig(MatrixAwareOptimConfig):
             params=params["lm_head"], opts=dict(algorithm="adamw")
         )
 
-        return [matrix_override, vector_override, embed_override, lm_head_override]
+        return [
+            matrix_override,
+            *attention_overrides,
+            vector_override,
+            embed_override,
+            lm_head_override,
+        ]
 
     def build_groups(
         self, model: torch.nn.Module, strict: bool = True

--- a/src/olmo_core/train/train_module/transformer/common.py
+++ b/src/olmo_core/train/train_module/transformer/common.py
@@ -1,8 +1,10 @@
 import logging
+from collections.abc import Iterable
 from typing import List, Optional, TypeVar, cast
 
 import torch
 from torch.distributed import DeviceMesh
+from torch.optim import Optimizer
 
 from olmo_core.distributed.parallel import (
     DataParallelType,
@@ -29,6 +31,36 @@ log = logging.getLogger(__name__)
 
 
 M = TypeVar("M", Transformer, List[Transformer])
+
+_MUON_ALGORITHMS = frozenset({"muon", "normuon"})
+
+
+def get_parameters_for_gradient_clipping(
+    optimizers: Iterable[Optimizer],
+) -> tuple[list[torch.Tensor], bool]:
+    """
+    Get the parameters that should participate in gradient clipping.
+
+    Muon and NorMuon orthogonalize their matrix updates and should not have their gradients
+    clipped. When either algorithm is present, only parameters in AdamW groups are returned.
+    Otherwise all optimizer parameters are returned.
+
+    :returns: The parameters to clip and whether they were restricted to AdamW groups.
+    """
+    param_groups = [group for optim in optimizers for group in optim.param_groups]
+    adamw_only = any(group.get("algorithm") in _MUON_ALGORITHMS for group in param_groups)
+    if adamw_only:
+        return (
+            [
+                param
+                for group in param_groups
+                if group.get("algorithm") == "adamw"
+                for param in group["params"]
+            ],
+            True,
+        )
+    else:
+        return [param for group in param_groups for param in group["params"]], False
 
 
 def parallelize_model(

--- a/src/olmo_core/train/train_module/transformer/config.py
+++ b/src/olmo_core/train/train_module/transformer/config.py
@@ -310,6 +310,10 @@ class TransformerTrainModuleConfig(TrainModuleConfig):
 
     optim: OptimConfig
     max_grad_norm: Optional[float] = None
+    """
+    Clip gradient norms to this value. With Muon or NorMuon, only the AdamW parameter groups are
+    clipped.
+    """
     scheduler: Optional[Scheduler] = None
 
     # Model settings.

--- a/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
@@ -51,7 +51,7 @@ from olmo_core.utils import (
 
 from ...common import MetricMergeStrategy, ReduceType
 from ..train_module import EvalBatchSizeUnit, EvalBatchSpec, TrainModule
-from .common import parallelize_model
+from .common import get_parameters_for_gradient_clipping, parallelize_model
 from .config import (
     TransformerActivationCheckpointingConfig,
     TransformerContextParallelConfig,
@@ -92,7 +92,8 @@ class TransformerPipelineTrainModule(TrainModule):
     :param ac_config: Activation checkpointing configuration for the model.
     :param z_loss_multiplier: Use Z-loss with this multiplier.
     :param autocast_precision: Enable AMP with this data type.
-    :param max_grad_norm: Clip gradient norms to this value.
+    :param max_grad_norm: Clip gradient norms to this value. With Muon or NorMuon, only the
+        AdamW parameter groups are clipped.
     :param scheduler: Optional learning rate scheduler for the optimizer.
     :param device: The device to train on.
     :param state_dict_save_opts: Can be used to override the state dict options used
@@ -660,7 +661,7 @@ class TransformerPipelineTrainModule(TrainModule):
     ) -> torch.Tensor:
         # Adapted from https://github.com/pytorch/torchtitan/blob/2a4437014e66bcf88a3f0419b816266e6326d539/torchtitan/utils.py#L348
 
-        parameters = [p for m in self.model_parts for p in m.parameters()]
+        parameters, _ = get_parameters_for_gradient_clipping(self.optimizers)
         grads = [p.grad for p in parameters if p.grad is not None]
 
         total_norm = nn.utils.get_total_norm(

--- a/src/olmo_core/train/train_module/transformer/train_module.py
+++ b/src/olmo_core/train/train_module/transformer/train_module.py
@@ -50,7 +50,7 @@ from olmo_core.utils import (
 
 from ...common import ReduceType
 from ..train_module import EvalBatchSpec, TrainModule
-from .common import parallelize_model
+from .common import get_parameters_for_gradient_clipping, parallelize_model
 from .config import (
     TransformerActivationCheckpointingConfig,
     TransformerContextParallelConfig,
@@ -88,7 +88,8 @@ class TransformerTrainModule(TrainModule):
     :param ac_config: Activation checkpointing configuration for the model.
     :param z_loss_multiplier: Use Z-loss with this multiplier.
     :param autocast_precision: Enable AMP with this data type.
-    :param max_grad_norm: Clip gradient norms to this value.
+    :param max_grad_norm: Clip gradient norms to this value. With Muon or NorMuon, only the
+        AdamW parameter groups are clipped.
     :param scheduler: Optional learning rate scheduler for the optimizer.
     :param device: The device to train on.
     :param state_dict_save_opts: Can be used to override the state dict options used
@@ -611,12 +612,13 @@ class TransformerTrainModule(TrainModule):
     def _clip_grad_norm(
         self, max_grad_norm: float, norm_type: float = 2.0, foreach: Optional[bool] = None
     ) -> torch.Tensor:
-        if isinstance(self.model, FSDP):
+        parameters, adamw_only = get_parameters_for_gradient_clipping([self.optim])
+
+        if isinstance(self.model, FSDP) and not adamw_only:
             return self.model.clip_grad_norm_(max_grad_norm)
 
         # Adapted from https://github.com/pytorch/torchtitan/blob/2a4437014e66bcf88a3f0419b816266e6326d539/torchtitan/utils.py#L348
 
-        parameters = [p for p in self.model.parameters()]
         grads = [p.grad for p in parameters if p.grad is not None]
 
         total_norm = nn.utils.get_total_norm(

--- a/src/test/optim/muon_test.py
+++ b/src/test/optim/muon_test.py
@@ -1,11 +1,13 @@
 import pytest
 import torch
+import torch.nn as nn
 
 from olmo_core.distributed.checkpoint import (
     load_model_and_optim_state,
     save_model_and_optim_state,
 )
 from olmo_core.distributed.parallel import DataParallelType, build_world_mesh
+from olmo_core.nn.attention import FusedAttention
 from olmo_core.nn.transformer.config import TransformerConfig
 from olmo_core.nn.transformer.model import Transformer
 from olmo_core.optim.muon import MuonConfig
@@ -24,6 +26,56 @@ def build_transformer_model() -> Transformer:
     return model
 
 
+def _parameter_options(config: MuonConfig, model: Transformer) -> dict[str, dict]:
+    return {
+        param_name: override.opts
+        for override in config.default_group_overrides(model)
+        for param_name in override.params
+    }
+
+
+def test_muon_splits_attention_projections_by_head():
+    model = TransformerConfig.llama_like(
+        d_model=64,
+        vocab_size=128,
+        n_layers=1,
+        n_heads=4,
+        n_kv_heads=2,
+        hidden_size_multiple_of=8,
+    ).build()
+
+    parameter_options = _parameter_options(MuonConfig(), model)
+
+    assert parameter_options["blocks.0.attention.w_q.weight"]["num_heads"] == 4
+    assert parameter_options["blocks.0.attention.w_k.weight"]["num_heads"] == 2
+    assert parameter_options["blocks.0.attention.w_v.weight"]["num_heads"] == 2
+    assert "num_heads" not in parameter_options["blocks.0.attention.w_out.weight"]
+
+
+def test_muon_splits_fused_qkv_projection_by_head():
+    model = TransformerConfig.llama_like(
+        d_model=64,
+        vocab_size=128,
+        n_layers=1,
+        n_heads=4,
+        hidden_size_multiple_of=8,
+    ).build()
+
+    # Construct a FusedAttention module without initializing its optional flash-attention backend;
+    # parameter grouping only needs its projection weights and head count.
+    attention = FusedAttention.__new__(FusedAttention)
+    nn.Module.__init__(attention)
+    attention.n_heads = 4
+    attention.w_qkv = nn.Linear(64, 3 * 64, bias=False)
+    attention.w_out = nn.Linear(64, 64, bias=False)
+    model.blocks["0"].attention = attention
+
+    parameter_options = _parameter_options(MuonConfig(), model)
+
+    assert parameter_options["blocks.0.attention.w_qkv.weight"]["num_heads"] == 12
+    assert "num_heads" not in parameter_options["blocks.0.attention.w_out.weight"]
+
+
 @requires_dion
 def test_muon_config_to_optim():
     from dion import Muon  # type: ignore[reportMissingImports]
@@ -34,7 +86,7 @@ def test_muon_config_to_optim():
     optim = config.build(model)
 
     assert isinstance(optim, Muon)
-    assert len(optim.param_groups) == 4  # emb, matrix, vector, lm_head
+    assert len(optim.param_groups) == 5  # matrix, attention, vector, embedding, lm_head
 
     assert config.merge(["lr=1e-1"]).lr == 0.1
 

--- a/src/test/optim/muon_test.py
+++ b/src/test/optim/muon_test.py
@@ -7,7 +7,7 @@ from olmo_core.distributed.checkpoint import (
     save_model_and_optim_state,
 )
 from olmo_core.distributed.parallel import DataParallelType, build_world_mesh
-from olmo_core.nn.attention import FusedAttention
+from olmo_core.nn.attention import Attention, FusedAttention
 from olmo_core.nn.transformer.config import TransformerConfig
 from olmo_core.nn.transformer.model import Transformer
 from olmo_core.optim.muon import MuonConfig
@@ -73,6 +73,41 @@ def test_muon_splits_fused_qkv_projection_by_head():
     parameter_options = _parameter_options(MuonConfig(), model)
 
     assert parameter_options["blocks.0.attention.w_qkv.weight"]["num_heads"] == 12
+    assert "num_heads" not in parameter_options["blocks.0.attention.w_out.weight"]
+
+
+def test_muon_splits_mla_up_projections_by_head():
+    model = TransformerConfig.llama_like(
+        d_model=64,
+        vocab_size=128,
+        n_layers=1,
+        n_heads=4,
+        hidden_size_multiple_of=8,
+    ).build()
+
+    # Model an external MLA Attention subclass without adding it as an OLMo-core dependency.
+    class _MLAAttention(Attention):
+        pass
+
+    attention = _MLAAttention.__new__(_MLAAttention)
+    nn.Module.__init__(attention)
+    attention.n_heads = 4
+    attention.n_kv_heads = 2
+    attention.w_q_a = nn.Linear(64, 32, bias=False)
+    attention.w_q_b = nn.Linear(32, 4 * 24, bias=False)
+    attention.w_kv_a = nn.Linear(64, 16 + 8, bias=False)
+    attention.w_k_b = nn.Linear(16, 2 * 16, bias=False)
+    attention.w_v_b = nn.Linear(16, 2 * 16, bias=False)
+    attention.w_out = nn.Linear(4 * 16, 64, bias=False)
+    model.blocks["0"].attention = attention
+
+    parameter_options = _parameter_options(MuonConfig(), model)
+
+    assert parameter_options["blocks.0.attention.w_q_b.weight"]["num_heads"] == 4
+    assert parameter_options["blocks.0.attention.w_k_b.weight"]["num_heads"] == 2
+    assert parameter_options["blocks.0.attention.w_v_b.weight"]["num_heads"] == 2
+    assert "num_heads" not in parameter_options["blocks.0.attention.w_q_a.weight"]
+    assert "num_heads" not in parameter_options["blocks.0.attention.w_kv_a.weight"]
     assert "num_heads" not in parameter_options["blocks.0.attention.w_out.weight"]
 
 

--- a/src/test/train/train_module/transformer/train_module_test.py
+++ b/src/test/train/train_module/transformer/train_module_test.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from olmo_core.train.train_module.train_module import TrainModule
+from olmo_core.train.train_module.transformer.train_module import TransformerTrainModule
+
+
+def _build_train_module_with_grads(
+    param_groups: list[dict],
+) -> tuple[TransformerTrainModule, nn.Parameter, nn.Parameter]:
+    model = nn.Module()
+    model.adamw_param = nn.Parameter(torch.zeros(1))
+    model.muon_param = nn.Parameter(torch.zeros(1))
+    model.adamw_param.grad = torch.tensor([3.0])
+    model.muon_param.grad = torch.tensor([4.0])
+
+    train_module = TransformerTrainModule.__new__(TransformerTrainModule)
+    TrainModule.__init__(train_module)
+    train_module.model = model  # type: ignore[assignment]
+    train_module.optim = SimpleNamespace(param_groups=param_groups)  # type: ignore[assignment]
+    return train_module, model.adamw_param, model.muon_param
+
+
+def test_muon_gradient_clipping_only_clips_adamw_parameters():
+    train_module, adamw_param, muon_param = _build_train_module_with_grads([])
+    train_module.optim.param_groups = [
+        {"params": [adamw_param], "algorithm": "adamw"},
+        {"params": [muon_param], "algorithm": "muon"},
+    ]
+
+    total_norm = train_module._clip_grad_norm(1.0)
+
+    torch.testing.assert_close(total_norm, torch.tensor(3.0))
+    torch.testing.assert_close(adamw_param.grad, torch.tensor([1.0]))
+    torch.testing.assert_close(muon_param.grad, torch.tensor([4.0]))
+
+
+def test_gradient_clipping_still_clips_all_parameters_for_standard_optimizers():
+    train_module, adamw_param, other_param = _build_train_module_with_grads([])
+    train_module.optim.param_groups = [{"params": [adamw_param, other_param]}]
+
+    total_norm = train_module._clip_grad_norm(1.0)
+
+    torch.testing.assert_close(total_norm, torch.tensor(5.0))
+    torch.testing.assert_close(adamw_param.grad, torch.tensor([0.6]))
+    torch.testing.assert_close(other_param.grad, torch.tensor([0.8]))


### PR DESCRIPTION
## Summary

- Run Muon's Newton-Schulz step independently per attention head, including fused QKV and MLA-style up-projections.
- Restrict gradient clipping to AdamW parameter groups when Muon or NorMuon is active.
- Update Dion to a revision with per-head parameter-group support.

## Rationale

- [Dion documents per-head Newton-Schulz for attention projections](https://github.com/microsoft/dion/blob/27318de168a2487c4edc0adf36200556d713d871/README.md?plain=1#L248-L265).
- [The reference Muon setup separates hidden matrix weights from AdamW-managed parameters](https://github.com/KellerJordan/Muon/blob/f98f1cacc0263b04290753e32be8d498c1efc806/README.md#L9-L33); clipping follows the same optimizer-group boundary here.

## Tests

`pytest -q src/test/optim/muon_test.py src/test/train/train_module/transformer/train_module_test.py` (`5 passed, 7 skipped`)