### PR TITLE
Split the token embedding table so the pretrained block can be frozen (mm_olmo ft_embedding parity)

### DIFF
--- a/src/olmo_core/nn/embedding.py
+++ b/src/olmo_core/nn/embedding.py
@@ -1,0 +1,81 @@
+"""Embedding tables for transformer models."""
+
+from typing import Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+__all__ = ["SplitVocabEmbedding"]
+
+
+class SplitVocabEmbedding(nn.Module):
+    """
+    An embedding table split into a **base** block and a smaller **extra** block, held as two
+    separate parameters so they can be frozen, initialised and optimised independently.
+
+    This mirrors mm_olmo's ``Embedding(embedding, new_embedding)``. The base block carries the
+    language backbone's pretrained vocabulary; the extra block carries tokens added on top of
+    it — for Molmo2, the 128 image-special tokens (``<im_patch>``, ``<im_col>``, …).
+
+    Two properties make this more than a cosmetic split:
+
+    * **Independent freezing.** Molmo2's stage-1 recipe holds the pretrained vocabulary fixed
+      while learning the new image tokens. With a single fused table that is a partial-row
+      freeze, which ``requires_grad`` cannot express; with this split it is just
+      ``embeddings.weight.requires_grad_(False)``.
+    * **A base-width tied head.** The base block is named :attr:`weight`, so weight tying
+      (``lm_head.w_out.weight = embeddings.weight``) produces a head spanning the *base* vocab
+      only — the extra tokens are inputs, never prediction targets, which is exactly mm_olmo's
+      behaviour and removes the need to mask logit columns.
+
+    Lookups accept IDs across the whole range ``[0, num_embeddings)``; the two blocks are
+    concatenated on each forward, as in mm_olmo.
+
+    :param num_embeddings: Size of the base vocabulary.
+    :param num_extra_embeddings: Number of extra token rows appended after the base block.
+    :param embedding_dim: Model dimension.
+    """
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        num_extra_embeddings: int,
+        embedding_dim: int,
+        *,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[Union[str, torch.device]] = None,
+    ):
+        super().__init__()
+        if num_extra_embeddings <= 0:
+            raise ValueError(
+                f"num_extra_embeddings must be positive, got {num_extra_embeddings}; "
+                "use a plain nn.Embedding when there are no extra tokens"
+            )
+        # Mirrors `nn.Embedding`'s attribute so callers that do their own `F.embedding`
+        # lookup (e.g. MultimodalLM, which splices image features) work unchanged.
+        self.padding_idx: Optional[int] = None
+        self.num_base_embeddings = num_embeddings
+        self.num_extra_embeddings = num_extra_embeddings
+        self.embedding_dim = embedding_dim
+        self.weight = nn.Parameter(
+            torch.empty(num_embeddings, embedding_dim, dtype=dtype, device=device)
+        )
+        self.extra_weight = nn.Parameter(
+            torch.empty(num_extra_embeddings, embedding_dim, dtype=dtype, device=device)
+        )
+
+    @property
+    def num_embeddings(self) -> int:
+        """Total vocabulary size that can be looked up (base + extra)."""
+        return self.num_base_embeddings + self.num_extra_embeddings
+
+    def full_weight(self) -> torch.Tensor:
+        """The two blocks concatenated into one ``(num_embeddings, embedding_dim)`` tensor."""
+        return torch.cat([self.weight, self.extra_weight], dim=0)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        return F.embedding(input, self.full_weight())
+
+    def extra_repr(self) -> str:
+        return f"{self.num_base_embeddings}(+{self.num_extra_embeddings}), {self.embedding_dim}"

--- a/src/olmo_core/nn/transformer/config.py
+++ b/src/olmo_core/nn/transformer/config.py
@@ -331,11 +331,26 @@ class TransformerConfig(ModelConfig):
     block_overrides: Optional[Dict[int, TransformerBlockConfig]] = None
     embed_scale: Optional[float] = None
     tie_word_embeddings: bool = False
+    n_extra_vocab: int = 0
+    """
+    Number of extra token rows to append to the embedding table as a *separate* parameter
+    (see :class:`~olmo_core.nn.embedding.SplitVocabEmbedding`). When non-zero,
+    :data:`vocab_size` is the **base** vocab: lookups accept ``vocab_size + n_extra_vocab``
+    IDs while the LM head spans only ``vocab_size``, so the extra tokens are inputs and never
+    prediction targets. Used by Molmo2 for its 128 image-special tokens, and it lets the
+    pretrained base rows be frozen on their own (``embeddings.weight``).
+    """
 
     def __post_init__(self):
         if self.tie_word_embeddings and self.name == TransformerType.normalized:
             raise OLMoConfigurationError(
                 "Tying word embeddings is not supported with the normalized transformer"
+            )
+        if self.n_extra_vocab < 0:
+            raise OLMoConfigurationError("'n_extra_vocab' cannot be negative")
+        if self.n_extra_vocab and self.name == TransformerType.normalized:
+            raise OLMoConfigurationError(
+                "'n_extra_vocab' is not supported with the normalized transformer"
             )
         validate_block_resolution_config(
             n_layers=self.n_layers,
@@ -388,6 +403,7 @@ class TransformerConfig(ModelConfig):
                 block_pattern=self.block_pattern,
                 embed_scale=self.embed_scale,
                 tie_word_embeddings=self.tie_word_embeddings,
+                n_extra_vocab=self.n_extra_vocab,
             )
         elif self.name == TransformerType.normalized:
             assert self.embedding_norm is None

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -35,6 +35,7 @@ from olmo_core.nn.attention.ring import (
     RingContextParallelStyle,
     UlyssesContextParallelStyle,
 )
+from olmo_core.nn.embedding import SplitVocabEmbedding
 from olmo_core.utils import get_default_device, mark_dynamic, move_to_device
 
 from ..attention import (
@@ -62,7 +63,7 @@ from .config import (
     TransformerDataParallelWrappingStrategy,
     resolve_block_configs,
 )
-from .init import InitMethod
+from .init import InitMethod, _apply_init
 
 if TYPE_CHECKING:
     from olmo_core.train.common import ReduceType
@@ -118,6 +119,7 @@ class Transformer(nn.Module):
         block_pattern: Optional[List[str]] = None,
         embed_scale: Optional[float] = None,
         tie_word_embeddings: bool = False,
+        n_extra_vocab: int = 0,
     ):
         super().__init__()
 
@@ -129,7 +131,17 @@ class Transformer(nn.Module):
         self.dtype = dtype
         self.embed_scale = embed_scale
 
-        self.embeddings = nn.Embedding(vocab_size, d_model, dtype=dtype, device=init_device)
+        # With extra tokens the table is split into two parameters (see
+        # :class:`SplitVocabEmbedding`): ``vocab_size`` is then the *base* vocab, and the
+        # tied LM head spans only that base — the extra tokens are inputs, never targets.
+        self.n_extra_vocab = n_extra_vocab
+        self.embeddings: nn.Module
+        if n_extra_vocab > 0:
+            self.embeddings = SplitVocabEmbedding(
+                vocab_size, n_extra_vocab, d_model, dtype=dtype, device=init_device
+            )
+        else:
+            self.embeddings = nn.Embedding(vocab_size, d_model, dtype=dtype, device=init_device)
         self.embedding_norm = (
             None
             if embedding_norm is None
@@ -310,6 +322,19 @@ class Transformer(nn.Module):
                 ),
                 generator=generator,
             )
+            if isinstance(self.embeddings, SplitVocabEmbedding):
+                # mm_olmo initialises the added rows from `new_embedding_init_range`, which
+                # matches our `init_std` default of 0.02.
+                _apply_init(
+                    nn.init.normal_,
+                    self.embeddings.extra_weight,
+                    generator=generator,
+                    std=(
+                        self.embedding_init_std
+                        if self.embedding_init_std is not None
+                        else self.init_std
+                    ),
+                )
 
         # Re-establish weight tying since `to_empty` above allocates fresh storage.
         if self.tie_word_embeddings:
@@ -632,9 +657,7 @@ class Transformer(nn.Module):
             all_block_kwargs["and_mask"] = move_to_device(and_mask, self.device)
 
         if flex_attn_is_image is not None:
-            all_block_kwargs["flex_attn_is_image"] = move_to_device(
-                flex_attn_is_image, self.device
-            )
+            all_block_kwargs["flex_attn_is_image"] = move_to_device(flex_attn_is_image, self.device)
         if flex_attn_subsegment_ids is not None:
             all_block_kwargs["flex_attn_subsegment_ids"] = move_to_device(
                 flex_attn_subsegment_ids, self.device

--- a/src/olmo_core/nn/vision/molmo2_loader.py
+++ b/src/olmo_core/nn/vision/molmo2_loader.py
@@ -334,36 +334,26 @@ def molmo2_hf_state_dict_to_multimodal_lm(
     has_qk_norm = _has_qk_norm(lm_cfg)
 
     # --- LM: token embeddings -----------------------------------------------
+    # HF Molmo2 keeps the base vocab and the 128 image-special rows as two parameters
+    # (``wte.embedding`` / ``wte.new_embedding``); so do we, via
+    # :class:`~olmo_core.nn.embedding.SplitVocabEmbedding`, which maps 1:1.
     base_emb = _require(hf_state_dict, "model.transformer.wte.embedding")
     new_emb = _require(hf_state_dict, "model.transformer.wte.new_embedding")
-    out["lm.embeddings.weight"] = torch.cat([base_emb, new_emb], dim=0)
+    out["lm.embeddings.weight"] = base_emb
+    out["lm.embeddings.extra_weight"] = new_emb
 
     # --- LM: final norm + lm head ------------------------------------------
     out["lm.lm_head.norm.weight"] = _require(hf_state_dict, "model.transformer.ln_f.weight")
 
-    # HF Molmo2's lm_head is sized to the *base* vocab only — image special
-    # tokens are inputs-only and never predicted (mm_olmo computes logits
-    # against the base embedding table / a base-sized ``ff_out``). Our
-    # OLMo-core LM head spans the full input vocab, so the extra rows must be
-    # filled; :attr:`MultimodalLMConfig.output_vocab_size` masks their logit
-    # columns at forward time, which makes them exactly inert.
-    #
-    # Under ``tie_word_embeddings`` (Molmo2-4B / Qwen3-4B backbone) the head
-    # *shares storage* with the embedding table, so both state-dict keys must
-    # hold identical tensors — zero-padding here would let whichever key loads
-    # last clobber the other (wiping the 128 new-embedding input rows). The HF
-    # checkpoint exports the tied weight as a copy in ``lm_head.weight``; we
-    # verify that and emit the concatenated embedding table for both keys.
+    # Both HF Molmo2's lm_head and ours span the *base* vocab only — the image-special
+    # tokens are inputs, never predicted — so the head maps across directly.
     hf_lm_head = _require(hf_state_dict, "lm_head.weight")
-    extra_rows = lm_cfg.vocab_size - hf_lm_head.shape[0]
-    if extra_rows < 0:
+    if hf_lm_head.shape != base_emb.shape:
         raise Molmo2LoaderError(
-            f"HF lm_head has {hf_lm_head.shape[0]} rows but our LM "
-            f"vocab_size is only {lm_cfg.vocab_size}"
+            f"HF lm_head {tuple(hf_lm_head.shape)} does not match wte.embedding "
+            f"{tuple(base_emb.shape)}"
         )
-    head_matches_embedding = hf_lm_head.shape == base_emb.shape and torch.equal(
-        hf_lm_head, base_emb
-    )
+    head_matches_embedding = torch.equal(hf_lm_head, base_emb)
     if getattr(lm_cfg, "tie_word_embeddings", False):
         if not head_matches_embedding:
             raise Molmo2LoaderError(
@@ -371,19 +361,14 @@ def molmo2_hf_state_dict_to_multimodal_lm(
                 "lm_head.weight differs from wte.embedding — the checkpoint is genuinely "
                 "untied. Build the LM config with tie_word_embeddings=False instead."
             )
-        out["lm.lm_head.w_out.weight"] = out["lm.embeddings.weight"]
-    elif extra_rows > 0:
+        out["lm.lm_head.w_out.weight"] = base_emb
+    else:
         if head_matches_embedding:
             log.info(
                 "HF lm_head.weight equals wte.embedding (the checkpoint was trained "
                 "weight-tied) but the LM config is untied; the head and embedding "
                 "will drift apart if the model is fine-tuned."
             )
-        # new_zeros preserves the source tensor's device and dtype, so this
-        # works when the HF state dict is already on CUDA.
-        pad = hf_lm_head.new_zeros((extra_rows, hf_lm_head.shape[1]))
-        out["lm.lm_head.w_out.weight"] = torch.cat([hf_lm_head, pad], dim=0)
-    else:
         out["lm.lm_head.w_out.weight"] = hf_lm_head
 
     # --- LM: per-block --------------------------------------------------------
@@ -504,6 +489,9 @@ def multimodal_lm_state_dict_to_hf(
     patch_size = cfg.vision.image_patch_size
     vit_layers = cfg.vision.image_num_layers
 
+    # Our embedding table is split exactly like HF's (base + extra), so both map straight
+    # across. Older fused checkpoints (one `embeddings.weight` spanning base + extra) are
+    # still accepted by slicing.
     embeddings = _require(oc_state_dict, "lm.embeddings.weight")
     if embeddings.shape[0] < base_vocab_size:
         raise Molmo2LoaderError(
@@ -511,7 +499,9 @@ def multimodal_lm_state_dict_to_hf(
             f"base_vocab_size={base_vocab_size}"
         )
     out["model.transformer.wte.embedding"] = embeddings[:base_vocab_size].contiguous()
-    if embeddings.shape[0] > base_vocab_size:
+    if (extra := _maybe(oc_state_dict, "lm.embeddings.extra_weight")) is not None:
+        out["model.transformer.wte.new_embedding"] = extra.contiguous()
+    elif embeddings.shape[0] > base_vocab_size:
         out["model.transformer.wte.new_embedding"] = embeddings[base_vocab_size:].contiguous()
 
     out["model.transformer.ln_f.weight"] = _require(oc_state_dict, "lm.lm_head.norm.weight")
@@ -602,7 +592,7 @@ def multimodal_lm_state_dict_to_hf(
 # ---------------------------------------------------------------------------
 
 
-def _build_lm_config(text_cfg, total_vocab_size: int) -> TransformerConfig:
+def _build_lm_config(text_cfg, total_vocab_size: int, n_extra_vocab: int = 0) -> TransformerConfig:
     """Build a :class:`TransformerConfig` matching an HF Molmo2 text_config.
 
     Dispatches to ``qwen3_4B`` / ``qwen3_8B`` (qk_norm_type="qwen3"),
@@ -643,6 +633,7 @@ def _build_lm_config(text_cfg, total_vocab_size: int) -> TransformerConfig:
         # shares the head with the base rows of the embedding table.
         return TransformerConfig.qwen3_4B(
             vocab_size=total_vocab_size,
+            n_extra_vocab=n_extra_vocab,
             rope_theta=rope_theta,
             attn_backend=attn_backend,
             dtype=DType.float32,
@@ -650,6 +641,7 @@ def _build_lm_config(text_cfg, total_vocab_size: int) -> TransformerConfig:
     if qk_norm_type == "qwen3" and hidden_size == 4096 and n_layers == 36:
         return TransformerConfig.qwen3_8B(
             vocab_size=total_vocab_size,
+            n_extra_vocab=n_extra_vocab,
             rope_theta=rope_theta,
             attn_backend=attn_backend,
             dtype=DType.float32,
@@ -673,6 +665,7 @@ def _build_lm_config(text_cfg, total_vocab_size: int) -> TransformerConfig:
             )
         return TransformerConfig.olmo3_7B(
             vocab_size=total_vocab_size,
+            n_extra_vocab=n_extra_vocab,
             rope_theta=rope_theta,
             attn_backend=attn_backend,
             dtype=DType.float32,
@@ -768,8 +761,11 @@ def molmo2_config_from_hf_config(hf_config: Any) -> MultimodalLMConfig:
     # combined vocab as its *input* vocab. The extra tokens are inputs-only —
     # HF's lm_head covers just ``text_cfg.vocab_size`` — so the base vocab
     # becomes ``output_vocab_size`` (masking the extra logit columns).
-    total_vocab = text_cfg.vocab_size + text_cfg.additional_vocab_size
-    lm_cfg = _build_lm_config(text_cfg, total_vocab_size=total_vocab)
+    lm_cfg = _build_lm_config(
+        text_cfg,
+        total_vocab_size=text_cfg.vocab_size,
+        n_extra_vocab=text_cfg.additional_vocab_size,
+    )
     vis_cfg = _build_vision_config(vit_cfg, adapter_cfg.vit_layers)
     conn_cfg = _build_connector_config(adapter_cfg, vit_hidden_size=vit_cfg.hidden_size)
 
@@ -790,5 +786,7 @@ def molmo2_config_from_hf_config(hf_config: Any) -> MultimodalLMConfig:
         connector=conn_cfg,
         image_patch_token_id=hf_config.image_patch_id,
         vit_layers=resolved_vit_layers,
-        output_vocab_size=text_cfg.vocab_size,
+        # No logit masking needed: the LM head now spans the base vocab only (the extra
+        # image-token rows live in `embeddings.extra_weight` and are never prediction targets).
+        output_vocab_size=None,
     )

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -11,6 +11,7 @@ from torch.distributed.tensor import DTensor
 from olmo_core.config import Config, DType
 from olmo_core.distributed.utils import barrier, is_distributed
 from olmo_core.exceptions import OLMoConfigurationError
+from olmo_core.nn.embedding import SplitVocabEmbedding
 from olmo_core.nn.lm_head import LMOutputWithLoss
 from olmo_core.nn.transformer.config import TransformerConfig
 from olmo_core.nn.vision.config import VisionEncoderConfig
@@ -23,6 +24,7 @@ from olmo_core.nn.vision.molmo2_tokens import IM_PATCH_ID
 
 __all__ = [
     "MOLMO2_BASE_VOCAB_SIZE",
+    "MOLMO2_N_EXTRA_TOKENS",
     "MOLMO2_VOCAB_SIZE",
     "MultimodalLMConfig",
     "MultimodalLM",
@@ -31,8 +33,11 @@ __all__ = [
 MOLMO2_BASE_VOCAB_SIZE = 151_936
 """Molmo2's base text vocab (Qwen3's) — the number of IDs the model may *predict*."""
 
-MOLMO2_VOCAB_SIZE = MOLMO2_BASE_VOCAB_SIZE + 128
-"""Molmo2's *input* vocab: the base text vocab plus 128 inputs-only image-special tokens."""
+MOLMO2_N_EXTRA_TOKENS = 128
+"""Molmo2's inputs-only image-special tokens, held in a separate embedding block."""
+
+MOLMO2_VOCAB_SIZE = MOLMO2_BASE_VOCAB_SIZE + MOLMO2_N_EXTRA_TOKENS
+"""Molmo2's total *input* vocab (base + extra); the LM head spans only the base."""
 
 
 def _molmo2_attn_backend():
@@ -158,7 +163,8 @@ class MultimodalLMConfig(Config):
             ),
             image_patch_token_id=IM_PATCH_ID,
             vit_layers=(24, 18),
-            output_vocab_size=MOLMO2_BASE_VOCAB_SIZE,
+            # The head spans the base vocab structurally, so no logit masking is required.
+            output_vocab_size=None,
             **kwargs,
         )
 
@@ -181,7 +187,8 @@ class MultimodalLMConfig(Config):
         """
         return cls._molmo2_like(
             TransformerConfig.qwen3_4B(
-                vocab_size=MOLMO2_VOCAB_SIZE,
+                vocab_size=MOLMO2_BASE_VOCAB_SIZE,
+                n_extra_vocab=MOLMO2_N_EXTRA_TOKENS,
                 rope_theta=rope_theta,
                 attn_backend=_molmo2_attn_backend(),
                 dtype=DType.float32,
@@ -205,7 +212,8 @@ class MultimodalLMConfig(Config):
         """
         return cls._molmo2_like(
             TransformerConfig.qwen3_8B(
-                vocab_size=MOLMO2_VOCAB_SIZE,
+                vocab_size=MOLMO2_BASE_VOCAB_SIZE,
+                n_extra_vocab=MOLMO2_N_EXTRA_TOKENS,
                 rope_theta=rope_theta,
                 attn_backend=_molmo2_attn_backend(),
                 dtype=DType.float32,
@@ -482,9 +490,17 @@ class MultimodalLM(nn.Module):
         # forward would unshard, so gather it to a full tensor for the lookup (a no-op for
         # DDP / single-GPU where the weight is already a plain tensor).
         emb = self.lm.embeddings
-        emb_weight = emb.weight
-        if isinstance(emb_weight, DTensor):
-            emb_weight = emb_weight.full_tensor()
+
+        def _full(weight: torch.Tensor) -> torch.Tensor:
+            return weight.full_tensor() if isinstance(weight, DTensor) else weight
+
+        if isinstance(emb, SplitVocabEmbedding):
+            # The image-special token IDs live in the *extra* block, so the lookup must span
+            # both parameters — `emb.weight` alone covers only the base vocab. Gradients still
+            # reach both blocks through the concatenation.
+            emb_weight = torch.cat([_full(emb.weight), _full(emb.extra_weight)], dim=0)
+        else:
+            emb_weight = _full(emb.weight)
         h = F.embedding(input_ids, emb_weight, padding_idx=emb.padding_idx)
         if self.lm.embed_scale is not None:
             h = h * self.lm.embed_scale

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -184,6 +184,12 @@ LLM_WARMUP = 2000
 TRAIN_VIT = True
 VIT_LR = 6e-6
 VIT_WARMUP = 2000
+# Hold the pretrained token embeddings fixed, matching mm_olmo's `ft_embedding="lm_head"`
+# default: only the 128 image-special rows (`embeddings.extra_weight`) are learned. Because
+# the table is split, this is a plain whole-tensor freeze. For a *tied* backbone (Molmo2-4B)
+# the base block is also the LM head, so both roles are frozen; for an untied one
+# (Molmo2-8B) only the input table is, and the head keeps training — exactly mm_olmo.
+FREEZE_BASE_EMBEDDINGS = True
 ALPHA_F = 0.1
 
 # Data: the canonical PixMoCap "cap" dataset (HF DatasetDict, load_from_disk). Override as needed.
@@ -236,6 +242,10 @@ class ExperimentConfig(Config):
     train_vit: bool = TRAIN_VIT
     """Train the vision encoder in its own optimizer group (mm_olmo ``ft_vit``). When False
     the encoder is frozen and kept in eval mode."""
+
+    freeze_base_embeddings: bool = FREEZE_BASE_EMBEDDINGS
+    """Freeze the pretrained token-embedding block, training only the extra image-token rows
+    (mm_olmo ``ft_embedding="lm_head"``)."""
 
     pack_sequences: bool = PACK_SEQUENCES
     """Pack several short examples per sequence (mm_olmo dynamic packer)."""
@@ -306,6 +316,9 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
     # Resolved pre-merge because it shapes `freeze_params`, the optimizer groups and the
     # per-group scheduler, all of which are built before `Config.merge` runs.
     train_vit = _read_bool_override(overrides, "train_vit", TRAIN_VIT)
+    freeze_base_embeddings = _read_bool_override(
+        overrides, "freeze_base_embeddings", FREEZE_BASE_EMBEDDINGS
+    )
     model_config = _build_model_config(model_size, init_from)
 
     dataset_config = PixMoCapDatasetConfig(
@@ -353,7 +366,12 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         ),
         # An empty list keeps the encoder trainable *and* in train mode — the train module
         # only forces `vision.eval()` when `vision.*` is frozen.
-        freeze_params=[] if train_vit else ["vision.*"],
+        freeze_params=(
+            ([] if train_vit else ["vision.*"])
+            # The extra image-token rows live in `embeddings.extra_weight`, so freezing
+            # `embeddings.weight` leaves them trainable.
+            + (["lm.embeddings.weight"] if freeze_base_embeddings else [])
+        ),
         z_loss_multiplier=1e-4,
         max_grad_norm=1.0,
         compile_model=COMPILE_MODEL,
@@ -448,11 +466,17 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
     # `_resolve_model_spec` already validated the pre-merge values; re-check the merged
     # config so a stray `--model_size`/`--init_from`/`--train_vit` cannot slip through, and
     # fail here rather than after a Beaker job has queued, started and downloaded weights.
-    resolved = (model_size, init_from, train_vit)
-    merged = (config.model_size, config.init_from, config.train_vit)
+    resolved = (model_size, init_from, train_vit, freeze_base_embeddings)
+    merged = (
+        config.model_size,
+        config.init_from,
+        config.train_vit,
+        config.freeze_base_embeddings,
+    )
     if merged != resolved:
         raise OLMoConfigurationError(
-            f"model_size / init_from / train_vit changed during merge: " f"{resolved} -> {merged}"
+            f"model_size / init_from / train_vit / freeze_base_embeddings changed during merge: "
+            f"{resolved} -> {merged}"
         )
 
     return config
@@ -538,34 +562,25 @@ def _init_weights_from_scratch(
     lm_state = convert_state_from_hf(hf_lm.config, hf_lm.state_dict(), model_type="qwen3")
     del hf_lm
 
+    # The base checkpoint's vocab must match our base block exactly; the extra image-token
+    # rows are a separate parameter, initialised here from mm_olmo's `new_embedding_init_range`.
     emb = lm_state["embeddings.weight"]
-    extra = model_cfg.lm.vocab_size - emb.shape[0]
-    if extra < 0:
-        raise RuntimeError(f"Base LM vocab {emb.shape[0]} exceeds target {model_cfg.lm.vocab_size}")
+    if emb.shape[0] != model_cfg.lm.vocab_size:
+        raise RuntimeError(
+            f"Base LM vocab {emb.shape[0]} != target base vocab {model_cfg.lm.vocab_size}"
+        )
+    n_extra = model_cfg.lm.n_extra_vocab
     gen = torch.Generator().manual_seed(0)  # same rows on every rank
-    new_rows = torch.empty(extra, emb.shape[1], dtype=emb.dtype)
-    new_rows.normal_(std=NEW_EMBEDDING_INIT_STD, generator=gen)
-    full_emb = torch.cat([emb, new_rows], dim=0)
+    extra_rows = torch.empty(n_extra, emb.shape[1], dtype=emb.dtype)
+    extra_rows.normal_(std=NEW_EMBEDDING_INIT_STD, generator=gen)
 
     converted = {f"lm.{k}": v for k, v in lm_state.items()}
-    converted["lm.embeddings.weight"] = full_emb
-    # The LM head has to span our full input vocab, but the base checkpoint only covers the
-    # base one, so it needs the same `extra` rows appended. How depends on tying:
+    converted["lm.embeddings.extra_weight"] = extra_rows
+    # Both our LM head and the base checkpoint's span the base vocab, so it maps straight
+    # across: no padding, and for a tied config the head simply *is* the base block
+    # (`retie_word_embeddings` below restores the share that `to_empty` broke).
     if model_cfg.lm.tie_word_embeddings:
-        # Tied (Molmo2-4B / Qwen3-4B, mm_olmo `weight_tying=True`): head *is* the embedding
-        # table. Identical values make the load order-independent; `retie_word_embeddings`
-        # below restores the share that `to_empty` broke.
-        converted["lm.lm_head.w_out.weight"] = full_emb.clone()
-    else:
-        # Untied (Molmo2-8B / Qwen3-8B): the base checkpoint carries a *distinct trained*
-        # output head — keep it rather than overwriting it with the embedding table. The
-        # appended rows are zeros because `output_vocab_size` masks logit columns >= the base
-        # vocab: they never enter the softmax and receive exactly zero gradient, matching
-        # mm_olmo, whose untied `ff_out` spans only the base vocab.
-        base_head = lm_state["lm_head.w_out.weight"]
-        converted["lm.lm_head.w_out.weight"] = torch.cat(
-            [base_head, base_head.new_zeros(extra, base_head.shape[1])], dim=0
-        )
+        converted["lm.lm_head.w_out.weight"] = emb
     del lm_state
 
     log.info(f"[scratch init] Loading base ViT weights from {SCRATCH_VIT_ID} ...")

--- a/src/test/nn/embedding_test.py
+++ b/src/test/nn/embedding_test.py
@@ -1,0 +1,79 @@
+import pytest
+import torch
+
+from olmo_core.nn.attention import AttentionBackendName
+from olmo_core.nn.embedding import SplitVocabEmbedding
+from olmo_core.nn.transformer.config import TransformerConfig
+
+BASE, EXTRA, D = 40, 6, 8
+
+
+def test_shapes_and_total_vocab():
+    emb = SplitVocabEmbedding(BASE, EXTRA, D)
+    assert emb.weight.shape == (BASE, D)
+    assert emb.extra_weight.shape == (EXTRA, D)
+    assert emb.num_embeddings == BASE + EXTRA
+    assert emb.full_weight().shape == (BASE + EXTRA, D)
+
+
+def test_lookup_spans_both_blocks():
+    emb = SplitVocabEmbedding(BASE, EXTRA, D)
+    torch.nn.init.normal_(emb.weight)
+    torch.nn.init.normal_(emb.extra_weight)
+    ids = torch.tensor([[0, BASE - 1, BASE, BASE + EXTRA - 1]])
+    out = emb(ids)
+    torch.testing.assert_close(out[0, 0], emb.weight[0])
+    torch.testing.assert_close(out[0, 1], emb.weight[BASE - 1])
+    # IDs past the base block must resolve into the extra block, not go out of range.
+    torch.testing.assert_close(out[0, 2], emb.extra_weight[0])
+    torch.testing.assert_close(out[0, 3], emb.extra_weight[EXTRA - 1])
+
+
+def test_requires_positive_extra_rows():
+    with pytest.raises(ValueError, match="num_extra_embeddings"):
+        SplitVocabEmbedding(BASE, 0, D)
+
+
+@pytest.mark.parametrize("tied", [True, False])
+def test_transformer_head_spans_base_vocab_only(tied: bool):
+    """The whole point of naming the base block ``weight``: tying yields a base-width head."""
+    cfg = TransformerConfig.olmo3_1M(
+        vocab_size=BASE,
+        n_extra_vocab=EXTRA,
+        attn_backend=AttentionBackendName.torch,
+        tie_word_embeddings=tied,
+    )
+    model = cfg.build(init_device="cpu")
+    model.init_weights()
+
+    assert isinstance(model.embeddings, SplitVocabEmbedding)
+    assert model.lm_head.w_out.weight.shape[0] == BASE
+    assert (model.lm_head.w_out.weight is model.embeddings.weight) is tied
+
+    # Lookups accept the extra IDs even though they can never be predicted.
+    logits = model(input_ids=torch.randint(0, BASE + EXTRA, (2, 5)))
+    assert logits.shape == (2, 5, BASE)
+
+
+@pytest.mark.parametrize("tied", [True, False])
+def test_freezing_base_block_leaves_extra_rows_trainable(tied: bool):
+    """mm_olmo's ``ft_embedding="lm_head"``: the pretrained rows are pinned, the added
+    image-token rows keep learning. With a fused table this would be a partial-row freeze
+    that ``requires_grad`` cannot express."""
+    cfg = TransformerConfig.olmo3_1M(
+        vocab_size=BASE,
+        n_extra_vocab=EXTRA,
+        attn_backend=AttentionBackendName.torch,
+        tie_word_embeddings=tied,
+    )
+    model = cfg.build(init_device="cpu")
+    model.init_weights()
+    model.embeddings.weight.requires_grad_(False)
+
+    extra_id = BASE + 2
+    ids = torch.full((1, 4), extra_id)
+    model(input_ids=ids).float().sum().backward()
+
+    assert model.embeddings.weight.grad is None  # pinned (and, when tied, so is the head)
+    assert model.embeddings.extra_weight.grad is not None
+    assert model.embeddings.extra_weight.grad[2].abs().sum() > 0

--- a/src/test/nn/vision/molmo2_loader_test.py
+++ b/src/test/nn/vision/molmo2_loader_test.py
@@ -12,6 +12,7 @@ A separate ``@pytest.mark.slow`` numerical-parity test that requires a real
 HF Molmo2 checkpoint can be added later (task follow-up).
 """
 
+import dataclasses
 from typing import Dict
 
 import pytest
@@ -59,7 +60,8 @@ def _tiny_cfg(tie_word_embeddings: bool = False) -> MultimodalLMConfig:
     # fused ff_proj + qk_norm), just with d_model=12. Force the `torch`
     # SDPA backend so the tiny test config builds without a CUDA flash-attn.
     lm_cfg = TransformerConfig.olmo3_1M(
-        vocab_size=_FULL_VOCAB,
+        vocab_size=_BASE_VOCAB,
+        n_extra_vocab=_EXTRA_VOCAB,
         attn_backend=AttentionBackendName.torch,
         tie_word_embeddings=tie_word_embeddings,
     )
@@ -87,7 +89,8 @@ def _tiny_cfg(tie_word_embeddings: bool = False) -> MultimodalLMConfig:
         vision=vis_cfg,
         connector=conn_cfg,
         image_patch_token_id=_IMAGE_PATCH_ID,
-        output_vocab_size=_BASE_VOCAB,
+        # The head spans the base vocab structurally, so no logit masking.
+        output_vocab_size=None,
     )
 
 
@@ -135,14 +138,12 @@ def _synthetic_hf_state_dict(cfg: MultimodalLMConfig) -> Dict[str, torch.Tensor]
 
     has_qk_norm = _has_qk_norm(lm_cfg)
 
-    # Vocab: HF Molmo2 keeps base + extra vocab in separate buffers, and its
-    # lm_head predicts only the *base* vocab (the extras are input-only).
-    # Our config has lm.vocab_size == base + extra (already padded). Split
-    # at the same boundary that the converter uses. Tied configs export
-    # lm_head.weight as a copy of wte.embedding, so mirror that.
-    full_vocab = lm_cfg.vocab_size
-    new_vocab = _EXTRA_VOCAB
-    base_vocab = full_vocab - new_vocab
+    # Vocab: HF Molmo2 keeps base + extra vocab in separate buffers, and its lm_head
+    # predicts only the *base* vocab (the extras are input-only). Our config mirrors that
+    # split, so `lm.vocab_size` is the base and `lm.n_extra_vocab` the extra block. Tied
+    # configs export lm_head.weight as a copy of wte.embedding, so mirror that.
+    base_vocab = lm_cfg.vocab_size
+    new_vocab = lm_cfg.n_extra_vocab
     sd["model.transformer.wte.embedding"] = torch.randn(base_vocab, d_model)
     sd["model.transformer.wte.new_embedding"] = torch.randn(new_vocab, d_model)
     sd["model.transformer.ln_f.weight"] = torch.randn(d_model)
@@ -342,11 +343,10 @@ def test_forward_runs_with_converted_weights():
     model.eval()
     # Text-only forward.
     out = model(input_ids=torch.randint(0, 100, (1, 8)))
-    assert out.shape == (1, 8, cfg.lm.vocab_size)
-    # Base-vocab logits are real; extra-vocab columns are masked to the dtype
-    # minimum so they carry zero softmax mass and can never be sampled.
-    assert torch.isfinite(out[..., :_BASE_VOCAB]).all()
-    assert (out[..., _BASE_VOCAB:] == torch.finfo(out.dtype).min).all()
+    # The LM head spans the base vocab only — the extra image-special tokens are inputs and
+    # are structurally unpredictable, so there are no masked columns to check.
+    assert out.shape == (1, 8, _BASE_VOCAB)
+    assert torch.isfinite(out).all()
 
 
 # ---------------------------------------------------------------------------
@@ -355,29 +355,29 @@ def test_forward_runs_with_converted_weights():
 
 
 def test_tied_lm_head_shares_embedding_table_and_preserves_new_embedding():
-    """For a tied LM the converter must emit one consistent table for both keys.
+    """For a tied LM the head shares the *base* block, and the extra rows are untouched.
 
-    Regression test: zero-padding the lm_head of a *tied* model used to clobber
-    the ``new_embedding`` input rows on ``load_state_dict`` (both state-dict keys
-    copy into the same shared tensor, last write wins)."""
+    The base block and the extra image-token rows are separate parameters, so the tied head
+    (which is the base block) can no longer clobber the extra rows on ``load_state_dict`` —
+    the failure mode this test was originally written for is now structurally impossible."""
     cfg = _tiny_cfg(tie_word_embeddings=True)
     hf_sd = _synthetic_hf_state_dict(cfg)
     converted = molmo2_hf_state_dict_to_multimodal_lm(hf_sd, cfg)
 
-    # Both keys hold the same concatenated table.
+    # The tied head is the base block itself, and it spans the base vocab only.
     assert converted["lm.lm_head.w_out.weight"] is converted["lm.embeddings.weight"]
+    assert converted["lm.embeddings.weight"].shape[0] == _BASE_VOCAB
+    assert converted["lm.embeddings.extra_weight"].shape[0] == _EXTRA_VOCAB
 
-    # Loading into a truly tied model (built on CPU, tie intact) must keep the
-    # new_embedding rows in the shared table.
     model = MultimodalLM(cfg, init_device="cpu")
     assert model.lm.lm_head.w_out.weight is model.lm.embeddings.weight
     model.load_state_dict(converted, strict=False)
     torch.testing.assert_close(
-        model.lm.embeddings.weight[_BASE_VOCAB:],
+        model.lm.embeddings.extra_weight,
         hf_sd["model.transformer.wte.new_embedding"],
     )
     torch.testing.assert_close(
-        model.lm.embeddings.weight[:_BASE_VOCAB],
+        model.lm.embeddings.weight,
         hf_sd["model.transformer.wte.embedding"],
     )
 
@@ -406,16 +406,23 @@ def test_retie_word_embeddings_after_to_empty():
     retie_word_embeddings(model)
     assert model.lm.lm_head.w_out.weight is model.lm.embeddings.weight
     torch.testing.assert_close(
-        model.lm.embeddings.weight[_BASE_VOCAB:],
+        model.lm.embeddings.extra_weight,
         hf_sd["model.transformer.wte.new_embedding"],
+    )
+    torch.testing.assert_close(
+        model.lm.embeddings.weight,
+        hf_sd["model.transformer.wte.embedding"],
     )
 
 
 def test_labels_path_guarded_when_output_vocab_masked():
-    """Passing ``labels`` through MultimodalLM would compute the loss over the
-    full padded vocab, bypassing the output-vocab masking — must raise."""
+    """Passing ``labels`` through MultimodalLM bypasses output-vocab masking — must raise.
+
+    Molmo2 no longer needs the masking (its head spans the base vocab structurally), so this
+    exercises the feature on a config that opts into it explicitly."""
     cfg = _tiny_cfg()
+    cfg = dataclasses.replace(cfg, output_vocab_size=_BASE_VOCAB - 4)
     model = MultimodalLM(cfg, init_device="cpu")
-    input_ids = torch.randint(0, _BASE_VOCAB, (1, 8))
+    input_ids = torch.randint(0, _BASE_VOCAB - 4, (1, 8))
     with pytest.raises(Exception, match="output_vocab_size"):
         model(input_ids=input_ids, labels=input_ids.clone())

--- a/src/test/nn/vision/molmo2_native_config_test.py
+++ b/src/test/nn/vision/molmo2_native_config_test.py
@@ -75,9 +75,13 @@ def test_native_config_shape(factory_name: str, d_model: int, ffn_hidden_size: i
     assert cfg.lm.d_model == d_model
     assert cfg.lm.n_layers == 36
     assert cfg.lm.block.feed_forward.hidden_size == ffn_hidden_size
-    assert cfg.lm.vocab_size == 152_064  # 151,936 base + 128 image-special tokens
+    # The table is split: `vocab_size` is the base vocab, the 128 image-special tokens live
+    # in a separate `embeddings.extra_weight` block, and the LM head spans the base only —
+    # so no logit masking (`output_vocab_size`) is needed.
+    assert cfg.lm.vocab_size == 151_936
+    assert cfg.lm.n_extra_vocab == 128
     assert cfg.lm.tie_word_embeddings is tied
-    assert cfg.output_vocab_size == 151_936
+    assert cfg.output_vocab_size is None
     # The vision stack is shared across variants.
     assert cfg.vision.image_num_layers == 25  # SigLIP2 blocks 0..24 of 27
     assert cfg.vit_layers == (24, 18)


### PR DESCRIPTION
The last Tier-1 divergence from mm_olmo's stage-1 captioner.

mm_olmo's `TrainConfig.ft_embedding` defaults to `"lm_head"` and `train_captioner.py` never
overrides it, so with `ft_llm=True` `run_trainer.py` reaches
`transformer.wte.embedding.requires_grad = False`: the **pretrained token embeddings are held
fixed** and only the 128 image-special rows (`wte.new_embedding`) are learned. Its optimizer
then drops the frozen tensor entirely (`get_param_groups` filters `p.requires_grad`). We
trained the whole table.

That is not marginal. Measured on a tied model mirroring the real layout, **every** base row
receives gradient on **every** step — densely, because with weight tying the table *is* the
output head (`Molmo2.forward:923` → `wte(x, logits=True)` → `F.linear(x, self.embedding)`).
It is the single largest tensor in the model: **389.0M params (8.7%)** on the 4B,
**622.3M (7.2%)** on the 8B.

## Why a flag wasn't enough

`requires_grad` could not express this, because we fused the base and extra rows into one
`nn.Embedding(152064, d)` — freezing it would also pin the image-token rows mm_olmo *trains*.
So the table is now split the way mm_olmo splits it: `SplitVocabEmbedding` holds `weight`
(base) and `extra_weight` (extra) as separate parameters, behind
`TransformerConfig.n_extra_vocab` (**default 0**, so every other model in the repo is
untouched).

Naming the base block `weight` is what makes this cheap: weight tying
(`lm_head.w_out.weight = embeddings.weight`) now yields a head spanning the **base vocab
only** — exactly mm_olmo's behaviour — and `init_embeddings` keeps working unchanged.

Freezing is then a plain `freeze_params=["lm.embeddings.weight"]`, and it reproduces the
4B/8B asymmetry *structurally* rather than by emulation:

| | `embeddings.weight` | `extra_weight` | LM head |
|---|---|---|---|
| 4B (tied) | frozen — 389.0M, 8.7% | trainable | **is** the base block → frozen |
| 8B (untied) | frozen — 622.3M, 7.2% | trainable | separate param → **trainable** |

That asymmetry comes from two independent causes: Qwen ties the 4B backbone and not the 8B,
and `ft_embedding="lm_head"` freezes `wte` but deliberately *not* `ff_out` — so with tying
there is no `ff_out` and the head is pinned too, while untied it keeps learning.

`FREEZE_BASE_EMBEDDINGS` defaults to `True` for parity; `--freeze_base_embeddings=false`
trains the full table.

Unlike a gradient-masking approach, this actually **drops the optimizer state**: 2.90 GiB
(4B) / 4.64 GiB (8B) of fp32 AdamW moments are no longer allocated.

## The split simplified more than it complicated

* The converter's embedding/head section lost the zero-padding, the extra-row arithmetic and
  the tied-key clobbering hazard — HF Molmo2's `lm_head` is base-width and now so is ours, so
  it maps straight across.
* `output_vocab_size` masking is no longer used by Molmo2 (set to `None`): the extra tokens
  are *structurally* unpredictable instead of predictable-then-masked. The feature remains for
  other callers and its guard is still tested.
* The from-scratch init no longer concatenates or zero-pads; the 128 rows go straight to
  `extra_weight`.

## Two real bugs surfaced, both caught by tests

* **`MultimodalLM.forward` does its own embedding lookup** (so it can splice image features)
  off `emb.weight` — which after the split is only the base block, so **every image-special
  token ID would have been out of range**. It now looks up across both blocks, DTensor-aware,
  with gradients still reaching both.
* `SplitVocabEmbedding` was missing `padding_idx`, which that same lookup reads.

## Verification

**Real-weight parity on the released Molmo2-4B.** Only the config had been cached, so I
downloaded the 19.4 GB of shards specifically to avoid shipping a converter rewrite
unvalidated:

```
test_molmo2_embedding_parity[allenai/Molmo2-4B]            PASSED
test_molmo2_lm_forward_parity[allenai/Molmo2-4B]           PASSED
test_molmo2_full_pipeline_logit_parity[allenai/Molmo2-4B]  PASSED
molmo2_parity_test + molmo2_training_logits_parity_test    2 passed
```

* 249 passed / 17 skipped across `src/test/nn/vision`, `src/test/nn/embedding_test.py` and
  `src/test/data/multimodal` on the rebased tree. A broader run over `src/test/nn` +
  `src/test/data/multimodal` gave 497 passed / 1195 skipped; the single failure,
  `convert_test.py::test_logprobs_match_after_roundtrip[gemma3]`, is a gated-HF-repo auth
  error that fails identically on `vision`.
* New `src/test/nn/embedding_test.py` (7 tests): shapes, lookups spanning both blocks, the
  base-width tied head, and base-frozen/extra-trainable for both tied and untied.
* `isort`/`black`/`ruff` over `src/` identical to the `vision` baseline (19 isort, 6 ruff),
  with one *fewer* black-reformat file.

## Checkpoint layout note for reviewers

`lm.embeddings.weight` is now 151,936 rows plus a separate `lm.embeddings.extra_weight`. Both
HF conversion directions handle the new layout, and the reverse converter still accepts older
**fused** checkpoints by slicing. Native olmo-core checkpoints written before this change
(e.g. the completed 32k stage-1 run) would need splitting to resume from — say the word and I
will add a migration helper.
