### PR TITLE
Add HuggingFace auth and 429 retry handling to HTTP downloads

### DIFF
--- a/src/olmo_core/io.py
+++ b/src/olmo_core/io.py
@@ -91,7 +91,8 @@ def resource_path(folder: PathOrStr, fname: str, local_cache: Optional[PathOrStr
         log.info(f"Found local cache of {fname} at {local_path}")
         return local_path
     else:
-        return cached_path(f"{folder}/{fname}", quiet=True)
+        url = f"{folder}/{fname}"
+        return cached_path(url, quiet=True, headers=_http_auth_headers(url))
 
 
 def is_url(path: PathOrStr) -> bool:

--- a/src/olmo_core/io.py
+++ b/src/olmo_core/io.py
@@ -20,9 +20,10 @@ except ImportError:
 import requests
 import torch
 from cached_path import cached_path
-from cached_path.schemes import S3Client, SchemeClient, add_scheme_client
+from cached_path.schemes import HttpClient, S3Client, SchemeClient, add_scheme_client
 from requests.adapters import HTTPAdapter
 from rich.progress import track
+from urllib3.util.retry import Retry as Urllib3Retry
 
 from .aliases import PathOrStr
 from .exceptions import (
@@ -609,18 +610,55 @@ def retriable(
 ######################
 
 
+HTTP_RETRY_STATUS_CODES = (429, 502, 503, 504)
+"""
+HTTP status codes that are worth retrying: rate limiting (429) and transient server errors.
+"""
+
+HTTP_MAX_RETRIES = 5
+"""
+The maximum number of adapter-level retries for sessions built with a retry policy.
+"""
+
+
+def _build_http_session(
+    headers: Optional[dict] = None,
+    retry_status_codes: Optional[Tuple[int, ...]] = None,
+) -> requests.Session:
+    """
+    Build an HTTP session with connection pooling, which prevents resource exhaustion when making
+    many HTTP requests.
+
+    :param headers: Default headers to send with every request from the session.
+    :param retry_status_codes: If set, responses with these status codes are retried with
+        exponential backoff, honoring the ``Retry-After`` header. Leave unset when the caller
+        handles retries itself (see :func:`retriable`).
+    """
+    session = requests.Session()
+    max_retries: Union[int, Urllib3Retry] = 0
+    if retry_status_codes:
+        max_retries = Urllib3Retry(
+            total=HTTP_MAX_RETRIES,
+            backoff_factor=1,
+            status_forcelist=retry_status_codes,
+            respect_retry_after_header=True,
+        )
+    adapter = HTTPAdapter(pool_maxsize=50, max_retries=max_retries)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    if headers:
+        session.headers.update(headers)
+    return session
+
+
 @cache
 def _get_http_session() -> requests.Session:
     """
-    Get a shared HTTP session with connection pooling.
-    This prevents resource exhaustion when making many HTTP requests.
+    Get the shared HTTP session used by the ``_http_*`` helpers below. Those helpers retry through
+    the :func:`retriable` decorator (see :func:`_http_retry_condition`), so the session itself
+    doesn't set a retry policy.
     """
-    session = requests.Session()
-    # Configure connection pooling to reuse connections
-    adapter = HTTPAdapter(pool_maxsize=50)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    return session
+    return _build_http_session()
 
 
 # Hosts that receive a bearer token on outgoing HTTP requests, mapped to the env var that holds the
@@ -646,18 +684,21 @@ def _http_auth_headers(url: str) -> dict:
 
 
 def _http_retry_condition(exc: Exception) -> bool:
-    # Retry on transient rate-limit (429) and bad-gateway (502) responses.
     return (
         isinstance(exc, requests.exceptions.HTTPError)
         and exc.response is not None
-        and exc.response.status_code in (429, 502)
+        and exc.response.status_code in HTTP_RETRY_STATUS_CODES
     )
 
 
-@retriable()
+@retriable(retry_condition=_http_retry_condition)
 def _http_file_size(url: str) -> int:
     session = _get_http_session()
     response = session.head(url, allow_redirects=True, headers=_http_auth_headers(url))
+    if response.status_code == 404:
+        raise FileNotFoundError(url)
+
+    response.raise_for_status()
     content_length = response.headers.get("content-length")
     if content_length is None:
         raise OLMoNetworkError(
@@ -1106,9 +1147,9 @@ def _s3_list_directory(
                 )
 
 
-#############################################
-## Custom cached path client for 'weka://' ##
-#############################################
+################################
+## Custom cached-path clients ##
+################################
 
 
 def add_cached_path_clients():
@@ -1116,6 +1157,49 @@ def add_cached_path_clients():
     Add additional cached-path clients.
     """
     add_scheme_client(_WekaClient)
+    add_scheme_client(_RetryableHttpClient)
+
+
+class _RetryableHttpClient(HttpClient):
+    """
+    A cached-path client for ``http(s)://`` URLs that retries every status code in
+    :data:`HTTP_RETRY_STATUS_CODES`, whereas cached-path's built-in client only retries server
+    errors. Retrying rate-limited (429) responses matters when many ranks download checkpoint
+    files from the same host concurrently.
+
+    .. note::
+        This subclasses cached-path's ``HttpClient`` because ``cached_path()`` only forwards custom
+        headers, such as the auth headers from :func:`_http_auth_headers`, to clients derived from
+        it.
+    """
+
+    scheme = ("http", "https")
+
+    recoverable_errors = HttpClient.recoverable_errors + (requests.exceptions.RetryError,)
+    """
+    Treat exhausted retries like the other recoverable errors, so ``cached_path()`` can fall back to
+    a previously cached version of the resource instead of failing.
+    """
+
+    def _session(self) -> requests.Session:
+        return _build_http_session(self.headers, retry_status_codes=HTTP_RETRY_STATUS_CODES)
+
+    @property
+    def head_response(self):
+        if self._head_response is None:
+            with self._session() as session:
+                response = session.head(self.resource, allow_redirects=True)
+            self.validate_response(response)
+            self._head_response = response
+        return self._head_response
+
+    def get_resource(self, temp_file: io.BufferedWriter) -> None:
+        with self._session() as session:
+            response = session.get(self.resource, stream=True)
+            self.validate_response(response)
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive chunks
+                    temp_file.write(chunk)
 
 
 class _WekaClient(SchemeClient):

--- a/src/olmo_core/io.py
+++ b/src/olmo_core/io.py
@@ -622,10 +622,41 @@ def _get_http_session() -> requests.Session:
     return session
 
 
+# Hosts that receive a bearer token on outgoing HTTP requests, mapped to the env var that holds the
+# token. Authenticating typically raises the host's rate limit (e.g. HuggingFace resolver reads).
+# See https://huggingface.co/docs/hub/rate-limits.
+_HTTP_BEARER_TOKEN_ENV_VARS = {
+    "huggingface.co": "HF_TOKEN",
+    "hf.co": "HF_TOKEN",
+}
+
+
+def _http_auth_headers(url: str) -> dict:
+    """
+    ``Authorization: Bearer`` header for hosts registered in :data:`_HTTP_BEARER_TOKEN_ENV_VARS` when
+    the corresponding env var is set, otherwise an empty dict. The token is only attached to its own
+    host, and ``requests`` strips the header on cross-host redirects (e.g. to a CDN).
+    """
+    from urllib.parse import urlparse
+
+    env_var = _HTTP_BEARER_TOKEN_ENV_VARS.get(urlparse(url).hostname or "")
+    token = os.environ.get(env_var) if env_var is not None else None
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _http_retry_condition(exc: Exception) -> bool:
+    # Retry on transient rate-limit (429) and bad-gateway (502) responses.
+    return (
+        isinstance(exc, requests.exceptions.HTTPError)
+        and exc.response is not None
+        and exc.response.status_code in (429, 502)
+    )
+
+
 @retriable()
 def _http_file_size(url: str) -> int:
     session = _get_http_session()
-    response = session.head(url, allow_redirects=True)
+    response = session.head(url, allow_redirects=True, headers=_http_auth_headers(url))
     content_length = response.headers.get("content-length")
     if content_length is None:
         raise OLMoNetworkError(
@@ -636,17 +667,15 @@ def _http_file_size(url: str) -> int:
     return int(content_length)
 
 
-@retriable(
-    retry_condition=lambda exc: (
-        isinstance(exc, requests.exceptions.HTTPError)
-        and exc.response is not None
-        and exc.response.status_code == 502
-    ),
-)
+@retriable(retry_condition=_http_retry_condition)
 def _http_get_bytes_range(url: str, bytes_start: int, num_bytes: int) -> bytes:
     session = _get_http_session()
     response = session.get(
-        url, headers={"Range": f"bytes={bytes_start}-{bytes_start + num_bytes - 1}"}
+        url,
+        headers={
+            "Range": f"bytes={bytes_start}-{bytes_start + num_bytes - 1}",
+            **_http_auth_headers(url),
+        },
     )
 
     if response.status_code == 404:
@@ -661,10 +690,10 @@ def _http_get_bytes_range(url: str, bytes_start: int, num_bytes: int) -> bytes:
     return result
 
 
-@retriable()
+@retriable(retry_condition=_http_retry_condition)
 def _http_file_exists(url: str) -> bool:
     session = _get_http_session()
-    response = session.head(url)
+    response = session.head(url, headers=_http_auth_headers(url))
     if response.status_code == 404:
         return False
 

--- a/src/olmo_core/train/checkpoint.py
+++ b/src/olmo_core/train/checkpoint.py
@@ -31,6 +31,7 @@ from ..distributed.utils import (
 )
 from ..exceptions import OLMoConfigurationError
 from ..io import (
+    _http_auth_headers,
     clear_directory,
     dir_is_empty,
     file_exists,
@@ -201,7 +202,10 @@ class Checkpointer:
             # doesn't exist, which can happen when we're restoring a checkpoint with a different world size.
             for path in (f"{dir}/train/rank{get_rank()}.pt", f"{dir}/train/rank0.pt"):
                 try:
-                    trainer_state = torch.load(cached_path(path, quiet=True), weights_only=False)
+                    trainer_state = torch.load(
+                        cached_path(path, quiet=True, headers=_http_auth_headers(path)),
+                        weights_only=False,
+                    )
                     break
                 except FileNotFoundError:
                     pass
@@ -328,7 +332,10 @@ class Checkpointer:
 
                 # Filter out based on ephemeral flag.
                 if ephemeral is not None:
-                    metadata_path = cached_path(join_path(path, cls.METADATA_FNAME), quiet=True)
+                    metadata_url = str(join_path(path, cls.METADATA_FNAME))
+                    metadata_path = cached_path(
+                        metadata_url, quiet=True, headers=_http_auth_headers(metadata_url)
+                    )
                     metadata = CheckpointMetadata.from_file(metadata_path)
 
                     # Assume not ephemeral for backwards compat.

--- a/src/scripts/official/README.md
+++ b/src/scripts/official/README.md
@@ -39,7 +39,7 @@ and export it as `HF_TOKEN`:
 export HF_TOKEN=hf_...
 ```
 
-The token must be a **fine-grained** token with the "Read contents of public gated repos you can
-access" permission. Unscoped `read` and `write` tokens are rejected with a `403` when reading the
+The token must be a **fine-grained** token; which permissions you give it doesn't matter, since the
+bucket is public. Unscoped `read` and `write` tokens are rejected with a `403` when reading the
 bucket. See [user access tokens](https://huggingface.co/docs/hub/security-tokens) for the difference
 between token types.

--- a/src/scripts/official/README.md
+++ b/src/scripts/official/README.md
@@ -8,3 +8,38 @@ Each Python training script in this directory has the same CLI, and they're inte
 The scripts themselves take several required arguments as well as any number of config overrides in dot-notation.
 Run a script with the `--help` flag to see which arguments are required, and run with the `--dry-run` flag to see the full config that will be used.
 To override a field in the config such as the `data_loader`'s `prefetch_factor`, you could add the option `--data_loader.prefetch_factor=4` to your command-line options.
+
+## Loading checkpoints from Hugging Face
+
+Scripts that continue training from a released checkpoint read it from the public
+[`allenai/ai2-llm`](https://huggingface.co/buckets/allenai/ai2-llm) Hugging Face storage bucket, e.g.
+`https://huggingface.co/buckets/allenai/ai2-llm/resolve/checkpoints/OLMo25/step1413814/`.
+The bucket is public, so no credentials are required.
+
+Hugging Face does, however, [rate limit requests](https://huggingface.co/docs/hub/rate-limits), and
+anonymous requests get the lowest quota, counted **per IP address** and therefore shared with anyone
+else on your network. Loading a distributed checkpoint issues many range requests from every rank at
+once, so a large checkpoint may exhaust that quota and fail with `429 Too Many Requests`.
+
+**Without a token,** you are encouraged to download the checkpoint once and train from the local copy instead of streaming
+it on every run:
+
+```bash
+hf buckets sync hf://buckets/allenai/ai2-llm/checkpoints/OLMo25/step1413814 ./step1413814
+```
+
+Then point the script at it with `--trainer.load_path=./step1413814`. See the
+[storage bucket docs](https://huggingface.co/docs/hub/storage-buckets) for other ways to download.
+
+**With a token,** requests count against your own account's higher quota instead of the shared
+anonymous one. Create a token from your [access token settings](https://huggingface.co/settings/tokens)
+and export it as `HF_TOKEN`:
+
+```bash
+export HF_TOKEN=hf_...
+```
+
+The token must be a **fine-grained** token with the "Read contents of public gated repos you can
+access" permission. Unscoped `read` and `write` tokens are rejected with a `403` when reading the
+bucket. See [user access tokens](https://huggingface.co/docs/hub/security-tokens) for the difference
+between token types.

--- a/src/test/io_test.py
+++ b/src/test/io_test.py
@@ -4,7 +4,9 @@ import pytest
 
 from olmo_core.io import (
     _http_auth_headers,
+    _RetryableHttpClient,
     _s3_retry_condition,
+    add_cached_path_clients,
     copy_dir,
     copy_file,
     deserialize_from_tensor,
@@ -20,6 +22,29 @@ from olmo_core.io import (
 def test_serde_from_tensor():
     data = {"a": (1, 2)}
     assert deserialize_from_tensor(serialize_to_tensor(data)) == data
+
+
+def test_retryable_http_client_is_used_by_cached_path():
+    from cached_path.schemes import get_scheme_client
+
+    add_cached_path_clients()
+
+    # cached-path resolves http(s) URLs to our client, and still forwards custom headers to it
+    # (which it only does for clients derived from its own 'HttpClient').
+    client = get_scheme_client(
+        "https://huggingface.co/buckets/allenai/ai2-llm/resolve/checkpoints/OLMo25/step0/config.json",
+        headers={"Authorization": "Bearer hf_secret"},
+    )
+    assert isinstance(client, _RetryableHttpClient)
+    assert client.headers == {"Authorization": "Bearer hf_secret"}
+
+    # Its session retries rate-limited responses, honoring 'Retry-After'.
+    from requests.adapters import HTTPAdapter
+
+    adapter = client._session().adapters["https://"]
+    assert isinstance(adapter, HTTPAdapter)
+    assert 429 in adapter.max_retries.status_forcelist
+    assert adapter.max_retries.respect_retry_after_header
 
 
 def test_http_auth_headers(monkeypatch):

--- a/src/test/io_test.py
+++ b/src/test/io_test.py
@@ -3,6 +3,7 @@ from glob import glob
 import pytest
 
 from olmo_core.io import (
+    _http_auth_headers,
     _s3_retry_condition,
     copy_dir,
     copy_file,
@@ -19,6 +20,19 @@ from olmo_core.io import (
 def test_serde_from_tensor():
     data = {"a": (1, 2)}
     assert deserialize_from_tensor(serialize_to_tensor(data)) == data
+
+
+def test_http_auth_headers(monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    hf_url = "https://huggingface.co/buckets/allenai/ai2-llm/resolve/checkpoints/OLMo25/step0/config.json"
+
+    # No token set -> no header, even on a registered host.
+    assert _http_auth_headers(hf_url) == {}
+
+    # Token set -> bearer header, but only for the registered host (never leaked to other hosts).
+    monkeypatch.setenv("HF_TOKEN", "hf_secret")
+    assert _http_auth_headers(hf_url) == {"Authorization": "Bearer hf_secret"}
+    assert _http_auth_headers("https://storage.googleapis.com/ai2-llm/x") == {}
 
 
 def test_s3_retry_condition_includes_ssl_errors():


### PR DESCRIPTION
# Add HuggingFace auth and 429 retry handling to HTTP downloads

## Why

Checkpoints now load from public HuggingFace bucket URLs. A distributed checkpoint load issues many concurrent ranged GETs, which trips HF's per-window rate limit: nothing sent an `HF_TOKEN` (anonymous requests get the lowest rate tier) and 429 responses weren't retried.

## Changes

- Add `_http_auth_headers()`, which attaches `Authorization: Bearer $HF_TOKEN` for hosts in a `host → env var` registry (`huggingface.co`, `hf.co`). Returns no header when the env var is unset, so anonymous access is unchanged.
- Send those headers from `_http_file_size()`, `_http_get_bytes_range()`, and `_http_file_exists()`.
- Pass those headers through the `cached_path()` calls that read trainer state and checkpoint metadata (`resource_path()` in `io.py`, `Checkpoint.load()` and the ephemeral-check read in `train/checkpoint.py`), which previously requested anonymously.
- Add `HTTP_RETRY_STATUS_CODES = (429, 502, 503, 504)` and `HTTP_MAX_RETRIES` as the single retry policy for HTTP.
- Add `_build_http_session()`, which builds a pooled session and optionally attaches a urllib3 retry policy honoring `Retry-After`. `_get_http_session()` now delegates to it.
- Add `_RetryableHttpClient`, a cached-path scheme client for `http(s)://` that retries `HTTP_RETRY_STATUS_CODES`; registered in `add_cached_path_clients()`. Subclasses cached-path's `HttpClient` because `get_scheme_client()` only forwards custom headers to clients derived from it, and treats exhausted retries as recoverable so a cached copy can be used.
- Change `_http_retry_condition()` to read `HTTP_RETRY_STATUS_CODES` instead of a hardcoded `(429, 502)`, and apply it to all three `_http_*` helpers.
- Add `response.raise_for_status()` to `_http_file_size()` so error statuses surface as HTTP errors rather than a missing `content-length` error, and raise `FileNotFoundError` on 404 to match the GCS and S3 equivalents.
- Rename the `io.py` cached-path section header to cover both clients.
- Add tests for the auth headers and for the retryable client's registration, header forwarding, and retry policy.

## Notes

- `HF_TOKEN` (read scope) raises the rate limit tier; unset leaves behavior as before.
- Retries honor `Retry-After` but not HF's `RateLimit: t=<reset>` header.
- The adapter-level policy is only applied to sessions whose callers don't already retry via `@retriable`, so retries don't stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
