### PR TITLE
SpeedMonitor: use the B200 dense BF16 peak for B300 devices

### DIFF
--- a/src/olmo_core/train/callbacks/speed_monitor.py
+++ b/src/olmo_core/train/callbacks/speed_monitor.py
@@ -107,8 +107,10 @@ class SpeedMonitorCallback(Callback):
                         self.device_peak_flops_per_second = int(1513e12 * dense_correction)
                     else:  # for SXM and other variants
                         self.device_peak_flops_per_second = int(1979e12 * dense_correction)
-                elif "B200" in device_name:
+                elif "B200" in device_name or "B300" in device_name:
                     # data from https://www.nvidia.com/en-us/data-center/hgx/
+                    # NOTE: B300 (Blackwell Ultra) mainly raises FP4 throughput; its dense
+                    # BF16 peak is approximately B200's, so we reuse the B200 figure.
                     self.device_peak_flops_per_second = int(4.5e15 * dense_correction)
                 else:  # for other GPU types, assume A100
                     # data from https://www.nvidia.com/en-us/data-center/a100/


### PR DESCRIPTION
`SpeedMonitorCallback` picks `device_peak_flops_per_second` by substring-matching
`torch.cuda.get_device_name()`. The chain was `H100` → `B200` → *else assume A100*, so
B300 devices — which report as `NVIDIA B300 SXM6 AC` — matched nothing and silently fell
through to the A100 fallback. Since MFU is `100 * flops_ps / device_peak_flops_per_second`,
every MFU number reported on B300 was inflated by the ratio of those two peaks.

| | |
|---|---|
| Peak used (A100 fallback, `624e12 × 0.5`) | 312 TFLOP/s |
| Correct peak (B200 dense BF16, `4.5e15 × 0.5`) | 2,250 TFLOP/s |
| Overstatement | **7.212×** |

## Observed on a real run

A Molmo2-4B stage-1 run on 2×8 B300 (`ai2/holmes`, 32,000 steps, 2.097B tokens,
[beaker.org/ex/01KZR051T3P57SFFMC9NEG3D9Y](https://beaker.org/ex/01KZR051T3P57SFFMC9NEG3D9Y)):

| Reported | Achieved (correct, unaffected) | True MFU |
|---|---|---|
| MFU avg 88.32% | 275.6 TFLOP/s/GPU | **12.25%** |
| MFU inst 105.70% | 329.8 TFLOP/s/GPU | **14.66%** |

The instantaneous reading above 100% is what surfaced the bug — MFU is bounded by 1 by
definition, so exceeding it means the denominator is wrong.

## Scope

Denominator only. `flops_ps` is computed from `num_flops_per_token × tokens` plus the
`extra_flops_per_batch` hook (implemented by `MultimodalTransformerTrainModule` for
per-image vision-encoder compute), and is unaffected — as are TPS, token counts, and loss.
Previously logged B300 MFU values can be recovered by dividing by 7.212.

B300 (Blackwell Ultra) mainly raises FP4 throughput; its dense BF16 peak is approximately
B200's, so the B200 figure is reused rather than adding a separate constant.

## Testing

`isort`, `black`, `ruff` clean. `mypy` clean on the changed file (the 4 errors it reports
in `multimodal_train_module.py` / `attention/__init__.py` are pre-existing on `vision`).
No unit test added: the mapping is inline in `pre_train` and needs a live trainer to
exercise; making it testable would require extracting it to a pure helper, which felt
out of scope for a 3-line fix — happy to do that instead if preferred.
