### PR TITLE
Keep checkpoint cleanup asynchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Old checkpoint deletion no longer blocks subsequent checkpoint saves. Cleanup continues in the
+  background and is still awaited during graceful shutdown.
 - The CPU `Test` CI job now caches `HF_HOME` across runs so the HuggingFace roundtrip tests (Qwen3-0.6B, Gemma-3-270m) don't re-download their checkpoints every run.
 - Excluded `mark_dynamic` from `torch.compile` tracing (`@torch.compiler.disable`).
 - Clearer error messages (now include the offending values) when a rank batch size isn't divisible by the sequence length, or `max_target_sequence_length` isn't a multiple of `sequence_length`.

--- a/src/olmo_core/train/callbacks/checkpointer.py
+++ b/src/olmo_core/train/callbacks/checkpointer.py
@@ -193,11 +193,16 @@ class CheckpointerCallback(Callback):
                     path,
                     op_name=f"clear_directory {path}",
                     distributed=False,
+                    checkpoint_dependent=False,
                     soft_timeout=180,  # this can take a while on GCS, for example
                 )
         elif get_fs_local_rank() == 0:
             self.trainer.run_bookkeeping_op(
-                clear_directory, path, op_name=f"clear_directory {path}", distributed=False
+                clear_directory,
+                path,
+                op_name=f"clear_directory {path}",
+                distributed=False,
+                checkpoint_dependent=False,
             )
 
     def _schedule_for_removal(self, path: str):

--- a/src/olmo_core/train/trainer.py
+++ b/src/olmo_core/train/trainer.py
@@ -304,6 +304,7 @@ class Trainer:
     _bookkeeping_queue: Dict[str, Dict[str, Future]] = field(
         default_factory=lambda: defaultdict(OrderedDict)
     )
+    _checkpoint_independent_bookkeeping_ops: Set[Future] = field(repr=False, default_factory=set)
     _bookkeeping_pg: Optional[dist.ProcessGroup] = None
     _blocking_ephemeral_checkpoints: Set[str] = field(repr=False, default_factory=set)
     """Callbacks that are blocking ephemeral checkpoints."""
@@ -972,7 +973,7 @@ class Trainer:
         # Some state (e.g. in a callback) might be tied to metrics, or depend on another bookkeeping
         # operation to be finished first.
         self._log_metrics()
-        self._join_bookkeeping_ops()
+        self._join_bookkeeping_ops(checkpoint_dependent_only=True)
 
         self.checkpointer.save(
             path,
@@ -1010,7 +1011,7 @@ class Trainer:
         # Some state (e.g. in a callback) might be tied to metrics, or depend on another bookkeeping
         # operation to be finished first.
         self._log_metrics()
-        self._join_bookkeeping_ops()
+        self._join_bookkeeping_ops(checkpoint_dependent_only=True)
 
         fut = self.checkpointer.save_async(
             path,
@@ -1259,6 +1260,7 @@ class Trainer:
         allow_multiple: bool = True,
         soft_timeout: Optional[int] = None,
         distributed: bool = True,
+        checkpoint_dependent: bool = True,
         **kwargs,
     ):
         """
@@ -1277,6 +1279,10 @@ class Trainer:
             takes longer than this a warning will be issued.
         :param distributed: This should only be set to ``False`` if the op doesn't use distributed
             communication, in which case it will be allowed to run concurrently with other ops.
+        :param checkpoint_dependent: Whether a checkpoint save must wait for this operation to
+            finish. Set this to ``False`` for operations such as removing an old checkpoint that
+            can safely continue while a new checkpoint is saved. All operations are still awaited
+            during graceful shutdown.
         """
         if cancel_in_progress is not None:
             warnings.warn(
@@ -1336,6 +1342,8 @@ class Trainer:
 
             op_id = uuid.uuid4().hex
             self._bookkeeping_queue[op_name][op_id] = future
+            if not checkpoint_dependent:
+                self._checkpoint_independent_bookkeeping_ops.add(future)
 
             def callback(fut: Future[T]):
                 try:
@@ -1346,25 +1354,40 @@ class Trainer:
                 finally:
                     # Remove the completed op from the queue.
                     assert op_name is not None  # for mypy
+                    self._checkpoint_independent_bookkeeping_ops.discard(fut)
                     self._bookkeeping_queue[op_name].pop(op_id, None)
 
             future.add_done_callback(callback)
         else:
             wrapped_op(*args, **kwargs)
 
-    def _join_bookkeeping_ops(self, timeout: Optional[float] = None):
+    def _join_bookkeeping_ops(
+        self, timeout: Optional[float] = None, checkpoint_dependent_only: bool = False
+    ):
         """
         Block until all queued bookkeeping operations are done.
+
+        :param checkpoint_dependent_only: Only wait for operations that must finish before saving
+            a checkpoint.
         """
         futures: List[Future] = []
         for op_name, futures_dict in self._bookkeeping_queue.items():
-            if futures_dict:
+            op_futures = [
+                future
+                for future in futures_dict.values()
+                if not checkpoint_dependent_only
+                or future not in self._checkpoint_independent_bookkeeping_ops
+            ]
+            if op_futures:
                 log.info(
-                    f"Waiting for bookkeeping ops to finish: '{op_name}' ({len(futures_dict)} ops)..."
+                    f"Waiting for bookkeeping ops to finish: '{op_name}' ({len(op_futures)} ops)..."
                 )
-                futures.extend(futures_dict.values())
+                futures.extend(op_futures)
         concurrent.futures.wait(futures, timeout=timeout)
-        log.info("All bookkeeping ops complete")
+        if checkpoint_dependent_only:
+            log.info("All checkpoint-dependent bookkeeping ops complete")
+        else:
+            log.info("All bookkeeping ops complete")
 
     def _check_if_canceled(self):
         if self._canceled:

--- a/src/test/train/trainer_test.py
+++ b/src/test/train/trainer_test.py
@@ -1,0 +1,79 @@
+from collections import OrderedDict, defaultdict
+from threading import Event
+from unittest.mock import Mock, patch
+
+from olmo_core.io import clear_directory
+from olmo_core.train.callbacks.checkpointer import CheckpointerCallback
+from olmo_core.train.trainer import Trainer
+
+
+def test_checkpoint_save_skips_checkpoint_independent_bookkeeping():
+    trainer = Trainer.__new__(Trainer)
+    trainer.bookkeeping_soft_timeout = 30
+    trainer._multi_thread_pool = None
+    trainer._single_thread_pool = None
+    trainer._bookkeeping_queue = defaultdict(OrderedDict)
+    trainer._checkpoint_independent_bookkeeping_ops = set()
+    trainer._error = None
+    trainer.global_step = 2
+    trainer.save_folder = "checkpoints"
+    trainer.checkpointer = Mock()
+    trainer.checkpointer.checkpoint_dirname.return_value = "step2"
+    trainer.train_module = Mock()
+    trainer.callbacks = {}
+    trainer._metrics = {}
+    trainer._metrics_reduce_type = {}
+
+    cleanup_started = Event()
+    cleanup_finished = Event()
+    release_cleanup = Event()
+
+    def cleanup():
+        cleanup_started.set()
+        release_cleanup.wait()
+        cleanup_finished.set()
+
+    try:
+        trainer.run_bookkeeping_op(
+            cleanup,
+            distributed=False,
+            checkpoint_dependent=False,
+        )
+        assert cleanup_started.wait(timeout=5)
+
+        checkpoint_future = Mock()
+        trainer.checkpointer.save_async.return_value = checkpoint_future
+        with patch.object(trainer, "state_dict", return_value={}):
+            path, future = trainer.save_checkpoint_async()
+
+        assert str(path) == "checkpoints/step2"
+        assert future is checkpoint_future
+        trainer.checkpointer.save_async.assert_called_once()
+        assert not cleanup_finished.is_set()
+
+        release_cleanup.set()
+        trainer._join_bookkeeping_ops()
+        assert cleanup_finished.is_set()
+    finally:
+        release_cleanup.set()
+        if trainer._multi_thread_pool is not None:
+            trainer._multi_thread_pool.shutdown(wait=True)
+
+
+def test_checkpoint_removal_does_not_block_checkpoint_saves(tmp_path):
+    checkpoint_path = tmp_path / "step1"
+    checkpoint_path.mkdir()
+
+    callback = Mock()
+    callback.trainer = Mock()
+    callback.trainer.checkpointer.METADATA_FNAME = "metadata.json"
+
+    CheckpointerCallback._remove_checkpoint(callback, str(checkpoint_path))
+
+    callback.trainer.run_bookkeeping_op.assert_called_once_with(
+        clear_directory,
+        str(checkpoint_path),
+        op_name=f"clear_directory {checkpoint_path}",
+        distributed=False,
+        checkpoint_dependent=False,
+    )


### PR DESCRIPTION
## Summary

- classify bookkeeping operations by whether checkpoint saves depend on them
- allow old checkpoint directory deletion to continue while a new checkpoint is saved
- continue tracking cleanup failures and await all cleanup during graceful shutdown
- add regression coverage for the save/delete overlap and cleanup classification

## Motivation

Old checkpoint deletion is submitted to the asynchronous bookkeeping executor, but both synchronous and asynchronous checkpoint saves call `_join_bookkeeping_ops()` before writing. That join waits for the deletion future, making cleanup effectively synchronous again at the next save. On Weka, deleting a large checkpoint tree can take long enough to hold filesystem rank 0 out of the distributed save and trigger a process-group timeout.

This draft keeps the existing safety property: `_remove_checkpoint()` removes checkpoint metadata before scheduling directory cleanup, so the checkpoint is invalid before a subsequent save begins. It only removes the unnecessary dependency between deleting one checkpoint directory and writing a different one.

Related context: https://github.com/allenai/open-instruct/pull/1810

## Test plan

- `pytest -q src/test/train/trainer_test.py src/test/train/checkpoint_test.py -k 'trainer or local_dir'` (4 passed)
- `make type-check` (398 source files, passed)
- changed-file Ruff, Black, and isort checks (passed)
- broader `src/test/train` run passed through 47 selected tests; the final HF converter test was terminated by the local environment while building its model, and credentialed remote S3 tests could not run due to `AccessDenied`