### PR TITLE
Molmo2-Stage1: make the data-loader knobs CLI-overridable

### DIFF
--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -281,6 +281,21 @@ class ExperimentConfig(Config):
     """``"molmo2"`` (released Molmo2-4B weights) or ``"scratch"`` (mm_olmo stage-1 init:
     base Qwen3-4B + base SigLIP2 + random connector/new embeddings)."""
 
+    # Data-loader knobs. Exposed as fields (rather than left as module constants) so they can
+    # be swept from the CLI: data loading was measured at ~11% of step time, and the packer
+    # parameters are the other lever on examples/sec.
+    data_prefetch_workers: int = DATA_PREFETCH_WORKERS
+    """Background threads preprocessing examples (0 = synchronous)."""
+
+    pack_max_crops: int = PACK_MAX_CROPS
+    """Image-crop budget per pack — the knapsack's second dimension."""
+
+    pack_buffer_size: int = PACK_BUFFER_SIZE
+    """Examples buffered before the 2D knapsack picks a pack (mm_olmo ``buffer_size``)."""
+
+    pack_image_weight: float = PACK_IMAGE_WEIGHT
+    """Objective weight per image crop in the knapsack (mm_olmo ``image_weight``)."""
+
 
 def _build_model_config(model_size: str, init_from: str) -> MultimodalLMConfig:
     """Build the Molmo2-4B :class:`MultimodalLMConfig` natively (no weights, no HF read).
@@ -721,10 +736,10 @@ def train(config: ExperimentConfig):
             global_batch_size=config.global_batch_size,
             seed=config.data_seed,
             pack=config.pack_sequences,
-            pack_max_crops=PACK_MAX_CROPS if config.pack_sequences else None,
-            pack_buffer_size=PACK_BUFFER_SIZE,
-            pack_image_weight=PACK_IMAGE_WEIGHT,
-            prefetch_workers=DATA_PREFETCH_WORKERS,
+            pack_max_crops=config.pack_max_crops if config.pack_sequences else None,
+            pack_buffer_size=config.pack_buffer_size,
+            pack_image_weight=config.pack_image_weight,
+            prefetch_workers=config.data_prefetch_workers,
             dp_world_size=dp_world_size,
             dp_rank=dp_rank,
         )


### PR DESCRIPTION
Stacked on #826 (its two commits appear here; review the top commit only).

`DATA_PREFETCH_WORKERS`, `PACK_MAX_CROPS`, `PACK_BUFFER_SIZE` and `PACK_IMAGE_WEIGHT` were module
constants passed straight into `MixtureDataLoader`, so sweeping any of them meant editing the
script. They become `ExperimentConfig` fields with identical defaults (4 / 27 / 48 / 1.0), so the
CLI can reach them.

Motivated by a measurement, not a hypothetical: the 2-node stage-1 baseline on holmes spends
**11.4% of step time in data loading** (0.213 s of a 1.86 s step, median of the last 50 steps),
which makes prefetch-worker count a real throughput lever. The packer parameters are the other
lever on examples/sec — and `pack_image_weight` is the one that had to be pinned to mm_olmo's 1.0
rather than the loader's own 30.0 default, so having it visible in the config dump is worth
something on its own.

Behaviour at the defaults is unchanged; this only widens what the CLI can override. Verified that
the defaults still resolve to 4 / 27 / 48 / 1.0 and that `--data_prefetch_workers=8
--pack_max_crops=45 --pack_image_weight=10.0` each take effect in the built loader.