### PR TITLE
Stage 1: format pointing prompts with the stage-1 family, not stage 2's

### DIFF
--- a/src/olmo_core/data/multimodal/pixmo_points.py
+++ b/src/olmo_core/data/multimodal/pixmo_points.py
@@ -25,7 +25,7 @@ from olmo_core.config import Config
 
 from .grounding import normalize_points, pointing_answer
 from .qwen3_layout import branch_context_ids, image_prefix_ids
-from .sequence_builder import example_rng, build_branched_sequence
+from .sequence_builder import build_branched_sequence, example_rng
 from .sft_formatter import SftFormatter
 
 __all__ = [
@@ -67,9 +67,7 @@ def _build_example(
         rng.shuffle(order)
         branches_text = [branches_text[i] for i in order]
 
-    preprocess_rng = (
-        shuffle_rng if shuffle_rng is not None else np.random.RandomState(seed)
-    )
+    preprocess_rng = shuffle_rng if shuffle_rng is not None else np.random.RandomState(seed)
     images_t, pooling_t, image_grid = preprocess_image_molmo2(
         pil_image,
         dtype=torch.float32,
@@ -88,7 +86,9 @@ def _build_example(
         )
         for i, (q, a) in enumerate(branches_text)
     ]
-    from olmo_core.data.multimodal.message_weight import apply_message_weight_to_loss_masks
+    from olmo_core.data.multimodal.message_weight import (
+        apply_message_weight_to_loss_masks,
+    )
 
     seq = build_branched_sequence(
         prefix,
@@ -139,6 +139,10 @@ class PixMoPointsDatasetConfig(Config):
     message_weight: float | None = None
     p_high_res: float = 0.0
     seed: int = 0
+    prompt_templates: str = "uber_model_v2"
+    """Prompt family for the question text; stage 1 uses ``"none"`` (bare label)."""
+    system_prompt: str = "demo_or_style_v2"
+    """Prompt family for the style prefix; stage 1 uses ``"style_and_length_v2"``."""
 
     def build(self, tokenizer) -> "PixMoPointsDataset":
         return PixMoPointsDataset(self, tokenizer)
@@ -153,7 +157,9 @@ class PixMoPointsDataset:
         )
         from datasets import concatenate_datasets
 
-        self._data = concatenate_datasets([_load_split(f"{PIXMO_DATASETS}/{s}", "train") for s in sub])
+        self._data = concatenate_datasets(
+            [_load_split(f"{PIXMO_DATASETS}/{s}", "train") for s in sub]
+        )
         # Pre-split each row's labels into sub-batches with <= max_total_points (mm_olmo).
         self._index = self._build_sub_index()
 
@@ -183,7 +189,11 @@ class PixMoPointsDataset:
         row_idx, label_idxs = self._index[i]
         rng = example_rng(self.config.seed, i)
         row = self._data[row_idx]
-        fmt = SftFormatter(seed=self.config.seed)
+        fmt = SftFormatter(
+            seed=self.config.seed,
+            prompt_templates=self.config.prompt_templates,
+            system_prompt=self.config.system_prompt,
+        )
         specs: List[Tuple[str, str, Any]] = []
         for li in label_idxs:
             label = row["label"][li]
@@ -227,6 +237,10 @@ class PixMoCountDatasetConfig(Config):
     message_weight: float | None = None
     p_high_res: float = 0.0
     seed: int = 0
+    prompt_templates: str = "uber_model_v2"
+    """Prompt family for the question text; stage 1 uses ``"none"`` (bare label)."""
+    system_prompt: str = "demo_or_style_v2"
+    """Prompt family for the style prefix; stage 1 uses ``"style_and_length_v2"``."""
 
     def build(self, tokenizer) -> "PixMoCountDataset":
         return PixMoCountDataset(self, tokenizer)
@@ -253,7 +267,11 @@ class PixMoCountDataset:
         pil = _open_image(row["image"])
         pts = row.get("points") or {"x": [], "y": []}
         rng = example_rng(self.config.seed, i)
-        fmt = SftFormatter(seed=self.config.seed)
+        fmt = SftFormatter(
+            seed=self.config.seed,
+            prompt_templates=self.config.prompt_templates,
+            system_prompt=self.config.system_prompt,
+        )
         xy = np.array([pts["x"], pts["y"]], dtype=np.float64).T.reshape(-1, 2)
         sub = {
             "style": style,
@@ -288,6 +306,10 @@ class CoSynPointDatasetConfig(Config):
     message_weight: float | None = None
     p_high_res: float = 0.0
     seed: int = 0
+    prompt_templates: str = "uber_model_v2"
+    """Prompt family for the question text; stage 1 uses ``"none"`` (bare label)."""
+    system_prompt: str = "demo_or_style_v2"
+    """Prompt family for the style prefix; stage 1 uses ``"style_and_length_v2"``."""
 
     def build(self, tokenizer) -> "CoSynPointDataset":
         return CoSynPointDataset(self, tokenizer)

--- a/src/olmo_core/data/multimodal/sft_formatter.py
+++ b/src/olmo_core/data/multimodal/sft_formatter.py
@@ -1,4 +1,12 @@
-"""SFT prompt formatting for Molmo2 stage-2 (uber_model_v2 + demo_or_style_v2)."""
+"""SFT prompt formatting for Molmo2.
+
+Defaults to the stage-2 family (``uber_model_v2`` templates + ``demo_or_style_v2`` system
+prompt). Stage 1 uses a different family -- ``prompt_templates="none"`` with
+``system_prompt="style_and_length_v2"`` -- which asks for a point with the bare lowercased
+label behind a ``"<style>:"`` prefix rather than a natural-language template. Both are
+selectable, because the form has to follow the checkpoint: a model trained on one and
+evaluated on the other is out of distribution.
+"""
 
 from __future__ import annotations
 
@@ -115,15 +123,55 @@ def _apply_chain_of_thought_prompt(question: str) -> str:
 
 @dataclass
 class SftFormatter:
-    """Minimal port of mm_olmo DataFormatter for image-only-v9 SFT."""
+    """Minimal port of mm_olmo DataFormatter.
+
+    The prompt family must match the checkpoint. The defaults are the stage-2 family used by
+    ``image_only_v9``; stage 1 passes ``prompt_templates="none"`` and
+    ``system_prompt="style_and_length_v2"`` to match the released ``Molmo2-4B-Pretrain``
+    config, whose ``data_formatter`` records exactly those.
+
+    Getting it wrong is quiet and costly: a stage-1 4B checkpoint trained on the templated
+    form but evaluated on the terse form scored 0.706 f1 on ``pixmo_point_eval_v3_mp`` against
+    0.815 for the released Pretrain checkpoint, losing most of it on abstention (zero-slice f1
+    0.718 vs 0.913) because the "Please say 'There are none.'" instruction lives only in the
+    stage-2 template.
+    """
 
     select_answer: str = "best"
     seed: int = 0
+    prompt_templates: str = "uber_model_v2"
+    """``"uber_model_v2"`` samples a natural-language template; ``"none"`` uses the bare
+    lowercased label (mm_olmo ``data_formatter.py:1759-1779``)."""
+    system_prompt: str = "demo_or_style_v2"
+    """``"demo_or_style_v2"`` adds no style prefix; ``"style_and_length"``/``"_v2"`` prefix the
+    pointing/counting styles with ``"<style>:"``."""
     p_multi_point_all_image: float = 0.5
     """Probability that a multi-image pointing question targets "all images" instead of
     a random image subset (mm_olmo stage-2 sets 0.5)."""
 
+    #: mm_olmo styles taking a ``"<style>:"`` prefix under the ``style_and_length`` families
+    #: (``data_formatter.py:1649-1653``). They are also in :data:`DEMO_STYLES`, which is what
+    #: suppresses the prefix under ``demo_or_style_v*``.
+    STYLE_PREFIX_STYLES = frozenset(
+        {
+            "pointing",
+            "point_count",
+            "point_then_count",
+            "cosyn_point",
+            "text_sft",
+            "aux_pointing",
+            "aux_point_count",
+            "v3det_points",
+        }
+    )
+    #: System-prompt families that prefix the style name.
+    STYLE_AND_LENGTH_FAMILIES = frozenset({"style_and_length", "style_and_length_v2"})
+
     def style_prefix(self, style: str) -> str:
+        if self.system_prompt in self.STYLE_AND_LENGTH_FAMILIES:
+            # Pointing/counting styles are prefixed under this family even though they are
+            # demo styles; captions get their own "<style> <bucket>:" prefix upstream.
+            return f"{style}:" if style in self.STYLE_PREFIX_STYLES else ""
         if not style or style in DEMO_STYLES or style in IMAGE_MC_STYLES:
             return ""
         return f"{style}:"
@@ -160,9 +208,7 @@ class SftFormatter:
         if not is_training or rng.random() < 0.1:
             if labelled:
                 prefixes = string.ascii_uppercase
-                option_text = "\n".join(
-                    f"{p}. {o}" for p, o in zip(prefixes, example["options"])
-                )
+                option_text = "\n".join(f"{p}. {o}" for p, o in zip(prefixes, example["options"]))
                 option_names = list(prefixes[: len(example["options"])])
                 outputs = [f"{n}. {o}" for n, o in zip(option_names, example["options"])]
             else:
@@ -170,9 +216,7 @@ class SftFormatter:
                 option_names = list(example["unlabelled_options"])
                 outputs = list(example["unlabelled_options"])
             question = (
-                example["question"]
-                + "\nOnly return the correct answer option.\n"
-                + option_text
+                example["question"] + "\nOnly return the correct answer option.\n" + option_text
             )
         else:
             question = example["question"]
@@ -218,9 +262,7 @@ class SftFormatter:
         else:
             label = example.get("question", "")
         point_scale = example["point_scale"] if "point_scale" in example else 100
-        norm = normalize_points(
-            xy, point_scale=point_scale, image_size=example.get("image_size")
-        )
+        norm = normalize_points(xy, point_scale=point_scale, image_size=example.get("image_size"))
         style = example.get("style", "pointing")
         # mm_olmo's count is always len(points) (data_formatter.py:1141) — never a
         # dataset-provided "count" field, which its formatter cannot even see.
@@ -304,18 +346,14 @@ class SftFormatter:
 
         if selected_images == "all images":
             valid = [
-                i
-                for i in all_images
-                if norm_labels[i] == selected_norm and len(points[i]) > 0
+                i for i in all_images if norm_labels[i] == selected_norm and len(points[i]) > 0
             ]
         else:
             chosen_idx = [int(s.split("_")[1]) - 1 for s in selected_images.split(", ")]
             valid = [
                 i
                 for i in chosen_idx
-                if i < len(norm_labels)
-                and norm_labels[i] == selected_norm
-                and len(points[i]) > 0
+                if i < len(norm_labels) and norm_labels[i] == selected_norm and len(points[i]) > 0
             ]
         if not valid:
             return question, "There are none."
@@ -323,10 +361,7 @@ class SftFormatter:
         scale = float(example.get("point_scale", 100))
         by_image = []
         for i in valid:
-            xy = [
-                (p["x"], p["y"]) if isinstance(p, dict) else (p[0], p[1])
-                for p in points[i]
-            ]
+            xy = [(p["x"], p["y"]) if isinstance(p, dict) else (p[0], p[1]) for p in points[i]]
             # clip_points clamping is equivalent to the [0, 1] clamp inside
             # _scale_point after normalization.
             by_image.append((i + 1, [(x / scale, y / scale) for x, y in xy]))
@@ -368,10 +403,7 @@ class SftFormatter:
             for msg in example["message_list"]:
                 if "messages" in msg:
                     messages = msg["messages"]
-                    conv = [
-                        (messages[u], messages[u + 1])
-                        for u in range(0, len(messages) - 1, 2)
-                    ]
+                    conv = [(messages[u], messages[u + 1]) for u in range(0, len(messages) - 1, 2)]
                     conv = [(q, a) for q, a in conv if a and str(a).strip()]
                     if conv:
                         # Style prefix on the first user turn of the conversation.
@@ -423,19 +455,24 @@ class SftFormatter:
                         label = label.lower()
                 else:
                     label = example["label_cased"]
-                pool = (
-                    POINT_COUNT_PROMPTS
-                    if style in ("point_count", "point_then_count")
-                    else POINTING_PROMPTS
-                )
-                prompt = pool[rng.randint(len(pool))].format(label=label)
+                if self.prompt_templates == "none":
+                    # mm_olmo data_formatter.py:1770-1779: no templating or instructions,
+                    # just the lowercased label (the "<style>:" prefix is added separately).
+                    prompt = (
+                        example["label"].lower() if "label" in example else example["label_cased"]
+                    )
+                else:
+                    pool = (
+                        POINT_COUNT_PROMPTS
+                        if style in ("point_count", "point_then_count")
+                        else POINTING_PROMPTS
+                    )
+                    prompt = pool[rng.randint(len(pool))].format(label=label)
             if not is_training:
                 output = None
             else:
                 output = self.format_points(example)
-        elif "question" in example and (
-            "options" in example or "unlabelled_options" in example
-        ):
+        elif "question" in example and ("options" in example or "unlabelled_options" in example):
             prompt, output, _ = self.template_options(example, is_training, rng)
         elif "question" in example:
             prompt = example["question"]
@@ -475,7 +512,5 @@ class SftFormatter:
         Kept for callers that treat every turn as an independent branch; use
         :meth:`format_branches` to preserve multi-turn conversations.
         """
-        branches = self.format_branches(
-            example, is_training=is_training, index=index, rng=rng
-        )
+        branches = self.format_branches(example, is_training=is_training, index=index, rng=rng)
         return [turn for branch in branches for turn in branch]

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -224,6 +224,18 @@ DATASET_PATH = f"{PIXMO_DATASETS}/cap"
 MAX_STEPS = 32000
 
 # Stage-1 mixture rates (mm_olmo train_captioner --pointing/--nlp). Caption gets the
+# Prompt family for the pointing/counting data, from the released Molmo2-4B-Pretrain
+# `data_formatter` (`prompt_templates: none`, `system_prompt: style_and_length_v2`): the question
+# is the bare lowercased label behind a `"<style>:"` prefix, not a natural-language template.
+# The formatter defaults to the stage-2 family, which trains a model that is then out of
+# distribution for pointing evals -- worth ~11 f1 on pixmo_point_eval_v3_mp, most of it
+# abstention, because the "Please say 'There are none.'" instruction only exists in the
+# stage-2 template.
+POINTING_PROMPT_FAMILY = {
+    "prompt_templates": "none",
+    "system_prompt": "style_and_length_v2",
+}
+
 # remainder (1 - POINTING_RATE - NLP_RATE). Set both to 0.0 for a caption-only run.
 POINTING_RATE = 0.30
 NLP_RATE = 0.10
@@ -681,10 +693,14 @@ def _build_mixture_sources(tokenizer, config: ExperimentConfig):
 
     if p > 0:
         pointing = [
-            PixMoPointsDatasetConfig(kind="basic", max_crops=MAX_CROPS).build(tokenizer),
-            PixMoCountDatasetConfig(max_crops=MAX_CROPS).build(tokenizer),
-            PixMoPointsDatasetConfig(kind="high_frequency", max_crops=MAX_CROPS).build(tokenizer),
-            CoSynPointDatasetConfig(max_crops=MAX_CROPS).build(tokenizer),
+            PixMoPointsDatasetConfig(
+                kind="basic", max_crops=MAX_CROPS, **POINTING_PROMPT_FAMILY
+            ).build(tokenizer),
+            PixMoCountDatasetConfig(max_crops=MAX_CROPS, **POINTING_PROMPT_FAMILY).build(tokenizer),
+            PixMoPointsDatasetConfig(
+                kind="high_frequency", max_crops=MAX_CROPS, **POINTING_PROMPT_FAMILY
+            ).build(tokenizer),
+            CoSynPointDatasetConfig(max_crops=MAX_CROPS, **POINTING_PROMPT_FAMILY).build(tokenizer),
         ]
         frac = np.sqrt(np.array([len(d) for d in pointing], dtype=np.float64))
         frac = frac / frac.sum()

--- a/src/test/data/multimodal/pointing_prompt_family_test.py
+++ b/src/test/data/multimodal/pointing_prompt_family_test.py
@@ -1,0 +1,60 @@
+"""The pointing prompt form must follow the checkpoint's family, not the dataset.
+
+Stage 1 trains with the released ``Molmo2-4B-Pretrain`` family (``prompt_templates="none"`` +
+``system_prompt="style_and_length_v2"``): the question is the bare lowercased label behind a
+``"<style>:"`` prefix. Stage 2 (``image_only_v9``) uses ``uber_model_v2`` templates with no
+prefix. Training on one and evaluating on the other is out of distribution: a stage-1 4B
+checkpoint trained on the stage-2 form scored 0.706 f1 on ``pixmo_point_eval_v3_mp`` against
+0.815 for the released Pretrain checkpoint, losing most of it on abstention (zero-slice f1
+0.718 vs 0.913) because the "Please say 'There are none.'" instruction exists only in the
+stage-2 template.
+"""
+
+import numpy as np
+import pytest
+
+from olmo_core.data.multimodal.sft_formatter import SftFormatter
+
+STAGE1 = {"prompt_templates": "none", "system_prompt": "style_and_length_v2"}
+POINTS = [{"x": 10.5, "y": 20.5}, {"x": 30.0, "y": 40.0}]
+
+
+def _turn(style: str, points, **family):
+    fmt = SftFormatter(seed=0, **family)
+    example = {"style": style, "label": "Leather Earmuff", "points": points, "point_scale": 100}
+    return fmt.format_turns(example, index=3, rng=np.random.RandomState(0))[0]
+
+
+@pytest.mark.parametrize("style", ["pointing", "point_count"])
+def test_stage1_family_is_the_terse_prefixed_form(style: str):
+    """mm_olmo ``data_formatter.py:1770-1779`` plus the ``"<style>:"`` prefix."""
+    user, _ = _turn(style, POINTS, **STAGE1)
+    assert user == f"{style}: leather earmuff"
+
+
+@pytest.mark.parametrize("style", ["pointing", "point_count"])
+def test_stage2_family_is_unchanged(style: str):
+    """The default must stay the templated, unprefixed stage-2 form."""
+    user, _ = _turn(style, POINTS)
+    assert not user.startswith(f"{style}:")
+    assert "leather earmuff" in user.lower()
+    assert len(user) > len(f"{style}: leather earmuff")
+
+
+def test_target_never_carries_the_prefix():
+    """Only the prompt is prefixed; the answer's label stays bare in both families.
+
+    The 08/14 checkpoint echoed ``pointing:`` back inside ``<points>...</points>`` at eval,
+    which is what a model does when the prefix is unfamiliar -- not something the targets ever
+    contained.
+    """
+    for family in ({}, STAGE1):
+        _, target = _turn("pointing", POINTS, **family)
+        assert target == '<points coords="1 1 105 205 2 300 400">leather earmuff</points>'
+
+
+def test_absent_label_abstains_in_both_families():
+    """Zero points must yield the abstention string regardless of prompt family."""
+    for family in ({}, STAGE1):
+        _, target = _turn("pointing", [], **family)
+        assert target == "There are none."


### PR DESCRIPTION
`SftFormatter` is a port of mm_olmo's `DataFormatter` for the **stage-2** prompt family — its
docstring said so: `uber_model_v2` templates plus `demo_or_style_v2`. Stage 1 used it anyway, so its
pointing data trained on

```
Point to leather earmuff
Please say 'There are none.' if it is not in the image.
```

where the released `Molmo2-4B-Pretrain` config (`prompt_templates: none`,
`system_prompt: style_and_length_v2`) trains on

```
pointing: leather earmuff
```

The evals send the released form, so our checkpoint was answering a prompt shape it had never seen.

## Measured

`pixmo_point_eval_v3_mp:test`, 1215 instances, each checkpoint prompted for its own family:

| slice | ours | released 4B-Pretrain | delta |
|---|---|---|---|
| f1 | 0.7062 | 0.8152 | −0.109 |
| precision | 0.7231 | 0.8342 | −0.111 |
| recall | 0.7232 | 0.8232 | −0.100 |
| **zero (absent objects)** | 0.7181 | 0.9128 | **−0.195** |
| single | 0.7647 | 0.8570 | −0.092 |
| low_freq | 0.7233 | 0.8387 | −0.116 |
| med_freq | 0.5795 | 0.6895 | −0.110 |
| high_freq | 0.6739 | 0.7624 | −0.089 |

Abstention is worst because the instruction to abstain — *"Please say 'There are none.'"* — exists
**only inside the stage-2 template**. Given the terse eval prompt our model has no cue to abstain,
and says "There are none" 115× where the released one says it 153×. The same mismatch made our model
echo the unfamiliar prefix into its answer: `<points coords="...">pointing: needle-nose tong</points>`.

## Two other explanations tested and eliminated first

- **Negative examples are not scarce.** Zero-count labels are 13.6% of pointing and 27.1% of
  counting label-instances under our `max_points=60` filter, versus 13.6% / 25.0% under mm_olmo's
  unfiltered defaults — we have slightly *more*.
- **Coordinates are fine.** Differencing 1925 paired points against the released model: dx/dy
  medians 0.0 / −2.0 on a 0–1000 scale, 65% of points within 2.0 units. No convention or scaling bug.

## The change

`SftFormatter` takes `prompt_templates` and `system_prompt`, **defaulting to the stage-2 family** so
`image_only_v9` is untouched. Under `style_and_length*` the pointing/counting styles get their
`"<style>:"` prefix (they live in `DEMO_STYLES`, which is what suppressed it), and under
`prompt_templates="none"` the question is the bare lowercased label, matching
`data_formatter.py:1770-1779`. The three pointing dataset configs plumb both settings, and
`Molmo2-Stage1.py` sets them via `POINTING_PROMPT_FAMILY`.

## Verification

6 new tests pin both families, that the target label never carries the prefix, and that absent
labels still abstain in both — the stage-1 assertions fail without the fix. 151 tests pass across
`src/test/data/multimodal/`. Stage-1 `dry_run` builds and the family reaches all three configs
(defaults confirmed unchanged). isort/black/ruff clean; mypy unchanged at its 3 pre-existing errors
in this file.

**This changes what stage 1 trains on**, so it needs a fresh run to land — the 08/14 checkpoint and
the two runs cancelled today all carry the stage-2 pointing form.