### PR TITLE
Molmo2-Stage1: align with the released Molmo2-4B-Pretrain config

### DIFF
--- a/src/olmo_core/nn/vision/molmo2_loader.py
+++ b/src/olmo_core/nn/vision/molmo2_loader.py
@@ -635,6 +635,8 @@ def _build_lm_config(text_cfg, total_vocab_size: int, n_extra_vocab: int = 0) ->
             vocab_size=total_vocab_size,
             n_extra_vocab=n_extra_vocab,
             rope_theta=rope_theta,
+            # mm_olmo's Molmo2 llm configs all set `rope_full_precision: true`.
+            rope_full_precision=True,
             attn_backend=attn_backend,
             dtype=DType.float32,
         )
@@ -643,6 +645,8 @@ def _build_lm_config(text_cfg, total_vocab_size: int, n_extra_vocab: int = 0) ->
             vocab_size=total_vocab_size,
             n_extra_vocab=n_extra_vocab,
             rope_theta=rope_theta,
+            # mm_olmo's Molmo2 llm configs all set `rope_full_precision: true`.
+            rope_full_precision=True,
             attn_backend=attn_backend,
             dtype=DType.float32,
         )
@@ -667,6 +671,8 @@ def _build_lm_config(text_cfg, total_vocab_size: int, n_extra_vocab: int = 0) ->
             vocab_size=total_vocab_size,
             n_extra_vocab=n_extra_vocab,
             rope_theta=rope_theta,
+            # mm_olmo's Molmo2 llm configs all set `rope_full_precision: true`.
+            rope_full_precision=True,
             attn_backend=attn_backend,
             dtype=DType.float32,
         )

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -190,6 +190,8 @@ class MultimodalLMConfig(Config):
                 vocab_size=MOLMO2_BASE_VOCAB_SIZE,
                 n_extra_vocab=MOLMO2_N_EXTRA_TOKENS,
                 rope_theta=rope_theta,
+                # The released pretrain configs set `rope_full_precision: true`.
+                rope_full_precision=True,
                 attn_backend=_molmo2_attn_backend(),
                 dtype=DType.float32,
             ),
@@ -215,6 +217,8 @@ class MultimodalLMConfig(Config):
                 vocab_size=MOLMO2_BASE_VOCAB_SIZE,
                 n_extra_vocab=MOLMO2_N_EXTRA_TOKENS,
                 rope_theta=rope_theta,
+                # The released pretrain configs set `rope_full_precision: true`.
+                rope_full_precision=True,
                 attn_backend=_molmo2_attn_backend(),
                 dtype=DType.float32,
             ),

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -149,7 +149,7 @@ INIT_FROM_CHOICES = ("scratch", "molmo2")
 _BOOLS = {"true": True, "false": False, "1": True, "0": False, "yes": True, "no": False}
 SCRATCH_VIT_ID = "google/siglip2-so400m-patch14-384"  # shared by every Molmo2 variant
 NEW_EMBEDDING_INIT_STD = 0.02  # mm_olmo `new_embedding_init_range`
-SEQUENCE_LENGTH = 4096  # fixed pad length; mm_olmo's captioner default is 2536
+SEQUENCE_LENGTH = 2536  # fixed pad length; matches mm_olmo's captioner `--seq_len`
 USE_FLEX_ATTN = True  # fused FlexAttention backend for the multimodal masks (~+8% MFU)
 PACK_SEQUENCES = True  # pack several examples per sequence (most are ~1.4k of 4096 tokens)
 COMPILE_MODEL = True  # torch.compile the LM (fuses pointwise ops; one-time compile warmup)
@@ -166,8 +166,18 @@ MAX_CROPS = 8
 # reproduction. (The other mm_olmo delta, the `style_and_length_v2` length-conditioning
 # system prompt, IS implemented — see PixMoCapDataset.style_length_conditioning.)
 
-# Instance-based batching (mm_olmo: global 8, device microbatch 1), expressed in tokens.
-GLOBAL_BATCH_INSTANCES = 8
+# Instance-based batching, expressed in tokens for the token-based Trainer.
+#
+# `GLOBAL_BATCH_INSTANCES` matches mm_olmo's `global_train_batch_size=128` — the
+# optimization-relevant quantity. 128 also divides every DP world size we run (8/16/32),
+# which the previous default of 8 did not: at 16 GPUs it failed the
+# `global % (microbatch x dp_world_size) == 0` check.
+#
+# mm_olmo uses `device_train_microbatch_size=4`; we keep 1. That is purely a
+# memory/throughput knob — gradient accumulation makes the two mathematically identical for
+# the same global batch — and microbatch >1 at this sequence length OOM'd without activation
+# checkpointing (see the `ac_config` follow-up).
+GLOBAL_BATCH_INSTANCES = 128
 RANK_MICROBATCH_INSTANCES = 1
 GLOBAL_BATCH_SIZE = GLOBAL_BATCH_INSTANCES * SEQUENCE_LENGTH
 RANK_MICROBATCH_SIZE = RANK_MICROBATCH_INSTANCES * SEQUENCE_LENGTH
@@ -326,7 +336,11 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         mode="transcript_and_caption",
         max_crops=MAX_CROPS,
         max_sequence_length=SEQUENCE_LENGTH,
-        loss_token_weighting="root_subsegments",
+        # mm_olmo's captioner leaves `loss_token_weighting` at its "none" default, so every
+        # response token is weighted equally. `root_subsegments` (1/sqrt(n_branches)) does not
+        # cancel out of the global `sum(CE*w)/sum(w)` divisor when branch counts differ across
+        # examples, so it would re-weight caption vs pointing vs NLP relative to mm_olmo.
+        loss_token_weighting="none",
         seed=34521,
     )
 

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -118,21 +118,28 @@ class ModelSizeSpec:
         return self.scratch_rope_theta if init_from == "scratch" else self.molmo2_rope_theta
 
 
-# `rope_theta` follows the *weight source*: every base Qwen3 backbone uses 1e6, and so does
-# the released Molmo2-8B — the released Molmo2-4B is the sole variant that differs (5e6).
-# Deriving the architecture from a released config while loading base weights therefore puts
-# 4B weights on the wrong rotary base.
+# Per-variant weight sources, taken from the released pretrain configs at
+# /weka/oe-training-default/mm-olmo/released-models-molmo2-1225/Molmo2-{4B,8B}-Pretrain/.
+# `rope_theta` follows the weight source, and the two variants used different backbones.
 MODEL_SIZES = {
     "4b": ModelSizeSpec(
         factory=MultimodalLMConfig.molmo2_4B,
         molmo2_id="allenai/Molmo2-4B",
-        scratch_lm_id="Qwen/Qwen3-4B",
-        scratch_rope_theta=1_000_000,
+        # The released 4B pretrain ran `train_captioner.py qwen3_4b_instruct`, i.e. the
+        # *instruct* backbone (`Qwen/Qwen3-4B-Instruct-2507`), whose RoPE base is 5e6 — which
+        # is where the released Molmo2-4B's 5e6 comes from. Its tokenizer is identical to
+        # Molmo2's for everything the data pipeline uses (BPE, eos_token_id 151645, and the
+        # user-turn chat template).
+        scratch_lm_id="Qwen/Qwen3-4B-Instruct-2507",
+        scratch_rope_theta=5_000_000,
         molmo2_rope_theta=5_000_000,
     ),
     "8b": ModelSizeSpec(
         factory=MultimodalLMConfig.molmo2_8B,
         molmo2_id="allenai/Molmo2-8B",
+        # The released 8B pretrain ran `train_captioner.py qwen3_8b` — the *base* backbone,
+        # RoPE base 1e6, untied. Hence the 4B/8B asymmetry: different backbones, not a
+        # Molmo2-side change.
         scratch_lm_id="Qwen/Qwen3-8B",
         scratch_rope_theta=1_000_000,
         molmo2_rope_theta=1_000_000,
@@ -149,7 +156,7 @@ INIT_FROM_CHOICES = ("scratch", "molmo2")
 _BOOLS = {"true": True, "false": False, "1": True, "0": False, "yes": True, "no": False}
 SCRATCH_VIT_ID = "google/siglip2-so400m-patch14-384"  # shared by every Molmo2 variant
 NEW_EMBEDDING_INIT_STD = 0.02  # mm_olmo `new_embedding_init_range`
-SEQUENCE_LENGTH = 2536  # fixed pad length; matches mm_olmo's captioner `--seq_len`
+SEQUENCE_LENGTH = 2560  # fixed pad length; the released runs passed `--seq_len=2560`
 USE_FLEX_ATTN = True  # fused FlexAttention backend for the multimodal masks (~+8% MFU)
 PACK_SEQUENCES = True  # pack several examples per sequence (most are ~1.4k of 4096 tokens)
 COMPILE_MODEL = True  # torch.compile the LM (fuses pointwise ops; one-time compile warmup)
@@ -240,8 +247,8 @@ class ExperimentConfig(Config):
     model_size: str = MODEL_SIZE
     """``"4b"`` or ``"8b"`` — selects the architecture, the base LM to initialise from, and
     the released checkpoint used by ``--init_from=molmo2``."""
-    data_seed: int = 34521
-    init_seed: int = 12536
+    data_seed: int = 95818  # mm_olmo `data.seed`
+    init_seed: int = 6198  # mm_olmo `seed`
     global_batch_size: int = GLOBAL_BATCH_SIZE
     """Global batch in *tokens* (= global instances × seq len). Override to scale the batch;
     pair with ``--train_module.rank_microbatch_size`` to set sequences/forward (GEMM size)."""
@@ -341,7 +348,7 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         # cancel out of the global `sum(CE*w)/sum(w)` divisor when branch counts differ across
         # examples, so it would re-weight caption vs pointing vs NLP relative to mm_olmo.
         loss_token_weighting="none",
-        seed=34521,
+        seed=95818,
     )
 
     # Pad token: Molmo2/Qwen2.5 EOS (151643). Fixed-length padding so every batch has a
@@ -403,7 +410,9 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         ),
         dp_config=TransformerDataParallelConfig(
             name=DataParallelType.fsdp,
-            param_dtype=DType.bfloat16,
+            # mm_olmo's released pretrain used `fsdp.precision: float` — fp32 params,
+            # gradients and buffers, with bf16 only from the `amp_bf16` autocast below.
+            param_dtype=DType.float32,
             reduce_dtype=DType.float32,
         ),
     )


### PR DESCRIPTION
Aligns stage 1 with the config the released model was **actually** trained with:
`/weka/oe-training-default/mm-olmo/released-models-molmo2-1225/Molmo2-4B-Pretrain/config.yaml`,
whose `runtime_data.args` records the exact launch command. That supersedes the argparse
defaults in `train_captioner.py`, which earlier work in this series had been treating as
ground truth.

**30/30 settings now match** in a field-by-field diff against the YAML.

## Corrected by the real config

| | was | released config | source |
|---|---|---|---|
| `seq_len` | 2536 | **2560** | `--seq_len=2560` passed explicitly; `data.sequence_length: 2560` in both 4B and 8B |
| 4B backbone | base `Qwen/Qwen3-4B` | **`Qwen/Qwen3-4B-Instruct-2507`** | launch line `train_captioner.py qwen3_4b_instruct`; `init_path .../qwen3-4b-instruct.pt` |
| 4B scratch `rope_theta` | 1e6 | **5e6** | Instruct-2507's own `rope_theta` is 5e6 |
| `rope_full_precision` | false | **true** | `model.llm.rope_full_precision: true` in both configs |
| FSDP `param_dtype` | bf16 | **fp32** | `fsdp.precision: float` → fp32 params/grads/buffers, bf16 only via `amp_bf16` autocast |
| seeds | 12536 / 34521 | **6198 / 95818** | `seed` / `data.seed` |

**The RoPE-base question is now properly resolved.** Qwen3-4B-Instruct-2507 has `rope_theta=5e6`
(base Qwen3-4B has 1e6), so the released Molmo2-4B's 5e6 comes from **its backbone**, not from a
Molmo2-side long-context change as #818 assumed. The 8B confirms it from the other direction: it
ran `train_captioner.py qwen3_8b` — the *base* backbone, theta 1e6, untied. Different backbones,
not a Molmo2 quirk. The 8B settings are unchanged.

The 4B tokenizer switch is safe for the data pipeline: Instruct-2507 is identical to Molmo2's for
everything used — BPE (`encode` matches on ASCII, unicode, emoji and pointing markup),
`eos_token_id` 151645, and the user-turn chat template.

## Confirmed already correct (no change)

`max_duration: 32000` — I had flagged this as needing to be 31,000; the released run really is
32,000 and its checkpoint directory is `step32000`. Mixture rates 0.6 / 0.3 / 0.1.
**`loss_token_weighting: null`**, which independently validates the `"none"` change in the first
commit. `ft_embedding: lm_head`; `ft_vit`/`ft_llm`/`ft_connector` all true;
`global_train_batch_size: 128`; every per-component LR, warmup, beta, eps and weight decay;
`alpha_f 0.1`; z-loss 1e-4; grad clip 1.0; `batch_divisor: global_batch`; `max_crops: 8`.

**Correction to an earlier recommendation:** `response_logits_only: false` in the released config.
I had proposed enabling it as a "free memory win" based on `train_captioner.py`; the run that
produced the released model did not use it, so our `False` already matches. That item comes off
the follow-up list.

## Also in this PR (first commit)

* `loss_token_weighting`: `"root_subsegments"` → `"none"`. Verified with `build_branched_sequence`:
  a 2-branch example weights 0.707107 (= 1/√2) before and 1.0 after, while a single-branch example
  is 1.0 either way — confirming the divergence was purely cross-example re-weighting between
  caption / pointing / NLP.
* Global batch 8 → **128** sequences. This also fixes a real footgun: the old global of 8 failed the
  `global % (microbatch x dp_world_size) == 0` check at 16 GPUs, which is what killed the first
  16-GPU launch of this script ~30 s after it logged `Training for 32,000 steps`. 128 divides
  8/16/32/64.

## Verification

* 30/30 field-by-field match against the released YAML.
* 249 passed / 17 skipped across `src/test/nn/vision`, `src/test/data/multimodal` and
  `src/test/nn/embedding_test.py`.
* Real-weight Molmo2-4B parity on GPU — logits, LM forward, embedding and training-logits: 5 passed.
  `rope_full_precision=True` is a no-op there (the parity path is fp32) and parity is unchanged.
* Native-config-vs-HF-derived equality test still passes, since `rope_full_precision` was set on
  both paths.
* `isort`/`black` clean on the changed files; ruff and mypy at the `vision` baseline (the F841 in
  `molmo2_loader.py` and the 21 mypy errors are pre-existing).

## Still divergent, needing more than a constant

Rough priority order: `activation_checkpointing: true` (LM `whole_layer`) together with
`device_train_microbatch_size: 4`; packing `dynamic_solver` buffer 48 with **`image_weight: 1.0`**
(we use token-only next-fit, and the ported knapsack defaults to 30.0); `float32_attention: true`
for LM and ViT; `multi_component_grad_norm: true`; `pointing_format: html-v1` (we emit html-v2);
`response_residual_dropout: 0.1`; `compile` covering ViT and connector as well as the LM;
`enable_variable_sized_token_pooling: true`.
