### PR TITLE
Align OLMoE3 3p5b geometry to 256 for TPU MXU friendliness

### DIFF
--- a/src/scripts/standalone/README.md
+++ b/src/scripts/standalone/README.md
@@ -138,4 +138,13 @@ parameter counts.
 | Config | Total parameters | Active parameters | Active non-embedding |
 | --- | ---: | ---: | ---: |
 | `30m` | 32,323,588 | 29,964,292 | 17,119,236 |
-| `3p5b` | 65,342,371,200 | 3,479,664,000 | 3,299,833,216 |
+| `3p5b` | 62,864,102,080 | 3,475,903,168 | 3,296,072,384 |
+
+`3p5b`'s shapes (`head_dim`, `expert_hidden_size`, `latent_dim`) are all multiples of
+256 for TPU MXU alignment; see `tpu-optimizations-guide.md` (Principle 1) and the PR
+that introduced this geometry for the parameter-count trade-off versus the prior,
+unaligned shapes (`head_dim=128`, `expert_hidden_size=1600`, `latent_dim=896`), which
+had 65,342,371,200 total / 3,479,664,000 active parameters. Active params are matched
+to within 0.1%; total parameters (and therefore the sparsity ratio) are about 3.8%
+lower, since no combination of 256-aligned `expert_hidden_size`/`latent_dim` exactly
+reproduces both simultaneously.

--- a/src/scripts/standalone/fused_model.py
+++ b/src/scripts/standalone/fused_model.py
@@ -24,7 +24,7 @@ Pass ``--device meta`` to construct shapes without parameter storage, or ``--dev
 cuda`` on appropriately sharded hardware. Module construction requires the production
 FLA, FlashAttention 4, Triton, and (for expert parallelism) NVSHMEM environment.
 Use ``--model-size 30m`` for the single-GPU smoke configuration; the default is
-the 3.5B-active / 65B-stored target configuration.
+the 3.5B-active / 63B-stored target configuration.
 """
 
 from __future__ import annotations
@@ -70,7 +70,6 @@ from olmo_core.nn.transformer import (
 )
 
 VOCAB_SIZE = 100_352
-HEAD_DIM = 128
 TOP_K = 16
 
 
@@ -80,14 +79,12 @@ class Geometry:
     n_layers: int
     n_heads: int
     n_kv_heads: int
+    head_dim: int
     expert_hidden_size: int
     num_routed_experts: int
+    latent_dim: int
     expected_total_params: int
     expected_active_params: int
-
-    @property
-    def latent_dim(self) -> int:
-        return self.d_model // 2
 
     @property
     def full_attention_layers(self) -> tuple[int, ...]:
@@ -95,8 +92,12 @@ class Geometry:
 
 
 GEOMETRIES = {
-    "30m": Geometry(128, 5, 1, 1, 192, 32, 32_323_588, 29_964_292),
-    "3p5b": Geometry(1792, 30, 16, 8, 1600, 512, 65_342_371_200, 3_479_664_000),
+    # Left unaligned: a fast plumbing/correctness check, not performance-representative.
+    "30m": Geometry(128, 5, 1, 1, 128, 192, 32, 64, 32_323_588, 29_964_292),
+    # head_dim/expert_hidden_size/latent_dim are all multiples of 256 for TPU MXU
+    # alignment (tpu-optimizations-guide.md, Principle 1); see PR description for
+    # the parameter-count trade-off this implies relative to the prior geometry.
+    "3p5b": Geometry(1792, 30, 8, 4, 256, 1792, 512, 768, 62_864_102_080, 3_475_903_168),
 }
 
 
@@ -129,7 +130,7 @@ def build_fused_config(options: FusedModelOptions) -> OLMoDDPModelConfig:
     kda = KimiDeltaAttentionConfig(
         n_heads=geometry.n_heads,
         n_v_heads=geometry.n_heads,
-        head_dim=HEAD_DIM,
+        head_dim=geometry.head_dim,
         expand_v=2.0,
         allow_neg_eigval=True,
         conv_size=4,
@@ -141,7 +142,7 @@ def build_fused_config(options: FusedModelOptions) -> OLMoDDPModelConfig:
         name=AttentionType.default,
         n_heads=geometry.n_heads,
         n_kv_heads=geometry.n_kv_heads,
-        head_dim=HEAD_DIM,
+        head_dim=geometry.head_dim,
         bias=False,
         gate=GateConfig(granularity=GateGranularity.elementwise, full_precision=True),
         rope=None,

--- a/src/scripts/standalone/standalone_model.py
+++ b/src/scripts/standalone/standalone_model.py
@@ -17,7 +17,7 @@ model layers.  The KDA recurrence and expert dispatch below are unfused referenc
 implementations and are meant for inspection and small-shape tests, not production.
 
 Importing this module creates ``largest_model`` on the meta device.  This instantiates
-the complete 65.34B-parameter module hierarchy without allocating parameter storage.
+the complete 62.86B-parameter module hierarchy without allocating parameter storage.
 Call ``OLMoE3(largest_config, device=...)`` only on appropriately sharded hardware.
 """
 
@@ -36,13 +36,13 @@ class OLMoE3Config:
     vocab_size: int = 100_352
     d_model: int = 1792
     n_layers: int = 30
-    n_heads: int = 16
-    n_kv_heads: int = 8
-    head_dim: int = 128
-    expert_hidden_size: int = 1600
+    n_heads: int = 8
+    n_kv_heads: int = 4
+    head_dim: int = 256
+    expert_hidden_size: int = 1792
     num_routed_experts: int = 512
     top_k: int = 16
-    latent_compression: int = 2
+    latent_dim: int = 768
     kda_expand_v: float = 2.0
     kda_conv_size: int = 4
     rms_norm_eps: float = 1e-6
@@ -61,15 +61,20 @@ class OLMoE3Config:
     emo_eval_document_expert_pool: int = 512
 
     @property
-    def latent_dim(self) -> int:
-        return self.d_model // self.latent_compression
-
-    @property
     def full_attention_layers(self) -> tuple[int, ...]:
         return tuple(range(4, self.n_layers, 5))
 
     def validate(self) -> None:
-        assert self.d_model % self.latent_compression == 0
+        # TPU MXU alignment (256x256 systolic array): every reduction/output
+        # dimension that appears in a GEMM must be a multiple of 256, or the
+        # matmul pads out to the next tile and burns cycles on zeros.
+        for name, dim in (
+            ("d_model", self.d_model),
+            ("head_dim", self.head_dim),
+            ("expert_hidden_size", self.expert_hidden_size),
+            ("latent_dim", self.latent_dim),
+        ):
+            assert dim % 256 == 0, f"{name}={dim} must be a multiple of 256 for MXU alignment"
         assert self.n_heads % self.n_kv_heads == 0
         assert self.top_k <= self.num_routed_experts
         if self.emo_enabled:


### PR DESCRIPTION
head_dim (128->256), expert_hidden_size (1600->1792), and latent_dim (896->768, replacing the latent_compression field) are now all multiples of 256, per tpu-optimizations-guide.md Principle 1: every GEMM reduction/ output dimension should tile evenly on the MXU's 256x256 systolic array. n_heads/n_kv_heads are halved (16->8, 8->4) to keep attention projection widths and the GQA ratio unchanged as head_dim doubles.

Active parameters land within 0.1% of the original count (3,475,903,168 vs 3,479,664,000); the small residual comes from KDA's gating projections, which scale with head_dim*kda_expand_v rather than n_heads*head_dim. Total parameters (and the sparsity ratio) come out ~3.8% lower, since no pair of 256-aligned expert_hidden_size/latent_dim values reproduces both the original total and active counts exactly. latent_dim=768 keeps LatentMoE's compression at 2.33x, within the recommended 2-4x band. The 30m smoke config is left unaligned since it's a plumbing/correctness check, not a performance benchmark.

Added a validate() guardrail asserting the 256-alignment on all four affected dims to prevent future regressions.