### PR TITLE
Molmo2-Stage1: enable LM activation checkpointing, microbatch 4, and the 2D-knapsack packer

### DIFF
--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -56,6 +56,7 @@ from olmo_core.internal.common import (
     get_root_dir,
 )
 from olmo_core.launch.beaker import BeakerEnvVar, BeakerLaunchConfig
+from olmo_core.nn.transformer.config import TransformerActivationCheckpointingMode
 from olmo_core.nn.vision import MultimodalLM, MultimodalLMConfig
 from olmo_core.optim import (
     AdamWConfig,
@@ -80,6 +81,7 @@ from olmo_core.train.callbacks import (
 )
 from olmo_core.train.train_module import (
     MultimodalTransformerTrainModuleConfig,
+    TransformerActivationCheckpointingConfig,
     TransformerDataParallelConfig,
 )
 from olmo_core.utils import get_default_device, seed_all
@@ -158,7 +160,17 @@ SCRATCH_VIT_ID = "google/siglip2-so400m-patch14-384"  # shared by every Molmo2 v
 NEW_EMBEDDING_INIT_STD = 0.02  # mm_olmo `new_embedding_init_range`
 SEQUENCE_LENGTH = 2560  # fixed pad length; the released runs passed `--seq_len=2560`
 USE_FLEX_ATTN = True  # fused FlexAttention backend for the multimodal masks (~+8% MFU)
-PACK_SEQUENCES = True  # pack several examples per sequence (most are ~1.4k of 4096 tokens)
+PACK_SEQUENCES = True  # pack several examples per sequence
+# mm_olmo `packing: {mode: dynamic_solver, buffer_size: 48, text_weight: 1.0,
+# image_weight: 1.0}` — a 2D knapsack over (text tokens, image crops) rather than the
+# token-only next-fit we used before. The crop budget is the second knapsack dimension: an
+# 8-crop example costs at most 9 crops (1 global + 8 high-res) and ~1348 image tokens, so at
+# seq 2560 the token budget binds first and this mainly bounds worst-case ViT/collator
+# memory. Set below a single example's 9 crops it would force that example into its own
+# mostly-padding pack.
+PACK_MAX_CROPS = 3 * (1 + 8)
+PACK_BUFFER_SIZE = 48
+PACK_IMAGE_WEIGHT = 1.0
 COMPILE_MODEL = True  # torch.compile the LM (fuses pointwise ops; one-time compile warmup)
 DATA_PREFETCH_WORKERS = 4  # background threads preprocessing examples (0 = synchronous)
 MAX_CROPS = 8
@@ -185,7 +197,10 @@ MAX_CROPS = 8
 # the same global batch — and microbatch >1 at this sequence length OOM'd without activation
 # checkpointing (see the `ac_config` follow-up).
 GLOBAL_BATCH_INSTANCES = 128
-RANK_MICROBATCH_INSTANCES = 1
+# mm_olmo's `device_train_microbatch_size: 4`, which its `activation_checkpointing: true`
+# pays for. NOTE 128 % (4 x dp_world_size) must be 0, so this supports world sizes up to 32
+# (the released 4B ran 16 GPUs, the 8B 32); at 64 use microbatch 2.
+RANK_MICROBATCH_INSTANCES = 4
 GLOBAL_BATCH_SIZE = GLOBAL_BATCH_INSTANCES * SEQUENCE_LENGTH
 RANK_MICROBATCH_SIZE = RANK_MICROBATCH_INSTANCES * SEQUENCE_LENGTH
 
@@ -387,6 +402,14 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         ),
         # An empty list keeps the encoder trainable *and* in train mode — the train module
         # only forces `vision.eval()` when `vision.*` is frozen.
+        # mm_olmo: `activation_checkpointing: true` with `llm.activation_checkpoint:
+        # whole_layer` — every block checkpointed. This is what makes microbatch 4 fit.
+        # (vision/connector AC are already on by default in the train module, matching
+        # the released config's vit `activation_checkpointing: true` and
+        # `connector_activation_checkpointing: true`.)
+        ac_config=TransformerActivationCheckpointingConfig(
+            mode=TransformerActivationCheckpointingMode.full
+        ),
         freeze_params=(
             ([] if train_vit else ["vision.*"])
             # The extra image-token rows live in `embeddings.extra_weight`, so freezing
@@ -700,6 +723,9 @@ def train(config: ExperimentConfig):
             global_batch_size=config.global_batch_size,
             seed=config.data_seed,
             pack=config.pack_sequences,
+            pack_max_crops=PACK_MAX_CROPS if config.pack_sequences else None,
+            pack_buffer_size=PACK_BUFFER_SIZE,
+            pack_image_weight=PACK_IMAGE_WEIGHT,
             prefetch_workers=DATA_PREFETCH_WORKERS,
             dp_world_size=dp_world_size,
             dp_rank=dp_rank,


### PR DESCRIPTION
The two remaining settings from the released `Molmo2-4B-Pretrain/config.yaml` that were
reachable without new code. Both are already-implemented capabilities this script never
turned on.

## Activation checkpointing + microbatch 4

Released config: `activation_checkpointing: true`, `llm.activation_checkpoint: whole_layer`,
`device_train_microbatch_size: 4`.

`ac_config` already exists on `MultimodalTransformerTrainModuleConfig` and wires to
`Transformer.apply_activation_checkpointing` — it was simply left `None`, which is why
microbatch >1 OOM'd in earlier probes. Setting `mode=full` (checkpoint every block, i.e.
mm_olmo's `whole_layer`) and microbatch 4 together, since the first is what pays for the
second. Vision and connector AC were already on by default, matching the released config's
vit `activation_checkpointing: true` and `connector_activation_checkpointing: true`.

**Divisibility:** `128 % (4 x dp_world_size)` must be 0, so microbatch 4 supports world sizes
up to 32 — the released 4B ran 16 GPUs, the 8B ran 32. At 64 GPUs use microbatch 2.

## 2D-knapsack packing

Released config: `packing: {mode: dynamic_solver, buffer_size: 48, text_weight: 1.0,
image_weight: 1.0}`.

`iter_dynamic_packs` (a verbatim port of mm_olmo's solver) has been in the repo since #806,
but stage 1 never passed `pack_max_crops`, so it silently fell through to token-only
next-fit. Now wired — **with `image_weight=1.0`**, since `MixtureDataLoader` defaults to
30.0 and wiring it up without overriding that would still have diverged.

`PACK_MAX_CROPS = 3 * (1 + 8)` — the crop budget is the knapsack's second dimension. Measured
with `build_image_token_ids`, an 8-crop example costs at most 9 crops (1 global + 8 high-res)
and ~1348 image tokens, so at seq 2560 the **token** budget binds first and the crop cap
mainly bounds worst-case ViT/collator memory. Set below a single example's 9 crops, it would
force that example into its own mostly-padding pack.

### Measured effect, and where it actually comes from

Synthetic stream shaped like the real mixture (image examples ~1400 tok / 9 crops, text-only
~600 tok), 81 packs each:

| stream | knapsack | next-fit |
|---|---|---|
| image-only | 1.00 ex/pack, 54.7% fill | **identical** |
| with text-only (Tulu) | **1.70 ex/pack, 69.3% fill** | 1.00 ex/pack, 44.3% fill |

So the gain is almost entirely **cross-modal packing**. `iter_packs` deliberately refuses to
mix text-only and image-bearing examples in one pack ("head-truncating a cross-modal pack can
orphan `<im_patch>` tokens from their pooled rows"); the knapsack has no such guard, and
mm_olmo likewise packs across modalities whenever `nlp > 0`
(`shortcut_max_len_images: args.nlp == 0`).

**That removed guard deserves review attention.** The invariant it protects — one
`<im_patch>` token per pooled row — held in **0/81 packs** for both packers on both streams,
because the knapsack respects the token budget by construction so nothing gets truncated.
Note also that the equal-length synthetic *understates* the knapsack on image-only data: real
caption lengths vary, which a knapsack can exploit and sequential next-fit cannot.

## Verification

* 242 passed / 17 skipped across `src/test/nn/vision` and `src/test/data/multimodal`.
* Packer exercised directly (numbers above), including the `<im_patch>`/pooled-row invariant.
* `isort` / `black` / `ruff` / `mypy` clean.

## Not yet validated

**Whether microbatch 4 with AC actually fits at seq 2560 has not been confirmed on GPU.**
That is the entire point of the change and it matches what mm_olmo ran on comparable
hardware, but it warrants a short GPU run before a full launch — earlier microbatch probes
OOM'd precisely because AC was off.
