### PR TITLE
Support EMO document routing under pipeline parallelism

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,18 @@ on:
       # Temporary: run CI for the incremental MoE PRs landing into this integration branch.
       # Remove before merging akshitab/moe-v2-core into main.
       - akshitab/moe-v2-core
+      # Temporary: run CI for the PRs landing into this integration branch.
+      # Remove before merging akshitab/global-lb-emo-router into main.
+      - akshitab/global-lb-emo-router
   push:
     branches:
       - main
       # Temporary: keep the MoE integration branch continuously tested as PRs merge in.
       # Remove before merging akshitab/moe-v2-core into main.
       - akshitab/moe-v2-core
+      # Temporary: keep this integration branch continuously tested as PRs merge in.
+      # Remove before merging akshitab/global-lb-emo-router into main.
+      - akshitab/global-lb-emo-router
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,8 +322,8 @@ jobs:
             --env 'GOOGLE_APPLICATION_CREDENTIALS=/.google/credentials.json' \
             --env 'TOKENIZERS_PARALLELISM=false' \
             --env 'CUBLAS_WORKSPACE_CONFIG=:16:8' \
-            --env-secret 'AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID' \
-            --env-secret 'AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY' \
+            --env-secret 'AWS_ACCESS_KEY_ID=olmocore_AWS_ACCESS_KEY_ID' \
+            --env-secret 'AWS_SECRET_ACCESS_KEY=olmocore_AWS_SECRET_ACCESS_KEY' \
             -- ${{ matrix.task.run }}
 
   release:

--- a/src/olmo_core/distributed/parallel/pipeline_parallel.py
+++ b/src/olmo_core/distributed/parallel/pipeline_parallel.py
@@ -902,6 +902,17 @@ class PipelineSchedule:
             old_num_microbatches = self.schedule_impl._n_microbatches
             self.schedule_impl.reset_n_microbatches(num_microbatches)
 
+        # NOTE: checked here, after the active microbatch count has been selected above, so that
+        # training, evaluation, and reduced dry runs are all validated against the count they
+        # actually run with. Stages size their P2P buffers from a single floor-divided microbatch
+        # shape, so uneven microbatches would leave receivers with undersized buffers.
+        active_num_microbatches = self.schedule_impl._n_microbatches
+        if active_num_microbatches > 0 and input_ids.size(0) % active_num_microbatches != 0:
+            raise RuntimeError(
+                f"Pipeline batch size {input_ids.size(0)} must be divisible by the active number "
+                f"of microbatches ({active_num_microbatches}); uneven microbatches are not supported"
+            )
+
         self.schedule_impl.prepare_step(
             global_batch_size=input_ids.size(0),
             seqlen=input_ids.size(1),

--- a/src/olmo_core/nn/hf/config.py
+++ b/src/olmo_core/nn/hf/config.py
@@ -380,7 +380,9 @@ def _get_olmo3moe_kda_emo_config(model: "OLMoDDPModel") -> PretrainedConfig:
     latent_moe_dim = latent_down_proj.out_features if latent_down_proj is not None else None
     latent_moe_bias = latent_down_proj is not None and latent_down_proj.bias is not None
     if latent_up_proj is not None and (latent_up_proj.bias is not None) != latent_moe_bias:
-        raise NotImplementedError("LatentMoE down and up projections must use the same bias setting.")
+        raise NotImplementedError(
+            "LatentMoE down and up projections must use the same bias setting."
+        )
     latent_moe_up_proj_input_norm = representative.latent_up_proj_input_norm is not None
     emo = getattr(router, "emo", None)
     sparse_signature = None

--- a/src/olmo_core/nn/hf/convert_checkpoint.py
+++ b/src/olmo_core/nn/hf/convert_checkpoint.py
@@ -48,7 +48,7 @@ log = logging.getLogger(__name__)
 
 
 def _load_ddp_optimizer_model_state(
-    checkpoint_dir: str | Path,
+    checkpoint_dir: PathOrStr,
     model: Transformer,
     *,
     work_dir: str | Path,

--- a/src/olmo_core/nn/moe/v2/hf/modeling_olmo3moe.py
+++ b/src/olmo_core/nn/moe/v2/hf/modeling_olmo3moe.py
@@ -1,6 +1,6 @@
+import os
 from collections.abc import Callable
 from inspect import signature
-import os
 from typing import Optional, Union, cast
 
 import torch

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -264,6 +264,17 @@ class Transformer(nn.Module):
             )
         return eos_token_ids.pop()
 
+    def invalidate_block_topology_caches(self) -> None:
+        """
+        Drop the cached properties derived from the block list.
+
+        Must be called after blocks are added or removed, such as when splitting a model into
+        pipeline stages. Deliberately leaves the parameter-count caches alone: those are populated
+        up-front precisely so they survive having their parameters removed.
+        """
+        self.__dict__.pop("emo_block_indices", None)
+        self.__dict__.pop("emo_eos_token_id", None)
+
     @property
     def device(self) -> torch.device:
         if self._device is None:

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -230,6 +230,40 @@ class Transformer(nn.Module):
     def is_moe(self) -> bool:
         return False
 
+    @cached_property
+    def emo_block_indices(self) -> List[int]:
+        """
+        The indices of the blocks in this model whose routed-expert router routes by document and
+        therefore requires per-token segment IDs.
+        """
+        return [
+            int(block_idx)
+            for block_idx, block in self.blocks.items()
+            if getattr(getattr(block, "routed_experts_router", None), "requires_segment_ids", False)
+        ]
+
+    @cached_property
+    def emo_eos_token_id(self) -> Optional[int]:
+        """
+        The EOS token ID that document segment IDs are derived from, or ``None`` if this model has
+        no document-routed blocks.
+
+        :raises OLMoConfigurationError: If the document-routed blocks disagree on the EOS token ID.
+        """
+        eos_token_ids = {
+            router.eos_token_id
+            for block in self.blocks.values()
+            if (router := getattr(block, "routed_experts_router", None)) is not None
+            and getattr(router, "requires_segment_ids", False)
+        }
+        if not eos_token_ids:
+            return None
+        if len(eos_token_ids) != 1:
+            raise OLMoConfigurationError(
+                "All EMO routers in a model must use the same eos_token_id"
+            )
+        return eos_token_ids.pop()
+
     @property
     def device(self) -> torch.device:
         if self._device is None:
@@ -616,29 +650,30 @@ class Transformer(nn.Module):
             if cache_leftpad is not None:
                 all_block_kwargs["cache_leftpad"] = move_to_device(cache_leftpad, self.device)
 
-        emo_blocks = []
-        emo_eos_token_ids = set()
-        for block_idx, block in self.blocks.items():
-            router = getattr(block, "routed_experts_router", None)
-            if router is not None and getattr(router, "requires_segment_ids", False):
-                emo_blocks.append(int(block_idx))
-                emo_eos_token_ids.add(router.eos_token_id)
-        if emo_blocks:
-            if self._pp_enabled:
-                raise OLMoConfigurationError(
-                    "EMO routing does not currently support pipeline parallelism because "
-                    "token-derived segment IDs are not carried between pipeline stages"
-                )
+        segment_ids: Optional[torch.Tensor] = kwargs.pop("segment_ids", None)
+        if emo_block_indices := self.emo_block_indices:
             if self._cp_load_balancer is not None:
                 raise OLMoConfigurationError(
                     "EMO routing does not currently support context parallelism"
                 )
-            if len(emo_eos_token_ids) != 1:
-                raise OLMoConfigurationError(
-                    "All EMO routers in a model must use the same eos_token_id"
-                )
-            segment_ids = moe_ops.segment_ids_from_eos(input_ids, emo_eos_token_ids.pop())
-            for block_idx in emo_blocks:
+            if segment_ids is None:
+                # Only the first pipeline stage receives token IDs; later stages get hidden states,
+                # so under PP the caller derives the segment IDs once and passes them to every stage.
+                if self._pp_enabled:
+                    raise OLMoConfigurationError(
+                        "EMO routing with pipeline parallelism requires 'segment_ids' to be passed "
+                        "in, because only the first stage receives token IDs"
+                    )
+                assert self.emo_eos_token_id is not None
+                segment_ids = moe_ops.segment_ids_from_eos(input_ids, self.emo_eos_token_id)
+            else:
+                segment_ids = move_to_device(segment_ids, self.device)
+                if segment_ids.shape != (B, S):
+                    raise ValueError(
+                        f"'segment_ids' shape {tuple(segment_ids.shape)} must match the input "
+                        f"batch and sequence dimensions {(B, S)}"
+                    )
+            for block_idx in emo_block_indices:
                 per_block_kwargs[block_idx]["segment_ids"] = segment_ids
 
         if "cu_doc_lens" in all_block_kwargs:
@@ -770,13 +805,6 @@ class Transformer(nn.Module):
         """
         Prepare the model for pipeline parallelism after it's been split into stages.
         """
-        for block in self.blocks.values():
-            router = getattr(block, "routed_experts_router", None)
-            if router is not None and getattr(router, "requires_segment_ids", False):
-                raise OLMoConfigurationError(
-                    "EMO routing does not currently support pipeline parallelism because "
-                    "token-derived segment IDs are not carried between pipeline stages"
-                )
         for block in self.blocks.values():
             block = cast(TransformerBlockBase, block)
             block.apply_pp(pp_mesh)
@@ -910,14 +938,7 @@ class Transformer(nn.Module):
         # EMO samples a routed-expert pool size for each document. Recompute must replay those
         # samples so it routes through the same experts as the original checkpointed forward.
         # TODO: also preserve RNG state if dropout is active.
-        preserve_rng_state = any(
-            getattr(
-                getattr(block, "routed_experts_router", None),
-                "requires_segment_ids",
-                False,
-            )
-            for block in self.blocks.values()
-        )
+        preserve_rng_state = bool(self.emo_block_indices)
 
         if mode == TransformerActivationCheckpointingMode.selected_modules:
             from fnmatch import fnmatch

--- a/src/olmo_core/train/train_module/transformer/common.py
+++ b/src/olmo_core/train/train_module/transformer/common.py
@@ -1,7 +1,8 @@
 import logging
-from typing import List, Optional, TypeVar, cast
+from typing import Iterable, List, Optional, TypeVar, cast
 
 import torch
+import torch.nn as nn
 from torch.distributed import DeviceMesh
 
 from olmo_core.distributed.parallel import (
@@ -16,6 +17,7 @@ from olmo_core.distributed.parallel import (
 from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.float8 import Float8Config
 from olmo_core.nn.transformer import MoETransformer, Transformer
+from olmo_core.ops.moe import segment_ids_from_eos
 
 from .config import (
     TransformerActivationCheckpointingConfig,
@@ -29,6 +31,36 @@ log = logging.getLogger(__name__)
 
 
 M = TypeVar("M", Transformer, List[Transformer])
+
+
+def get_emo_segment_ids(
+    model_parts: Iterable[nn.Module], input_ids: torch.Tensor
+) -> Optional[torch.Tensor]:
+    """
+    Derive the per-token document segment IDs needed by document-routed (EMo) blocks.
+
+    Only the first pipeline stage receives token IDs, so under pipeline parallelism the segment IDs
+    must be derived from the full batch here and passed to every stage as a side input.
+
+    :param model_parts: The local model parts, which may be wrapped for distributed training.
+    :param input_ids: The full-batch token IDs, shape ``(batch_size, seq_len)``.
+
+    :returns: The segment IDs, shape ``(batch_size, seq_len)``, or ``None`` if none of the local
+        blocks route by document.
+
+    :raises OLMoConfigurationError: If the local model parts disagree on the EOS token ID. Each part
+        validates its own blocks, so this covers the disagreements that survive a pipeline split.
+    """
+    eos_token_ids = {
+        eos_token_id
+        for model in model_parts
+        if (eos_token_id := getattr(model, "emo_eos_token_id", None)) is not None
+    }
+    if not eos_token_ids:
+        return None
+    if len(eos_token_ids) != 1:
+        raise OLMoConfigurationError("All EMO routers in a model must use the same eos_token_id")
+    return segment_ids_from_eos(input_ids, eos_token_ids.pop())
 
 
 def parallelize_model(

--- a/src/olmo_core/train/train_module/transformer/config.py
+++ b/src/olmo_core/train/train_module/transformer/config.py
@@ -178,6 +178,10 @@ class TransformerPipelineParallelConfig(PipelineParallelConfig):
             if not is_last:
                 model_chunk.lm_head = None  # type: ignore
 
+            # The deepcopy above carries over any block-derived caches the full model had already
+            # populated, which would leave this chunk describing the unsplit block list.
+            model_chunk.invalidate_block_topology_caches()
+
             if self.use_custom_stage_implementation:
                 # Custom stage implementation re-uses receive buffers across micro-batches.
                 stage = CustomPipelineStage(

--- a/src/olmo_core/train/train_module/transformer/config.py
+++ b/src/olmo_core/train/train_module/transformer/config.py
@@ -151,6 +151,11 @@ class TransformerPipelineParallelConfig(PipelineParallelConfig):
                 "share a weight."
             )
 
+        # Validate the document-routing EOS token while the whole block list is still visible.
+        # Afterwards each stage only sees its own blocks, so blocks that disagree would each derive
+        # their own segment IDs and routing would silently depend on where the split landed.
+        model.emo_eos_token_id
+
         pp_rank = pp_mesh.get_local_rank()
 
         def build_stage(

--- a/src/olmo_core/train/train_module/transformer/ddp_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/ddp_train_module.py
@@ -89,6 +89,7 @@ from .config import (
     TransformerPipelineParallelConfig,
     TransformerTensorParallelConfig,
 )
+from .pipeline.pipeline_schedule import SUPPORTED_MODEL_KWARGS
 
 log = logging.getLogger(__name__)
 
@@ -966,8 +967,8 @@ class OLMoDDPTrainModule(TrainModule):
         if callable(clear_step_info):
             clear_step_info()
 
+    @staticmethod
     def _split_pp_dry_run_model_kwargs(
-        self,
         kwargs: Dict[str, Any],
         *,
         original_batch_size: int,
@@ -981,6 +982,12 @@ class OLMoDDPTrainModule(TrainModule):
                     start = mb_idx * micro_batch_size
                     end = start + micro_batch_size
                     kwargs_mbs[mb_idx][key] = value[start:end].contiguous()
+            elif isinstance(value, (list, tuple)) and len(value) == original_batch_size:
+                # Per-instance metadata such as 'max_doc_lens' is a Python list, so it has to be
+                # sliced on the same boundaries rather than handed whole to every microbatch.
+                for mb_idx in range(num_microbatches):
+                    start = mb_idx * micro_batch_size
+                    kwargs_mbs[mb_idx][key] = value[start : start + micro_batch_size]
             else:
                 for kwargs_mb in kwargs_mbs:
                     kwargs_mb[key] = value
@@ -1012,8 +1019,7 @@ class OLMoDDPTrainModule(TrainModule):
                 "Cannot run independent PP dry-run with empty pipeline microbatches"
             )
 
-        supported_model_kwargs = {"cp_already_sharded", "cp_original_seq_len"}
-        unexpected_model_kwargs = set(kwargs) - supported_model_kwargs
+        unexpected_model_kwargs = set(kwargs) - SUPPORTED_MODEL_KWARGS
         if unexpected_model_kwargs:
             raise OLMoConfigurationError(
                 "Independent PP dry-run only supports the same model kwargs as the PP "

--- a/src/olmo_core/train/train_module/transformer/ddp_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/ddp_train_module.py
@@ -80,6 +80,7 @@ from olmo_core.utils import get_default_device, log_once, move_to_device
 
 from ...common import MetricMergeStrategy, ReduceType
 from ..train_module import EvalBatchSpec, TrainModule
+from .common import get_emo_segment_ids
 from .config import (
     TransformerActivationCheckpointingConfig,
     TransformerContextParallelConfig,
@@ -871,6 +872,28 @@ class OLMoDDPTrainModule(TrainModule):
         return int(
             getattr(schedule_impl, "_n_microbatches", self._train_pp_schedule.num_microbatches)
         )
+
+    @staticmethod
+    def _pad_pp_batch_dim(value: Any, multiple: int) -> Any:
+        """
+        Pad a batch-leading value up to a multiple of ``multiple`` by repeating its last instance.
+
+        Handles the Python lists used for per-instance metadata such as ``max_doc_lens`` as well as
+        tensors, so that all batch-leading inputs stay the same length after padding.
+        """
+        if isinstance(value, torch.Tensor):
+            if value.size(0) % multiple == 0:
+                return value
+            pad_size = multiple - (value.size(0) % multiple)
+            padding = value[-1].unsqueeze(0).expand(pad_size, *value.size()[1:])
+            return torch.cat([value, padding], dim=0).contiguous()
+        if isinstance(value, (list, tuple)):
+            if len(value) % multiple == 0:
+                return value
+            pad_size = multiple - (len(value) % multiple)
+            padded = list(value) + [value[-1]] * pad_size
+            return tuple(padded) if isinstance(value, tuple) else padded
+        return value
 
     @staticmethod
     def _slice_pp_batch_dim(value: Any, original_batch_size: int, batch_size: int) -> Any:
@@ -1942,25 +1965,18 @@ class OLMoDDPTrainModule(TrainModule):
         **kwargs,
     ) -> List[List[Optional[LMOutputWithLoss]]]:
         # the micro-batch size should be a multiple of pp degree
-        def pad_dim_0_to_multiple_of(tensor: torch.Tensor, multiple: int) -> torch.Tensor:
-            bsz = tensor.size(0)
-            if bsz % multiple == 0:
-                return tensor
-            pad_size = multiple - (bsz % multiple)
-            padding_tensor = (
-                tensor[-1].unsqueeze(0).expand(pad_size, *tensor.size()[1:])
-            )  # repeat last element
-            padded_tensor = torch.cat([tensor, padding_tensor], dim=0).contiguous()
-            return padded_tensor
-
+        multiple = self.train_pp_schedule.pp_mesh.size()
         original_batch_size = input_ids.size(0)
-        padded_input_ids = pad_dim_0_to_multiple_of(
-            input_ids, self.train_pp_schedule.pp_mesh.size()
-        )
-        padded_labels = pad_dim_0_to_multiple_of(labels, self.train_pp_schedule.pp_mesh.size())
+        padded_input_ids = self._pad_pp_batch_dim(input_ids, multiple)
+        padded_labels = self._pad_pp_batch_dim(labels, multiple)
         for k, v in kwargs.items():
-            if isinstance(v, torch.Tensor) and v.size(0) == original_batch_size:
-                kwargs[k] = pad_dim_0_to_multiple_of(v, self.train_pp_schedule.pp_mesh.size())
+            length = (
+                v.size(0)
+                if isinstance(v, torch.Tensor)
+                else (len(v) if isinstance(v, (list, tuple)) else None)
+            )
+            if length == original_batch_size:
+                kwargs[k] = self._pad_pp_batch_dim(v, multiple)
 
         with self._model_forward_context():
             schedule_outputs = self.train_pp_schedule.step(
@@ -2464,6 +2480,8 @@ class OLMoDDPTrainModule(TrainModule):
                 log_once(log, "intra-document masking enabled")
                 kwargs["doc_lens"] = batch["doc_lens"]
                 kwargs["max_doc_lens"] = batch["max_doc_lens"]
+            if (segment_ids := get_emo_segment_ids(self.model_parts, input_ids)) is not None:
+                kwargs["segment_ids"] = segment_ids
             return input_ids, labels, kwargs
         else:
             input_ids = batch.pop("input_ids")

--- a/src/olmo_core/train/train_module/transformer/pipeline/pipeline_schedule.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline/pipeline_schedule.py
@@ -377,20 +377,66 @@ class CustomScheduleInterleaved1F1B:
             if len(args) > 1:
                 raise ValueError(f"Expected zero or one positional tensor arg, got {len(args)}")
 
+            # Kwargs carrying one entry per instance, which are split alongside 'input_ids'.
+            batch_leading_keys = ("labels", "segment_ids", "doc_lens", "max_doc_lens")
+
             input_ids: Optional[torch.Tensor] = None
-            args_split: List[Tuple[Any, ...]]
             if len(args) == 1:
                 input_ids = args[0]
                 if not isinstance(input_ids, torch.Tensor) or input_ids.dim() == 0:
                     raise TypeError(
                         "args must be empty or a tuple containing one non-scalar tensor"
                     )
-                if input_ids.size(0) < self._n_microbatches:
+
+            # Every batch-leading value is split on the same equal boundaries so that each stage's
+            # side inputs stay aligned with the activations it receives. Ranks that don't own the
+            # first stage have empty positional args, so the batch size may have to come from any
+            # one of the batch-leading kwargs instead.
+            batch_size: Optional[int] = None
+            if input_ids is not None:
+                batch_size = input_ids.size(0)
+            else:
+                for key in batch_leading_keys:
+                    value = (kwargs or {}).get(key)
+                    if isinstance(value, torch.Tensor):
+                        batch_size = value.size(0)
+                        break
+                    if isinstance(value, (list, tuple)):
+                        batch_size = len(value)
+                        break
+
+            bounds: Optional[List[Tuple[int, int]]] = None
+            if batch_size is not None:
+                if batch_size < self._n_microbatches:
                     raise ValueError(
-                        f"input batch size {input_ids.size(0)} is smaller than num_microbatches={self._n_microbatches}"
+                        f"input batch size {batch_size} is smaller than num_microbatches={self._n_microbatches}"
                     )
-                input_id_chunks = list(torch.tensor_split(input_ids, self._n_microbatches, dim=0))
-                args_split = [(chunk,) for chunk in input_id_chunks]
+                # Uneven microbatches are unsupported: stages size their P2P buffers from a single
+                # floor-divided microbatch shape, so larger leading chunks would overrun them.
+                if batch_size % self._n_microbatches != 0:
+                    raise ValueError(
+                        f"input batch size {batch_size} is not divisible by "
+                        f"num_microbatches={self._n_microbatches}"
+                    )
+                micro_batch_size = batch_size // self._n_microbatches
+                bounds = [
+                    (i * micro_batch_size, (i + 1) * micro_batch_size)
+                    for i in range(self._n_microbatches)
+                ]
+
+            def split_batch_dim(key: str, value: Any) -> List[Any]:
+                if bounds is None:
+                    raise ValueError(f"cannot split {key!r} without knowing the batch size")
+                length = value.size(0) if isinstance(value, torch.Tensor) else len(value)
+                if length != batch_size:
+                    raise ValueError(
+                        f"{key!r} batch size {length} does not match input batch size {batch_size}"
+                    )
+                return [value[start:stop] for start, stop in bounds]
+
+            args_split: List[Tuple[Any, ...]]
+            if input_ids is not None:
+                args_split = [(chunk,) for chunk in split_batch_dim("input_ids", input_ids)]
             else:
                 args_split = [()] * self._n_microbatches
             kwargs_split: List[Dict[str, Any]] = [{} for _ in range(self._n_microbatches)]
@@ -398,6 +444,9 @@ class CustomScheduleInterleaved1F1B:
             supported_keys = {
                 "loss_div_factor",
                 "labels",
+                "segment_ids",
+                "doc_lens",
+                "max_doc_lens",
                 "ignore_index",
                 "loss_reduction",
                 "z_loss_multiplier",
@@ -412,19 +461,17 @@ class CustomScheduleInterleaved1F1B:
                 )
 
             for key, value in kwargs.items():
-                if key == "labels":
+                if key in batch_leading_keys and key != "max_doc_lens":
                     if not isinstance(value, torch.Tensor) or value.dim() == 0:
-                        raise TypeError("'labels' must be a non-scalar tensor")
-                    if value.size(0) < self._n_microbatches:
-                        raise ValueError(
-                            f"'labels' batch size {value.size(0)} is smaller than num_microbatches={self._n_microbatches}"
-                        )
-                    if input_ids is not None and value.size(0) != input_ids.size(0):
-                        raise ValueError(
-                            f"'labels' batch size {value.size(0)} does not match input batch size {input_ids.size(0)}"
-                        )
-                    value_chunks = list(torch.tensor_split(value, self._n_microbatches, dim=0))
-                    for i, chunk in enumerate(value_chunks):
+                        raise TypeError(f"{key!r} must be a non-scalar tensor")
+                    for i, chunk in enumerate(split_batch_dim(key, value)):
+                        kwargs_split[i][key] = chunk
+                elif key == "max_doc_lens":
+                    # A per-instance Python list, so it's sliced on the same boundaries rather than
+                    # passed through the tensor branch.
+                    if not isinstance(value, (list, tuple)):
+                        raise TypeError("'max_doc_lens' must be a list or tuple")
+                    for i, chunk in enumerate(split_batch_dim(key, value)):
                         kwargs_split[i][key] = chunk
                 elif key == "loss_div_factor":
                     if isinstance(value, torch.Tensor):

--- a/src/olmo_core/train/train_module/transformer/pipeline/pipeline_schedule.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline/pipeline_schedule.py
@@ -30,6 +30,27 @@ from .pipeline_stage import CustomPipelineStage
 logger = logging.getLogger(__name__)
 
 
+BATCH_LEADING_MODEL_KWARGS = ("labels", "segment_ids", "doc_lens", "max_doc_lens")
+"""Model kwargs carrying one entry per instance, split alongside ``input_ids`` into microbatches."""
+
+SUPPORTED_MODEL_KWARGS = frozenset(BATCH_LEADING_MODEL_KWARGS) | {
+    "loss_div_factor",
+    "ignore_index",
+    "loss_reduction",
+    "z_loss_multiplier",
+    "return_logits",
+    "cp_already_sharded",
+    "cp_original_seq_len",
+}
+"""
+Every model kwarg the pipeline schedule knows how to split into microbatches.
+
+Anything that splits a batch for the pipeline outside of
+:meth:`CustomScheduleInterleaved1F1B._split_inputs` -- such as the independent PP dry run -- must
+accept the same set, or configurations that train fine will fail there instead.
+"""
+
+
 # Helper to parse an action string like 1F0 into a tuple of (stage_index, computation_type, microbatch_index)
 _action_regex = re.compile(r"(\d+)(F|I|B|W|SEND_F|RECV_F|SEND_B|RECV_B)(\d*)")
 
@@ -377,8 +398,7 @@ class CustomScheduleInterleaved1F1B:
             if len(args) > 1:
                 raise ValueError(f"Expected zero or one positional tensor arg, got {len(args)}")
 
-            # Kwargs carrying one entry per instance, which are split alongside 'input_ids'.
-            batch_leading_keys = ("labels", "segment_ids", "doc_lens", "max_doc_lens")
+            batch_leading_keys = BATCH_LEADING_MODEL_KWARGS
 
             input_ids: Optional[torch.Tensor] = None
             if len(args) == 1:
@@ -441,20 +461,7 @@ class CustomScheduleInterleaved1F1B:
                 args_split = [()] * self._n_microbatches
             kwargs_split: List[Dict[str, Any]] = [{} for _ in range(self._n_microbatches)]
 
-            supported_keys = {
-                "loss_div_factor",
-                "labels",
-                "segment_ids",
-                "doc_lens",
-                "max_doc_lens",
-                "ignore_index",
-                "loss_reduction",
-                "z_loss_multiplier",
-                "return_logits",
-                "cp_already_sharded",
-                "cp_original_seq_len",
-            }
-            unexpected_keys = set(kwargs) - supported_keys
+            unexpected_keys = set(kwargs) - SUPPORTED_MODEL_KWARGS
             if unexpected_keys:
                 raise ValueError(
                     f"Unsupported kwargs for pipeline splitting: {sorted(unexpected_keys)}"

--- a/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/pipeline_train_module.py
@@ -51,7 +51,7 @@ from olmo_core.utils import (
 
 from ...common import MetricMergeStrategy, ReduceType
 from ..train_module import EvalBatchSizeUnit, EvalBatchSpec, TrainModule
-from .common import parallelize_model
+from .common import get_emo_segment_ids, parallelize_model
 from .config import (
     TransformerActivationCheckpointingConfig,
     TransformerContextParallelConfig,
@@ -769,4 +769,6 @@ class TransformerPipelineTrainModule(TrainModule):
             log_once(log, "intra-document masking enabled")
             kwargs["doc_lens"] = batch["doc_lens"]
             kwargs["max_doc_lens"] = batch["max_doc_lens"]
+        if (segment_ids := get_emo_segment_ids(self.model_parts, input_ids)) is not None:
+            kwargs["segment_ids"] = segment_ids
         return input_ids, labels, kwargs

--- a/src/test/examples/huggingface/convert_checkpoint_to_hf_test.py
+++ b/src/test/examples/huggingface/convert_checkpoint_to_hf_test.py
@@ -20,8 +20,8 @@ from olmo_core.distributed.checkpoint import (
     save_model_and_optim_state,
 )
 from olmo_core.nn.attention import AttentionBackendName, AttentionConfig
-from olmo_core.nn.hf import convert_checkpoint_to_hf
 from olmo_core.nn.hf import convert_checkpoint as convert_checkpoint_module
+from olmo_core.nn.hf import convert_checkpoint_to_hf
 from olmo_core.nn.transformer.config import TransformerBlockConfig, TransformerConfig
 from olmo_core.nn.transformer.model import Transformer
 

--- a/src/test/launch/beaker_test.py
+++ b/src/test/launch/beaker_test.py
@@ -2,7 +2,11 @@ import os
 
 import pytest
 
-from olmo_core.launch.beaker import BeakerLaunchConfig, OLMoCoreBeakerImage, get_beaker_client
+from olmo_core.launch.beaker import (
+    BeakerLaunchConfig,
+    OLMoCoreBeakerImage,
+    get_beaker_client,
+)
 
 
 def test_launch_config_accepts_min_runtime():

--- a/src/test/nn/moe/v2/emo_pp_parity_test.py
+++ b/src/test/nn/moe/v2/emo_pp_parity_test.py
@@ -17,6 +17,7 @@ import torch
 from olmo_core.config import DType
 from olmo_core.nn.attention import AttentionConfig, AttentionType
 from olmo_core.nn.ddp.block import OLMoDDPTransformerBlockConfig
+from olmo_core.nn.ddp.model import OLMoDDPModel
 from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
 from olmo_core.nn.lm_head import LMHeadConfig
 from olmo_core.nn.moe.emo import EmoRouterConfig
@@ -27,7 +28,6 @@ from olmo_core.nn.transformer import (
     TransformerBlockType,
     TransformerType,
 )
-from olmo_core.nn.transformer.model import Transformer
 from olmo_core.ops.moe import segment_ids_from_eos
 from olmo_core.testing import requires_gpu
 
@@ -78,11 +78,16 @@ def _emo_model_config(d_model: int = 64) -> OLMoDDPModelConfig:
     )
 
 
-def _split_into_stages(model: Transformer) -> List[Transformer]:
+def _split_into_stages(model: OLMoDDPModel) -> List[OLMoDDPModel]:
     """
     Prune ``model`` into two pipeline stages the same way
     :meth:`TransformerPipelineParallelConfig.split_model` does, without needing a process group.
+
+    CUDA events cannot be deepcopied, so they are purged before the split and reinstalled on the
+    original and every chunk afterwards, matching what the train module does around its split.
     """
+    model.purge_cuda_events()
+
     stages = []
     for stage_idx, (start, stop) in enumerate([(0, SPLIT_AFTER), (SPLIT_AFTER, N_LAYERS)]):
         chunk = copy.deepcopy(model)
@@ -96,11 +101,29 @@ def _split_into_stages(model: Transformer) -> List[Transformer]:
             chunk.lm_head = None  # type: ignore[assignment]
         chunk.invalidate_block_topology_caches()
         chunk._pp_enabled = True
+        chunk.eval()
         stages.append(chunk)
+
+    model.install_cuda_events()
+    for chunk in stages:
+        chunk.install_cuda_events()
     return stages
 
 
-def _capture_expert_indices(model: Transformer, into: Dict[int, torch.Tensor]) -> List:
+def _build_reference_and_stages():
+    """
+    Build the model and split it immediately, before any forward.
+
+    The split has to happen on a freshly built model, as it does in the train module: a forward
+    leaves per-block runtime state behind that the deepcopy would either trip over or carry along.
+    """
+    model = _emo_model_config().build(init_device="cuda")
+    model.eval()
+    first, last = _split_into_stages(model)
+    return model, first, last
+
+
+def _capture_expert_indices(model: OLMoDDPModel, into: Dict[int, torch.Tensor]) -> List:
     """Record each document router's selected experts, keyed by the block index it belongs to."""
     handles = []
     for block_key, block in model.blocks.items():
@@ -133,8 +156,7 @@ def _batch(device: torch.device):
 @requires_gpu
 def test_split_stages_match_unsplit_model():
     device = torch.device("cuda")
-    model = _emo_model_config().build(init_device="cuda")
-    model.eval()
+    model, first, last = _build_reference_and_stages()
 
     input_ids, labels = _batch(device)
     segment_ids = segment_ids_from_eos(input_ids, EOS_TOKEN_ID)
@@ -145,10 +167,6 @@ def test_split_stages_match_unsplit_model():
         reference = model(input_ids, labels=labels, loss_reduction="sum")
     for handle in handles:
         handle.remove()
-
-    first, last = _split_into_stages(model)
-    first.eval()
-    last.eval()
 
     staged_indices: Dict[int, torch.Tensor] = {}
     handles = _capture_expert_indices(first, staged_indices)
@@ -175,8 +193,7 @@ def test_split_stages_diverge_without_segment_ids_on_later_stage():
     # Guards the assertion above against being vacuous: if the later stage's segment IDs were
     # wrong, the parity check has to be able to notice.
     device = torch.device("cuda")
-    model = _emo_model_config().build(init_device="cuda")
-    model.eval()
+    model, first, last = _build_reference_and_stages()
 
     input_ids, labels = _batch(device)
     segment_ids = segment_ids_from_eos(input_ids, EOS_TOKEN_ID)
@@ -186,9 +203,6 @@ def test_split_stages_diverge_without_segment_ids_on_later_stage():
     with torch.no_grad():
         reference = model(input_ids, labels=labels, loss_reduction="sum")
 
-    first, last = _split_into_stages(model)
-    first.eval()
-    last.eval()
     with torch.no_grad():
         hidden = first(input_ids, segment_ids=segment_ids)
         staged = last(hidden, labels=labels, loss_reduction="sum", segment_ids=wrong_segment_ids)
@@ -200,8 +214,7 @@ def test_split_stages_diverge_without_segment_ids_on_later_stage():
 @requires_gpu
 def test_split_stages_match_unsplit_model_gradients():
     device = torch.device("cuda")
-    model = _emo_model_config().build(init_device="cuda")
-    model.eval()
+    model, first, last = _build_reference_and_stages()
 
     input_ids, labels = _batch(device)
     segment_ids = segment_ids_from_eos(input_ids, EOS_TOKEN_ID)
@@ -213,10 +226,6 @@ def test_split_stages_match_unsplit_model_gradients():
         if param.grad is not None
     }
 
-    model.zero_grad(set_to_none=True)
-    first, last = _split_into_stages(model)
-    first.eval()
-    last.eval()
     hidden = first(input_ids, segment_ids=segment_ids)
     last(hidden, labels=labels, loss_reduction="sum", segment_ids=segment_ids).loss.backward()
 

--- a/src/test/nn/moe/v2/emo_pp_parity_test.py
+++ b/src/test/nn/moe/v2/emo_pp_parity_test.py
@@ -1,0 +1,235 @@
+"""
+Numerical parity between an unsplit EMo model and the same model split into pipeline stages.
+
+The unsplit model derives per-token segment IDs from token IDs internally. A split model cannot:
+only the first stage sees token IDs, so later stages take the segment IDs as an input. These tests
+pin that the two produce identical routing decisions and identical outputs.
+
+Transport and microbatch alignment are covered separately by the multi-GPU pipeline execution
+tests; here both stages run in one process so any difference is attributable to the routing itself.
+"""
+
+import copy
+from typing import Dict, List
+
+import torch
+
+from olmo_core.config import DType
+from olmo_core.nn.attention import AttentionConfig, AttentionType
+from olmo_core.nn.ddp.block import OLMoDDPTransformerBlockConfig
+from olmo_core.nn.layer_norm import LayerNormConfig, LayerNormType
+from olmo_core.nn.lm_head import LMHeadConfig
+from olmo_core.nn.moe.emo import EmoRouterConfig
+from olmo_core.nn.moe.v2.routed_experts import RoutedExpertsConfig
+from olmo_core.nn.moe.v2.router import MoERouterConfigV2
+from olmo_core.nn.transformer import (
+    OLMoDDPModelConfig,
+    TransformerBlockType,
+    TransformerType,
+)
+from olmo_core.nn.transformer.model import Transformer
+from olmo_core.ops.moe import segment_ids_from_eos
+from olmo_core.testing import requires_gpu
+
+EOS_TOKEN_ID = 0
+N_LAYERS = 4
+SPLIT_AFTER = 2
+
+
+def _emo_model_config(d_model: int = 64) -> OLMoDDPModelConfig:
+    layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=DType.float32)
+    return OLMoDDPModelConfig(
+        init_seed=0,
+        d_model=d_model,
+        recompute_each_block=False,
+        vocab_size=128,
+        n_layers=N_LAYERS,
+        name=TransformerType.moe_fused_v2,
+        block=OLMoDDPTransformerBlockConfig(
+            name=TransformerBlockType.moe_fused_v2,
+            attention=AttentionConfig(
+                name=AttentionType.default,
+                n_heads=4,
+                bias=False,
+                use_flash=False,
+                dtype=DType.float32,
+            ),
+            routed_experts=RoutedExpertsConfig(
+                d_model=d_model, hidden_size=128, num_experts=8, bias=False, dtype=DType.float32
+            ),
+            routed_experts_router=MoERouterConfigV2(
+                d_model=d_model,
+                num_experts=8,
+                top_k=2,
+                dtype=DType.float32,
+                emo=EmoRouterConfig(
+                    eos_token_id=EOS_TOKEN_ID,
+                    min_document_expert_pool=2,
+                    max_document_expert_pool=8,
+                    # Pin the pool so the comparison is well defined: while training, EMo samples a
+                    # pool size per document from the global RNG, which the two runs would not share.
+                    eval_document_expert_pool=4,
+                ),
+            ),
+            shared_experts=None,
+            layer_norm=layer_norm,
+        ),
+        lm_head=LMHeadConfig(layer_norm=layer_norm, bias=False, dtype=DType.float32),
+    )
+
+
+def _split_into_stages(model: Transformer) -> List[Transformer]:
+    """
+    Prune ``model`` into two pipeline stages the same way
+    :meth:`TransformerPipelineParallelConfig.split_model` does, without needing a process group.
+    """
+    stages = []
+    for stage_idx, (start, stop) in enumerate([(0, SPLIT_AFTER), (SPLIT_AFTER, N_LAYERS)]):
+        chunk = copy.deepcopy(model)
+        if stage_idx != 0:
+            chunk.embeddings = None  # type: ignore[assignment]
+            chunk.embedding_norm = None  # type: ignore[assignment]
+        for block_idx in range(N_LAYERS):
+            if not start <= block_idx < stop:
+                del chunk.blocks[str(block_idx)]
+        if stage_idx != 1:
+            chunk.lm_head = None  # type: ignore[assignment]
+        chunk.invalidate_block_topology_caches()
+        chunk._pp_enabled = True
+        stages.append(chunk)
+    return stages
+
+
+def _capture_expert_indices(model: Transformer, into: Dict[int, torch.Tensor]) -> List:
+    """Record each document router's selected experts, keyed by the block index it belongs to."""
+    handles = []
+    for block_key, block in model.blocks.items():
+        router = getattr(block, "routed_experts_router", None)
+        if router is None:
+            continue
+
+        def hook(_module, _args, output, block_idx=int(block_key)):
+            # The router returns (expert_weights, expert_indices, counts, aux_loss_info).
+            into[block_idx] = output[1].detach().clone()
+
+        handles.append(router.register_forward_hook(hook))
+    return handles
+
+
+def _batch(device: torch.device):
+    # Several packed documents of differing lengths, including one that ends exactly at the
+    # sequence boundary, so document pooling has something non-trivial to do.
+    input_ids = torch.tensor(
+        [
+            [7, 3, EOS_TOKEN_ID, 5, 9, 1, EOS_TOKEN_ID, 4],
+            [2, EOS_TOKEN_ID, 6, 8, EOS_TOKEN_ID, 3, 5, EOS_TOKEN_ID],
+        ],
+        device=device,
+    )
+    labels = input_ids.roll(-1, dims=1)
+    return input_ids, labels
+
+
+@requires_gpu
+def test_split_stages_match_unsplit_model():
+    device = torch.device("cuda")
+    model = _emo_model_config().build(init_device="cuda")
+    model.eval()
+
+    input_ids, labels = _batch(device)
+    segment_ids = segment_ids_from_eos(input_ids, EOS_TOKEN_ID)
+
+    reference_indices: Dict[int, torch.Tensor] = {}
+    handles = _capture_expert_indices(model, reference_indices)
+    with torch.no_grad():
+        reference = model(input_ids, labels=labels, loss_reduction="sum")
+    for handle in handles:
+        handle.remove()
+
+    first, last = _split_into_stages(model)
+    first.eval()
+    last.eval()
+
+    staged_indices: Dict[int, torch.Tensor] = {}
+    handles = _capture_expert_indices(first, staged_indices)
+    handles += _capture_expert_indices(last, staged_indices)
+    with torch.no_grad():
+        hidden = first(input_ids, segment_ids=segment_ids)
+        staged = last(hidden, labels=labels, loss_reduction="sum", segment_ids=segment_ids)
+    for handle in handles:
+        handle.remove()
+
+    # Every block must route to the same experts, including the ones on the later stage that could
+    # not have derived the segment IDs themselves.
+    assert set(staged_indices) == set(reference_indices) == set(range(N_LAYERS))
+    for block_idx in range(N_LAYERS):
+        assert torch.equal(
+            staged_indices[block_idx], reference_indices[block_idx]
+        ), f"block {block_idx} routed differently"
+
+    torch.testing.assert_close(staged.loss, reference.loss, rtol=1e-6, atol=1e-6)
+
+
+@requires_gpu
+def test_split_stages_diverge_without_segment_ids_on_later_stage():
+    # Guards the assertion above against being vacuous: if the later stage's segment IDs were
+    # wrong, the parity check has to be able to notice.
+    device = torch.device("cuda")
+    model = _emo_model_config().build(init_device="cuda")
+    model.eval()
+
+    input_ids, labels = _batch(device)
+    segment_ids = segment_ids_from_eos(input_ids, EOS_TOKEN_ID)
+    # Every token in one document, which is not what the batch actually contains.
+    wrong_segment_ids = torch.zeros_like(segment_ids)
+
+    with torch.no_grad():
+        reference = model(input_ids, labels=labels, loss_reduction="sum")
+
+    first, last = _split_into_stages(model)
+    first.eval()
+    last.eval()
+    with torch.no_grad():
+        hidden = first(input_ids, segment_ids=segment_ids)
+        staged = last(hidden, labels=labels, loss_reduction="sum", segment_ids=wrong_segment_ids)
+
+    # Well clear of the tolerance the parity test above passes at, so that test is not vacuous.
+    assert (staged.loss - reference.loss).abs() > 1e-4
+
+
+@requires_gpu
+def test_split_stages_match_unsplit_model_gradients():
+    device = torch.device("cuda")
+    model = _emo_model_config().build(init_device="cuda")
+    model.eval()
+
+    input_ids, labels = _batch(device)
+    segment_ids = segment_ids_from_eos(input_ids, EOS_TOKEN_ID)
+
+    model(input_ids, labels=labels, loss_reduction="sum").loss.backward()
+    reference_grads = {
+        name: param.grad.detach().clone()
+        for name, param in model.named_parameters()
+        if param.grad is not None
+    }
+
+    model.zero_grad(set_to_none=True)
+    first, last = _split_into_stages(model)
+    first.eval()
+    last.eval()
+    hidden = first(input_ids, segment_ids=segment_ids)
+    last(hidden, labels=labels, loss_reduction="sum", segment_ids=segment_ids).loss.backward()
+
+    staged_grads: Dict[str, torch.Tensor] = {}
+    for stage in (first, last):
+        for name, param in stage.named_parameters():
+            if param.grad is not None:
+                staged_grads[name] = param.grad.detach()
+
+    assert reference_grads, "reference run produced no gradients"
+    missing = set(reference_grads) - set(staged_grads)
+    assert not missing, f"stages produced no gradient for {sorted(missing)[:5]}"
+    for name, expected in reference_grads.items():
+        torch.testing.assert_close(
+            staged_grads[name], expected, rtol=1e-5, atol=1e-6, msg=f"gradient mismatch for {name}"
+        )

--- a/src/test/nn/transformer/emo_segment_ids_test.py
+++ b/src/test/nn/transformer/emo_segment_ids_test.py
@@ -145,3 +145,16 @@ def test_segment_ids_helper_rejects_parts_that_disagree_on_eos_token_id() -> Non
 
 def test_segment_ids_helper_returns_none_without_document_routed_parts() -> None:
     assert get_emo_segment_ids([_build_model()], torch.tensor([[1, 2, 0, 3]])) is None
+
+
+def test_block_topology_caches_are_invalidated_after_pruning() -> None:
+    # Splitting a model into pipeline stages prunes blocks from a deepcopy, so a chunk whose caches
+    # were populated beforehand would otherwise keep describing the unsplit block list.
+    model = _build_model([EOS_TOKEN_ID, EOS_TOKEN_ID, EOS_TOKEN_ID])
+    assert model.emo_block_indices == [0, 1, 2]
+
+    del model.blocks["2"]
+    assert model.emo_block_indices == [0, 1, 2], "expected the cache to be stale until invalidated"
+
+    model.invalidate_block_topology_caches()
+    assert model.emo_block_indices == [0, 1]

--- a/src/test/nn/transformer/emo_segment_ids_test.py
+++ b/src/test/nn/transformer/emo_segment_ids_test.py
@@ -1,0 +1,147 @@
+"""
+Coverage for how the transformer discovers document-routed (EMo) blocks and routes per-token
+segment IDs to them, including the pipeline-parallel path where segment IDs are supplied by the
+caller instead of derived from token IDs.
+"""
+
+from types import SimpleNamespace
+from typing import List, Optional
+
+import pytest
+import torch
+
+from olmo_core.exceptions import OLMoConfigurationError
+from olmo_core.nn.attention import AttentionConfig
+from olmo_core.nn.feed_forward import FeedForwardConfig
+from olmo_core.nn.layer_norm import LayerNormConfig
+from olmo_core.nn.lm_head import LMHeadConfig
+from olmo_core.nn.transformer.config import TransformerBlockConfig, TransformerConfig
+from olmo_core.nn.transformer.model import Transformer
+from olmo_core.train.train_module.transformer.common import get_emo_segment_ids
+
+EOS_TOKEN_ID = 0
+
+
+def _build_model(eos_token_ids: Optional[List[Optional[int]]] = None) -> Transformer:
+    """
+    Build a tiny transformer, attaching a stand-in document router to the blocks named by
+    ``eos_token_ids``. Only the two attributes the model reads are needed, which keeps this
+    independent of the MoE kernels the real router depends on.
+    """
+    n_layers = 2 if eos_token_ids is None else len(eos_token_ids)
+    model = TransformerConfig(
+        d_model=32,
+        vocab_size=64,
+        n_layers=n_layers,
+        block=TransformerBlockConfig(
+            sequence_mixer=AttentionConfig(n_heads=2),
+            feed_forward=FeedForwardConfig(hidden_size=64),
+            layer_norm=LayerNormConfig(),
+        ),
+        lm_head=LMHeadConfig(),
+    ).build()
+
+    if eos_token_ids is not None:
+        for block, eos_token_id in zip(model.blocks.values(), eos_token_ids):
+            if eos_token_id is not None:
+                block.routed_experts_router = SimpleNamespace(
+                    requires_segment_ids=True, eos_token_id=eos_token_id
+                )
+    return model
+
+
+def test_emo_blocks_and_eos_token_id_discovered_from_blocks() -> None:
+    model = _build_model([None, EOS_TOKEN_ID])
+    assert model.emo_block_indices == [1]
+    assert model.emo_eos_token_id == EOS_TOKEN_ID
+
+
+def test_emo_eos_token_id_is_none_without_document_routed_blocks() -> None:
+    model = _build_model()
+    assert model.emo_block_indices == []
+    assert model.emo_eos_token_id is None
+
+
+def test_emo_eos_token_id_rejects_disagreeing_routers() -> None:
+    model = _build_model([0, 1])
+    with pytest.raises(OLMoConfigurationError, match="same eos_token_id"):
+        model.emo_eos_token_id
+
+
+def test_segment_ids_derived_from_token_ids_without_pipeline_parallelism() -> None:
+    model = _build_model([EOS_TOKEN_ID, EOS_TOKEN_ID])
+    input_ids = torch.tensor([[1, 2, EOS_TOKEN_ID, 3]])
+
+    _, _, _, per_block_kwargs, _ = model._prepare_inputs(input_ids)
+
+    expected = torch.tensor([[0, 0, 1, 1]])
+    assert set(per_block_kwargs) == {0, 1}
+    for block_idx in (0, 1):
+        assert torch.equal(per_block_kwargs[block_idx]["segment_ids"], expected)
+
+
+def test_caller_supplied_segment_ids_take_precedence() -> None:
+    model = _build_model([EOS_TOKEN_ID])
+    input_ids = torch.tensor([[1, 2, EOS_TOKEN_ID, 3]])
+    # Deliberately unlike anything derivable from 'input_ids' so the source is unambiguous.
+    segment_ids = torch.tensor([[0, 1, 1, 2]])
+
+    _, _, _, per_block_kwargs, _ = model._prepare_inputs(input_ids, segment_ids=segment_ids)
+
+    assert torch.equal(per_block_kwargs[0]["segment_ids"], segment_ids)
+
+
+def test_pipeline_parallelism_requires_caller_supplied_segment_ids() -> None:
+    model = _build_model([EOS_TOKEN_ID])
+    model._pp_enabled = True
+
+    with pytest.raises(OLMoConfigurationError, match="requires 'segment_ids'"):
+        model._prepare_inputs(torch.tensor([[1, 2, EOS_TOKEN_ID, 3]]))
+
+
+def test_segment_ids_route_to_blocks_given_hidden_state_input() -> None:
+    # A non-first pipeline stage receives hidden states in place of token IDs, so segment IDs
+    # cannot be derived locally and must survive being passed in alongside them.
+    model = _build_model([EOS_TOKEN_ID])
+    model._pp_enabled = True
+    hidden_states = torch.randn(2, 4, 32)
+    segment_ids = torch.tensor([[0, 0, 1, 1], [0, 1, 1, 1]])
+
+    _, _, _, per_block_kwargs, _ = model._prepare_inputs(hidden_states, segment_ids=segment_ids)
+
+    assert torch.equal(per_block_kwargs[0]["segment_ids"], segment_ids)
+
+
+def test_segment_ids_shape_must_match_the_input() -> None:
+    model = _build_model([EOS_TOKEN_ID])
+
+    with pytest.raises(ValueError, match="must match the input"):
+        model._prepare_inputs(
+            torch.tensor([[1, 2, EOS_TOKEN_ID, 3]]), segment_ids=torch.tensor([[0, 0, 1]])
+        )
+
+
+def test_segment_ids_ignored_by_a_stage_without_document_routed_blocks() -> None:
+    # Every rank derives segment IDs from its own batch, so a stage holding only dense blocks
+    # receives them too and must simply drop them.
+    model = _build_model()
+    model._pp_enabled = True
+
+    _, _, all_block_kwargs, per_block_kwargs, _ = model._prepare_inputs(
+        torch.randn(1, 4, 32), segment_ids=torch.tensor([[0, 0, 1, 1]])
+    )
+
+    assert per_block_kwargs == {}
+    assert "segment_ids" not in all_block_kwargs
+
+
+def test_segment_ids_helper_rejects_parts_that_disagree_on_eos_token_id() -> None:
+    # A pipeline split leaves each part validating only its own blocks, so the disagreement has to
+    # be caught again across the parts a rank holds.
+    parts = [_build_model([0]), _build_model([1])]
+    with pytest.raises(OLMoConfigurationError, match="same eos_token_id"):
+        get_emo_segment_ids(parts, torch.tensor([[1, 2, 0, 3]]))
+
+
+def test_segment_ids_helper_returns_none_without_document_routed_parts() -> None:
+    assert get_emo_segment_ids([_build_model()], torch.tensor([[1, 2, 0, 3]])) is None

--- a/src/test/nn/transformer/emo_segment_ids_test.py
+++ b/src/test/nn/transformer/emo_segment_ids_test.py
@@ -18,6 +18,9 @@ from olmo_core.nn.lm_head import LMHeadConfig
 from olmo_core.nn.transformer.config import TransformerBlockConfig, TransformerConfig
 from olmo_core.nn.transformer.model import Transformer
 from olmo_core.train.train_module.transformer.common import get_emo_segment_ids
+from olmo_core.train.train_module.transformer.config import (
+    TransformerPipelineParallelConfig,
+)
 
 EOS_TOKEN_ID = 0
 
@@ -158,3 +161,18 @@ def test_block_topology_caches_are_invalidated_after_pruning() -> None:
 
     model.invalidate_block_topology_caches()
     assert model.emo_block_indices == [0, 1]
+
+
+def test_pipeline_split_rejects_blocks_that_disagree_on_eos_token_id() -> None:
+    # Each stage only sees its own blocks, so a disagreement has to be caught while the whole block
+    # list is still visible; otherwise routing silently depends on where the split landed. The
+    # check runs before the mesh is touched, so none is needed here.
+    model = _build_model([0, 0, 1, 1])
+    config = TransformerPipelineParallelConfig(degree=2)
+
+    with pytest.raises(OLMoConfigurationError, match="same eos_token_id"):
+        config.split_model(
+            model,
+            pp_mesh=None,  # type: ignore[arg-type]
+            device=torch.device("cpu"),
+        )

--- a/src/test/train/train_module/transformer/ddp_train_module_test.py
+++ b/src/test/train/train_module/transformer/ddp_train_module_test.py
@@ -304,3 +304,26 @@ def test_pad_pp_batch_dim_pads_tensors_by_repeating_the_last_instance():
     value = torch.tensor([[1, 2], [3, 4], [5, 6]])
     padded = OLMoDDPTrainModule._pad_pp_batch_dim(value, 2)
     assert torch.equal(padded, torch.tensor([[1, 2], [3, 4], [5, 6], [5, 6]]))
+
+
+def test_split_pp_dry_run_model_kwargs_slices_batch_leading_values():
+    # The independent PP dry run splits model kwargs itself, so per-instance metadata has to be
+    # sliced there too rather than handed whole to every microbatch.
+    kwargs = {
+        "segment_ids": torch.arange(8).reshape(4, 2),
+        "max_doc_lens": [4, 2, 3, 4],
+        "cp_original_seq_len": 2,
+    }
+    split = OLMoDDPTrainModule._split_pp_dry_run_model_kwargs(
+        kwargs,
+        original_batch_size=4,
+        micro_batch_size=2,
+        num_microbatches=2,
+    )
+
+    assert torch.equal(split[0]["segment_ids"], kwargs["segment_ids"][0:2])
+    assert torch.equal(split[1]["segment_ids"], kwargs["segment_ids"][2:4])
+    assert split[0]["max_doc_lens"] == [4, 2]
+    assert split[1]["max_doc_lens"] == [3, 4]
+    # Scalars are broadcast rather than sliced.
+    assert split[0]["cp_original_seq_len"] == split[1]["cp_original_seq_len"] == 2

--- a/src/test/train/train_module/transformer/ddp_train_module_test.py
+++ b/src/test/train/train_module/transformer/ddp_train_module_test.py
@@ -21,7 +21,7 @@ from olmo_core.nn.transformer import (
 )
 from olmo_core.optim import OLMoDDPOptimizerConfig
 from olmo_core.testing import requires_multi_gpu, run_distributed_test
-from olmo_core.train.train_module import OLMoDDPTrainModuleConfig
+from olmo_core.train.train_module import OLMoDDPTrainModule, OLMoDDPTrainModuleConfig
 from olmo_core.train.train_module.transformer import (
     TransformerDataParallelConfig,
     TransformerExpertParallelConfig,
@@ -284,3 +284,23 @@ def test_moe_v2_train_module_direct_checkpoint_restores_buffers(tmp_path):
         start_method="spawn",
         func_args=(str(tmp_path / "checkpoint"),),
     )
+
+
+@pytest.mark.parametrize(
+    "value, multiple, expected",
+    [
+        ([4, 2, 3], 2, [4, 2, 3, 3]),
+        ([4, 2], 2, [4, 2]),
+        ((4, 2, 3), 2, (4, 2, 3, 3)),
+    ],
+)
+def test_pad_pp_batch_dim_pads_batch_leading_sequences(value, multiple, expected):
+    # Per-instance metadata such as 'max_doc_lens' is a Python list, so it has to be padded
+    # alongside the tensors it accompanies or it ends up shorter than the padded batch.
+    assert OLMoDDPTrainModule._pad_pp_batch_dim(value, multiple) == expected
+
+
+def test_pad_pp_batch_dim_pads_tensors_by_repeating_the_last_instance():
+    value = torch.tensor([[1, 2], [3, 4], [5, 6]])
+    padded = OLMoDDPTrainModule._pad_pp_batch_dim(value, 2)
+    assert torch.equal(padded, torch.tensor([[1, 2], [3, 4], [5, 6], [5, 6]]))

--- a/src/test/train/train_module/transformer/ddp_train_module_test.py
+++ b/src/test/train/train_module/transformer/ddp_train_module_test.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import pytest
 import torch
+import torch.distributed as dist
 
 from olmo_core.config import DType
 from olmo_core.distributed.parallel import DataParallelType
@@ -62,6 +63,7 @@ def _tiny_model_config(
     n_layers: int = 2,
     dtype: DType = DType.float32,
     router_bias_gamma: Optional[float] = None,
+    global_load_balancing: bool = False,
 ) -> OLMoDDPModelConfig:
     layer_norm = LayerNormConfig(name=LayerNormType.rms, eps=1e-6, bias=False, dtype=dtype)
     return OLMoDDPModelConfig(
@@ -80,7 +82,12 @@ def _tiny_model_config(
                 d_model=d_model, hidden_size=128, num_experts=4, bias=False, dtype=dtype
             ),
             routed_experts_router=MoERouterConfigV2(
-                d_model=d_model, num_experts=4, top_k=2, dtype=dtype, bias_gamma=router_bias_gamma
+                d_model=d_model,
+                num_experts=4,
+                top_k=2,
+                dtype=dtype,
+                bias_gamma=router_bias_gamma,
+                global_load_balancing=global_load_balancing,
             ),
             shared_experts=None,
             layer_norm=layer_norm,
@@ -327,3 +334,45 @@ def test_split_pp_dry_run_model_kwargs_slices_batch_leading_values():
     assert split[1]["max_doc_lens"] == [3, 4]
     # Scalars are broadcast rather than sliced.
     assert split[0]["cp_original_seq_len"] == split[1]["cp_original_seq_len"] == 2
+
+
+def _run_global_lb_group_is_stage_local():
+    train_module = OLMoDDPTrainModule.__new__(OLMoDDPTrainModule)
+    train_module.world_mesh = {}
+    train_module._build_world_mesh(
+        dp=TransformerDataParallelConfig(name=DataParallelType.ddp),
+        pp=TransformerPipelineParallelConfig(degree=2),
+        device_type="cpu",
+    )
+    pp_rank = train_module.dense_mesh["pp"].get_local_rank()
+
+    model = _tiny_model_config(global_load_balancing=True).build(init_device="cpu")
+    # Call apply_dp directly rather than building the whole train module: the PP path installs
+    # CUDA events, which this CPU-only test cannot do. This is the call that hands the routers
+    # their load-balancing group, which is what the test is about.
+    model.apply_dp(dp_mesh=train_module.dense_mesh["dp"], ep_mesh=None)
+
+    expected_size = dist.get_world_size() // 2
+    for block in model.blocks.values():
+        lb_group = block.routed_experts_router.lb_process_group
+        assert lb_group is not None, "global load balancing needs a group after apply_dp"
+        assert dist.get_world_size(lb_group) == expected_size
+
+        # Every member has to be a data-parallel replica of this rank's own pipeline stage.
+        # A group spanning stages would average expert counts over unrelated layers, which
+        # nothing else would catch: the reduction still succeeds, it just balances the wrong thing.
+        gathered = [torch.zeros(1, dtype=torch.long) for _ in range(expected_size)]
+        dist.all_gather(gathered, torch.tensor([pp_rank], dtype=torch.long), group=lb_group)
+        assert {int(t.item()) for t in gathered} == {
+            pp_rank
+        }, f"rank {dist.get_rank()} shares a load-balancing group with another pipeline stage"
+
+
+def test_global_lb_group_is_stage_local():
+    # 2 pipeline stages x 2 data-parallel replicas.
+    run_distributed_test(
+        _run_global_lb_group_is_stage_local,
+        world_size=4,
+        backend="gloo",
+        start_method="spawn",
+    )

--- a/src/test/train/train_module/transformer/pipeline_execution_test.py
+++ b/src/test/train/train_module/transformer/pipeline_execution_test.py
@@ -40,8 +40,11 @@ class ToyStage(nn.Module):
         self.stage_index = stage_index
         self.is_last = is_last
         self.bias = nn.Parameter(torch.full((self.d_model,), 0.01 * (stage_index + 1)))
+        self.seen_segment_ids: list[torch.Tensor] = []
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor, segment_ids: torch.Tensor | None = None):
+        if segment_ids is not None:
+            self.seen_segment_ids.append(segment_ids)
         if x.dtype == torch.long:
             h = x.to(torch.float32).unsqueeze(-1).expand(-1, -1, self.d_model).to(torch.bfloat16)
         else:
@@ -121,6 +124,77 @@ def _run_rma_transport():
     dist.barrier()
 
     transport.close()
+
+
+def _run_segment_ids_reach_every_stage():
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device("cuda", rank)
+    torch.cuda.set_device(device)
+
+    num_stages = 4
+    n_microbatches = 2
+    batch_size, seq_len = 4, 4
+
+    stages = []
+    modules = []
+    for stage_index in (rank, rank + world_size):
+        module = ToyStage(stage_index, is_last=stage_index == num_stages - 1).to(device)
+        modules.append(module)
+        stages.append(
+            CustomPipelineStage(
+                module,
+                stage_index,
+                num_stages,
+                device,
+                group=dist.group.WORLD,
+                p2p_backend="nccl",
+            )
+        )
+
+    schedule = CustomScheduleInterleaved1F1B(stages, n_microbatches=n_microbatches)
+    schedule.prepare_step(global_batch_size=batch_size, seqlen=seq_len)
+
+    # One distinct document ID per instance, so a chunk identifies exactly which microbatch it
+    # belongs to and a misaligned split can't go unnoticed.
+    segment_ids = (
+        torch.arange(batch_size, device=device)
+        .unsqueeze(1)
+        .expand(batch_size, seq_len)
+        .contiguous()
+    )
+    micro_batch_size = batch_size // n_microbatches
+    expected = [
+        segment_ids[i * micro_batch_size : (i + 1) * micro_batch_size]
+        for i in range(n_microbatches)
+    ]
+
+    if rank == 0:
+        input_ids = torch.arange(batch_size * seq_len, device=device, dtype=torch.long).view(
+            batch_size, seq_len
+        )
+        schedule.step(input_ids, segment_ids=segment_ids)
+    else:
+        # Later stages get no token IDs at all, which is exactly why segment IDs have to be
+        # supplied as a side input rather than derived from the stage's own input.
+        schedule.step(segment_ids=segment_ids)
+
+    for module in modules:
+        assert (
+            len(module.seen_segment_ids) == n_microbatches
+        ), f"rank {rank} stage {module.stage_index} saw {len(module.seen_segment_ids)} microbatches"
+        for seen, want in zip(module.seen_segment_ids, expected):
+            assert torch.equal(seen, want), f"rank {rank} stage {module.stage_index} got {seen}"
+
+
+@requires_multi_gpu
+def test_segment_ids_reach_every_stage():
+    run_distributed_test(
+        _run_segment_ids_reach_every_stage,
+        world_size=2,
+        backend="nccl",
+        start_method="spawn",
+    )
 
 
 @requires_multi_gpu

--- a/src/test/train/train_module/transformer/pipeline_schedule_test.py
+++ b/src/test/train/train_module/transformer/pipeline_schedule_test.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from typing import Any, Dict
 
 import pytest
+import torch
 
 from olmo_core.distributed.parallel.pipeline_parallel import (
     PipelineSchedule,
@@ -354,3 +355,77 @@ def test_pipeline_schedule_rejects_standard_schedules(schedule_name: PipelineSch
             pp_mesh=None,  # type: ignore[arg-type]
             schedule_name=schedule_name,
         )
+
+
+def _build_splitter(n_microbatches: int) -> CustomScheduleInterleaved1F1B:
+    schedule = CustomScheduleInterleaved1F1B.__new__(CustomScheduleInterleaved1F1B)
+    schedule._n_microbatches = n_microbatches
+    schedule._args_chunk_spec = None
+    schedule._kwargs_chunk_spec = None
+    return schedule
+
+
+def test_split_inputs_keeps_segment_ids_aligned_with_input_ids():
+    splitter = _build_splitter(2)
+    input_ids = torch.arange(16).reshape(4, 4)
+    segment_ids = torch.arange(16).reshape(4, 4) // 2
+
+    args_split, kwargs_split = splitter._split_inputs((input_ids,), {"segment_ids": segment_ids})
+
+    assert len(args_split) == len(kwargs_split) == 2
+    for i, (start, stop) in enumerate([(0, 2), (2, 4)]):
+        assert torch.equal(args_split[i][0], input_ids[start:stop])
+        assert torch.equal(kwargs_split[i]["segment_ids"], segment_ids[start:stop])
+
+
+def test_split_inputs_splits_packed_document_metadata():
+    splitter = _build_splitter(2)
+    input_ids = torch.arange(16).reshape(4, 4)
+    doc_lens = torch.tensor([[4, 0], [2, 2], [3, 1], [4, 0]])
+    max_doc_lens = [4, 2, 3, 4]
+
+    _, kwargs_split = splitter._split_inputs(
+        (input_ids,), {"doc_lens": doc_lens, "max_doc_lens": max_doc_lens}
+    )
+
+    assert torch.equal(kwargs_split[0]["doc_lens"], doc_lens[0:2])
+    assert torch.equal(kwargs_split[1]["doc_lens"], doc_lens[2:4])
+    # The Python list has to be sliced on the same boundaries as the tensors.
+    assert kwargs_split[0]["max_doc_lens"] == [4, 2]
+    assert kwargs_split[1]["max_doc_lens"] == [3, 4]
+
+
+def test_split_inputs_rejects_uneven_microbatches():
+    # Stages size their P2P buffers from one floor-divided microbatch shape, so a batch that
+    # doesn't divide evenly would leave receivers with undersized buffers.
+    splitter = _build_splitter(4)
+
+    with pytest.raises(ValueError, match="not divisible"):
+        splitter._split_inputs((torch.arange(24).reshape(6, 4),), {})
+
+
+@pytest.mark.parametrize("present_keys", [("labels",), ("segment_ids",), ("max_doc_lens",)])
+def test_split_inputs_infers_batch_size_on_later_stages(present_keys):
+    # Ranks that don't own the first stage get empty positional args, so the batch size has to come
+    # from whichever batch-leading kwargs happen to be present.
+    splitter = _build_splitter(2)
+    available = {
+        "labels": torch.arange(16).reshape(4, 4),
+        "segment_ids": torch.zeros(4, 4, dtype=torch.long),
+        "max_doc_lens": [4, 4, 4, 4],
+    }
+    kwargs = {key: available[key] for key in present_keys}
+
+    args_split, kwargs_split = splitter._split_inputs((), kwargs)
+
+    assert args_split == [(), ()]
+    for key in present_keys:
+        assert len(kwargs_split[0][key]) == 2
+        assert len(kwargs_split[1][key]) == 2
+
+
+def test_split_inputs_rejects_metadata_with_mismatched_batch_size():
+    splitter = _build_splitter(2)
+
+    with pytest.raises(ValueError, match="does not match input batch size"):
+        splitter._split_inputs((torch.arange(16).reshape(4, 4),), {"max_doc_lens": [1, 2, 3]})

--- a/src/test/train/train_module/transformer/pipeline_schedule_test.py
+++ b/src/test/train/train_module/transformer/pipeline_schedule_test.py
@@ -16,6 +16,8 @@ from olmo_core.train.train_module.transformer.pipeline.helpers import (
     generate_stage_to_rank_mapping,
 )
 from olmo_core.train.train_module.transformer.pipeline.pipeline_schedule import (
+    BATCH_LEADING_MODEL_KWARGS,
+    SUPPORTED_MODEL_KWARGS,
     CustomSchedule1F1BV,
     CustomScheduleInterleaved1F1B,
     PipelineActionType,
@@ -429,3 +431,28 @@ def test_split_inputs_rejects_metadata_with_mismatched_batch_size():
 
     with pytest.raises(ValueError, match="does not match input batch size"):
         splitter._split_inputs((torch.arange(16).reshape(4, 4),), {"max_doc_lens": [1, 2, 3]})
+
+
+def test_supported_model_kwargs_covers_every_batch_leading_kwarg():
+    # The independent PP dry run validates against this same set, so a kwarg the splitter accepts
+    # but the set omits would train fine and then fail the dry run.
+    assert set(BATCH_LEADING_MODEL_KWARGS) <= SUPPORTED_MODEL_KWARGS
+
+
+@pytest.mark.parametrize("key", sorted(SUPPORTED_MODEL_KWARGS - {"labels"}))
+def test_split_inputs_accepts_every_supported_model_kwarg(key):
+    splitter = _build_splitter(2)
+    values = {
+        "segment_ids": torch.zeros(4, 4, dtype=torch.long),
+        "doc_lens": torch.tensor([[4, 0], [2, 2], [3, 1], [4, 0]]),
+        "max_doc_lens": [4, 2, 3, 4],
+        "loss_div_factor": 2.0,
+        "ignore_index": -100,
+        "loss_reduction": "sum",
+        "z_loss_multiplier": None,
+        "return_logits": False,
+        "cp_already_sharded": False,
+        "cp_original_seq_len": 4,
+    }
+    _, kwargs_split = splitter._split_inputs((torch.arange(16).reshape(4, 4),), {key: values[key]})
+    assert all(key in kwargs_mb for kwargs_mb in kwargs_split)


### PR DESCRIPTION
EMo derives per-token `segment_ids` from token IDs and EOS positions, but only the first pipeline stage receives token IDs — later stages receive hidden states. Both the model and the pipeline schedule rejected the combination outright.

The batch is already available on every pipeline rank, and keyword arguments (unlike positional ones) reach every stage, so segment IDs need no transport. They are derived once per rank and passed through as a side input.

## Model

- `emo_block_indices` / `emo_eos_token_id` on `Transformer` replace the per-forward block scan. Both resolve lazily, after the pipeline split, so a stage sees only the blocks it owns.
- `_prepare_inputs` accepts caller-supplied `segment_ids`, deriving them from token IDs only as the non-pipelined fallback. It has to be an explicit pop — unrecognized kwargs are otherwise dropped silently.
- Both EMo+PP guards removed (`_prepare_inputs` and `apply_pp`). The adjacent context-parallelism guard stays.

## Pipeline schedule

- `segment_ids`, `doc_lens`, and `max_doc_lens` are now split into microbatches. `max_doc_lens` is a per-instance Python list, so it is sliced rather than passed through the tensor branch. Intra-document masking was already broken under PP for this reason, independent of EMo.
- Every batch-leading value splits on one set of shared, equal boundaries instead of independent `tensor_split` calls.
- Uneven microbatches are rejected. Stages size their P2P buffers from a single floor-divided microbatch shape (`prepare_step` → `example_p2p_tensor`), so larger leading chunks would overrun the receiver — a buffer shape mismatch, not just inconsistent metadata. The check sits after the active microbatch count is selected, so training, evaluation, and reduced dry runs each validate against the count they actually run with.
- Batch size is inferred from any batch-leading kwarg, not just `labels`, so a stage receiving `segment_ids` without `labels` still works.

## Evaluation

`run_pipeline_eval` padding now covers batch-leading lists and tuples, which a list-valued `max_doc_lens` would otherwise be left short by. The reduced-microbatch dry-run path already handled these.

## Not covered

- Two-batch overlap still rejects EMo separately: segment IDs are not split between lanes.
- Context parallelism is unchanged and still rejected.
- Cross-*rank* disagreement on the EOS token ID is unvalidated; catching it needs a collective. Disagreement across the model parts a single rank holds is caught.

## Testing

`pytest src/test/` passes apart from pre-existing failures (GCS credential tests, and the reshard suite, both confirmed identical on a clean tree). New coverage:

- Model-side: EMo block/EOS discovery, derivation vs. caller-supplied precedence, the PP guard, shape validation, and routing segment IDs to blocks given a hidden-state input.
- Splitter: alignment with `input_ids`, packed-document metadata, uneven-batch rejection, batch-size inference on later stages.
- Evaluation padding for lists, tuples, and tensors.
- A multi-GPU execution test asserting each stage receives the correct microbatch's segment IDs, including a rank that gets no token IDs at all. **This one has not been run** — it requires GPUs.

## CI

A second commit temporarily adds this base branch to the workflow triggers, mirroring the existing `akshitab/moe-v2-core` entries. Revert before merging the base branch into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)