### PR TITLE
launch: expose Beaker minRuntime on BeakerLaunchConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OLMO_RICH_LOGGING` can now explicitly enable *or* disable rich console logging (`0`/`false`/`no`/`off` disables it); previously setting it to any value only force-enabled rich logging.
 - `init_distributed()` now bootstraps a minimal single-process environment (`RANK=0`, `WORLD_SIZE=1`, `MASTER_ADDR`/`MASTER_PORT`) when launch env vars are absent, so scripts can be run directly (without `torchrun`) for single-process debugging.
 - Added a configurable `determinism_check` option to activation checkpointing (default `"default"`); set it to `"none"` to skip torch's recompute metadata check for opaque linear-attention kernels under `torch.compile`.
+- Added `min_runtime` to `BeakerLaunchConfig` (and `--min-runtime` to the launch CLI), which sets Beaker's `minRuntime` on the task. A non-zero duration makes the job allocated, so it is guaranteed its minimum runtime within a scheduling window instead of only running on idle cycles. Defaults to `None`, leaving existing launches unallocated as before.
 
 
 ### Fixed

--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -303,6 +303,18 @@ class BeakerLaunchConfig(Config):
     If the job should be preemptible.
     """
 
+    min_runtime: str | None = None
+    """
+    Minimum guaranteed runtime, as a Beaker duration (e.g. ``"4h"``).
+
+    Setting this to a non-zero duration makes the job *allocated*: Beaker guarantees it that much
+    runtime within a scheduling window, subject to runtime quota, and it counts against the
+    workspace's non-preemptible slot limit. Leaving it unset makes the job *unallocated* -- always
+    interruptible, scheduled only on idle cycles, with no guarantee it ever starts.
+
+    Set this to cover initialization plus one full checkpoint cycle.
+    """
+
     retries: int | None = None
     """
     The number of times to retry the experiment if it fails.
@@ -638,6 +650,7 @@ class BeakerLaunchConfig(Config):
             budget=self.budget,
             priority=self.priority,
             preemptible=self.preemptible,
+            min_runtime=self.min_runtime,
             # Inputs.
             beaker_image=self._resolve_beaker_image(),
             env_vars=self._get_env_vars(),
@@ -906,6 +919,14 @@ def _parse_args():
         help="""If the job should be preemptible.""",
     )
     parser.add_argument(
+        "--min-runtime",
+        type=str,
+        default=None,
+        help="""Minimum guaranteed runtime as a Beaker duration (e.g. '4h'). Setting this makes
+        the job allocated rather than unallocated, so it is guaranteed to be scheduled within a
+        window instead of only running on idle cycles.""",
+    )
+    parser.add_argument(
         "--allow-dirty",
         action="store_true",
         help="""Allow launching with uncommitted changes.""",
@@ -1002,6 +1023,7 @@ def _build_config(opts: argparse.Namespace, command: list[str]) -> BeakerLaunchC
         num_nodes=opts.nodes,
         num_gpus=opts.gpus,
         preemptible=opts.preemptible,
+        min_runtime=opts.min_runtime,
         priority=opts.priority,
         beaker_image=opts.beaker_image,
         slack_notifications=opts.slack_notifications,


### PR DESCRIPTION
## Summary

Gantry's `Recipe` already accepts `min_runtime`, but `BeakerLaunchConfig` never passed it, so every job launched through it is **unallocated**: always interruptible, scheduled only on idle cycles, with no guarantee it ever starts. There was no way to request an allocated job short of bypassing the launcher.

Beaker classifies a job by its task's `minRuntime`:

- **allocated** (`minRuntime > 0`) — guaranteed its minimum runtime within a scheduling window, subject to runtime quota; counts against the workspace's non-preemptible slot limit.
- **unallocated** (`0s` or omitted) — no runtime guarantee, always interruptible, runs on idle cycles only.

## Changes

`src/olmo_core/launch/beaker.py`:

- `min_runtime: str | None = None` on `BeakerLaunchConfig`, documented next to `preemptible` since that is the flag it qualifies
- threaded through to `GantryRecipe`
- `--min-runtime` CLI flag, wired into `_build_config`

## Compatibility

Defaults to `None`, which is what the recipe already received implicitly, so existing launches are unchanged. Opt-in only.

## Testing

Verified the field resolves as `str | None = None` via `dataclasses.fields`, that gantry's `Recipe.__init__` accepts `min_runtime`, and that the flag, opts wiring, and recipe pass-through are all present. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HWNrUaiHaXMqYR6Zc9Nec