### PR TITLE
Molmo2-Stage1: pretrain from base Qwen3 + SigLIP2, and add the 8B variant

### DIFF
--- a/src/olmo_core/nn/vision/__init__.py
+++ b/src/olmo_core/nn/vision/__init__.py
@@ -14,9 +14,18 @@ from .connector import (
     VisionConnector,
     VisionConnectorConfig,
 )
-from .image_vit import VisionTransformer, ViTAttention, ViTBlock, ViTMLP
+from .image_vit import (
+    VisionTransformer,
+    ViTAttention,
+    ViTBlock,
+    ViTMLP,
+    siglip_state_dict_to_vision_encoder,
+)
 from .molmo2_image_processor import preprocess_image_molmo2
-from .molmo2_loader import molmo2_hf_state_dict_to_multimodal_lm, multimodal_lm_state_dict_to_hf
+from .molmo2_loader import (
+    molmo2_hf_state_dict_to_multimodal_lm,
+    multimodal_lm_state_dict_to_hf,
+)
 from .multimodal import MultimodalLM, MultimodalLMConfig
 
 __all__ = [
@@ -28,6 +37,7 @@ __all__ = [
     "ViTMLP",
     "ViTBlock",
     "VisionTransformer",
+    "siglip_state_dict_to_vision_encoder",
     "ImagePoolingType",
     "ImageProjectorType",
     "VisionConnectorConfig",

--- a/src/olmo_core/nn/vision/image_vit.py
+++ b/src/olmo_core/nn/vision/image_vit.py
@@ -15,6 +15,7 @@ __all__ = [
     "ViTMLP",
     "ViTBlock",
     "VisionTransformer",
+    "siglip_state_dict_to_vision_encoder",
 ]
 
 
@@ -325,3 +326,66 @@ class VisionTransformer(nn.Module):
                 x = block(x)
             hidden_states.append(x)
         return hidden_states
+
+
+def siglip_state_dict_to_vision_encoder(
+    hf_state: Dict[str, torch.Tensor],
+    *,
+    n_blocks: Optional[int] = None,
+    prefix: str = "",
+) -> Dict[str, torch.Tensor]:
+    """
+    Map a HuggingFace SigLIP / SigLIP2 vision-tower state dict onto
+    :class:`VisionTransformer` parameter names.
+
+    Accepts either a ``SiglipVisionTransformer`` state dict or a ``SiglipVisionModel``
+    one (whose keys carry a ``vision_model.`` prefix, stripped automatically).
+    ``post_layernorm`` and ``head.*`` are skipped: our encoder returns per-block hidden
+    states and does not model SigLIP's attention-pooling head.
+
+    :param hf_state: The HF vision-tower state dict.
+    :param n_blocks: Number of transformer blocks to emit. Defaults to every block found
+        in ``hf_state``. Pass a smaller value to load into a truncated encoder — e.g.
+        Molmo2 keeps blocks ``0..24`` of SigLIP2-SO400M's 27.
+    :param prefix: Prepended to every output key, e.g. ``"vision."`` when loading into a
+        :class:`~olmo_core.nn.vision.MultimodalLM` rather than a bare encoder.
+
+    :returns: A state dict suitable for ``load_state_dict``.
+
+    :raises KeyError: If an expected SigLIP key is absent.
+    """
+    hf_state = {k.removeprefix("vision_model."): v for k, v in hf_state.items()}
+
+    available = (
+        max((int(k.split(".")[2]) for k in hf_state if k.startswith("encoder.layers.")), default=-1)
+        + 1
+    )
+    if n_blocks is None:
+        n_blocks = available
+    elif n_blocks > available:
+        raise KeyError(f"requested {n_blocks} blocks but the state dict only has {available}")
+
+    patch_w = hf_state["embeddings.patch_embedding.weight"]
+    out: Dict[str, torch.Tensor] = {
+        # Conv2d (D, 3, p, p) -> our linear projection (D, 3 * p * p), C-first flatten.
+        f"{prefix}patch_embedding.weight": patch_w.reshape(patch_w.shape[0], -1),
+        f"{prefix}patch_embedding.bias": hf_state["embeddings.patch_embedding.bias"],
+        f"{prefix}positional_embedding": hf_state["embeddings.position_embedding.weight"],
+    }
+    for i in range(n_blocks):
+        src, dst = f"encoder.layers.{i}", f"{prefix}blocks.{i}"
+        for hf_name, ours in (("layer_norm1", "attn_norm"), ("layer_norm2", "ffn_norm")):
+            for suffix in ("weight", "bias"):
+                out[f"{dst}.{ours}.{suffix}"] = hf_state[f"{src}.{hf_name}.{suffix}"]
+        for hf_name, ours in (
+            ("q_proj", "wq"),
+            ("k_proj", "wk"),
+            ("v_proj", "wv"),
+            ("out_proj", "wo"),
+        ):
+            for suffix in ("weight", "bias"):
+                out[f"{dst}.attn.{ours}.{suffix}"] = hf_state[f"{src}.self_attn.{hf_name}.{suffix}"]
+        for hf_name, ours in (("fc1", "w1"), ("fc2", "w2")):
+            for suffix in ("weight", "bias"):
+                out[f"{dst}.ffn.{ours}.{suffix}"] = hf_state[f"{src}.mlp.{hf_name}.{suffix}"]
+    return out

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed.tensor import DTensor
 
-from olmo_core.config import Config
+from olmo_core.config import Config, DType
 from olmo_core.distributed.utils import barrier, is_distributed
 from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.lm_head import LMOutputWithLoss
@@ -22,9 +22,33 @@ from olmo_core.nn.vision.connector import (
 from olmo_core.nn.vision.molmo2_tokens import IM_PATCH_ID
 
 __all__ = [
+    "MOLMO2_BASE_VOCAB_SIZE",
+    "MOLMO2_VOCAB_SIZE",
     "MultimodalLMConfig",
     "MultimodalLM",
 ]
+
+MOLMO2_BASE_VOCAB_SIZE = 151_936
+"""Molmo2's base text vocab (Qwen3's) — the number of IDs the model may *predict*."""
+
+MOLMO2_VOCAB_SIZE = MOLMO2_BASE_VOCAB_SIZE + 128
+"""Molmo2's *input* vocab: the base text vocab plus 128 inputs-only image-special tokens."""
+
+
+def _molmo2_attn_backend():
+    """Attention backend for the Molmo2 LM, matching the HF loader's rule.
+
+    The multimodal masks (bidirectional image tokens + subsegment branch isolation) only run
+    on the dense ``torch`` backend or the fused ``flex`` one; ``OLMO2_FLEX_ATTN=1`` selects
+    FlexAttention (much faster for these masks, needs a GPU + ``torch.compile``).
+    """
+    from olmo_core.nn.attention import AttentionBackendName
+
+    return (
+        AttentionBackendName.flex
+        if os.environ.get("OLMO2_FLEX_ATTN") == "1"
+        else AttentionBackendName.torch
+    )
 
 
 @dataclass
@@ -89,37 +113,25 @@ class MultimodalLMConfig(Config):
     """
 
     @classmethod
-    def molmo2_4B(cls, *, rope_theta: int = 5_000_000, **kwargs) -> "MultimodalLMConfig":
+    def _molmo2_like(
+        cls,
+        lm: TransformerConfig,
+        *,
+        connector_mlp_hidden_size: int,
+        **kwargs,
+    ) -> "MultimodalLMConfig":
         """
-        Molmo2-4B architecture: a Qwen3-4B LM, a SigLIP2-SO400M/14-378 ViT truncated to
-        25 of its 27 blocks, and a two-layer attention-pooling connector.
+        Shared Molmo2 body: a SigLIP2-SO400M/14-378 ViT truncated to 25 of its 27 blocks
+        and a two-layer attention-pooling connector. Identical across the released
+        variants; only the LM and the connector's MLP width differ.
 
-        Equivalent to
-        :func:`~olmo_core.nn.vision.molmo2_loader.molmo2_config_from_hf_config` applied to
-        ``allenai/Molmo2-4B``, but without reading anything from the Hugging Face Hub — so
-        training from base checkpoints has no dependency on the released Molmo2 repo (whose
-        remote code also needs ``trust_remote_code=True``).
-
-        :param rope_theta: RoPE base. Defaults to ``5_000_000``, matching the *released*
-            Molmo2-4B weights. When initialising the LM from **base** Qwen3-4B, pass
-            ``1_000_000`` instead — that is what those weights were trained with (and what
-            mm_olmo's stage-1 ``QWEN3_4B`` config uses).
+        :param lm: The already-built language-model config.
+        :param connector_mlp_hidden_size: HF ``adapter_config.intermediate_size``. Equal to
+            the LM's feed-forward hidden size in every released variant, but a distinct
+            field, so it is passed explicitly rather than derived from ``lm``.
         """
-        import os
-
-        from olmo_core.config import DType
-        from olmo_core.nn.attention import AttentionBackendName
         from olmo_core.nn.vision.config import VisionEncoderType
 
-        base_vocab = 151_936
-        n_extra_tokens = 128
-        # Same backend rule as the HF loader: the multimodal masks (bidirectional image
-        # tokens + subsegment branch isolation) only run on dense ``torch`` or fused ``flex``.
-        attn_backend = (
-            AttentionBackendName.flex
-            if os.environ.get("OLMO2_FLEX_ATTN") == "1"
-            else AttentionBackendName.torch
-        )
         # Molmo2 keeps only blocks 0..24 of SigLIP2's 27 — everything past the deepest
         # feature layer (``vit_layers`` max 24) is dropped. ``name`` is a label only (the
         # SigLIP variant is selected by use_cls_token / patch_embedding_bias / use_pre_ln);
@@ -130,28 +142,75 @@ class MultimodalLMConfig(Config):
             image_num_layers=25,
         )
         return cls(
-            lm=TransformerConfig.qwen3_4B(
-                vocab_size=base_vocab + n_extra_tokens,
-                rope_theta=rope_theta,
-                attn_backend=attn_backend,
-                dtype=DType.float32,
-            ),
+            lm=lm,
             vision=vision,
             connector=VisionConnectorConfig(
                 image_emb_dim=vision.image_emb_dim,
                 image_num_heads=vision.image_num_heads,
                 image_num_key_value_heads=vision.image_num_key_value_heads,
                 image_head_dim=vision.image_head_dim,
-                output_dim=2560,
+                output_dim=lm.d_model,
                 num_input_layers=2,
                 pooling_type=ImagePoolingType.attention_meanq,
                 pooling_attention_mask=True,
                 projector_type=ImageProjectorType.mlp,
-                mlp_hidden_size=9728,
+                mlp_hidden_size=connector_mlp_hidden_size,
             ),
             image_patch_token_id=IM_PATCH_ID,
             vit_layers=(24, 18),
-            output_vocab_size=base_vocab,
+            output_vocab_size=MOLMO2_BASE_VOCAB_SIZE,
+            **kwargs,
+        )
+
+    @classmethod
+    def molmo2_4B(cls, *, rope_theta: int = 5_000_000, **kwargs) -> "MultimodalLMConfig":
+        """
+        Molmo2-4B architecture: a Qwen3-4B LM plus the shared Molmo2 vision stack.
+
+        Equivalent to
+        :func:`~olmo_core.nn.vision.molmo2_loader.molmo2_config_from_hf_config` applied to
+        ``allenai/Molmo2-4B``, but without reading anything from the Hugging Face Hub — so
+        training from base checkpoints has no dependency on the released Molmo2 repo (whose
+        remote code also needs ``trust_remote_code=True``).
+
+        :param rope_theta: RoPE base. Defaults to ``5_000_000``, matching the *released*
+            Molmo2-4B weights. When initialising the LM from **base** Qwen3-4B, pass
+            ``1_000_000`` instead — that is what those weights were trained with (and what
+            mm_olmo's stage-1 ``QWEN3_4B`` config uses). Note Molmo2-4B is the only released
+            variant whose base differs from its Qwen3 backbone's.
+        """
+        return cls._molmo2_like(
+            TransformerConfig.qwen3_4B(
+                vocab_size=MOLMO2_VOCAB_SIZE,
+                rope_theta=rope_theta,
+                attn_backend=_molmo2_attn_backend(),
+                dtype=DType.float32,
+            ),
+            connector_mlp_hidden_size=9728,
+            **kwargs,
+        )
+
+    @classmethod
+    def molmo2_8B(cls, *, rope_theta: int = 1_000_000, **kwargs) -> "MultimodalLMConfig":
+        """
+        Molmo2-8B architecture: a Qwen3-8B LM plus the shared Molmo2 vision stack.
+
+        Equivalent to
+        :func:`~olmo_core.nn.vision.molmo2_loader.molmo2_config_from_hf_config` applied to
+        ``allenai/Molmo2-8B``, without reading from the Hugging Face Hub.
+
+        :param rope_theta: RoPE base. ``1_000_000`` for both the released Molmo2-8B weights
+            and base Qwen3-8B, so unlike :meth:`molmo2_4B` the default is correct for either
+            weight source. Note this variant is **not** weight-tied (neither is Qwen3-8B).
+        """
+        return cls._molmo2_like(
+            TransformerConfig.qwen3_8B(
+                vocab_size=MOLMO2_VOCAB_SIZE,
+                rope_theta=rope_theta,
+                attn_backend=_molmo2_attn_backend(),
+                dtype=DType.float32,
+            ),
+            connector_mlp_hidden_size=12288,
             **kwargs,
         )
 

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import os
+from dataclasses import dataclass, replace
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -14,7 +14,12 @@ from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.lm_head import LMOutputWithLoss
 from olmo_core.nn.transformer.config import TransformerConfig
 from olmo_core.nn.vision.config import VisionEncoderConfig
-from olmo_core.nn.vision.connector import VisionConnectorConfig
+from olmo_core.nn.vision.connector import (
+    ImagePoolingType,
+    ImageProjectorType,
+    VisionConnectorConfig,
+)
+from olmo_core.nn.vision.molmo2_tokens import IM_PATCH_ID
 
 __all__ = [
     "MultimodalLMConfig",
@@ -82,6 +87,73 @@ class MultimodalLMConfig(Config):
     base-vocab-only head for loss, sampling, and (tied-embedding) training dynamics.
     ``None`` (default) disables masking.
     """
+
+    @classmethod
+    def molmo2_4B(cls, *, rope_theta: int = 5_000_000, **kwargs) -> "MultimodalLMConfig":
+        """
+        Molmo2-4B architecture: a Qwen3-4B LM, a SigLIP2-SO400M/14-378 ViT truncated to
+        25 of its 27 blocks, and a two-layer attention-pooling connector.
+
+        Equivalent to
+        :func:`~olmo_core.nn.vision.molmo2_loader.molmo2_config_from_hf_config` applied to
+        ``allenai/Molmo2-4B``, but without reading anything from the Hugging Face Hub — so
+        training from base checkpoints has no dependency on the released Molmo2 repo (whose
+        remote code also needs ``trust_remote_code=True``).
+
+        :param rope_theta: RoPE base. Defaults to ``5_000_000``, matching the *released*
+            Molmo2-4B weights. When initialising the LM from **base** Qwen3-4B, pass
+            ``1_000_000`` instead — that is what those weights were trained with (and what
+            mm_olmo's stage-1 ``QWEN3_4B`` config uses).
+        """
+        import os
+
+        from olmo_core.config import DType
+        from olmo_core.nn.attention import AttentionBackendName
+        from olmo_core.nn.vision.config import VisionEncoderType
+
+        base_vocab = 151_936
+        n_extra_tokens = 128
+        # Same backend rule as the HF loader: the multimodal masks (bidirectional image
+        # tokens + subsegment branch isolation) only run on dense ``torch`` or fused ``flex``.
+        attn_backend = (
+            AttentionBackendName.flex
+            if os.environ.get("OLMO2_FLEX_ATTN") == "1"
+            else AttentionBackendName.torch
+        )
+        # Molmo2 keeps only blocks 0..24 of SigLIP2's 27 — everything past the deepest
+        # feature layer (``vit_layers`` max 24) is dropped. ``name`` is a label only (the
+        # SigLIP variant is selected by use_cls_token / patch_embedding_bias / use_pre_ln);
+        # we use ``siglip`` so this is byte-identical to the HF-derived config.
+        vision = replace(
+            VisionEncoderConfig.siglip2_so400m_patch14_378(),
+            name=VisionEncoderType.siglip,
+            image_num_layers=25,
+        )
+        return cls(
+            lm=TransformerConfig.qwen3_4B(
+                vocab_size=base_vocab + n_extra_tokens,
+                rope_theta=rope_theta,
+                attn_backend=attn_backend,
+                dtype=DType.float32,
+            ),
+            vision=vision,
+            connector=VisionConnectorConfig(
+                image_emb_dim=vision.image_emb_dim,
+                image_num_heads=vision.image_num_heads,
+                image_num_key_value_heads=vision.image_num_key_value_heads,
+                image_head_dim=vision.image_head_dim,
+                output_dim=2560,
+                num_input_layers=2,
+                pooling_type=ImagePoolingType.attention_meanq,
+                pooling_attention_mask=True,
+                projector_type=ImageProjectorType.mlp,
+                mlp_hidden_size=9728,
+            ),
+            image_patch_token_id=IM_PATCH_ID,
+            vit_layers=(24, 18),
+            output_vocab_size=base_vocab,
+            **kwargs,
+        )
 
     def build(self, init_device: str = "cpu") -> "MultimodalLM":
         """
@@ -247,9 +319,7 @@ class MultimodalLM(nn.Module):
                 end = min(start + microbatch, T)
                 chunk = images[:, start:end].reshape(B * (end - start), N, -1)
                 chunk_features = self._vit_forward_features(chunk)
-                parts.append(
-                    chunk_features.reshape(B, (end - start) * chunk_features.shape[1], -1)
-                )
+                parts.append(chunk_features.reshape(B, (end - start) * chunk_features.shape[1], -1))
             features = torch.cat(parts, dim=1)
 
         return self.connector(features, pooled_patches_idx)
@@ -335,9 +405,7 @@ class MultimodalLM(nn.Module):
         flex_mask_kwargs: Optional[dict] = None
         if use_flex_attn:
             B, S = input_ids.shape
-            flex_is_image = (
-                token_type_ids.to(device) != 0 if token_type_ids is not None else None
-            )
+            flex_is_image = token_type_ids.to(device) != 0 if token_type_ids is not None else None
             flex_subseg = subsegment_ids.to(device) if subsegment_ids is not None else None
             flex_eid = example_ids.to(device) if example_ids is not None else None
             flex_mask_kwargs = dict(

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -6,11 +6,13 @@ Trains the connector + LM on PixMoCap captions/transcripts with the vision encod
 learning rates / warmups. In-loop evaluation is intentionally omitted.
 
 Weights start from **base** checkpoints, matching mm_olmo's ``reset_with_pretrained_weights``:
-the LM from ``Qwen/Qwen3-4B``, the ViT from ``google/siglip2-so400m-patch14-384``, and the
-connector / extra-token embeddings randomly initialised (``INIT_FROM = "scratch"``). This is
-stage-1 *pretraining*. Passing ``--init_from=molmo2`` instead continues the released,
-already-post-trained ``allenai/Molmo2-4B`` on the stage-1 objective, which is a fine-tune —
+the LM from the base Qwen3 backbone, the ViT from ``google/siglip2-so400m-patch14-384``, and
+the connector / extra-token embeddings randomly initialised (``INIT_FROM = "scratch"``). This
+is stage-1 *pretraining*. Passing ``--init_from=molmo2`` instead continues the released,
+already-post-trained Molmo2 checkpoint on the stage-1 objective, which is a fine-tune —
 useful for parity tests and continuation experiments, but not a stage-1 reproduction.
+
+``--model_size`` selects the variant: ``4b`` (Qwen3-4B, the default) or ``8b`` (Qwen3-8B).
 
 Run without arguments for usage. Quick local smoke test on synthetic data::
 
@@ -25,9 +27,10 @@ Run without arguments for usage. Quick local smoke test on synthetic data::
 
 import logging
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import List, Optional, cast
+from typing import List, Optional, Tuple, cast
 
 from olmo_core.config import Config, DType
 from olmo_core.data.multimodal import (
@@ -84,24 +87,64 @@ log = logging.getLogger(__name__)
 #### CONFIGURATION ####
 #######################
 
-# Architecture + tokenizer source. Only the HF *config* and tokenizer are read from this
-# repo id; stage-1 weights come from the base checkpoints below (see INIT_FROM).
-MODEL_ID = "allenai/Molmo2-4B"
+# Model size. Selects the architecture factory, the base LM to initialise from, and the
+# released checkpoint used by `--init_from=molmo2`. Override with `--model_size=8b`.
+MODEL_SIZE = "4b"
 
-# Weight init. "scratch" is mm_olmo's true stage-1 start and the default: base Qwen3-4B LM
+
+@dataclass(frozen=True)
+class ModelSizeSpec:
+    """Weight sources and RoPE bases for one Molmo2 variant."""
+
+    factory: Callable[..., MultimodalLMConfig]
+    """Native architecture factory, e.g. :meth:`MultimodalLMConfig.molmo2_4B`."""
+
+    molmo2_id: str
+    """Released checkpoint, used by ``--init_from=molmo2``."""
+
+    scratch_lm_id: str
+    """Base Qwen3 backbone, used by ``--init_from=scratch``."""
+
+    scratch_rope_theta: int
+    """RoPE base of ``scratch_lm_id``'s weights."""
+
+    molmo2_rope_theta: int
+    """RoPE base of ``molmo2_id``'s weights."""
+
+    def rope_theta(self, init_from: str) -> int:
+        return self.scratch_rope_theta if init_from == "scratch" else self.molmo2_rope_theta
+
+
+# `rope_theta` follows the *weight source*: every base Qwen3 backbone uses 1e6, and so does
+# the released Molmo2-8B — the released Molmo2-4B is the sole variant that differs (5e6).
+# Deriving the architecture from a released config while loading base weights therefore puts
+# 4B weights on the wrong rotary base.
+MODEL_SIZES = {
+    "4b": ModelSizeSpec(
+        factory=MultimodalLMConfig.molmo2_4B,
+        molmo2_id="allenai/Molmo2-4B",
+        scratch_lm_id="Qwen/Qwen3-4B",
+        scratch_rope_theta=1_000_000,
+        molmo2_rope_theta=5_000_000,
+    ),
+    "8b": ModelSizeSpec(
+        factory=MultimodalLMConfig.molmo2_8B,
+        molmo2_id="allenai/Molmo2-8B",
+        scratch_lm_id="Qwen/Qwen3-8B",
+        scratch_rope_theta=1_000_000,
+        molmo2_rope_theta=1_000_000,
+    ),
+}
+
+# Weight init. "scratch" is mm_olmo's true stage-1 start and the default: base Qwen3 LM
 # + base SigLIP2 ViT + randomly-initialised connector / new-token embeddings. "molmo2"
-# instead *continues* the released (already post-trained) Molmo2-4B on the stage-1
+# instead *continues* the released (already post-trained) Molmo2 checkpoint on the stage-1
 # objective — that is a fine-tune, not stage-1 pretraining, so it is opt-in only
 # (`--init_from=molmo2`), kept for parity tests and continuation experiments.
 INIT_FROM = "scratch"
 INIT_FROM_CHOICES = ("scratch", "molmo2")
-SCRATCH_LM_ID = "Qwen/Qwen3-4B"
-SCRATCH_VIT_ID = "google/siglip2-so400m-patch14-384"
+SCRATCH_VIT_ID = "google/siglip2-so400m-patch14-384"  # shared by every Molmo2 variant
 NEW_EMBEDDING_INIT_STD = 0.02  # mm_olmo `new_embedding_init_range`
-# RoPE base per weight source: base Qwen3-4B was trained with 1e6 (as is mm_olmo's
-# stage-1 QWEN3_4B); the released Molmo2-4B checkpoint uses 5e6.
-SCRATCH_ROPE_THETA = 1_000_000
-MOLMO2_ROPE_THETA = 5_000_000
 SEQUENCE_LENGTH = 4096  # fixed pad length; mm_olmo's captioner default is 2536
 USE_FLEX_ATTN = True  # fused FlexAttention backend for the multimodal masks (~+8% MFU)
 PACK_SEQUENCES = True  # pack several examples per sequence (most are ~1.4k of 4096 tokens)
@@ -167,7 +210,9 @@ class ExperimentConfig(Config):
     collator: MultimodalCollatorConfig
     train_module: MultimodalTransformerTrainModuleConfig
     trainer: TrainerConfig
-    model_id: str = MODEL_ID
+    model_size: str = MODEL_SIZE
+    """``"4b"`` or ``"8b"`` — selects the architecture, the base LM to initialise from, and
+    the released checkpoint used by ``--init_from=molmo2``."""
     data_seed: int = 34521
     init_seed: int = 12536
     global_batch_size: int = GLOBAL_BATCH_SIZE
@@ -185,7 +230,7 @@ class ExperimentConfig(Config):
     base Qwen3-4B + base SigLIP2 + random connector/new embeddings)."""
 
 
-def _build_model_config(init_from: str) -> MultimodalLMConfig:
+def _build_model_config(model_size: str, init_from: str) -> MultimodalLMConfig:
     """Build the Molmo2-4B :class:`MultimodalLMConfig` natively (no weights, no HF read).
 
     ``MultimodalLMConfig.molmo2_4B`` is byte-identical to
@@ -197,25 +242,36 @@ def _build_model_config(init_from: str) -> MultimodalLMConfig:
     — was trained with ``1e6`` (mm_olmo's stage-1 ``QWEN3_4B`` also uses ``1e6``). Using
     the released value with base weights would put them on the wrong rotary base.
     """
-    rope_theta = SCRATCH_ROPE_THETA if init_from == "scratch" else MOLMO2_ROPE_THETA
-    return MultimodalLMConfig.molmo2_4B(rope_theta=rope_theta)
+    spec = MODEL_SIZES[model_size]
+    return spec.factory(rope_theta=spec.rope_theta(init_from))
 
 
-def _resolve_init_from(overrides: List[str]) -> str:
-    """Read ``init_from`` out of the raw overrides.
+def _read_override(overrides: List[str], key: str, default: str) -> str:
+    """Read a top-level scalar out of the raw overrides.
 
-    The model config depends on it (RoPE base), and it has to be built before
-    :meth:`Config.merge` runs, so the override cannot be read off the merged config.
-    Later occurrences win, matching ``merge``.
+    The model config depends on ``model_size`` and ``init_from`` (architecture and RoPE
+    base), and it is built before :meth:`Config.merge` runs, so those overrides cannot be
+    read off the merged config. Later occurrences win, matching ``merge``.
     """
-    init_from = INIT_FROM
+    value = default
     for override in overrides:
-        key, _, value = override.lstrip("-").partition("=")
-        if key == "init_from" and value:
-            init_from = value
+        name, _, raw = override.lstrip("-").partition("=")
+        if name == key and raw:
+            value = raw
+    return value
+
+
+def _resolve_model_spec(overrides: List[str]) -> Tuple[str, str]:
+    """Resolve ``(model_size, init_from)`` from the raw overrides, validating both."""
+    model_size = _read_override(overrides, "model_size", MODEL_SIZE).lower()
+    init_from = _read_override(overrides, "init_from", INIT_FROM)
+    if model_size not in MODEL_SIZES:
+        raise OLMoConfigurationError(
+            f"model_size={model_size!r} is not one of {tuple(MODEL_SIZES)}"
+        )
     if init_from not in INIT_FROM_CHOICES:
         raise OLMoConfigurationError(f"init_from={init_from!r} is not one of {INIT_FROM_CHOICES}")
-    return init_from
+    return model_size, init_from
 
 
 def build_config(script: str, run_name: str, overrides: List[str]) -> ExperimentConfig:
@@ -223,7 +279,8 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
     beaker_user = get_beaker_username()
     assert beaker_user is not None
 
-    model_config = _build_model_config(_resolve_init_from(overrides))
+    model_size, init_from = _resolve_model_spec(overrides)
+    model_config = _build_model_config(model_size, init_from)
 
     dataset_config = PixMoCapDatasetConfig(
         dataset_path=DATASET_PATH,
@@ -342,16 +399,19 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         launch=launch_config,
     ).merge(overrides)
 
-    # Fail here rather than after a Beaker job has queued, started and downloaded weights.
-    if config.init_from not in INIT_FROM_CHOICES:
+    # `_resolve_model_spec` already validated the pre-merge values; re-check the merged
+    # config so a stray `--model_size`/`--init_from` cannot slip through, and fail here
+    # rather than after a Beaker job has queued, started and downloaded weights.
+    if (config.model_size, config.init_from) != (model_size, init_from):
         raise OLMoConfigurationError(
-            f"init_from={config.init_from!r} is not one of {INIT_FROM_CHOICES}"
+            f"model_size / init_from changed during merge: "
+            f"({model_size!r}, {init_from!r}) -> ({config.model_size!r}, {config.init_from!r})"
         )
 
     return config
 
 
-def _load_tokenizer(init_from: str):
+def _load_tokenizer(model_size: str, init_from: str):
     """Load the tokenizer for this init mode.
 
     A ``"scratch"`` run uses base ``Qwen/Qwen3-4B``'s tokenizer — what mm_olmo's stage 1
@@ -366,13 +426,19 @@ def _load_tokenizer(init_from: str):
     """
     from transformers import AutoTokenizer
 
+    spec = MODEL_SIZES[model_size]
     if init_from == "scratch":
-        return AutoTokenizer.from_pretrained(SCRATCH_LM_ID)
-    return AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
+        return AutoTokenizer.from_pretrained(spec.scratch_lm_id)
+    return AutoTokenizer.from_pretrained(spec.molmo2_id, trust_remote_code=True)
 
 
-def _init_weights_from_hf(model: MultimodalLM, model_cfg: MultimodalLMConfig) -> None:
-    """Load converted HF Molmo2 weights into the (meta-initialised) model."""
+def _init_weights_from_hf(
+    model: MultimodalLM, model_cfg: MultimodalLMConfig, molmo2_id: str
+) -> None:
+    """Load converted HF Molmo2 weights into the (meta-initialised) model.
+
+    :param molmo2_id: The released checkpoint to continue from, e.g. ``allenai/Molmo2-4B``.
+    """
     from transformers import AutoModelForImageTextToText
 
     from olmo_core.nn.vision.molmo2_loader import (
@@ -383,28 +449,35 @@ def _init_weights_from_hf(model: MultimodalLM, model_cfg: MultimodalLMConfig) ->
     )
 
     ensure_default_rope_registered()
-    log.info(f"Loading HF weights from {MODEL_ID} ...")
-    hf = AutoModelForImageTextToText.from_pretrained(MODEL_ID, trust_remote_code=True)
+    log.info(f"Loading HF weights from {molmo2_id} ...")
+    hf = AutoModelForImageTextToText.from_pretrained(molmo2_id, trust_remote_code=True)
     reinit_rope_buffers(hf)
     converted = molmo2_hf_state_dict_to_multimodal_lm(hf.state_dict(), model_cfg)
     del hf
     model.to_empty(device=get_default_device())
     model.load_state_dict(converted, strict=False)
-    # `to_empty` silently un-ties tied word embeddings (Molmo2-4B); restore the share so
-    # training updates the head and the embedding table as one parameter, like mm_olmo.
+    # `to_empty` silently un-ties tied word embeddings (Molmo2-4B is tied; the 8B is not);
+    # restore the share so training updates the head and the embedding table as one
+    # parameter, like mm_olmo. A no-op for untied configs.
     retie_word_embeddings(model)
     del converted
 
 
-def _init_weights_from_scratch(model: MultimodalLM, model_cfg: MultimodalLMConfig) -> None:
+def _init_weights_from_scratch(
+    model: MultimodalLM, model_cfg: MultimodalLMConfig, scratch_lm_id: str
+) -> None:
     """mm_olmo's true stage-1 init (``reset_with_pretrained_weights``):
 
-    * LM  <- base ``Qwen/Qwen3-4B`` (weight-tied), via the generic HF->olmo-core converter;
+    * LM  <- the base Qwen3 backbone, via the generic HF->olmo-core converter;
       the 128 extra-token embedding rows are ``N(0, 0.02)`` (mm_olmo
-      ``new_embedding_init_range``) and the LM head is tied to the embeddings.
-    * vision <- base ``google/siglip2-so400m-patch14-384`` (blocks 0..24).
+      ``new_embedding_init_range``) and the LM head is tied to the embeddings when the
+      config is tied (Molmo2-4B; the 8B and Qwen3-8B are untied).
+    * vision <- base ``google/siglip2-so400m-patch14-384`` (blocks 0..24), shared by every
+      released Molmo2 variant.
     * connector <- random (``reset_parameters``: ``N(0, 0.02)`` weights, zero biases —
       matches mm_olmo's pooling + projector init).
+
+    :param scratch_lm_id: The base LM to initialise from, e.g. ``Qwen/Qwen3-4B``.
     """
     import torch
     from transformers import AutoModelForCausalLM, SiglipVisionModel
@@ -413,8 +486,8 @@ def _init_weights_from_scratch(model: MultimodalLM, model_cfg: MultimodalLMConfi
     from olmo_core.nn.vision import siglip_state_dict_to_vision_encoder
     from olmo_core.nn.vision.molmo2_loader import retie_word_embeddings
 
-    log.info(f"[scratch init] Loading base LM weights from {SCRATCH_LM_ID} ...")
-    hf_lm = AutoModelForCausalLM.from_pretrained(SCRATCH_LM_ID, dtype=torch.float32)
+    log.info(f"[scratch init] Loading base LM weights from {scratch_lm_id} ...")
+    hf_lm = AutoModelForCausalLM.from_pretrained(scratch_lm_id, dtype=torch.float32)
     lm_state = convert_state_from_hf(hf_lm.config, hf_lm.state_dict(), model_type="qwen3")
     del hf_lm
 
@@ -429,9 +502,23 @@ def _init_weights_from_scratch(model: MultimodalLM, model_cfg: MultimodalLMConfi
 
     converted = {f"lm.{k}": v for k, v in lm_state.items()}
     converted["lm.embeddings.weight"] = full_emb
-    # Tied head (mm_olmo `weight_tying=True`): identical values regardless of whether the
-    # target params share storage.
-    converted["lm.lm_head.w_out.weight"] = full_emb.clone()
+    # The LM head has to span our full input vocab, but the base checkpoint only covers the
+    # base one, so it needs the same `extra` rows appended. How depends on tying:
+    if model_cfg.lm.tie_word_embeddings:
+        # Tied (Molmo2-4B / Qwen3-4B, mm_olmo `weight_tying=True`): head *is* the embedding
+        # table. Identical values make the load order-independent; `retie_word_embeddings`
+        # below restores the share that `to_empty` broke.
+        converted["lm.lm_head.w_out.weight"] = full_emb.clone()
+    else:
+        # Untied (Molmo2-8B / Qwen3-8B): the base checkpoint carries a *distinct trained*
+        # output head — keep it rather than overwriting it with the embedding table. The
+        # appended rows are zeros because `output_vocab_size` masks logit columns >= the base
+        # vocab: they never enter the softmax and receive exactly zero gradient, matching
+        # mm_olmo, whose untied `ff_out` spans only the base vocab.
+        base_head = lm_state["lm_head.w_out.weight"]
+        converted["lm.lm_head.w_out.weight"] = torch.cat(
+            [base_head, base_head.new_zeros(extra, base_head.shape[1])], dim=0
+        )
     del lm_state
 
     log.info(f"[scratch init] Loading base ViT weights from {SCRATCH_VIT_ID} ...")
@@ -497,13 +584,14 @@ def _build_mixture_sources(tokenizer, config: ExperimentConfig):
 def train(config: ExperimentConfig):
     seed_all(config.init_seed)
 
-    tokenizer = _load_tokenizer(config.init_from)
+    tokenizer = _load_tokenizer(config.model_size, config.init_from)
 
     model = config.model.build(init_device="meta")
+    spec = MODEL_SIZES[config.model_size]
     if config.init_from == "scratch":
-        _init_weights_from_scratch(model, config.model)
+        _init_weights_from_scratch(model, config.model, spec.scratch_lm_id)
     elif config.init_from == "molmo2":
-        _init_weights_from_hf(model, config.model)
+        _init_weights_from_hf(model, config.model, spec.molmo2_id)
     else:  # unreachable via build_config, which validates; guards direct train() calls
         raise OLMoConfigurationError(
             f"init_from={config.init_from!r} is not one of {INIT_FROM_CHOICES}"
@@ -570,6 +658,9 @@ Examples
 
 Print the config:
 › python {sys.argv[0]} dry_run molmo2-stage1
+
+8B from-scratch run:
+› python {sys.argv[0]} launch molmo2-stage1-8b --model_size=8b
 
 Local synthetic smoke test:
 › torchrun --nproc-per-node=1 {sys.argv[0]} train smoke \\

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -5,6 +5,13 @@ Trains the connector + LM on PixMoCap captions/transcripts with the vision encod
 **frozen**, using the float ``root_subsegments``-weighted loss and per-component
 learning rates / warmups. In-loop evaluation is intentionally omitted.
 
+Weights start from **base** checkpoints, matching mm_olmo's ``reset_with_pretrained_weights``:
+the LM from ``Qwen/Qwen3-4B``, the ViT from ``google/siglip2-so400m-patch14-384``, and the
+connector / extra-token embeddings randomly initialised (``INIT_FROM = "scratch"``). This is
+stage-1 *pretraining*. Passing ``--init_from=molmo2`` instead continues the released,
+already-post-trained ``allenai/Molmo2-4B`` on the stage-1 objective, which is a fine-tune —
+useful for parity tests and continuation experiments, but not a stage-1 reproduction.
+
 Run without arguments for usage. Quick local smoke test on synthetic data::
 
     torchrun --nproc-per-node=1 src/scripts/train/Molmo2-Stage1.py train smoke \\
@@ -33,8 +40,10 @@ from olmo_core.data.multimodal import (
     PixMoPointsDatasetConfig,
     Tulu4DatasetConfig,
 )
+from olmo_core.data.multimodal.paths import PIXMO_DATASETS
 from olmo_core.distributed.parallel import DataParallelType
 from olmo_core.distributed.utils import get_rank, get_world_size
+from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.internal.common import (
     build_launch_config,
     get_beaker_username,
@@ -42,7 +51,12 @@ from olmo_core.internal.common import (
 )
 from olmo_core.launch.beaker import BeakerEnvVar, BeakerLaunchConfig
 from olmo_core.nn.vision import MultimodalLM, MultimodalLMConfig
-from olmo_core.optim import AdamWConfig, CosWithWarmup, OptimGroupOverride, PerGroupScheduler
+from olmo_core.optim import (
+    AdamWConfig,
+    CosWithWarmup,
+    OptimGroupOverride,
+    PerGroupScheduler,
+)
 from olmo_core.train import (
     Duration,
     TrainerConfig,
@@ -70,8 +84,21 @@ log = logging.getLogger(__name__)
 #### CONFIGURATION ####
 #######################
 
-MODEL_ID = "allenai/Molmo2-4B"  # HF checkpoint to initialise from (also provides the tokenizer)
-SEQUENCE_LENGTH = 4096  # fixed pad length; mm_olmo stage 1 uses ~5248
+# Architecture + tokenizer source. Only the HF *config* and tokenizer are read from this
+# repo id; stage-1 weights come from the base checkpoints below (see INIT_FROM).
+MODEL_ID = "allenai/Molmo2-4B"
+
+# Weight init. "scratch" is mm_olmo's true stage-1 start and the default: base Qwen3-4B LM
+# + base SigLIP2 ViT + randomly-initialised connector / new-token embeddings. "molmo2"
+# instead *continues* the released (already post-trained) Molmo2-4B on the stage-1
+# objective — that is a fine-tune, not stage-1 pretraining, so it is opt-in only
+# (`--init_from=molmo2`), kept for parity tests and continuation experiments.
+INIT_FROM = "scratch"
+INIT_FROM_CHOICES = ("scratch", "molmo2")
+SCRATCH_LM_ID = "Qwen/Qwen3-4B"
+SCRATCH_VIT_ID = "google/siglip2-so400m-patch14-384"
+NEW_EMBEDDING_INIT_STD = 0.02  # mm_olmo `new_embedding_init_range`
+SEQUENCE_LENGTH = 4096  # fixed pad length; mm_olmo's captioner default is 2536
 USE_FLEX_ATTN = True  # fused FlexAttention backend for the multimodal masks (~+8% MFU)
 PACK_SEQUENCES = True  # pack several examples per sequence (most are ~1.4k of 4096 tokens)
 COMPILE_MODEL = True  # torch.compile the LM (fuses pointwise ops; one-time compile warmup)
@@ -100,8 +127,6 @@ LLM_LR = 2e-5
 CONNECTOR_WARMUP = 200
 LLM_WARMUP = 2000
 ALPHA_F = 0.1
-
-from olmo_core.data.multimodal.paths import PIXMO_DATASETS
 
 # Data: the canonical PixMoCap "cap" dataset (HF DatasetDict, load_from_disk). Override as needed.
 DATASET_PATH = f"{PIXMO_DATASETS}/cap"
@@ -150,6 +175,10 @@ class ExperimentConfig(Config):
     """Fraction of mixture samples from Tulu4 NLP SFT (mm_olmo ``--nlp``)."""
     pack_sequences: bool = PACK_SEQUENCES
     """Pack several short examples per sequence (mm_olmo dynamic packer)."""
+
+    init_from: str = INIT_FROM
+    """``"molmo2"`` (released Molmo2-4B weights) or ``"scratch"`` (mm_olmo stage-1 init:
+    base Qwen3-4B + base SigLIP2 + random connector/new embeddings)."""
 
 
 def _build_model_config() -> MultimodalLMConfig:
@@ -281,7 +310,7 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
             BeakerEnvVar(name="OLMO2_FLEX_ATTN", value="1")
         ]
 
-    return ExperimentConfig(
+    config = ExperimentConfig(
         model=model_config,
         dataset=dataset_config,
         collator=collator_config,
@@ -289,6 +318,14 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         trainer=trainer_config,
         launch=launch_config,
     ).merge(overrides)
+
+    # Fail here rather than after a Beaker job has queued, started and downloaded weights.
+    if config.init_from not in INIT_FROM_CHOICES:
+        raise OLMoConfigurationError(
+            f"init_from={config.init_from!r} is not one of {INIT_FROM_CHOICES}"
+        )
+
+    return config
 
 
 def _load_tokenizer():
@@ -320,6 +357,100 @@ def _init_weights_from_hf(model: MultimodalLM, model_cfg: MultimodalLMConfig) ->
     # training updates the head and the embedding table as one parameter, like mm_olmo.
     retie_word_embeddings(model)
     del converted
+
+
+def _convert_siglip_vision_state(hf_sd, n_blocks: int):
+    """Map an HF ``SiglipVisionModel`` state dict onto ``MultimodalLM.vision`` keys.
+
+    Same (numerically parity-verified) mapping as ``_convert_siglip_state_dict`` in
+    ``src/test/nn/vision/parity_test.py``, with a ``vision.`` key prefix and truncation to
+    the target's ``n_blocks`` (Molmo2 keeps SigLIP2 blocks 0..24 of 27 — everything past
+    ``vit_layers`` max ``24`` is dropped, exactly like mm_olmo's truncated ViT).
+    ``post_layernorm`` / ``head.*`` have no counterpart in our encoder and are skipped.
+    """
+    hf_sd = {k.removeprefix("vision_model."): v for k, v in hf_sd.items()}
+    out = {}
+    w = hf_sd["embeddings.patch_embedding.weight"]  # Conv2d (D, 3, p, p) -> C-first flatten
+    out["vision.patch_embedding.weight"] = w.reshape(w.shape[0], -1)
+    out["vision.patch_embedding.bias"] = hf_sd["embeddings.patch_embedding.bias"]
+    out["vision.positional_embedding"] = hf_sd["embeddings.position_embedding.weight"]
+    for i in range(n_blocks):
+        src, dst = f"encoder.layers.{i}", f"vision.blocks.{i}"
+        for hf_name, ours in (("layer_norm1", "attn_norm"), ("layer_norm2", "ffn_norm")):
+            for suf in ("weight", "bias"):
+                out[f"{dst}.{ours}.{suf}"] = hf_sd[f"{src}.{hf_name}.{suf}"]
+        for hf_name, ours in (
+            ("q_proj", "wq"),
+            ("k_proj", "wk"),
+            ("v_proj", "wv"),
+            ("out_proj", "wo"),
+        ):
+            for suf in ("weight", "bias"):
+                out[f"{dst}.attn.{ours}.{suf}"] = hf_sd[f"{src}.self_attn.{hf_name}.{suf}"]
+        for hf_name, ours in (("fc1", "w1"), ("fc2", "w2")):
+            for suf in ("weight", "bias"):
+                out[f"{dst}.ffn.{ours}.{suf}"] = hf_sd[f"{src}.mlp.{hf_name}.{suf}"]
+    return out
+
+
+def _init_weights_from_scratch(model: MultimodalLM, model_cfg: MultimodalLMConfig) -> None:
+    """mm_olmo's true stage-1 init (``reset_with_pretrained_weights``):
+
+    * LM  <- base ``Qwen/Qwen3-4B`` (weight-tied), via the generic HF->olmo-core converter;
+      the 128 extra-token embedding rows are ``N(0, 0.02)`` (mm_olmo
+      ``new_embedding_init_range``) and the LM head is tied to the embeddings.
+    * vision <- base ``google/siglip2-so400m-patch14-384`` (blocks 0..24).
+    * connector <- random (``reset_parameters``: ``N(0, 0.02)`` weights, zero biases —
+      matches mm_olmo's pooling + projector init).
+    """
+    import torch
+    from transformers import AutoModelForCausalLM, SiglipVisionModel
+
+    from olmo_core.nn.hf import convert_state_from_hf
+    from olmo_core.nn.vision.molmo2_loader import retie_word_embeddings
+
+    log.info(f"[scratch init] Loading base LM weights from {SCRATCH_LM_ID} ...")
+    hf_lm = AutoModelForCausalLM.from_pretrained(SCRATCH_LM_ID, dtype=torch.float32)
+    lm_state = convert_state_from_hf(hf_lm.config, hf_lm.state_dict(), model_type="qwen3")
+    del hf_lm
+
+    emb = lm_state["embeddings.weight"]
+    extra = model_cfg.lm.vocab_size - emb.shape[0]
+    if extra < 0:
+        raise RuntimeError(f"Base LM vocab {emb.shape[0]} exceeds target {model_cfg.lm.vocab_size}")
+    gen = torch.Generator().manual_seed(0)  # same rows on every rank
+    new_rows = torch.empty(extra, emb.shape[1], dtype=emb.dtype)
+    new_rows.normal_(std=NEW_EMBEDDING_INIT_STD, generator=gen)
+    full_emb = torch.cat([emb, new_rows], dim=0)
+
+    converted = {f"lm.{k}": v for k, v in lm_state.items()}
+    converted["lm.embeddings.weight"] = full_emb
+    # Tied head (mm_olmo `weight_tying=True`): identical values regardless of whether the
+    # target params share storage.
+    converted["lm.lm_head.w_out.weight"] = full_emb.clone()
+    del lm_state
+
+    log.info(f"[scratch init] Loading base ViT weights from {SCRATCH_VIT_ID} ...")
+    hf_vit = SiglipVisionModel.from_pretrained(SCRATCH_VIT_ID, dtype=torch.float32)
+    converted.update(_convert_siglip_vision_state(hf_vit.state_dict(), len(model.vision.blocks)))
+    del hf_vit
+
+    model.to_empty(device=get_default_device())
+    missing, unexpected = model.load_state_dict(converted, strict=False)
+    del converted
+    # Everything except the connector must have been covered by the two base checkpoints.
+    non_connector_missing = [k for k in missing if not k.startswith("connector.")]
+    if non_connector_missing or unexpected:
+        raise RuntimeError(
+            f"[scratch init] unexpected state-dict coverage: missing={non_connector_missing[:8]} "
+            f"unexpected={list(unexpected)[:8]}"
+        )
+    # `to_empty` above un-ties tied word embeddings, so the head and the embedding table
+    # would otherwise train as two independent parameters. Restore the share so they move
+    # together, matching mm_olmo's `weight_tying=True` (no-op for untied configs).
+    retie_word_embeddings(model)
+    log.info("[scratch init] Randomly initialising the connector ...")
+    model.connector.reset_parameters()
 
 
 def _build_mixture_sources(tokenizer, config: ExperimentConfig):
@@ -361,7 +492,14 @@ def train(config: ExperimentConfig):
     tokenizer = _load_tokenizer()
 
     model = config.model.build(init_device="meta")
-    _init_weights_from_hf(model, config.model)
+    if config.init_from == "scratch":
+        _init_weights_from_scratch(model, config.model)
+    elif config.init_from == "molmo2":
+        _init_weights_from_hf(model, config.model)
+    else:  # unreachable via build_config, which validates; guards direct train() calls
+        raise OLMoConfigurationError(
+            f"init_from={config.init_from!r} is not one of {INIT_FROM_CHOICES}"
+        )
 
     train_module = config.train_module.build(model)
 

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -98,6 +98,10 @@ INIT_FROM_CHOICES = ("scratch", "molmo2")
 SCRATCH_LM_ID = "Qwen/Qwen3-4B"
 SCRATCH_VIT_ID = "google/siglip2-so400m-patch14-384"
 NEW_EMBEDDING_INIT_STD = 0.02  # mm_olmo `new_embedding_init_range`
+# RoPE base per weight source: base Qwen3-4B was trained with 1e6 (as is mm_olmo's
+# stage-1 QWEN3_4B); the released Molmo2-4B checkpoint uses 5e6.
+SCRATCH_ROPE_THETA = 1_000_000
+MOLMO2_ROPE_THETA = 5_000_000
 SEQUENCE_LENGTH = 4096  # fixed pad length; mm_olmo's captioner default is 2536
 USE_FLEX_ATTN = True  # fused FlexAttention backend for the multimodal masks (~+8% MFU)
 PACK_SEQUENCES = True  # pack several examples per sequence (most are ~1.4k of 4096 tokens)
@@ -181,18 +185,37 @@ class ExperimentConfig(Config):
     base Qwen3-4B + base SigLIP2 + random connector/new embeddings)."""
 
 
-def _build_model_config() -> MultimodalLMConfig:
-    """Build the :class:`MultimodalLMConfig` from the HF Molmo2 config (no weights)."""
-    from transformers import AutoConfig
+def _build_model_config(init_from: str) -> MultimodalLMConfig:
+    """Build the Molmo2-4B :class:`MultimodalLMConfig` natively (no weights, no HF read).
 
-    from olmo_core.nn.vision.molmo2_loader import (
-        ensure_default_rope_registered,
-        molmo2_config_from_hf_config,
-    )
+    ``MultimodalLMConfig.molmo2_4B`` is byte-identical to
+    ``molmo2_config_from_hf_config(AutoConfig.from_pretrained(MODEL_ID))``, so a
+    from-scratch run needs nothing from the released Molmo2 repo.
 
-    ensure_default_rope_registered()
-    hf_config = AutoConfig.from_pretrained(MODEL_ID, trust_remote_code=True)
-    return molmo2_config_from_hf_config(hf_config)
+    The one architecture field that depends on the weight source is the RoPE base: the
+    released Molmo2-4B uses ``5e6``, but base Qwen3-4B — whose weights ``"scratch"`` loads
+    — was trained with ``1e6`` (mm_olmo's stage-1 ``QWEN3_4B`` also uses ``1e6``). Using
+    the released value with base weights would put them on the wrong rotary base.
+    """
+    rope_theta = SCRATCH_ROPE_THETA if init_from == "scratch" else MOLMO2_ROPE_THETA
+    return MultimodalLMConfig.molmo2_4B(rope_theta=rope_theta)
+
+
+def _resolve_init_from(overrides: List[str]) -> str:
+    """Read ``init_from`` out of the raw overrides.
+
+    The model config depends on it (RoPE base), and it has to be built before
+    :meth:`Config.merge` runs, so the override cannot be read off the merged config.
+    Later occurrences win, matching ``merge``.
+    """
+    init_from = INIT_FROM
+    for override in overrides:
+        key, _, value = override.lstrip("-").partition("=")
+        if key == "init_from" and value:
+            init_from = value
+    if init_from not in INIT_FROM_CHOICES:
+        raise OLMoConfigurationError(f"init_from={init_from!r} is not one of {INIT_FROM_CHOICES}")
+    return init_from
 
 
 def build_config(script: str, run_name: str, overrides: List[str]) -> ExperimentConfig:
@@ -200,7 +223,7 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
     beaker_user = get_beaker_username()
     assert beaker_user is not None
 
-    model_config = _build_model_config()
+    model_config = _build_model_config(_resolve_init_from(overrides))
 
     dataset_config = PixMoCapDatasetConfig(
         dataset_path=DATASET_PATH,
@@ -328,9 +351,23 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
     return config
 
 
-def _load_tokenizer():
+def _load_tokenizer(init_from: str):
+    """Load the tokenizer for this init mode.
+
+    A ``"scratch"`` run uses base ``Qwen/Qwen3-4B``'s tokenizer — what mm_olmo's stage 1
+    uses — so nothing is read from the released Molmo2 repo. It is a drop-in for training:
+    identical BPE (``encode`` matches exactly), identical ``eos_token_id`` (151645), and
+    identical output for the only chat-template calls the data pipeline makes (user-turn +
+    generation prompt, see ``data/multimodal/qwen3_layout.py``). Qwen3's template differs
+    only for *assistant* messages, which that pipeline never passes. The image-special token
+    IDs come from ``nn/vision/molmo2_tokens.py`` constants, not from the tokenizer, so their
+    absence from the base vocab does not affect training (they are unmapped when *decoding*,
+    which only matters for debugging).
+    """
     from transformers import AutoTokenizer
 
+    if init_from == "scratch":
+        return AutoTokenizer.from_pretrained(SCRATCH_LM_ID)
     return AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
 
 
@@ -359,40 +396,6 @@ def _init_weights_from_hf(model: MultimodalLM, model_cfg: MultimodalLMConfig) ->
     del converted
 
 
-def _convert_siglip_vision_state(hf_sd, n_blocks: int):
-    """Map an HF ``SiglipVisionModel`` state dict onto ``MultimodalLM.vision`` keys.
-
-    Same (numerically parity-verified) mapping as ``_convert_siglip_state_dict`` in
-    ``src/test/nn/vision/parity_test.py``, with a ``vision.`` key prefix and truncation to
-    the target's ``n_blocks`` (Molmo2 keeps SigLIP2 blocks 0..24 of 27 — everything past
-    ``vit_layers`` max ``24`` is dropped, exactly like mm_olmo's truncated ViT).
-    ``post_layernorm`` / ``head.*`` have no counterpart in our encoder and are skipped.
-    """
-    hf_sd = {k.removeprefix("vision_model."): v for k, v in hf_sd.items()}
-    out = {}
-    w = hf_sd["embeddings.patch_embedding.weight"]  # Conv2d (D, 3, p, p) -> C-first flatten
-    out["vision.patch_embedding.weight"] = w.reshape(w.shape[0], -1)
-    out["vision.patch_embedding.bias"] = hf_sd["embeddings.patch_embedding.bias"]
-    out["vision.positional_embedding"] = hf_sd["embeddings.position_embedding.weight"]
-    for i in range(n_blocks):
-        src, dst = f"encoder.layers.{i}", f"vision.blocks.{i}"
-        for hf_name, ours in (("layer_norm1", "attn_norm"), ("layer_norm2", "ffn_norm")):
-            for suf in ("weight", "bias"):
-                out[f"{dst}.{ours}.{suf}"] = hf_sd[f"{src}.{hf_name}.{suf}"]
-        for hf_name, ours in (
-            ("q_proj", "wq"),
-            ("k_proj", "wk"),
-            ("v_proj", "wv"),
-            ("out_proj", "wo"),
-        ):
-            for suf in ("weight", "bias"):
-                out[f"{dst}.attn.{ours}.{suf}"] = hf_sd[f"{src}.self_attn.{hf_name}.{suf}"]
-        for hf_name, ours in (("fc1", "w1"), ("fc2", "w2")):
-            for suf in ("weight", "bias"):
-                out[f"{dst}.ffn.{ours}.{suf}"] = hf_sd[f"{src}.mlp.{hf_name}.{suf}"]
-    return out
-
-
 def _init_weights_from_scratch(model: MultimodalLM, model_cfg: MultimodalLMConfig) -> None:
     """mm_olmo's true stage-1 init (``reset_with_pretrained_weights``):
 
@@ -407,6 +410,7 @@ def _init_weights_from_scratch(model: MultimodalLM, model_cfg: MultimodalLMConfi
     from transformers import AutoModelForCausalLM, SiglipVisionModel
 
     from olmo_core.nn.hf import convert_state_from_hf
+    from olmo_core.nn.vision import siglip_state_dict_to_vision_encoder
     from olmo_core.nn.vision.molmo2_loader import retie_word_embeddings
 
     log.info(f"[scratch init] Loading base LM weights from {SCRATCH_LM_ID} ...")
@@ -432,7 +436,11 @@ def _init_weights_from_scratch(model: MultimodalLM, model_cfg: MultimodalLMConfi
 
     log.info(f"[scratch init] Loading base ViT weights from {SCRATCH_VIT_ID} ...")
     hf_vit = SiglipVisionModel.from_pretrained(SCRATCH_VIT_ID, dtype=torch.float32)
-    converted.update(_convert_siglip_vision_state(hf_vit.state_dict(), len(model.vision.blocks)))
+    converted.update(
+        siglip_state_dict_to_vision_encoder(
+            hf_vit.state_dict(), n_blocks=len(model.vision.blocks), prefix="vision."
+        )
+    )
     del hf_vit
 
     model.to_empty(device=get_default_device())
@@ -489,7 +497,7 @@ def _build_mixture_sources(tokenizer, config: ExperimentConfig):
 def train(config: ExperimentConfig):
     seed_all(config.init_seed)
 
-    tokenizer = _load_tokenizer()
+    tokenizer = _load_tokenizer(config.init_from)
 
     model = config.model.build(init_device="meta")
     if config.init_from == "scratch":

--- a/src/test/nn/vision/molmo2_native_config_test.py
+++ b/src/test/nn/vision/molmo2_native_config_test.py
@@ -1,0 +1,72 @@
+"""``MultimodalLMConfig.molmo2_4B`` must stay identical to the HF-derived config.
+
+The native factory exists so training from base checkpoints needs nothing from the
+released ``allenai/Molmo2-4B`` repo. That is only safe while it produces exactly what
+:func:`molmo2_config_from_hf_config` produces, so this test pins the two together.
+"""
+
+import pytest
+
+from olmo_core.nn.vision import MultimodalLMConfig
+
+from ._molmo2_common import _hf_cache_has
+
+transformers = pytest.importorskip("transformers")
+
+MODEL_ID = "allenai/Molmo2-4B"
+
+
+def _flatten(d, prefix=""):
+    out = {}
+    for key, value in d.items():
+        if isinstance(value, dict):
+            out.update(_flatten(value, f"{prefix}{key}."))
+        else:
+            out[f"{prefix}{key}"] = value
+    return out
+
+
+@pytest.mark.skipif(not _hf_cache_has(MODEL_ID), reason=f"{MODEL_ID} not in local HF cache")
+def test_molmo2_4b_native_config_matches_hf_derived():
+    from transformers import AutoConfig
+
+    from olmo_core.nn.vision.molmo2_loader import (
+        ensure_default_rope_registered,
+        molmo2_config_from_hf_config,
+    )
+
+    ensure_default_rope_registered()
+    hf_derived = molmo2_config_from_hf_config(
+        AutoConfig.from_pretrained(MODEL_ID, trust_remote_code=True)
+    )
+    native = MultimodalLMConfig.molmo2_4B()
+
+    expected, actual = _flatten(hf_derived.as_config_dict()), _flatten(native.as_config_dict())
+    differences = {
+        key: (expected.get(key), actual.get(key))
+        for key in expected.keys() | actual.keys()
+        if expected.get(key) != actual.get(key)
+    }
+    assert not differences, f"native config diverged from the HF-derived one: {differences}"
+
+
+def test_molmo2_4b_rope_theta_is_selectable():
+    """Base Qwen3-4B was trained at 1e6; the released Molmo2-4B checkpoint uses 5e6."""
+    assert MultimodalLMConfig.molmo2_4B().lm.block.sequence_mixer.rope.theta == 5_000_000
+    scratch = MultimodalLMConfig.molmo2_4B(rope_theta=1_000_000)
+    assert scratch.lm.block.sequence_mixer.rope.theta == 1_000_000
+
+
+def test_molmo2_4b_native_config_shape():
+    """Layout invariants that do not need the HF checkpoint cached."""
+    cfg = MultimodalLMConfig.molmo2_4B()
+    assert cfg.lm.d_model == 2560
+    assert cfg.lm.n_layers == 36
+    assert cfg.lm.vocab_size == 152_064  # 151,936 base + 128 image-special tokens
+    assert cfg.lm.tie_word_embeddings is True
+    assert cfg.output_vocab_size == 151_936
+    assert cfg.vision.image_num_layers == 25  # SigLIP2 blocks 0..24 of 27
+    assert cfg.vit_layers == (24, 18)
+    assert cfg.connector.num_input_layers == len(cfg.vit_layers)
+    assert cfg.connector.output_dim == cfg.lm.d_model
+    assert max(cfg.vit_layers) == cfg.vision.image_num_layers - 1

--- a/src/test/nn/vision/molmo2_native_config_test.py
+++ b/src/test/nn/vision/molmo2_native_config_test.py
@@ -13,7 +13,10 @@ from ._molmo2_common import _hf_cache_has
 
 transformers = pytest.importorskip("transformers")
 
-MODEL_ID = "allenai/Molmo2-4B"
+VARIANTS = [
+    ("allenai/Molmo2-4B", "molmo2_4B"),
+    ("allenai/Molmo2-8B", "molmo2_8B"),
+]
 
 
 def _flatten(d, prefix=""):
@@ -26,8 +29,11 @@ def _flatten(d, prefix=""):
     return out
 
 
-@pytest.mark.skipif(not _hf_cache_has(MODEL_ID), reason=f"{MODEL_ID} not in local HF cache")
-def test_molmo2_4b_native_config_matches_hf_derived():
+@pytest.mark.parametrize("model_id, factory_name", VARIANTS)
+def test_native_config_matches_hf_derived(model_id: str, factory_name: str):
+    if not _hf_cache_has(model_id):
+        pytest.skip(f"{model_id} not in local HF cache")
+
     from transformers import AutoConfig
 
     from olmo_core.nn.vision.molmo2_loader import (
@@ -37,9 +43,9 @@ def test_molmo2_4b_native_config_matches_hf_derived():
 
     ensure_default_rope_registered()
     hf_derived = molmo2_config_from_hf_config(
-        AutoConfig.from_pretrained(MODEL_ID, trust_remote_code=True)
+        AutoConfig.from_pretrained(model_id, trust_remote_code=True)
     )
-    native = MultimodalLMConfig.molmo2_4B()
+    native = getattr(MultimodalLMConfig, factory_name)()
 
     expected, actual = _flatten(hf_derived.as_config_dict()), _flatten(native.as_config_dict())
     differences = {
@@ -47,26 +53,35 @@ def test_molmo2_4b_native_config_matches_hf_derived():
         for key in expected.keys() | actual.keys()
         if expected.get(key) != actual.get(key)
     }
-    assert not differences, f"native config diverged from the HF-derived one: {differences}"
+    assert not differences, f"{factory_name} diverged from the HF-derived config: {differences}"
 
 
-def test_molmo2_4b_rope_theta_is_selectable():
-    """Base Qwen3-4B was trained at 1e6; the released Molmo2-4B checkpoint uses 5e6."""
+def test_rope_theta_defaults_match_the_released_checkpoints():
+    """Molmo2-4B is the only released variant whose base differs from its Qwen3 backbone's."""
     assert MultimodalLMConfig.molmo2_4B().lm.block.sequence_mixer.rope.theta == 5_000_000
-    scratch = MultimodalLMConfig.molmo2_4B(rope_theta=1_000_000)
-    assert scratch.lm.block.sequence_mixer.rope.theta == 1_000_000
+    assert MultimodalLMConfig.molmo2_8B().lm.block.sequence_mixer.rope.theta == 1_000_000
+    # Both must accept the base-Qwen3 value used when initialising from scratch.
+    for factory in (MultimodalLMConfig.molmo2_4B, MultimodalLMConfig.molmo2_8B):
+        assert factory(rope_theta=1_000_000).lm.block.sequence_mixer.rope.theta == 1_000_000
 
 
-def test_molmo2_4b_native_config_shape():
+@pytest.mark.parametrize(
+    "factory_name, d_model, ffn_hidden_size, tied",
+    [("molmo2_4B", 2560, 9728, True), ("molmo2_8B", 4096, 12288, False)],
+)
+def test_native_config_shape(factory_name: str, d_model: int, ffn_hidden_size: int, tied: bool):
     """Layout invariants that do not need the HF checkpoint cached."""
-    cfg = MultimodalLMConfig.molmo2_4B()
-    assert cfg.lm.d_model == 2560
+    cfg = getattr(MultimodalLMConfig, factory_name)()
+    assert cfg.lm.d_model == d_model
     assert cfg.lm.n_layers == 36
+    assert cfg.lm.block.feed_forward.hidden_size == ffn_hidden_size
     assert cfg.lm.vocab_size == 152_064  # 151,936 base + 128 image-special tokens
-    assert cfg.lm.tie_word_embeddings is True
+    assert cfg.lm.tie_word_embeddings is tied
     assert cfg.output_vocab_size == 151_936
+    # The vision stack is shared across variants.
     assert cfg.vision.image_num_layers == 25  # SigLIP2 blocks 0..24 of 27
     assert cfg.vit_layers == (24, 18)
+    assert max(cfg.vit_layers) == cfg.vision.image_num_layers - 1
     assert cfg.connector.num_input_layers == len(cfg.vit_layers)
     assert cfg.connector.output_dim == cfg.lm.d_model
-    assert max(cfg.vit_layers) == cfg.vision.image_num_layers - 1
+    assert cfg.connector.mlp_hidden_size == ffn_hidden_size

--- a/src/test/nn/vision/parity_test.py
+++ b/src/test/nn/vision/parity_test.py
@@ -19,6 +19,7 @@ from olmo_core.nn.vision import (
     VisionEncoderConfig,
     VisionEncoderType,
     VisionTransformer,
+    siglip_state_dict_to_vision_encoder,
 )
 
 transformers = pytest.importorskip("transformers")
@@ -67,45 +68,6 @@ def _convert_clip_state_dict(hf_sd: Dict[str, torch.Tensor]) -> Dict[str, torch.
     out["pre_ln.bias"] = hf_sd["pre_layrnorm.bias"]
 
     # Per-layer projections.
-    n_layers = (
-        max(int(k.split(".")[2]) for k in hf_sd.keys() if k.startswith("encoder.layers.")) + 1
-    )
-    for i in range(n_layers):
-        src = f"encoder.layers.{i}"
-        dst = f"blocks.{i}"
-        for hf_name, our_name in (
-            ("layer_norm1", "attn_norm"),
-            ("layer_norm2", "ffn_norm"),
-        ):
-            out[f"{dst}.{our_name}.weight"] = hf_sd[f"{src}.{hf_name}.weight"]
-            out[f"{dst}.{our_name}.bias"] = hf_sd[f"{src}.{hf_name}.bias"]
-        for hf_name, our_name in (
-            ("q_proj", "wq"),
-            ("k_proj", "wk"),
-            ("v_proj", "wv"),
-            ("out_proj", "wo"),
-        ):
-            out[f"{dst}.attn.{our_name}.weight"] = hf_sd[f"{src}.self_attn.{hf_name}.weight"]
-            out[f"{dst}.attn.{our_name}.bias"] = hf_sd[f"{src}.self_attn.{hf_name}.bias"]
-        for hf_name, our_name in (("fc1", "w1"), ("fc2", "w2")):
-            out[f"{dst}.ffn.{our_name}.weight"] = hf_sd[f"{src}.mlp.{hf_name}.weight"]
-            out[f"{dst}.ffn.{our_name}.bias"] = hf_sd[f"{src}.mlp.{hf_name}.bias"]
-    return out
-
-
-def _convert_siglip_state_dict(hf_sd: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
-    """Map a HuggingFace ``SiglipVisionTransformer`` state dict to ours.
-
-    Skips ``post_layernorm`` and ``head.*`` since we compare at the
-    pre-``post_layernorm`` boundary and don't model the pooling head.
-    """
-    out: Dict[str, torch.Tensor] = {}
-    out["patch_embedding.weight"] = hf_sd["embeddings.patch_embedding.weight"].reshape(
-        hf_sd["embeddings.patch_embedding.weight"].shape[0], -1
-    )
-    out["patch_embedding.bias"] = hf_sd["embeddings.patch_embedding.bias"]
-    out["positional_embedding"] = hf_sd["embeddings.position_embedding.weight"]
-
     n_layers = (
         max(int(k.split(".")[2]) for k in hf_sd.keys() if k.startswith("encoder.layers.")) + 1
     )
@@ -207,7 +169,7 @@ def test_siglip_parity():
 
     cfg = VisionEncoderConfig.siglip_so400m()
     ours = VisionTransformer(cfg, init_device="cpu").eval()
-    ours.load_state_dict(_convert_siglip_state_dict(hf.state_dict()))
+    ours.load_state_dict(siglip_state_dict_to_vision_encoder(hf.state_dict()))
 
     torch.manual_seed(0)
     # 378 = 27×14: both HF and our model produce a 27×27 patch grid.
@@ -244,7 +206,7 @@ def test_siglip2_parity():
 
     cfg = VisionEncoderConfig.siglip2_so400m_patch14_378()
     ours = VisionTransformer(cfg, init_device="cpu").eval()
-    ours.load_state_dict(_convert_siglip_state_dict(hf.state_dict()))
+    ours.load_state_dict(siglip_state_dict_to_vision_encoder(hf.state_dict()))
 
     torch.manual_seed(0)
     # 378 = 27×14: both HF and our model produce a 27×27 = 729 patch grid.


### PR DESCRIPTION
Stage 1 is pretraining, but `Molmo2-Stage1.py` started from the released
`allenai/Molmo2-4B` — an already post-trained model — and continued it on the stage-1
objective. That is a fine-tune, not a stage-1 reproduction. The most recent 32k-step run
opened at **CE ~1.15**; mm_olmo's true stage-1 start is **~3.1**.

`init_from` now defaults to `"scratch"`, reproducing mm_olmo's
`reset_with_pretrained_weights`, and a scratch run reads **nothing** from the released
Molmo2 repo — not weights, not the config, not the tokenizer.

| Component | Source |
|---|---|
| LM | the base Qwen3 backbone via the generic HF→olmo-core converter; 128 extra embedding rows `N(0, 0.02)` |
| ViT | base `google/siglip2-so400m-patch14-384`, blocks 0..24 of 27 (matches `vit_layers=[24, 18]`) — shared by every variant |
| Connector | random — `reset_parameters()`: `N(0, 0.02)` weights, zero biases |
| Architecture | `MultimodalLMConfig.molmo2_4B()` / `molmo2_8B()`, built natively |
| Tokenizer | the base Qwen3 backbone's |

`--init_from=molmo2` keeps the previous behaviour for parity tests and continuation
experiments.

## Both sizes: `--model_size=4b|8b`

An 8B stage-1 run is planned, so `molmo2_8B` lands with the plumbing that uses it rather
than as an unused public API. `--model_size` selects the architecture factory, the base
Qwen3 backbone, the released checkpoint for `--init_from=molmo2`, and the tokenizer.
`MODEL_SIZES` maps each size to a typed frozen `ModelSizeSpec` (a plain dict of mixed values
inferred `object` and cost 3 mypy errors). `ExperimentConfig.model_id` is replaced by
`model_size`.

Both factories share a `_molmo2_like` helper: the vision stack is identical across released
variants, so only the LM and the connector MLP width differ.

| | 4B | 8B |
|---|---|---|
| `d_model` / FFN | 2560 / 9728 | 4096 / 12288 |
| `tie_word_embeddings` | True | **False** |
| released `rope_theta` | **5e6** | 1e6 |
| base Qwen3 `rope_theta` | 1e6 | 1e6 |

### The 8B path exposed a second real bug

The from-scratch init unconditionally overwrote `lm_head.w_out.weight` with the embedding
table. That is correct for a weight-tied backbone, but **Qwen3-8B and Molmo2-8B are untied**
and the converter emits a *distinct trained* output head for them — so an 8B run would have
thrown away Qwen3-8B's trained `lm_head`. The head is now built per tying: tied configs reuse
the embedding table (then retie), untied ones keep the base head and pad the 128 extra rows
with zeros. Those rows are masked by `output_vocab_size`, so they never enter the softmax or
receive gradient — matching mm_olmo, whose untied `ff_out` spans only the base vocab.

Verified both ways: 8B `head[:151936]` equals the base trained `lm_head` and **differs** from
the embedding rows; 4B stays tied and shares storage; appended 8B head rows are all zero.

## A wrong RoPE base, caused by reading the released config

Deriving the architecture from the released model while loading base weights put those
weights on the wrong rotary base:

| | `rope_theta` |
|---|---|
| Released Molmo2-4B text config | **5,000,000** |
| Base Qwen3-4B (what `scratch` loads) | **1,000,000** |
| mm_olmo stage-1 `QWEN3_4B` | **1,000,000** |

RoPE base now follows the **weight source**, per size. The 8B independently confirms why
this matters: base Qwen3-8B and released Molmo2-8B are both 1e6, so the released Molmo2-4B
(5e6) is the sole variant that disagrees with its own backbone.

`model_size` and `init_from` are resolved from the raw overrides *before* the model config is
built, because that happens before `Config.merge` runs — otherwise `--model_size=8b` or
`--init_from=molmo2` would silently keep the defaults' architecture and theta.

## Native architecture factories

Composed from factories the repo already had: `TransformerConfig.qwen3_4B` / `qwen3_8B` +
`VisionEncoderConfig.siglip2_so400m_patch14_378` (truncated to 25 blocks) + the connector.
A cache-gated test asserts each is **field-for-field identical** to
`molmo2_config_from_hf_config` on the corresponding released config, so they stay
interchangeable.

Note the HF loader labels the ViT `siglip`, not `siglip2`; that field is a label only (the
variant is selected by `use_cls_token` / `patch_embedding_bias` / `use_pre_ln`), so the
factory matches it for exact equality.

## Tokenizer: verified drop-in, not assumed

For training, base Qwen3-4B's tokenizer is equivalent to Molmo2's:

- `encode` identical on ASCII, unicode, emoji and the pointing markup
- `eos_token_id` identical (151645)
- byte-identical output for the **only** chat-template calls the data pipeline makes
  (user turn + generation prompt, `data/multimodal/qwen3_layout.py`)

Qwen3's template *does* differ — it injects `<think>\n\n</think>` — but only for
**assistant** messages, which that pipeline never passes. Worth knowing for anyone who adds
an assistant-message call later. Image-special token IDs come from `molmo2_tokens.py`
constants, not the tokenizer, so their absence from the base vocab does not affect training
(they are unmapped when *decoding*, which only matters for debugging).

## One SigLIP converter, not two

There was no production SigLIP converter: the only one lived in `parity_test.py`, and the
from-scratch port copied it into the training script. Promoted to
`olmo_core.nn.vision.siglip_state_dict_to_vision_encoder` with `n_blocks` and `prefix`
arguments — covering both call sites (bare encoder for the parity test; prefixed and
truncated for the `MultimodalLM` load) — and both copies deleted. It also strips a
`vision_model.` prefix so it accepts `SiglipVisionModel` state dicts directly, and raises
if more blocks are requested than the checkpoint has.

(`molmo2_hf_state_dict_to_multimodal_lm` exists but converts from Molmo2's *own* HF format,
not a raw SigLIP tower, so it could not serve this path.)

## The tied head was not actually tied (bug in the ported code)

`544c7eae5` wrote `full_emb.clone()` into `lm_head.w_out.weight`, so values matched at init
but `to_empty` had already untied the parameters — head and embedding table were two
independent tensors that would drift apart during training, while mm_olmo has
`weight_tying=True` (and `Transformer.apply_fsdp`'s tied-weight handling assumes one
parameter). The `molmo2` path already called `retie_word_embeddings`; the scratch path did
not. Caught by comparing `data_ptr()`:

```
before:  tied values: True   shared storage: False
after:   tied values: True   shared storage: True   same Parameter object: True
```

## Also: `make checks` was already red on this file

The mid-file `PIXMO_DATASETS` import added in #806 trips ruff `E402`, and `isort`/`black`
were failing too (the Makefile checks run over the whole tree). Import moved to the top and
the file formatted, since this PR touches it anyway.

## Verification

- `src/test/nn/vision`: **97 passed, 17 skipped**. The 3 CLIP/SigLIP/SigLIP2 parity tests
  now exercise the shared converter.
- Both native configs **identical** to their HF-derived counterparts (cache-gated test pins
  4B and 8B).
- 8B scratch init exercised end-to-end — real SigLIP2 weights, and Qwen3-8B stood up from
  its real config so the converter and the strict coverage check run for real: 8.662B params,
  vocab `(152064, 4096)`, new rows std 0.0200, correctly untied, 25 vision blocks,
  0 non-finite.
- Size/init matrix: 4b scratch 1e6 / 4b molmo2 5e6 / 8b both 1e6. `--model_size=8B`
  case-normalises; `13b` rejected at config-build time.
- Scratch init run end-to-end on CPU against the real architecture: state-dict coverage
  exact (only `connector.*` missing, nothing unexpected), 4.462B params, vocab
  `(152064, 2560)`, 128 new rows at std **0.0200** (target 0.02) with base rows at 0.0220,
  25 vision blocks with `blocks.0.attn.wq` std **0.02654** (loaded SigLIP weights, not
  random), 0 non-finite tensors, head and embeddings one shared `Parameter`.
- `scratch` theta 1e6 / `molmo2` theta 5e6; `--init_from=bogus` rejected at config-build
  time rather than after a Beaker job has queued, started and downloaded weights.
- `isort` / `black` / `ruff` clean. `mypy` introduces no new errors — the 2 it reports in
  this script are present on `vision` under the same invocation.

## Not changed — worth a reviewer's opinion

The ViT remains frozen (`freeze_params=["vision.*"]`), so this trains a randomly initialised
connector against a **base** SigLIP2 encoder that never updates. mm_olmo trains the ViT
during stage 1 (`ft_vit=True`, lr 6e-6, warmup 2000, wd 0). Frozen-ViT was defensible when
the encoder came from a trained Molmo2; with base SigLIP2 it is a more consequential choice.
Deliberately left out to keep this PR to the init change — the `TRAIN_VIT` flag on
`jasonr/molmo2-infra-compare` is the follow-up.
