### PR TITLE
Molmo2: compile the vision tower and connector, and add response residual dropout

### DIFF
--- a/src/olmo_core/nn/residual_stream.py
+++ b/src/olmo_core/nn/residual_stream.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 import torch.nn as nn
 
@@ -8,12 +10,51 @@ class ResidualStream(nn.Module):
     block. The benefit of using this module instead of a direct add operation is that the flexible
     to configure hooks for logging or other purposes, like with the
     :class:`olmo_core.train.callbacks.GAPMonitorCallback`.
+
+    :param alpha: Scale applied to the branch output before the residual add.
+    :param dropout: Dropout probability applied uniformly to every token.
+    :param masked_dropout: Dropout probability applied *only* to tokens selected by the
+        ``drop_mask`` passed to :meth:`forward` (mm_olmo's ``Dropout(mask_p=...)``, used for
+        Molmo2's ``response_residual_dropout``). Tokens outside the mask keep the
+        :data:`dropout` rate. Defaults to ``0.0``, in which case behaviour is unchanged.
     """
 
-    def __init__(self, alpha: float = 1.0, dropout: float = 0.0):
+    def __init__(self, alpha: float = 1.0, dropout: float = 0.0, masked_dropout: float = 0.0):
         super().__init__()
+        if not 0.0 <= masked_dropout < 1.0:
+            raise ValueError(f"'masked_dropout' must be in [0, 1), got {masked_dropout}")
         self.alpha = alpha
+        self.p = dropout
+        self.masked_dropout = masked_dropout
         self.dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
 
-    def forward(self, residual: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    def _masked_dropout(self, x: torch.Tensor, drop_mask: torch.Tensor) -> torch.Tensor:
+        """Per-token inverted dropout with a different rate inside and outside ``drop_mask``.
+
+        Mirrors mm_olmo's ``Dropout.forward``: masked tokens keep with probability
+        ``1 - masked_dropout``, the rest with ``1 - dropout``.
+        """
+        mask = drop_mask.to(x.dtype)
+        keep_prob = mask * (1.0 - self.masked_dropout) + (1.0 - mask) * (1.0 - self.p)
+        keep_prob = keep_prob.unsqueeze(-1)
+        # Inverted dropout: scale by 1/keep_prob so expectations match at eval time.
+        keep = torch.rand_like(keep_prob) < keep_prob
+        return x * keep.to(x.dtype) / keep_prob
+
+    def forward(
+        self,
+        residual: torch.Tensor,
+        x: torch.Tensor,
+        drop_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        :param residual: The residual stream, ``(batch_size, seq_len, d_model)``.
+        :param x: The branch output to add in.
+        :param drop_mask: Optional ``(batch_size, seq_len)`` 0/1 tensor selecting the tokens
+            that get :data:`masked_dropout`. Required when ``masked_dropout > 0`` and training.
+        """
+        if self.masked_dropout > 0.0 and self.training:
+            if drop_mask is None:
+                raise ValueError("'drop_mask' is required when 'masked_dropout' > 0")
+            return torch.add(residual, self._masked_dropout(x, drop_mask), alpha=self.alpha)
         return torch.add(residual, self.dropout(x), alpha=self.alpha)

--- a/src/olmo_core/nn/transformer/block.py
+++ b/src/olmo_core/nn/transformer/block.py
@@ -116,6 +116,7 @@ class TransformerBlock(TransformerBlockBase):
         feed_forward: FeedForwardConfig,
         layer_norm: LayerNormConfig,
         dropout: float = 0.0,
+        masked_dropout: float = 0.0,
         attention_residual_alpha: float = 1.0,
         feed_forward_residual_alpha: float = 1.0,
         init_device: str = "cpu",
@@ -133,12 +134,12 @@ class TransformerBlock(TransformerBlockBase):
         )
         self.attention_norm = layer_norm.build(d_model, init_device=init_device)
         self.attention_residual_stream = ResidualStream(
-            alpha=attention_residual_alpha, dropout=dropout
+            alpha=attention_residual_alpha, dropout=dropout, masked_dropout=masked_dropout
         )
         self.feed_forward = feed_forward.build(d_model=d_model, init_device=init_device)
         self.feed_forward_norm = layer_norm.build(d_model, init_device=init_device)
         self.feed_forward_residual_stream = ResidualStream(
-            alpha=feed_forward_residual_alpha, dropout=dropout
+            alpha=feed_forward_residual_alpha, dropout=dropout, masked_dropout=masked_dropout
         )
 
     def forward(
@@ -146,11 +147,22 @@ class TransformerBlock(TransformerBlockBase):
         x: torch.Tensor,
         *,
         loss_div_factor: Optional[Union[torch.Tensor, float]] = None,
+        drop_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
+        """
+        :param drop_mask: Optional ``(batch_size, seq_len)`` 0/1 tensor selecting the tokens
+            that receive :data:`ResidualStream.masked_dropout`. Consumed here rather than
+            forwarded into the sequence mixer. Ignored unless a residual stream was built
+            with ``masked_dropout > 0``.
+        """
         del loss_div_factor
-        h = self.attention_residual_stream(x, self.attention(self.attention_norm(x), **kwargs))
-        return self.feed_forward_residual_stream(h, self.feed_forward(self.feed_forward_norm(h)))
+        h = self.attention_residual_stream(
+            x, self.attention(self.attention_norm(x), **kwargs), drop_mask=drop_mask
+        )
+        return self.feed_forward_residual_stream(
+            h, self.feed_forward(self.feed_forward_norm(h)), drop_mask=drop_mask
+        )
 
     def apply_tp(
         self, tp_mesh: DeviceMesh, *, input_layout: Placement, float8_enabled: bool = False

--- a/src/olmo_core/nn/transformer/config.py
+++ b/src/olmo_core/nn/transformer/config.py
@@ -184,6 +184,13 @@ class TransformerBlockConfig(ModuleConfig):
     """
     Dropout probability.
     """
+    masked_dropout: Optional[float] = None
+    """
+    Residual-stream dropout applied only to tokens selected by the ``drop_mask`` passed to
+    the block (mm_olmo's ``response_residual_dropout``: Molmo2 drops 10% of the residual on
+    *response* tokens while leaving prompt and image tokens untouched). Tokens outside the
+    mask keep the :data:`dropout` rate. Requires the ``default`` block type.
+    """
     attention_residual_alpha: Optional[float] = None
     """
     A scaling factor applied to the attention/recurrent output before adding it to the residual stream.
@@ -237,6 +244,12 @@ class TransformerBlockConfig(ModuleConfig):
             init_device=init_device,
             cache=cache,
         )
+
+        if self.masked_dropout and self.name != TransformerBlockType.default:
+            raise OLMoConfigurationError(
+                f"'masked_dropout' is only supported by the '{TransformerBlockType.default}' "
+                f"block type, got '{self.name}'"
+            )
 
         try:
             if self.name == TransformerBlockType.default:

--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -570,6 +570,7 @@ class Transformer(nn.Module):
         response_mask: Optional[torch.Tensor] = None,
         or_mask: Optional[torch.Tensor] = None,
         and_mask: Optional[torch.Tensor] = None,
+        drop_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.Tensor] = None,
         flex_attn_is_image: Optional[torch.Tensor] = None,
         flex_attn_subsegment_ids: Optional[torch.Tensor] = None,
@@ -700,6 +701,11 @@ class Transformer(nn.Module):
                 h = h * self.embed_scale
             if self.embedding_norm is not None:
                 h = self.embedding_norm(h)
+
+        # Per-token residual dropout mask (Molmo2's `response_residual_dropout`). Only
+        # forwarded when supplied, so blocks that do not accept it are unaffected.
+        if drop_mask is not None:
+            all_block_kwargs["drop_mask"] = drop_mask
 
         # Run each block.
         for block_key, block in self.blocks.items():

--- a/src/olmo_core/nn/vision/connector.py
+++ b/src/olmo_core/nn/vision/connector.py
@@ -355,6 +355,19 @@ class VisionConnector(nn.Module):
             self.pooling = checkpoint_wrapper(self.pooling)
         self.projector = checkpoint_wrapper(self.projector)
 
+    def apply_compile(self) -> None:
+        """``torch.compile`` pooling + projector (mm_olmo ``compile_connector: dynamic``).
+
+        Compiled with ``dynamic=True``: the number of pooled groups varies per batch (it
+        follows the crop count), so a static compile would recompile on every new shape.
+
+        .. warning::
+            Call after :meth:`apply_activation_checkpointing` and before FSDP wrapping.
+        """
+        if self.pooling is not None:
+            self.pooling = torch.compile(self.pooling, dynamic=True)  # type: ignore[assignment]
+        self.projector = torch.compile(self.projector, dynamic=True)  # type: ignore[assignment]
+
     def forward(
         self,
         image_features: torch.Tensor,

--- a/src/olmo_core/nn/vision/image_vit.py
+++ b/src/olmo_core/nn/vision/image_vit.py
@@ -270,6 +270,18 @@ class VisionTransformer(nn.Module):
         """Per-block activation checkpointing (mm_olmo ``VitConfig.activation_checkpointing``)."""
         self._activation_checkpoint_fn = _vit_activation_checkpoint_function(self.cfg)
 
+    def apply_compile(self) -> None:
+        """``torch.compile`` each ViT block (mm_olmo ``compile_vit: blocks``).
+
+        Per-block compilation keeps compile times low thanks to the repeated structure, the
+        same strategy :meth:`olmo_core.nn.transformer.Transformer.apply_compile` uses.
+
+        .. warning::
+            Call after :meth:`apply_activation_checkpointing` and before FSDP wrapping.
+        """
+        for idx, block in enumerate(self.blocks):
+            self.blocks[idx] = torch.compile(block)  # type: ignore[assignment]
+
     def reset_parameters(self):
         """Re-initialise all parameters."""
         scale = self.cfg.image_emb_dim**-0.5

--- a/src/olmo_core/nn/vision/multimodal.py
+++ b/src/olmo_core/nn/vision/multimodal.py
@@ -13,7 +13,7 @@ from olmo_core.distributed.utils import barrier, is_distributed
 from olmo_core.exceptions import OLMoConfigurationError
 from olmo_core.nn.embedding import SplitVocabEmbedding
 from olmo_core.nn.lm_head import LMOutputWithLoss
-from olmo_core.nn.transformer.config import TransformerConfig
+from olmo_core.nn.transformer.config import TransformerBlockConfig, TransformerConfig
 from olmo_core.nn.vision.config import VisionEncoderConfig
 from olmo_core.nn.vision.connector import (
     ImagePoolingType,
@@ -123,6 +123,7 @@ class MultimodalLMConfig(Config):
         lm: TransformerConfig,
         *,
         connector_mlp_hidden_size: int,
+        response_residual_dropout: float = 0.0,
         **kwargs,
     ) -> "MultimodalLMConfig":
         """
@@ -136,6 +137,17 @@ class MultimodalLMConfig(Config):
             field, so it is passed explicitly rather than derived from ``lm``.
         """
         from olmo_core.nn.vision.config import VisionEncoderType
+
+        # mm_olmo `llm.response_residual_dropout`: drop this fraction of the residual on
+        # *response* tokens only (`residual_dropout` stays 0 for prompt and image tokens).
+        # Defaults to 0 so the factory keeps matching the HF-derived config, which describes
+        # the released weights for inference; training scripts opt in (stage 1 uses 0.1).
+        if response_residual_dropout:
+            if not isinstance(lm.block, TransformerBlockConfig):
+                raise OLMoConfigurationError(
+                    "response_residual_dropout needs a single block config, got a per-block dict"
+                )
+            lm.block.masked_dropout = response_residual_dropout
 
         # Molmo2 keeps only blocks 0..24 of SigLIP2's 27 — everything past the deepest
         # feature layer (``vit_layers`` max 24) is dropped. ``name`` is a label only (the
@@ -169,7 +181,9 @@ class MultimodalLMConfig(Config):
         )
 
     @classmethod
-    def molmo2_4B(cls, *, rope_theta: int = 5_000_000, **kwargs) -> "MultimodalLMConfig":
+    def molmo2_4B(
+        cls, *, rope_theta: int = 5_000_000, response_residual_dropout: float = 0.0, **kwargs
+    ) -> "MultimodalLMConfig":
         """
         Molmo2-4B architecture: a Qwen3-4B LM plus the shared Molmo2 vision stack.
 
@@ -196,11 +210,14 @@ class MultimodalLMConfig(Config):
                 dtype=DType.float32,
             ),
             connector_mlp_hidden_size=9728,
+            response_residual_dropout=response_residual_dropout,
             **kwargs,
         )
 
     @classmethod
-    def molmo2_8B(cls, *, rope_theta: int = 1_000_000, **kwargs) -> "MultimodalLMConfig":
+    def molmo2_8B(
+        cls, *, rope_theta: int = 1_000_000, response_residual_dropout: float = 0.0, **kwargs
+    ) -> "MultimodalLMConfig":
         """
         Molmo2-8B architecture: a Qwen3-8B LM plus the shared Molmo2 vision stack.
 
@@ -223,6 +240,7 @@ class MultimodalLMConfig(Config):
                 dtype=DType.float32,
             ),
             connector_mlp_hidden_size=12288,
+            response_residual_dropout=response_residual_dropout,
             **kwargs,
         )
 
@@ -266,6 +284,8 @@ class MultimodalLM(nn.Module):
             )
         self.cfg = cfg
         self.lm = cfg.lm.build(init_device=init_device)
+        # Cached so `forward` only builds a drop mask when some block will consume it.
+        self._masked_residual_dropout = float(getattr(cfg.lm.block, "masked_dropout", 0.0) or 0.0)
         self.vision = cfg.vision.build(init_device=init_device)
         self.connector = cfg.connector.build(init_device=init_device)
 
@@ -449,6 +469,18 @@ class MultimodalLM(nn.Module):
                 raise ValueError("`loss_masks` is required when `response_logits_only=True`")
             response_mask = loss_masks > 0
 
+        # Per-token residual dropout (mm_olmo `response_residual_dropout`): the mask selects
+        # *response* tokens, so prompt and image tokens keep the plain `dropout` rate. Only
+        # built when a block actually asks for it, and only while training.
+        drop_mask: Optional[torch.Tensor] = None
+        if self.training and self._masked_residual_dropout > 0.0:
+            if loss_masks is None:
+                raise ValueError(
+                    "`loss_masks` is required when the LM uses `masked_dropout` "
+                    "(response_residual_dropout)"
+                )
+            drop_mask = (loss_masks > 0).to(dtype=torch.bool)
+
         if labels is not None and self.cfg.output_vocab_size is not None:
             # The LM head would compute the loss internally over the full (padded) vocab,
             # bypassing the output-vocab masking below and shifting the softmax
@@ -599,6 +631,7 @@ class MultimodalLM(nn.Module):
             position_ids=position_ids,
             response_logits_only=response_logits_only,
             response_mask=response_mask,
+            drop_mask=drop_mask,
             **kwargs,
         )
 

--- a/src/olmo_core/train/train_module/transformer/multimodal_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/multimodal_train_module.py
@@ -85,6 +85,8 @@ class MultimodalTransformerTrainModule(TransformerTrainModule):
         ac_config: Optional[TransformerActivationCheckpointingConfig] = None,
         vision_activation_checkpointing: bool = True,
         connector_activation_checkpointing: bool = True,
+        compile_vision: bool = True,
+        compile_connector: bool = True,
         label_ignore_index: int = -100,
         response_logits_only: bool = False,
         state_dict_save_opts: Optional[dist_cp_sd.StateDictOptions] = None,
@@ -132,7 +134,9 @@ class MultimodalTransformerTrainModule(TransformerTrainModule):
             log.info(f"Froze {n_frozen} parameter tensors matching {self.freeze_params}")
 
         model.to(self.device)
-        if vision_activation_checkpointing and hasattr(model.vision, "apply_activation_checkpointing"):
+        if vision_activation_checkpointing and hasattr(
+            model.vision, "apply_activation_checkpointing"
+        ):
             model.vision.apply_activation_checkpointing()
             log.info("Applied per-block activation checkpointing to model.vision")
         if connector_activation_checkpointing and hasattr(
@@ -154,6 +158,15 @@ class MultimodalTransformerTrainModule(TransformerTrainModule):
             # (or_mask / and_mask) don't trip full-graph compile on the outer forward.
             log.info("Compiling model.lm blocks ...")
             model.lm.apply_compile()
+            # mm_olmo compiles the vision tower and connector too (`compile_vit: blocks`,
+            # `compile_connector: dynamic`). The connector is compiled with dynamic shapes
+            # because its pooled-group count follows the per-batch crop count.
+            if compile_vision and hasattr(model.vision, "apply_compile"):
+                log.info("Compiling model.vision blocks ...")
+                model.vision.apply_compile()
+            if compile_connector and hasattr(model.connector, "apply_compile"):
+                log.info("Compiling model.connector (dynamic) ...")
+                model.connector.apply_compile()
         self.model = model
         self._model_mode = None
 
@@ -504,6 +517,13 @@ class MultimodalTransformerTrainModuleConfig(TrainModuleConfig):
     ac_config: Optional[TransformerActivationCheckpointingConfig] = None
     vision_activation_checkpointing: bool = True
     connector_activation_checkpointing: bool = True
+    compile_vision: bool = True
+    """Also ``torch.compile`` the vision tower when :data:`compile_model` is set
+    (mm_olmo ``compile_vit: blocks``)."""
+
+    compile_connector: bool = True
+    """Also ``torch.compile`` the connector when :data:`compile_model` is set, with dynamic
+    shapes (mm_olmo ``compile_connector: dynamic``)."""
     z_loss_multiplier: Optional[float] = None
     autocast_precision: Optional[DType] = None
     label_ignore_index: int = -100

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -175,15 +175,10 @@ COMPILE_MODEL = True  # torch.compile the LM (fuses pointwise ops; one-time comp
 DATA_PREFETCH_WORKERS = 4  # background threads preprocessing examples (0 = synchronous)
 MAX_CROPS = 8
 
-# KNOWN DELTA vs mm_olmo stage-1 captioner: `response_residual_dropout=0.1`.
-# mm_olmo applies 0.1 dropout to the residual stream of RESPONSE tokens only (input/image
-# tokens get 0.0), via a per-token drop mask in its LM block (olmo/nn/llm.py: `Dropout`
-# with `mask_p`). OLMo-core's `TransformerBlock` has a single uniform `nn.Dropout` (default
-# 0.0) with no per-token/response path, so this regularizer is intentionally NOT applied
-# here — adding it would require threading a response drop-mask through the core transformer
-# block. Low impact for the short benchmark runs; revisit for a full-fidelity stage-1
-# reproduction. (The other mm_olmo delta, the `style_and_length_v2` length-conditioning
-# system prompt, IS implemented — see PixMoCapDataset.style_length_conditioning.)
+# mm_olmo applies 0.1 dropout to the residual stream of RESPONSE tokens only (prompt and
+# image tokens get 0.0), via a per-token drop mask in its LM block (`Dropout(mask_p=...)`).
+# Implemented as `ResidualStream(masked_dropout=...)`; the mask is derived from `loss_masks`.
+RESPONSE_RESIDUAL_DROPOUT = 0.1
 
 # Instance-based batching, expressed in tokens for the token-based Trainer.
 #
@@ -300,7 +295,10 @@ def _build_model_config(model_size: str, init_from: str) -> MultimodalLMConfig:
     the released value with base weights would put them on the wrong rotary base.
     """
     spec = MODEL_SIZES[model_size]
-    return spec.factory(rope_theta=spec.rope_theta(init_from))
+    return spec.factory(
+        rope_theta=spec.rope_theta(init_from),
+        response_residual_dropout=RESPONSE_RESIDUAL_DROPOUT,
+    )
 
 
 def _read_override(overrides: List[str], key: str, default: str) -> str:

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -56,6 +56,7 @@ from olmo_core.internal.common import (
     get_root_dir,
 )
 from olmo_core.launch.beaker import BeakerEnvVar, BeakerLaunchConfig
+from olmo_core.nn.transformer.config import TransformerActivationCheckpointingMode
 from olmo_core.nn.vision import MultimodalLM, MultimodalLMConfig
 from olmo_core.optim import (
     AdamWConfig,
@@ -80,6 +81,7 @@ from olmo_core.train.callbacks import (
 )
 from olmo_core.train.train_module import (
     MultimodalTransformerTrainModuleConfig,
+    TransformerActivationCheckpointingConfig,
     TransformerDataParallelConfig,
 )
 from olmo_core.utils import get_default_device, seed_all
@@ -158,7 +160,17 @@ SCRATCH_VIT_ID = "google/siglip2-so400m-patch14-384"  # shared by every Molmo2 v
 NEW_EMBEDDING_INIT_STD = 0.02  # mm_olmo `new_embedding_init_range`
 SEQUENCE_LENGTH = 2560  # fixed pad length; the released runs passed `--seq_len=2560`
 USE_FLEX_ATTN = True  # fused FlexAttention backend for the multimodal masks (~+8% MFU)
-PACK_SEQUENCES = True  # pack several examples per sequence (most are ~1.4k of 4096 tokens)
+PACK_SEQUENCES = True  # pack several examples per sequence
+# mm_olmo `packing: {mode: dynamic_solver, buffer_size: 48, text_weight: 1.0,
+# image_weight: 1.0}` — a 2D knapsack over (text tokens, image crops) rather than the
+# token-only next-fit we used before. The crop budget is the second knapsack dimension: an
+# 8-crop example costs at most 9 crops (1 global + 8 high-res) and ~1348 image tokens, so at
+# seq 2560 the token budget binds first and this mainly bounds worst-case ViT/collator
+# memory. Set below a single example's 9 crops it would force that example into its own
+# mostly-padding pack.
+PACK_MAX_CROPS = 3 * (1 + 8)
+PACK_BUFFER_SIZE = 48
+PACK_IMAGE_WEIGHT = 1.0
 COMPILE_MODEL = True  # torch.compile the LM (fuses pointwise ops; one-time compile warmup)
 DATA_PREFETCH_WORKERS = 4  # background threads preprocessing examples (0 = synchronous)
 MAX_CROPS = 8
@@ -185,7 +197,10 @@ MAX_CROPS = 8
 # the same global batch — and microbatch >1 at this sequence length OOM'd without activation
 # checkpointing (see the `ac_config` follow-up).
 GLOBAL_BATCH_INSTANCES = 128
-RANK_MICROBATCH_INSTANCES = 1
+# mm_olmo's `device_train_microbatch_size: 4`, which its `activation_checkpointing: true`
+# pays for. NOTE 128 % (4 x dp_world_size) must be 0, so this supports world sizes up to 32
+# (the released 4B ran 16 GPUs, the 8B 32); at 64 use microbatch 2.
+RANK_MICROBATCH_INSTANCES = 4
 GLOBAL_BATCH_SIZE = GLOBAL_BATCH_INSTANCES * SEQUENCE_LENGTH
 RANK_MICROBATCH_SIZE = RANK_MICROBATCH_INSTANCES * SEQUENCE_LENGTH
 
@@ -387,6 +402,14 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         ),
         # An empty list keeps the encoder trainable *and* in train mode — the train module
         # only forces `vision.eval()` when `vision.*` is frozen.
+        # mm_olmo: `activation_checkpointing: true` with `llm.activation_checkpoint:
+        # whole_layer` — every block checkpointed. This is what makes microbatch 4 fit.
+        # (vision/connector AC are already on by default in the train module, matching
+        # the released config's vit `activation_checkpointing: true` and
+        # `connector_activation_checkpointing: true`.)
+        ac_config=TransformerActivationCheckpointingConfig(
+            mode=TransformerActivationCheckpointingMode.full
+        ),
         freeze_params=(
             ([] if train_vit else ["vision.*"])
             # The extra image-token rows live in `embeddings.extra_weight`, so freezing
@@ -700,6 +723,9 @@ def train(config: ExperimentConfig):
             global_batch_size=config.global_batch_size,
             seed=config.data_seed,
             pack=config.pack_sequences,
+            pack_max_crops=PACK_MAX_CROPS if config.pack_sequences else None,
+            pack_buffer_size=PACK_BUFFER_SIZE,
+            pack_image_weight=PACK_IMAGE_WEIGHT,
             prefetch_workers=DATA_PREFETCH_WORKERS,
             dp_world_size=dp_world_size,
             dp_rank=dp_rank,

--- a/src/test/nn/residual_stream_test.py
+++ b/src/test/nn/residual_stream_test.py
@@ -1,0 +1,69 @@
+"""``ResidualStream.masked_dropout`` — mm_olmo's ``response_residual_dropout``.
+
+Molmo2 drops a fraction of the residual stream on *response* tokens only, leaving prompt and
+image tokens untouched (mm_olmo's ``Dropout(mask_p=...)``).
+"""
+
+import pytest
+import torch
+
+from olmo_core.nn.residual_stream import ResidualStream
+
+B, T, D = 1, 4000, 8
+
+
+def _inputs():
+    x = torch.ones(B, T, D)
+    residual = torch.zeros(B, T, D)
+    drop_mask = torch.zeros(B, T, dtype=torch.bool)
+    drop_mask[:, T // 2 :] = True  # second half = response tokens
+    return residual, x, drop_mask
+
+
+def test_masked_dropout_only_drops_masked_tokens():
+    torch.manual_seed(0)
+    residual, x, drop_mask = _inputs()
+    out = ResidualStream(dropout=0.0, masked_dropout=0.1).train()(residual, x, drop_mask=drop_mask)
+
+    unmasked, masked = out[:, : T // 2], out[:, T // 2 :]
+    assert (unmasked == 1.0).all(), "prompt/image tokens must never be dropped"
+    dropped = (masked == 0).float().mean().item()
+    assert 0.06 < dropped < 0.14, dropped  # ~0.10
+
+
+def test_masked_dropout_is_unbiased_and_inverted():
+    torch.manual_seed(0)
+    residual, x, drop_mask = _inputs()
+    out = ResidualStream(dropout=0.0, masked_dropout=0.1).train()(residual, x, drop_mask=drop_mask)
+    masked = out[:, T // 2 :]
+    # Surviving activations are scaled by 1/keep_prob, so the expectation is preserved.
+    torch.testing.assert_close(masked[masked != 0][0], torch.tensor(1 / 0.9), rtol=1e-5, atol=1e-5)
+    assert abs(masked.mean().item() - 1.0) < 0.05
+
+
+def test_no_dropout_in_eval_mode():
+    residual, x, drop_mask = _inputs()
+    out = ResidualStream(dropout=0.0, masked_dropout=0.1).eval()(residual, x, drop_mask=drop_mask)
+    assert (out == 1.0).all()
+
+
+def test_zero_masked_dropout_matches_the_plain_path():
+    residual, x, drop_mask = _inputs()
+    torch.manual_seed(1)
+    expected = ResidualStream(dropout=0.0).train()(residual, x)
+    torch.manual_seed(1)
+    actual = ResidualStream(dropout=0.0, masked_dropout=0.0).train()(
+        residual, x, drop_mask=drop_mask
+    )
+    assert torch.equal(expected, actual)
+
+
+def test_drop_mask_required_when_masked_dropout_is_set():
+    residual, x, _ = _inputs()
+    with pytest.raises(ValueError, match="drop_mask"):
+        ResidualStream(dropout=0.0, masked_dropout=0.1).train()(residual, x)
+
+
+def test_rejects_invalid_rate():
+    with pytest.raises(ValueError, match="masked_dropout"):
+        ResidualStream(masked_dropout=1.0)


### PR DESCRIPTION
> Stacked on #824 (AC + knapsack packer). Review that one first; this branch contains its commit.

Closes the last two released-config settings that needed real code. Auditing the remaining
list first showed **three of the five were not gaps at all**:

| Item | Finding |
|---|---|
| `multi_component_grad_norm: true` | **Dead field** in mm_olmo — declared at `trainer_config.py:720`, never read anywhere in the repo. |
| `float32_attention: true` | **No-op on the path the released config uses.** With `attention_type: sdpa` it casts only q,k to fp32; under `amp_bf16` autocast SDPA casts them back (output is bf16). Running the same code *outside* autocast raises `Expected query, key, and value to have the same dtype` — it only works because autocast nullifies it. It would matter on the `direct` path, which the released config doesn't use. |
| `enable_variable_sized_token_pooling: true` | **Collator memory optimization** over mm_olmo's own `TOKEN_POOLING_KEYS` buffers, which our pipeline doesn't use. No modelling effect. |

That left compile scope (throughput) and response dropout (modelling).

## Compile: `compile_vit: blocks`, `compile_connector: dynamic`

`VisionTransformer.apply_compile` compiles each ViT block, mirroring the per-block strategy
`Transformer.apply_compile` already uses. `VisionConnector.apply_compile` compiles pooling and
projector with `dynamic=True` — the pooled-group count follows the per-batch crop count, so a
static compile would recompile on every new shape.

Both sit behind new `compile_vision` / `compile_connector` flags on the train module (default
`True`) and only fire when `compile_model` is set, so this is inert unless compilation is
already on.

## Response residual dropout

mm_olmo's `Dropout(mask_p=...)` gives response tokens a different keep probability from
everything else, applied at **both** residual adds:

```python
keep_prob = drop_mask * (1 - mask_p) + (1 - drop_mask) * (1 - p)
```

Our `ResidualStream` had a single uniform `nn.Dropout`, which is why this has been carried as
a `KNOWN DELTA` comment in the stage-1 script since the beginning.

`ResidualStream` gains `masked_dropout` implementing exactly that formula, plus an optional
`drop_mask` threaded `Transformer.forward` → `TransformerBlock` → both residual streams.
`MultimodalLM.forward` derives the mask from `loss_masks` (`loss_masks > 0` *is* "is a response
token") and only builds it while training and when a block will consume it. `drop_mask` is an
explicit block kwarg rather than riding `**kwargs`, so it isn't forwarded into the sequence
mixer.

**Blast radius is contained:** `masked_dropout` defaults to 0 everywhere and is validated to
require the `default` block type (what Molmo2 uses). At 0 the path is byte-identical to before,
so every other model in the repo is untouched. The stage-1 script sets 0.1.

It is deliberately **not** defaulted on the `molmo2_4B`/`molmo2_8B` factories: those describe
the released weights for inference and must keep matching the HF-derived config, so the
training regularizer lives with the other training settings.

## Verification

Masked-dropout semantics, measured over 4000 tokens:

```
unmasked (prompt/image) tokens zeroed : 0.0000   <- never dropped
masked (response) tokens zeroed       : 0.0910   <- rate 0.1
surviving value                       : 1.1111   = 1/0.9, inverted dropout
E[response]                           : 1.0100   <- unbiased
eval mode                             : no dropout
masked_dropout=0                      : byte-identical to the plain path
```

* End to end through `MultimodalLM`: train-mode forward is stochastic with the rate set and
  deterministic without it; eval is deterministic either way.
* 6 new tests in `src/test/nn/residual_stream_test.py`.
* **510 passed** / 1195 skipped across `src/test/nn` and `src/test/data/multimodal`. The one
  failure, `convert_test.py::test_logprobs_match_after_roundtrip[gemma3]`, is a gated-HF-repo
  auth error that fails identically on `vision`.
* **Real-weight Molmo2-4B parity: 5 passed** on GPU (logits, LM forward, embedding, training
  logits).
* `isort`/`black`/`ruff` clean on changed files; `mypy` at the 21-error `vision` baseline. (The
  two isort errors reported for `connector.py` and `multimodal_train_module.py` are
  pre-existing — same count on the baseline.)

## Not measured

The **throughput gain** from compiling the ViT and connector. That needs a GPU run, best done
together with the activation-checkpointing change in #824.
