### PR TITLE
Fix two bugs in #825's response residual dropout (it made stage 1 diverge)

### DIFF
--- a/src/olmo_core/nn/residual_stream.py
+++ b/src/olmo_core/nn/residual_stream.py
@@ -29,17 +29,22 @@ class ResidualStream(nn.Module):
         self.dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
 
     def _masked_dropout(self, x: torch.Tensor, drop_mask: torch.Tensor) -> torch.Tensor:
-        """Per-token inverted dropout with a different rate inside and outside ``drop_mask``.
+        """Inverted dropout whose *rate* varies per token, but which samples per **element**.
 
-        Mirrors mm_olmo's ``Dropout.forward``: masked tokens keep with probability
-        ``1 - masked_dropout``, the rest with ``1 - dropout``.
+        Mirrors mm_olmo's ``Dropout.forward``: masked tokens keep each activation with
+        probability ``1 - masked_dropout``, the rest with ``1 - dropout``.
+
+        The per-element sampling matters. Broadcasting the ``(batch, seq)`` rate to
+        ``(batch, seq, 1)`` and drawing one Bernoulli per *token* would zero a token's entire
+        residual contribution at once; across a 36-layer model's 72 residual adds that is
+        destructive rather than regularising, and it makes training diverge.
         """
         mask = drop_mask.to(x.dtype)
         keep_prob = mask * (1.0 - self.masked_dropout) + (1.0 - mask) * (1.0 - self.p)
-        keep_prob = keep_prob.unsqueeze(-1)
-        # Inverted dropout: scale by 1/keep_prob so expectations match at eval time.
-        keep = torch.rand_like(keep_prob) < keep_prob
-        return x * keep.to(x.dtype) / keep_prob
+        keep_prob = keep_prob.unsqueeze(-1).broadcast_to(x.shape)
+        # Inverted dropout: scale survivors by 1/keep_prob so the expectation is preserved.
+        multiplier = torch.empty_like(x).bernoulli_(keep_prob)
+        return x * (multiplier / keep_prob)
 
     def forward(
         self,

--- a/src/olmo_core/train/train_module/transformer/multimodal_train_module.py
+++ b/src/olmo_core/train/train_module/transformer/multimodal_train_module.py
@@ -369,7 +369,13 @@ class MultimodalTransformerTrainModule(TransformerTrainModule):
                         flat_labels = labels.to(self.device).reshape(-1)[response_mask.reshape(-1)]
                         flat_weights = mb_loss_masks.reshape(-1)[response_mask.reshape(-1)]
                     else:
-                        logits = self.model(input_ids, labels=None, **model_kwargs)
+                        # `loss_masks` is passed even though the logits are dense: the model
+                        # needs it to build the per-token residual drop mask when the LM was
+                        # configured with `masked_dropout` (response_residual_dropout). It is
+                        # popped by `MultimodalLM.forward` and ignored otherwise.
+                        logits = self.model(
+                            input_ids, labels=None, loss_masks=mb_loss_masks, **model_kwargs
+                        )
                         vocab_size = logits.shape[-1]
                         flat_logits = logits.reshape(-1, vocab_size)
                         flat_labels = labels.to(self.device).reshape(-1)

--- a/src/test/nn/residual_stream_test.py
+++ b/src/test/nn/residual_stream_test.py
@@ -9,7 +9,7 @@ import torch
 
 from olmo_core.nn.residual_stream import ResidualStream
 
-B, T, D = 1, 4000, 8
+B, T, D = 1, 4000, 8  # D small enough that per-token vs per-element is distinguishable
 
 
 def _inputs():
@@ -29,6 +29,30 @@ def test_masked_dropout_only_drops_masked_tokens():
     assert (unmasked == 1.0).all(), "prompt/image tokens must never be dropped"
     dropped = (masked == 0).float().mean().item()
     assert 0.06 < dropped < 0.14, dropped  # ~0.10
+
+
+def test_masked_dropout_samples_per_element_not_per_token():
+    """Each activation is dropped independently, not whole token vectors at once.
+
+    Regression test: sampling one Bernoulli per token (broadcasting a ``(B, T, 1)`` mask)
+    zeroes a token's entire residual contribution, which across a 36-layer model's 72
+    residual adds made training diverge. The element-fraction checks in the other tests pass
+    either way, so this is what distinguishes them.
+    """
+    torch.manual_seed(0)
+    residual, x, drop_mask = _inputs()
+    out = ResidualStream(dropout=0.0, masked_dropout=0.5).train()(residual, x, drop_mask=drop_mask)
+    masked = out[:, T // 2 :]  # rate 0.5 -> most tokens should be partially, not fully, dropped
+
+    zero_per_token = (masked == 0).sum(-1)
+    all_zero = int((zero_per_token == D).sum())
+    none_zero = int((zero_per_token == 0).sum())
+    mixed = int(masked.shape[1] - all_zero - none_zero)
+    # With per-element sampling at p=0.5 and D=8, all-or-nothing tokens are rare (2 * 0.5**8).
+    assert mixed > 0.9 * masked.shape[1], (
+        f"expected mostly partially-dropped tokens, got mixed={mixed} "
+        f"all_zero={all_zero} none_zero={none_zero}"
+    )
 
 
 def test_masked_dropout_is_unbiased_and_inverted():

--- a/src/test/train/train_module/multimodal_train_module_test.py
+++ b/src/test/train/train_module/multimodal_train_module_test.py
@@ -82,7 +82,17 @@ def _train_module(masked_dropout: float, response_logits_only: bool):
         compile_model=False,
         response_logits_only=response_logits_only,
     )
-    train_module = config.build(_model_config(masked_dropout).build(init_device="cpu"))
+    model = _model_config(masked_dropout).build(init_device="cpu")
+    # `build` allocates parameters without filling them, and `MultimodalLM` has no single
+    # `init_weights` — the training script initialises the three components separately (LM and
+    # ViT from pretrained checkpoints, connector randomly). Skipping this leaves the model running
+    # on whatever was in memory, which produced NaN logits in roughly half of all runs.
+    # `device` defaults to the default device, which is CUDA wherever a GPU is visible; this test
+    # is CPU-only, so pin it.
+    model.lm.init_weights(max_seq_len=SEQ_LEN, device=torch.device("cpu"))
+    model.vision.reset_parameters()
+    model.connector.reset_parameters()
+    train_module = config.build(model)
     train_module._trainer = _StubTrainer()  # type: ignore[assignment]
     return train_module
 

--- a/src/test/train/train_module/multimodal_train_module_test.py
+++ b/src/test/train/train_module/multimodal_train_module_test.py
@@ -1,0 +1,126 @@
+"""Regression tests for ``MultimodalTransformerTrainModule.train_batch``.
+
+These exercise the *train module*, not just ``MultimodalLM.forward``. That distinction caught a
+real bug: response residual dropout needs ``loss_masks`` to build its per-token drop mask, and
+the dense-logits path (``response_logits_only=False``, which is the released Molmo2 recipe) was
+not forwarding it — so training raised on the first batch even though calling the model directly
+with ``loss_masks`` worked fine.
+"""
+
+from typing import Dict
+
+import pytest
+import torch
+
+from olmo_core.nn.attention import AttentionBackendName
+from olmo_core.nn.transformer.config import TransformerConfig
+from olmo_core.nn.vision import (
+    MultimodalLMConfig,
+    VisionConnectorConfig,
+    VisionEncoderConfig,
+    VisionEncoderType,
+)
+from olmo_core.optim import AdamWConfig
+from olmo_core.train.train_module import MultimodalTransformerTrainModuleConfig
+
+BASE_VOCAB, EXTRA_VOCAB = 200, 8
+IMAGE_PATCH_ID = BASE_VOCAB + 2
+SEQ_LEN, N_POOLED = 16, 4
+
+
+def _model_config(masked_dropout: float) -> MultimodalLMConfig:
+    lm = TransformerConfig.llama_like(
+        d_model=16,
+        vocab_size=BASE_VOCAB,
+        n_layers=2,
+        n_heads=2,
+        n_extra_vocab=EXTRA_VOCAB,
+        attn_backend=AttentionBackendName.torch,
+    )
+    if masked_dropout:
+        lm.block.masked_dropout = masked_dropout
+    vision = VisionEncoderConfig(
+        name=VisionEncoderType.siglip,
+        use_cls_token=False,
+        patch_embedding_bias=True,
+        use_pre_ln=False,
+        image_default_input_size=(56, 56),
+        image_patch_size=14,
+        image_emb_dim=32,
+        image_num_heads=2,
+        image_num_key_value_heads=2,
+        image_num_layers=2,
+        image_head_dim=16,
+        image_mlp_dim=64,
+        image_num_pos=16,
+        image_norm_eps=1e-5,
+    )
+    connector = VisionConnectorConfig.from_vision_encoder(
+        vision, output_dim=lm.d_model, mlp_hidden_size=64
+    )
+    return MultimodalLMConfig(
+        lm=lm, vision=vision, connector=connector, image_patch_token_id=IMAGE_PATCH_ID
+    )
+
+
+class _StubTrainer:
+    """Minimal stand-in: ``train_batch`` only reaches the trainer to record metrics."""
+
+    def record_metric(self, *args, **kwargs) -> None:
+        pass
+
+    def record_ce_loss(self, *args, **kwargs) -> None:
+        pass
+
+
+def _train_module(masked_dropout: float, response_logits_only: bool):
+    config = MultimodalTransformerTrainModuleConfig(
+        rank_microbatch_size=SEQ_LEN,
+        max_sequence_length=SEQ_LEN,
+        optim=AdamWConfig(lr=1e-4),
+        z_loss_multiplier=1e-4,
+        compile_model=False,
+        response_logits_only=response_logits_only,
+    )
+    train_module = config.build(_model_config(masked_dropout).build(init_device="cpu"))
+    train_module._trainer = _StubTrainer()  # type: ignore[assignment]
+    return train_module
+
+
+def _batch() -> Dict[str, torch.Tensor]:
+    # Seeded: an unseeded random 2-layer model occasionally produces non-finite logits, which
+    # the trainer's finite-loss guard then reports. That is a tiny-random-model artifact (the
+    # real model starts from pretrained Qwen3 + SigLIP2 weights) and unrelated to what these
+    # tests check, so pin it rather than let the suite flake.
+    torch.manual_seed(0)
+    input_ids = torch.randint(0, BASE_VOCAB, (1, SEQ_LEN))
+    input_ids[0, 2 : 2 + N_POOLED] = IMAGE_PATCH_ID
+    loss_masks = torch.zeros(1, SEQ_LEN)
+    loss_masks[:, SEQ_LEN // 2 :] = 1.0  # second half = response tokens
+    return {
+        "input_ids": input_ids,
+        "labels": input_ids.clone(),
+        "loss_masks": loss_masks,
+        "images": torch.randn(1, 1, 16, 3 * 14**2),
+        "pooled_patches_idx": torch.arange(16).view(1, N_POOLED, 4),
+    }
+
+
+@pytest.mark.parametrize("response_logits_only", [False, True])
+def test_train_batch_with_response_residual_dropout(response_logits_only: bool):
+    """Both logit paths must supply ``loss_masks`` to the model.
+
+    The dense path (``False``) is the released Molmo2 recipe and previously raised
+    ``ValueError: loss_masks is required when the LM uses masked_dropout``.
+    """
+    torch.manual_seed(0)
+    train_module = _train_module(masked_dropout=0.1, response_logits_only=response_logits_only)
+    train_module.train_batch(_batch())
+
+
+@pytest.mark.parametrize("response_logits_only", [False, True])
+def test_train_batch_without_masked_dropout(response_logits_only: bool):
+    """Sanity: the same paths still work when masked dropout is off."""
+    torch.manual_seed(0)
+    train_module = _train_module(masked_dropout=0.0, response_logits_only=response_logits_only)
+    train_module.train_batch(_batch())


### PR DESCRIPTION
#825 added Molmo2's `response_residual_dropout`. On GPU it turned out to be broken in two
independent ways, the second of which silently prevented stage 1 from training at all. Both are
fixed here, each with a regression test that fails on the old code.

## Measured on 2 nodes of holmes (B300), 150 steps, from-scratch 4B

| step | 15 | 45 | 75 | 105 | 150 |
|---|---|---|---|---|---|
| **before** (bug 2) | 3.57 | 3.51 | 3.52 | 8.24 | ~7.7 |
| dropout disabled (control) | 2.71 | 2.33 | 2.27 | 2.14 | **2.10** |
| known-good reference run | 3.26 | 2.32 | 2.11 | 2.03 | **1.96** |

The broken version never descends — CE holds at 3.3-4.1 for 75 steps, then blows up to ~9 with
grad norms spiking to 537 / 174 / 156 against a clip of 1.0. Disabling the dropout entirely
recovers the reference curve, which is what localised the bug.

Beaker: baseline `01KZZ9J77QVJ21MGGW2C934K73` (diverged), unfreeze-embeddings ablation
`01KZZANAVXRDQNC28P7KGNF4B0` (still diverged, ruling out the embedding hypothesis), no-dropout
control `01KZZANAAV8BC7WM3QDECE2MWM` (healthy).

## Bug 1 — `loss_masks` was not forwarded on the dense-logits path

`train_batch` only passed `loss_masks` to the model on the `response_logits_only=True` branch. The
released Molmo2 recipe has `response_logits_only: false`, so the dense branch is the one that runs,
and it died on the first batch:

```
ValueError: loss_masks is required when the LM uses masked_dropout
```

Fixed by passing `loss_masks` on both branches (`MultimodalLM.forward` pops it and ignores it when
masked dropout is off).

## Bug 2 — dropout sampled per **token** instead of per **element**

mm_olmo (`olmo/nn/llm.py:916-946`) broadcasts the per-token keep probability to the full input
shape and draws one Bernoulli per element:

```python
dropout_shape = list(input.shape)                  # (B, T, D)
keep_prob = keep_prob.broadcast_to(dropout_shape)
multiplier = input.new_empty(dropout_shape).bernoulli_(keep_prob)
```

#825 called `torch.rand_like(keep_prob)` while `keep_prob` was still shaped `(B, T, 1)` — one
Bernoulli **per token**, which zeroes a token's entire `d_model` residual contribution at once.
Across 36 blocks x 2 residual adds that is 72 chances to delete a response token's contribution
outright: destructive rather than regularising, and a good match for training that limps and then
diverges.

## Why the existing tests missed it

Every assertion in #825 holds identically under both samplings — \"~9% of masked *elements* are
zero\", \"survivors are scaled by 1/0.9\", \"the expectation is preserved\". The element-level
statistics are the same; only the correlation structure differs.

- `test_masked_dropout_samples_per_element_not_per_token` targets that directly: at rate 0.5 with
  D=8, per-element sampling makes all-or-nothing tokens vanishingly rare (2 * 0.5\*\*8 per token),
  so it asserts almost every masked token is *partially* dropped.
- The new `multimodal_train_module_test.py` exercises `train_batch` — the real caller — across both
  logit paths. Bug 1 was invisible to tests that called `MultimodalLM.forward` directly with
  `loss_masks` already in hand.

## Verification

13 tests pass across `residual_stream_test.py` and `train_module/multimodal_train_module_test.py`;
both new tests confirmed to fail on the pre-fix code. `isort` / `black` / `ruff` clean; `mypy` at
the pre-existing baseline. A 2-node run with dropout re-enabled on the fixed code is in flight
(`01KZZHA0HJN9AXFE67Y9JAVT15`) to confirm the curve now tracks the reference.