### PR TITLE
Preserve RNG state across activation-checkpoint recompute when dropout is active

### DIFF
--- a/src/olmo_core/nn/transformer/model.py
+++ b/src/olmo_core/nn/transformer/model.py
@@ -36,6 +36,7 @@ from olmo_core.nn.attention.ring import (
     UlyssesContextParallelStyle,
 )
 from olmo_core.nn.embedding import SplitVocabEmbedding
+from olmo_core.nn.residual_stream import ResidualStream
 from olmo_core.utils import get_default_device, mark_dynamic, move_to_device
 
 from ..attention import (
@@ -839,6 +840,22 @@ class Transformer(nn.Module):
         if self.lm_head is not None:
             self.lm_head.apply_cp(cp_mesh)
 
+    def _dropout_is_active(self) -> bool:
+        """
+        Whether any submodule applies dropout, and therefore whether activation checkpointing has
+        to preserve the RNG state across recomputation.
+
+        Covers both :class:`~olmo_core.nn.residual_stream.ResidualStream` (whose ``masked_dropout``
+        drives Molmo2's ``response_residual_dropout``) and plain :class:`torch.nn.Dropout`.
+        """
+        for module in self.modules():
+            if isinstance(module, ResidualStream):
+                if module.p > 0.0 or module.masked_dropout > 0.0:
+                    return True
+            elif isinstance(module, nn.Dropout) and module.p > 0.0:
+                return True
+        return False
+
     def apply_activation_checkpointing(
         self,
         mode: TransformerActivationCheckpointingMode,
@@ -884,8 +901,12 @@ class Transformer(nn.Module):
         if mode == TransformerActivationCheckpointingMode.selected_modules and modules is None:
             raise ValueError("'modules' is required for 'selected_modules' mode")
 
-        # TODO: only preserve RNG state if dropout is active
-        preserve_rng_state = False
+        # Recomputation must replay the *same* dropout masks the forward pass used, otherwise the
+        # gradients are taken with respect to a different sample than the loss was. Saving and
+        # restoring the RNG state costs a little per checkpointed block, so only pay it when some
+        # dropout is actually active — which mirrors mm_olmo's
+        # `llm_activation_checkpoint_function`.
+        preserve_rng_state = self._dropout_is_active()
 
         if mode == TransformerActivationCheckpointingMode.selected_modules:
             from fnmatch import fnmatch

--- a/src/test/nn/transformer/ac_rng_test.py
+++ b/src/test/nn/transformer/ac_rng_test.py
@@ -1,0 +1,95 @@
+"""Activation checkpointing must replay dropout masks, not redraw them.
+
+Checkpointing runs the forward twice: once to get the output, once during backward to rebuild the
+activations it discarded. If the recomputed pass draws *fresh* dropout masks, the gradients are
+taken with respect to a different sample than the loss was, which silently biases training. The
+fix is to preserve the RNG state across recomputation whenever dropout is active — the same
+condition mm_olmo uses in `llm_activation_checkpoint_function`.
+
+This was not academic: with Molmo2's `response_residual_dropout=0.1` and full activation
+checkpointing, a 150-step benchmark landed 0.3 nats *worse* than the identical run with
+checkpointing off, which should be mathematically neutral.
+"""
+
+
+import pytest
+import torch
+
+from olmo_core.nn.attention import AttentionBackendName
+from olmo_core.nn.transformer import TransformerActivationCheckpointingMode
+from olmo_core.nn.transformer.config import TransformerConfig
+
+VOCAB, SEQ_LEN = 64, 8
+
+
+def _model(masked_dropout: float = 0.0, dropout: float = 0.0):
+    config = TransformerConfig.llama_like(
+        d_model=32,
+        vocab_size=VOCAB,
+        n_layers=2,
+        n_heads=2,
+        attn_backend=AttentionBackendName.torch,
+    )
+    config.block.masked_dropout = masked_dropout
+    config.block.dropout = dropout
+    return config.build(init_device="cpu")
+
+
+@pytest.mark.parametrize(
+    "masked_dropout, dropout, expected",
+    [
+        pytest.param(0.0, 0.0, False, id="no-dropout"),
+        pytest.param(0.1, 0.0, True, id="masked-dropout"),
+        pytest.param(0.0, 0.1, True, id="plain-dropout"),
+    ],
+)
+def test_preserve_rng_state_tracks_whether_dropout_is_active(
+    masked_dropout: float, dropout: float, expected: bool
+):
+    """RNG preservation costs something per block, so it should be on only when it matters."""
+    model = _model(masked_dropout=masked_dropout, dropout=dropout)
+    assert model._dropout_is_active() is expected
+
+    model.apply_activation_checkpointing(TransformerActivationCheckpointingMode.full)
+    wrapped = next(iter(model.blocks.values()))
+    assert wrapped.checkpoint_fn.keywords["preserve_rng_state"] is expected  # type: ignore[union-attr]
+
+
+def _grads(masked_dropout: float, ac: bool, seed: int = 0) -> list[torch.Tensor]:
+    """Gradients from one forward/backward, with the model built and run under a fixed seed."""
+    torch.manual_seed(seed)
+    model = _model(masked_dropout=masked_dropout)
+    if ac:
+        model.apply_activation_checkpointing(TransformerActivationCheckpointingMode.full)
+
+    input_ids = torch.randint(0, VOCAB, (1, SEQ_LEN))
+    loss_masks = torch.zeros(1, SEQ_LEN)
+    loss_masks[:, SEQ_LEN // 2 :] = 1.0
+
+    torch.manual_seed(seed + 1)  # same dropout draws for both the AC and non-AC paths
+    logits = model(input_ids, drop_mask=loss_masks > 0)
+    logits.sum().backward()
+    return [p.grad.clone() for p in model.parameters() if p.grad is not None]
+
+
+def test_checkpointed_grads_match_uncheckpointed_grads_under_dropout():
+    """The real property: checkpointing must not change the gradient.
+
+    With the masks replayed, the checkpointed backward sees exactly the forward's masks, so the
+    gradients match. Redrawing them instead produces visibly different gradients — this test fails
+    with ``preserve_rng_state=False``.
+    """
+    without_ac = _grads(masked_dropout=0.1, ac=False)
+    with_ac = _grads(masked_dropout=0.1, ac=True)
+
+    assert len(without_ac) == len(with_ac)
+    for expected, actual in zip(without_ac, with_ac):
+        torch.testing.assert_close(expected, actual, rtol=1e-5, atol=1e-6)
+
+
+def test_checkpointing_is_still_neutral_without_dropout():
+    """Sanity check on the harness: with no dropout there is no RNG to preserve either way."""
+    for expected, actual in zip(
+        _grads(masked_dropout=0.0, ac=False), _grads(masked_dropout=0.0, ac=True)
+    ):
+        torch.testing.assert_close(expected, actual, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
Stacked on #826 (its two commits appear here; review the top commit only).

`TransformerModel.apply_activation_checkpointing` hardcoded `preserve_rng_state = False`, directly
below a `TODO: only preserve RNG state if dropout is active`. Checkpointing discards activations
and rebuilds them by re-running the forward during backward; with the RNG state unpreserved, that
recompute draws **fresh** dropout masks, so the gradients are taken with respect to a different
sample than the loss was.

Harmless until now — no olmo-core model used dropout, so the flag cost nothing. #825 added Molmo2's
`response_residual_dropout=0.1`, and the released stage-1 recipe sets
`activation_checkpointing: true`, so the exact configuration we are reproducing hit this on every
step.

## How it surfaced

Measured on 2 nodes of holmes, 150 steps, from-scratch 4B, while sweeping throughput settings.
Turning activation checkpointing off is supposed to be mathematically neutral. It moved the loss:

| arm | AC | microbatch | CE @150 | examples/s/device |
|---|---|---|---|---|
| baseline | on | 4 | 2.495 | 6.077 |
| A2 | **off** | 4 | **2.195** | 6.767 |
| A4c | on | 8 | 2.487 | 7.126 |
| C1 | **off** | 8 | **2.194** | 7.750 |

The split follows AC exactly, not microbatch: both AC-off arms land at 2.194/2.195, both AC-on arms
at 2.487/2.495. A neutral knob shifting the loss 0.3 nats is mismatched gradients, not noise — the
baseline's own step-to-step oscillation is ±0.05. Beaker: `01KZZHSVW4EMG4R6MYQ2Y66PC3` (A2),
`01KZZHSX95NCGV94CGSWH4HTF9` (A4c), `01KZZJNCNH2V46X9H0MX94DGQM` (C1).

## The fix

mm_olmo gates the same flag on the same condition in `llm_activation_checkpoint_function`:

```python
preserve_rng_state = (
    (cfg.attention_dropout != 0.0) or
    (cfg.response_residual_dropout != 0.0) or
    (cfg.residual_dropout != 0.0)
)
```

`_dropout_is_active()` walks submodules for `ResidualStream` (whose `masked_dropout` carries
`response_residual_dropout`) and plain `nn.Dropout`, so the per-block save/restore is only paid when
there is a mask worth replaying.

## Tests

`test_checkpointed_grads_match_uncheckpointed_grads_under_dropout` asserts the property that
actually matters — checkpointing must not change the gradient — and a parametrized test pins the
flag itself so the cost stays off when dropout is disabled. Both fail on the pre-fix code.

Ran `model_test.py` + `train_module/` with and without the change: 9 failed / 60 passed / 5 skipped
either way, empty set difference in both directions, so the pre-existing MoE tensor-parallel
failures are untouched. isort/black/ruff clean.

## Note for the stage-1 recipe

With this fix, AC-on and AC-off are genuinely equivalent, and the new test enforces it. That makes
`ac_config=null` a free +11.4% throughput win on B300 (62 -> 161 GiB reserved, against 288 GiB
available) — worth considering separately for the stage-1 script, but not changed here.