### PR TITLE
Add Qwen3.5 dense text HF state export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added OLMo-core to Hugging Face state conversion for Qwen3.5 dense text models.
+
 ### Changed
 
 - Raised the minimum supported PyTorch version to 2.10.0. Updated the stable Beaker images to PyTorch 2.10 with CUDA 12.8 and PyTorch 2.11 with CUDA 13.0, and expanded CI coverage to include PyTorch 2.10 and 2.11 with CUDA 12.8 and Docker builds through PyTorch 2.12 with CUDA 13.0.

--- a/src/olmo_core/nn/hf/__init__.py
+++ b/src/olmo_core/nn/hf/__init__.py
@@ -14,6 +14,7 @@ from .config import (
 from .convert import (
     convert_hybrid_state_to_hf,
     convert_qwen3_5_state_from_hf,
+    convert_qwen3_5_state_to_hf,
     convert_state_from_hf,
     convert_state_to_hf,
     get_converter_from_hf,
@@ -29,6 +30,7 @@ __all__ = [
     "convert_checkpoint_to_hf",
     "convert_hybrid_state_to_hf",
     "convert_qwen3_5_state_from_hf",
+    "convert_qwen3_5_state_to_hf",
     "convert_state_from_hf",
     "convert_state_to_hf",
     "get_converter_from_hf",

--- a/src/olmo_core/nn/hf/convert.py
+++ b/src/olmo_core/nn/hf/convert.py
@@ -1031,7 +1031,8 @@ def convert_qwen3_5_state_to_hf(
                 "Qwen3.5 config ties word embeddings, but embeddings.weight and "
                 "lm_head.w_out.weight have different dtype or device"
             )
-        if not torch.equal(embeddings, lm_head):
+        # Meta states are used for structural export preflight and have no values to compare.
+        if not embeddings.is_meta and not torch.equal(embeddings, lm_head):
             raise ValueError(
                 "Qwen3.5 config ties word embeddings, but embeddings.weight and "
                 "lm_head.w_out.weight differ"

--- a/src/olmo_core/nn/hf/convert.py
+++ b/src/olmo_core/nn/hf/convert.py
@@ -460,6 +460,30 @@ def _apply_qwen3_5_norm_transform(state: Dict[str, Any]) -> Dict[str, Any]:
     return state
 
 
+def _apply_qwen3_5_norm_inverse_transform(state: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Transform regular Qwen3.5 norm weights from OLMo format back to HF format.
+
+    This is the inverse of :func:`_apply_qwen3_5_norm_transform`. The GDN output
+    norm (``linear_attn.norm``) is intentionally excluded because both implementations
+    store that gated norm's direct multiplicative weight.
+    """
+    norm_patterns = [
+        "input_layernorm.weight",
+        "post_attention_layernorm.weight",
+        "model.norm.weight",
+        "q_norm.weight",
+        "k_norm.weight",
+    ]
+
+    for key, value in state.items():
+        if any(pattern in key for pattern in norm_patterns):
+            if isinstance(value, torch.Tensor):
+                state[key] = value - 1.0
+
+    return state
+
+
 def _get_qwen3_5_text_config(config: PretrainedConfig) -> PretrainedConfig:
     text_config = getattr(config, "text_config", None)
     if text_config is not None:
@@ -669,6 +693,380 @@ def convert_qwen3_5_state_from_hf(
     return _apply_qwen3_5_norm_transform(olmo_state)
 
 
+def _get_qwen3_5_olmo_tensor(
+    olmo_state: Dict[str, Any],
+    key: str,
+    expected_shape: tuple[int, ...],
+    used_keys: set[str],
+) -> torch.Tensor:
+    try:
+        value = olmo_state[key]
+    except KeyError:
+        raise KeyError(f"Missing required Qwen3.5 OLMo-core state key: {key}") from None
+
+    if not isinstance(value, torch.Tensor):
+        raise TypeError(f"Expected {key!r} to be a tensor, found {type(value).__name__}")
+    if tuple(value.shape) != expected_shape:
+        raise ValueError(
+            f"Unexpected shape for {key!r}: expected {expected_shape}, found {tuple(value.shape)}"
+        )
+
+    used_keys.add(key)
+    return value
+
+
+QWEN3_5_SHARED_TO_HF_KEY_MAP: Dict[str, str] = {
+    "embeddings.weight": "model.embed_tokens.weight",
+    "lm_head.norm.weight": "model.norm.weight",
+    "lm_head.w_out.weight": "lm_head.weight",
+}
+
+QWEN3_5_COMMON_LAYER_TO_HF_KEY_MAP: Dict[str, str] = {
+    "attention_norm.weight": "input_layernorm.weight",
+    "feed_forward_norm.weight": "post_attention_layernorm.weight",
+    "feed_forward.w1.weight": "mlp.gate_proj.weight",
+    "feed_forward.w2.weight": "mlp.down_proj.weight",
+    "feed_forward.w3.weight": "mlp.up_proj.weight",
+}
+
+QWEN3_5_GDN_LAYER_TO_HF_KEY_MAP: Dict[str, str] = {
+    "attention.w_g.weight": "linear_attn.in_proj_z.weight",
+    "attention.w_a.weight": "linear_attn.in_proj_a.weight",
+    "attention.w_b.weight": "linear_attn.in_proj_b.weight",
+    "attention.w_out.weight": "linear_attn.out_proj.weight",
+    "attention.o_norm.weight": "linear_attn.norm.weight",
+    "attention.A_log": "linear_attn.A_log",
+    "attention.dt_bias": "linear_attn.dt_bias",
+}
+
+QWEN3_5_ATTN_LAYER_TO_HF_KEY_MAP: Dict[str, str] = {
+    "attention.w_k.weight": "self_attn.k_proj.weight",
+    "attention.w_v.weight": "self_attn.v_proj.weight",
+    "attention.w_out.weight": "self_attn.o_proj.weight",
+    "attention.q_norm.weight": "self_attn.q_norm.weight",
+    "attention.k_norm.weight": "self_attn.k_norm.weight",
+}
+
+
+def _map_qwen3_5_state_to_hf(
+    olmo_state: Dict[str, Any],
+    expected_shapes: Dict[str, tuple[int, ...]],
+    key_map: Dict[str, str],
+    used_keys: set[str],
+    *,
+    olmo_prefix: str = "",
+    hf_prefix: str = "",
+) -> Dict[str, torch.Tensor]:
+    mapped_state: Dict[str, torch.Tensor] = {}
+    for olmo_suffix, hf_suffix in key_map.items():
+        olmo_key = f"{olmo_prefix}{olmo_suffix}"
+        mapped_state[f"{hf_prefix}{hf_suffix}"] = _get_qwen3_5_olmo_tensor(
+            olmo_state,
+            olmo_key,
+            expected_shapes[olmo_key],
+            used_keys,
+        )
+    return mapped_state
+
+
+def _convert_qwen3_5_gdn_layer_to_hf(
+    olmo_state: Dict[str, Any],
+    layer_idx: int,
+    expected_shapes: Dict[str, tuple[int, ...]],
+    used_keys: set[str],
+) -> Dict[str, torch.Tensor]:
+    prefix = f"blocks.{layer_idx}."
+    hf_prefix = f"model.layers.{layer_idx}."
+    get_tensor = lambda suffix: _get_qwen3_5_olmo_tensor(  # noqa: E731
+        olmo_state,
+        f"{prefix}{suffix}",
+        expected_shapes[f"{prefix}{suffix}"],
+        used_keys,
+    )
+
+    state = _map_qwen3_5_state_to_hf(
+        olmo_state,
+        expected_shapes,
+        QWEN3_5_COMMON_LAYER_TO_HF_KEY_MAP,
+        used_keys,
+        olmo_prefix=prefix,
+        hf_prefix=hf_prefix,
+    )
+    state.update(
+        _map_qwen3_5_state_to_hf(
+            olmo_state,
+            expected_shapes,
+            QWEN3_5_GDN_LAYER_TO_HF_KEY_MAP,
+            used_keys,
+            olmo_prefix=prefix,
+            hf_prefix=hf_prefix,
+        )
+    )
+    state.update(
+        {
+            f"{hf_prefix}linear_attn.in_proj_qkv.weight": torch.cat(
+                [
+                    get_tensor("attention.w_q.weight"),
+                    get_tensor("attention.w_k.weight"),
+                    get_tensor("attention.w_v.weight"),
+                ],
+                dim=0,
+            ),
+            f"{hf_prefix}linear_attn.conv1d.weight": torch.cat(
+                [
+                    get_tensor("attention.q_conv1d.weight"),
+                    get_tensor("attention.k_conv1d.weight"),
+                    get_tensor("attention.v_conv1d.weight"),
+                ],
+                dim=0,
+            ),
+        }
+    )
+    return state
+
+
+def _merge_qwen3_5_q_proj(
+    w_q: torch.Tensor, w_g: torch.Tensor, n_heads: int, head_dim: int
+) -> torch.Tensor:
+    """
+    Interleave separate OLMo query and gate weights in HF's per-head layout.
+    """
+    hidden_size = w_q.shape[1]
+    q = w_q.reshape(n_heads, head_dim, hidden_size)
+    gate = w_g.reshape(n_heads, head_dim, hidden_size)
+    return torch.stack((q, gate), dim=1).reshape(2 * n_heads * head_dim, hidden_size)
+
+
+def _convert_qwen3_5_attn_layer_to_hf(
+    olmo_state: Dict[str, Any],
+    layer_idx: int,
+    n_heads: int,
+    head_dim: int,
+    expected_shapes: Dict[str, tuple[int, ...]],
+    used_keys: set[str],
+) -> Dict[str, torch.Tensor]:
+    prefix = f"blocks.{layer_idx}."
+    hf_prefix = f"model.layers.{layer_idx}."
+    get_tensor = lambda suffix: _get_qwen3_5_olmo_tensor(  # noqa: E731
+        olmo_state,
+        f"{prefix}{suffix}",
+        expected_shapes[f"{prefix}{suffix}"],
+        used_keys,
+    )
+
+    w_q = get_tensor("attention.w_q.weight")
+    w_g = get_tensor("attention.w_g.weight")
+    state = _map_qwen3_5_state_to_hf(
+        olmo_state,
+        expected_shapes,
+        QWEN3_5_COMMON_LAYER_TO_HF_KEY_MAP,
+        used_keys,
+        olmo_prefix=prefix,
+        hf_prefix=hf_prefix,
+    )
+    state.update(
+        _map_qwen3_5_state_to_hf(
+            olmo_state,
+            expected_shapes,
+            QWEN3_5_ATTN_LAYER_TO_HF_KEY_MAP,
+            used_keys,
+            olmo_prefix=prefix,
+            hf_prefix=hf_prefix,
+        )
+    )
+    state.update(
+        {
+            f"{hf_prefix}self_attn.q_proj.weight": _merge_qwen3_5_q_proj(
+                w_q, w_g, n_heads, head_dim
+            ),
+        }
+    )
+    return state
+
+
+def _get_qwen3_5_expected_olmo_shapes(
+    text_config: PretrainedConfig, layer_types: List[str]
+) -> Dict[str, tuple[int, ...]]:
+    hidden_size = int(text_config.hidden_size)
+    intermediate_size = int(text_config.intermediate_size)
+    vocab_size = int(text_config.vocab_size)
+    n_heads = int(text_config.num_attention_heads)
+    n_kv_heads = int(text_config.num_key_value_heads)
+    head_dim = int(text_config.head_dim)
+    n_key_heads = int(text_config.linear_num_key_heads)
+    n_value_heads = int(text_config.linear_num_value_heads)
+    key_head_dim = int(text_config.linear_key_head_dim)
+    value_head_dim = int(text_config.linear_value_head_dim)
+    conv_kernel_dim = int(text_config.linear_conv_kernel_dim)
+    key_dim = n_key_heads * key_head_dim
+    value_dim = n_value_heads * value_head_dim
+    query_dim = n_heads * head_dim
+    kv_dim = n_kv_heads * head_dim
+
+    shapes: Dict[str, tuple[int, ...]] = {
+        "embeddings.weight": (vocab_size, hidden_size),
+        "lm_head.norm.weight": (hidden_size,),
+        "lm_head.w_out.weight": (vocab_size, hidden_size),
+    }
+    for layer_idx, layer_type in enumerate(layer_types):
+        prefix = f"blocks.{layer_idx}."
+        shapes.update(
+            {
+                f"{prefix}attention_norm.weight": (hidden_size,),
+                f"{prefix}feed_forward_norm.weight": (hidden_size,),
+                f"{prefix}feed_forward.w1.weight": (intermediate_size, hidden_size),
+                f"{prefix}feed_forward.w2.weight": (hidden_size, intermediate_size),
+                f"{prefix}feed_forward.w3.weight": (intermediate_size, hidden_size),
+            }
+        )
+        if layer_type == "linear_attention":
+            shapes.update(
+                {
+                    f"{prefix}attention.w_q.weight": (key_dim, hidden_size),
+                    f"{prefix}attention.w_k.weight": (key_dim, hidden_size),
+                    f"{prefix}attention.w_v.weight": (value_dim, hidden_size),
+                    f"{prefix}attention.w_g.weight": (value_dim, hidden_size),
+                    f"{prefix}attention.w_a.weight": (n_value_heads, hidden_size),
+                    f"{prefix}attention.w_b.weight": (n_value_heads, hidden_size),
+                    f"{prefix}attention.w_out.weight": (hidden_size, value_dim),
+                    f"{prefix}attention.q_conv1d.weight": (
+                        key_dim,
+                        1,
+                        conv_kernel_dim,
+                    ),
+                    f"{prefix}attention.k_conv1d.weight": (
+                        key_dim,
+                        1,
+                        conv_kernel_dim,
+                    ),
+                    f"{prefix}attention.v_conv1d.weight": (
+                        value_dim,
+                        1,
+                        conv_kernel_dim,
+                    ),
+                    f"{prefix}attention.o_norm.weight": (value_head_dim,),
+                    f"{prefix}attention.A_log": (n_value_heads,),
+                    f"{prefix}attention.dt_bias": (n_value_heads,),
+                }
+            )
+        elif layer_type == "full_attention":
+            shapes.update(
+                {
+                    f"{prefix}attention.w_q.weight": (query_dim, hidden_size),
+                    f"{prefix}attention.w_g.weight": (query_dim, hidden_size),
+                    f"{prefix}attention.w_k.weight": (kv_dim, hidden_size),
+                    f"{prefix}attention.w_v.weight": (kv_dim, hidden_size),
+                    f"{prefix}attention.w_out.weight": (hidden_size, query_dim),
+                    f"{prefix}attention.q_norm.weight": (head_dim,),
+                    f"{prefix}attention.k_norm.weight": (head_dim,),
+                }
+            )
+        else:
+            raise ValueError(f"Unknown layer type {layer_type!r} at layer {layer_idx}")
+
+    return shapes
+
+
+@beta_feature
+def convert_qwen3_5_state_to_hf(
+    config: PretrainedConfig,
+    olmo_core_state: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Convert an unsharded OLMo-core Qwen3.5 text model state dict to official HF format.
+
+    The returned state is loadable by Hugging Face's ``Qwen3_5ForCausalLM``. Official
+    multimodal Qwen3.5 models include an additional vision tower and are outside this
+    converter's scope.
+
+    :param config: A Hugging Face ``Qwen3_5TextConfig``.
+    :param olmo_core_state: A complete canonical, unsharded OLMo-core model state dict.
+    """
+    if config.model_type != "qwen3_5_text":
+        raise ValueError("Qwen3.5 state export supports text models only; pass a Qwen3_5TextConfig")
+
+    layer_types = getattr(config, "layer_types", None)
+    n_layers = int(config.num_hidden_layers)
+    if layer_types is None or len(layer_types) != n_layers:
+        raise ValueError(
+            f"Expected one Qwen3.5 layer type per layer ({n_layers}), found {layer_types!r}"
+        )
+
+    wrapper_keys = sorted(
+        key for key in olmo_core_state if key == "model" or key.startswith(("model.", "module."))
+    )
+    if wrapper_keys:
+        raise ValueError(
+            "Qwen3.5 conversion expects canonical unwrapped OLMo-core state keys; "
+            f"found {wrapper_keys[:5]}"
+        )
+
+    n_heads = int(config.num_attention_heads)
+    head_dim = int(config.head_dim)
+
+    expected_shapes = _get_qwen3_5_expected_olmo_shapes(config, list(layer_types))
+    missing_keys = sorted(set(expected_shapes) - set(olmo_core_state))
+    if missing_keys:
+        raise KeyError(f"Missing required Qwen3.5 OLMo-core state keys: {missing_keys}")
+    unused_keys = sorted(set(olmo_core_state) - set(expected_shapes))
+    if unused_keys:
+        raise RuntimeError(f"Some state keys were not converted: {unused_keys}")
+
+    validated_keys: set[str] = set()
+    for key, shape in expected_shapes.items():
+        _get_qwen3_5_olmo_tensor(olmo_core_state, key, shape, validated_keys)
+
+    used_keys: set[str] = set()
+    hf_state: Dict[str, Any] = _map_qwen3_5_state_to_hf(
+        olmo_core_state,
+        expected_shapes,
+        QWEN3_5_SHARED_TO_HF_KEY_MAP,
+        used_keys,
+    )
+    embeddings = hf_state["model.embed_tokens.weight"]
+    lm_head = hf_state["lm_head.weight"]
+    if getattr(config, "tie_word_embeddings", False):
+        if embeddings.dtype != lm_head.dtype or embeddings.device != lm_head.device:
+            raise ValueError(
+                "Qwen3.5 config ties word embeddings, but embeddings.weight and "
+                "lm_head.w_out.weight have different dtype or device"
+            )
+        if not torch.equal(embeddings, lm_head):
+            raise ValueError(
+                "Qwen3.5 config ties word embeddings, but embeddings.weight and "
+                "lm_head.w_out.weight differ"
+            )
+
+    for layer_idx, layer_type in enumerate(layer_types):
+        if layer_type == "linear_attention":
+            hf_state.update(
+                _convert_qwen3_5_gdn_layer_to_hf(
+                    olmo_core_state,
+                    layer_idx,
+                    expected_shapes,
+                    used_keys,
+                )
+            )
+        elif layer_type == "full_attention":
+            hf_state.update(
+                _convert_qwen3_5_attn_layer_to_hf(
+                    olmo_core_state,
+                    layer_idx,
+                    n_heads,
+                    head_dim,
+                    expected_shapes,
+                    used_keys,
+                )
+            )
+        else:
+            raise ValueError(f"Unknown layer type {layer_type!r} at layer {layer_idx}")
+
+    if used_keys != set(expected_shapes):
+        raise RuntimeError("Internal error: not all validated Qwen3.5 state keys were converted")
+
+    return _apply_qwen3_5_norm_inverse_transform(hf_state)
+
+
 def _convert_state(
     config: PretrainedConfig,
     state: Dict[str, Any],
@@ -771,7 +1169,8 @@ def _apply_gemma3_norm_inverse_transform(state: Dict[str, Any]) -> Dict[str, Any
 
 @beta_feature
 def convert_state_to_hf(
-    config: PretrainedConfig, olmo_core_state: Dict[str, Any]
+    config: PretrainedConfig,
+    olmo_core_state: Dict[str, Any],
 ) -> Dict[str, Any]:
     """
     Converts an *unsharded* model state dict of OLMo Core format into Hugging Face transformers format.
@@ -780,6 +1179,14 @@ def convert_state_to_hf(
     :param olmo_core_state: An unsharded OLMo Core model state dict. None of the states can be
         :class:`DTensor` or :class:`ShardedTensor`
     """
+
+    if config.model_type == "qwen3_5":
+        raise ValueError(
+            "Official multimodal Qwen3.5 export is not supported; pass config.text_config "
+            "to export the text model"
+        )
+    if config.model_type == "qwen3_5_text":
+        return convert_qwen3_5_state_to_hf(config, olmo_core_state)
 
     converter = _get_converter_to_hf(config.model_type)
 

--- a/src/test/nn/hf/qwen3_5_convert_test.py
+++ b/src/test/nn/hf/qwen3_5_convert_test.py
@@ -1,0 +1,438 @@
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import load_file
+from transformers import Qwen3_5Config, Qwen3_5ForCausalLM, Qwen3_5TextConfig
+
+from olmo_core.nn.hf.convert import (
+    convert_qwen3_5_state_from_hf,
+    convert_qwen3_5_state_to_hf,
+    convert_state_from_hf,
+    convert_state_to_hf,
+)
+
+
+def _text_config(*, tie_word_embeddings: bool = False) -> Qwen3_5TextConfig:
+    return Qwen3_5TextConfig(
+        vocab_size=16,
+        hidden_size=8,
+        intermediate_size=12,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=2,
+        linear_num_key_heads=1,
+        linear_key_head_dim=2,
+        linear_num_value_heads=2,
+        linear_value_head_dim=2,
+        linear_conv_kernel_dim=4,
+        layer_types=["linear_attention", "full_attention"],
+        tie_word_embeddings=tie_word_embeddings,
+    )
+
+
+def _tensor(shape: tuple[int, ...], value: float) -> torch.Tensor:
+    numel = 1
+    for size in shape:
+        numel *= size
+    return torch.arange(numel, dtype=torch.float32).reshape(shape) / 100 + value
+
+
+def _olmo_state(*, tied: bool = False) -> dict[str, torch.Tensor]:
+    state = {
+        "embeddings.weight": _tensor((16, 8), 1),
+        "lm_head.norm.weight": _tensor((8,), 1),
+        "lm_head.w_out.weight": _tensor((16, 8), 2),
+        # GDN layer.
+        "blocks.0.attention.w_q.weight": _tensor((2, 8), 10),
+        "blocks.0.attention.w_k.weight": _tensor((2, 8), 20),
+        "blocks.0.attention.w_v.weight": _tensor((4, 8), 30),
+        "blocks.0.attention.w_g.weight": _tensor((4, 8), 40),
+        "blocks.0.attention.w_a.weight": _tensor((2, 8), 50),
+        "blocks.0.attention.w_b.weight": _tensor((2, 8), 60),
+        "blocks.0.attention.w_out.weight": _tensor((8, 4), 70),
+        "blocks.0.attention.q_conv1d.weight": _tensor((2, 1, 4), 80),
+        "blocks.0.attention.k_conv1d.weight": _tensor((2, 1, 4), 90),
+        "blocks.0.attention.v_conv1d.weight": _tensor((4, 1, 4), 100),
+        "blocks.0.attention.o_norm.weight": _tensor((2,), 110),
+        "blocks.0.attention.A_log": _tensor((2,), 120),
+        "blocks.0.attention.dt_bias": _tensor((2,), 130),
+        "blocks.0.attention_norm.weight": _tensor((8,), 1),
+        "blocks.0.feed_forward_norm.weight": _tensor((8,), 1.25),
+        "blocks.0.feed_forward.w1.weight": _tensor((12, 8), 140),
+        "blocks.0.feed_forward.w2.weight": _tensor((8, 12), 150),
+        "blocks.0.feed_forward.w3.weight": _tensor((12, 8), 160),
+        # Full-attention layer.
+        "blocks.1.attention.w_q.weight": _tensor((4, 8), 170),
+        "blocks.1.attention.w_g.weight": _tensor((4, 8), 180),
+        "blocks.1.attention.w_k.weight": _tensor((2, 8), 190),
+        "blocks.1.attention.w_v.weight": _tensor((2, 8), 200),
+        "blocks.1.attention.w_out.weight": _tensor((8, 4), 210),
+        "blocks.1.attention.q_norm.weight": _tensor((2,), 1.5),
+        "blocks.1.attention.k_norm.weight": _tensor((2,), 1.75),
+        "blocks.1.attention_norm.weight": _tensor((8,), 2),
+        "blocks.1.feed_forward_norm.weight": _tensor((8,), 2.25),
+        "blocks.1.feed_forward.w1.weight": _tensor((12, 8), 220),
+        "blocks.1.feed_forward.w2.weight": _tensor((8, 12), 230),
+        "blocks.1.feed_forward.w3.weight": _tensor((12, 8), 240),
+    }
+    if tied:
+        # DCP reconstruction preserves logical values but may not preserve storage aliasing.
+        state["lm_head.w_out.weight"] = state["embeddings.weight"].clone()
+    return state
+
+
+def _regular_norm_keys() -> set[str]:
+    return {
+        "lm_head.norm.weight",
+        "blocks.0.attention_norm.weight",
+        "blocks.0.feed_forward_norm.weight",
+        "blocks.1.attention.q_norm.weight",
+        "blocks.1.attention.k_norm.weight",
+        "blocks.1.attention_norm.weight",
+        "blocks.1.feed_forward_norm.weight",
+    }
+
+
+def _regular_hf_norm_keys(state: dict[str, torch.Tensor]) -> set[str]:
+    patterns = (
+        "input_layernorm.weight",
+        "post_attention_layernorm.weight",
+        "model.norm.weight",
+        "q_norm.weight",
+        "k_norm.weight",
+    )
+    return {key for key in state if any(pattern in key for pattern in patterns)}
+
+
+def test_qwen3_5_to_hf_uses_official_fused_layouts_and_is_non_mutating():
+    config = _text_config()
+    olmo_state = _olmo_state()
+    original = deepcopy(olmo_state)
+
+    hf_state = convert_qwen3_5_state_to_hf(config, olmo_state)
+
+    torch.testing.assert_close(
+        hf_state["model.layers.0.linear_attn.in_proj_qkv.weight"],
+        torch.cat(
+            [
+                original["blocks.0.attention.w_q.weight"],
+                original["blocks.0.attention.w_k.weight"],
+                original["blocks.0.attention.w_v.weight"],
+            ]
+        ),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        hf_state["model.layers.0.linear_attn.conv1d.weight"],
+        torch.cat(
+            [
+                original["blocks.0.attention.q_conv1d.weight"],
+                original["blocks.0.attention.k_conv1d.weight"],
+                original["blocks.0.attention.v_conv1d.weight"],
+            ]
+        ),
+        rtol=0,
+        atol=0,
+    )
+
+    q_proj = hf_state["model.layers.1.self_attn.q_proj.weight"]
+    for head_idx in range(config.num_attention_heads):
+        olmo_start = head_idx * config.head_dim
+        hf_start = head_idx * 2 * config.head_dim
+        torch.testing.assert_close(
+            q_proj[hf_start : hf_start + config.head_dim],
+            original["blocks.1.attention.w_q.weight"][olmo_start : olmo_start + config.head_dim],
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            q_proj[hf_start + config.head_dim : hf_start + 2 * config.head_dim],
+            original["blocks.1.attention.w_g.weight"][olmo_start : olmo_start + config.head_dim],
+            rtol=0,
+            atol=0,
+        )
+
+    torch.testing.assert_close(
+        hf_state["model.layers.0.linear_attn.norm.weight"],
+        original["blocks.0.attention.o_norm.weight"],
+        rtol=0,
+        atol=0,
+    )
+    for olmo_key, hf_key in [
+        ("lm_head.norm.weight", "model.norm.weight"),
+        ("blocks.0.attention_norm.weight", "model.layers.0.input_layernorm.weight"),
+        (
+            "blocks.1.attention.q_norm.weight",
+            "model.layers.1.self_attn.q_norm.weight",
+        ),
+    ]:
+        torch.testing.assert_close(hf_state[hf_key], original[olmo_key] - 1, rtol=0, atol=0)
+
+    expected_q_proj = torch.cat(
+        [
+            tensor
+            for head_idx in range(config.num_attention_heads)
+            for tensor in (
+                original["blocks.1.attention.w_q.weight"][
+                    head_idx * config.head_dim : (head_idx + 1) * config.head_dim
+                ],
+                original["blocks.1.attention.w_g.weight"][
+                    head_idx * config.head_dim : (head_idx + 1) * config.head_dim
+                ],
+            )
+        ]
+    )
+    expected = {
+        "model.embed_tokens.weight": original["embeddings.weight"],
+        "model.norm.weight": original["lm_head.norm.weight"] - 1,
+        "lm_head.weight": original["lm_head.w_out.weight"],
+        "model.layers.0.linear_attn.in_proj_qkv.weight": torch.cat(
+            [
+                original["blocks.0.attention.w_q.weight"],
+                original["blocks.0.attention.w_k.weight"],
+                original["blocks.0.attention.w_v.weight"],
+            ]
+        ),
+        "model.layers.0.linear_attn.in_proj_z.weight": original["blocks.0.attention.w_g.weight"],
+        "model.layers.0.linear_attn.in_proj_a.weight": original["blocks.0.attention.w_a.weight"],
+        "model.layers.0.linear_attn.in_proj_b.weight": original["blocks.0.attention.w_b.weight"],
+        "model.layers.0.linear_attn.out_proj.weight": original["blocks.0.attention.w_out.weight"],
+        "model.layers.0.linear_attn.conv1d.weight": torch.cat(
+            [
+                original["blocks.0.attention.q_conv1d.weight"],
+                original["blocks.0.attention.k_conv1d.weight"],
+                original["blocks.0.attention.v_conv1d.weight"],
+            ]
+        ),
+        "model.layers.0.linear_attn.norm.weight": original["blocks.0.attention.o_norm.weight"],
+        "model.layers.0.linear_attn.A_log": original["blocks.0.attention.A_log"],
+        "model.layers.0.linear_attn.dt_bias": original["blocks.0.attention.dt_bias"],
+        "model.layers.0.input_layernorm.weight": original["blocks.0.attention_norm.weight"] - 1,
+        "model.layers.0.post_attention_layernorm.weight": original[
+            "blocks.0.feed_forward_norm.weight"
+        ]
+        - 1,
+        "model.layers.0.mlp.gate_proj.weight": original["blocks.0.feed_forward.w1.weight"],
+        "model.layers.0.mlp.down_proj.weight": original["blocks.0.feed_forward.w2.weight"],
+        "model.layers.0.mlp.up_proj.weight": original["blocks.0.feed_forward.w3.weight"],
+        "model.layers.1.self_attn.q_proj.weight": expected_q_proj,
+        "model.layers.1.self_attn.k_proj.weight": original["blocks.1.attention.w_k.weight"],
+        "model.layers.1.self_attn.v_proj.weight": original["blocks.1.attention.w_v.weight"],
+        "model.layers.1.self_attn.o_proj.weight": original["blocks.1.attention.w_out.weight"],
+        "model.layers.1.self_attn.q_norm.weight": original["blocks.1.attention.q_norm.weight"] - 1,
+        "model.layers.1.self_attn.k_norm.weight": original["blocks.1.attention.k_norm.weight"] - 1,
+        "model.layers.1.input_layernorm.weight": original["blocks.1.attention_norm.weight"] - 1,
+        "model.layers.1.post_attention_layernorm.weight": original[
+            "blocks.1.feed_forward_norm.weight"
+        ]
+        - 1,
+        "model.layers.1.mlp.gate_proj.weight": original["blocks.1.feed_forward.w1.weight"],
+        "model.layers.1.mlp.down_proj.weight": original["blocks.1.feed_forward.w2.weight"],
+        "model.layers.1.mlp.up_proj.weight": original["blocks.1.feed_forward.w3.weight"],
+    }
+    assert hf_state.keys() == expected.keys()
+    for key, expected_value in expected.items():
+        torch.testing.assert_close(hf_state[key], expected_value, rtol=0, atol=0)
+
+    assert olmo_state.keys() == original.keys()
+    for key in olmo_state:
+        torch.testing.assert_close(olmo_state[key], original[key], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("tied", [False, True])
+def test_qwen3_5_bidirectional_roundtrips_complete_state(tied: bool):
+    config = _text_config(tie_word_embeddings=tied)
+    olmo_state = _olmo_state(tied=tied)
+
+    hf_state = convert_state_to_hf(config, olmo_state)
+    olmo_roundtrip = convert_state_from_hf(config, hf_state, model_type=config.model_type)
+
+    assert olmo_roundtrip.keys() == olmo_state.keys()
+    for key, expected in olmo_state.items():
+        torch.testing.assert_close(olmo_roundtrip[key], expected, rtol=0, atol=0)
+
+    hf_roundtrip = convert_qwen3_5_state_to_hf(
+        config,
+        convert_qwen3_5_state_from_hf(config, hf_state),
+    )
+    assert hf_roundtrip.keys() == hf_state.keys()
+    for key, expected in hf_state.items():
+        torch.testing.assert_close(hf_roundtrip[key], expected, rtol=0, atol=0)
+
+
+def test_qwen3_5_multimodal_export_is_out_of_scope():
+    wrapper_config = Qwen3_5Config(text_config=_text_config(tie_word_embeddings=True))
+
+    with pytest.raises(ValueError, match="multimodal Qwen3.5 export is not supported"):
+        convert_state_to_hf(wrapper_config, _olmo_state(tied=True))
+
+
+@pytest.mark.parametrize("tied", [False, True])
+def test_qwen3_5_strict_load(tied: bool):
+    config = _text_config(tie_word_embeddings=tied)
+    model = Qwen3_5ForCausalLM(config)
+    hf_state = convert_state_to_hf(config, _olmo_state(tied=tied))
+
+    incompatible = model.load_state_dict(hf_state, strict=True)
+
+    assert incompatible.missing_keys == []
+    assert incompatible.unexpected_keys == []
+
+
+@pytest.mark.parametrize("tied", [False, True])
+def test_qwen3_5_save_pretrained_and_reload(tmp_path: Path, tied: bool):
+    config = _text_config(tie_word_embeddings=tied)
+    hf_state = convert_state_to_hf(config, _olmo_state(tied=tied))
+    model = Qwen3_5ForCausalLM(config)
+    model.load_state_dict(hf_state, strict=True)
+
+    model.save_pretrained(tmp_path)
+    reloaded = Qwen3_5ForCausalLM.from_pretrained(tmp_path)
+    saved_state = load_file(tmp_path / "model.safetensors")
+
+    assert reloaded.config.model_type == "qwen3_5_text"
+    expected_saved_keys = set(hf_state)
+    if tied:
+        # Transformers deduplicates the aliased LM head during serialization.
+        expected_saved_keys.remove("lm_head.weight")
+    assert saved_state.keys() == expected_saved_keys
+    for key, expected in hf_state.items():
+        if key in saved_state:
+            assert saved_state[key].shape == expected.shape
+        torch.testing.assert_close(reloaded.state_dict()[key], expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_qwen3_5_olmo_origin_low_precision_norm_roundtrip_is_exact(dtype: torch.dtype):
+    config = _text_config()
+    olmo_state = {key: value.to(dtype) for key, value in _olmo_state().items()}
+    for key in _regular_norm_keys():
+        olmo_state[key] = torch.linspace(0.75, 1.25, olmo_state[key].numel(), dtype=dtype)
+
+    roundtrip = convert_qwen3_5_state_from_hf(
+        config,
+        convert_qwen3_5_state_to_hf(config, olmo_state),
+    )
+
+    for key, expected in olmo_state.items():
+        torch.testing.assert_close(roundtrip[key], expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_qwen3_5_hf_origin_low_precision_norm_roundtrip_matches_native_arithmetic(
+    dtype: torch.dtype,
+):
+    config = _text_config()
+    hf_state = {
+        key: value.to(dtype)
+        for key, value in convert_qwen3_5_state_to_hf(config, _olmo_state()).items()
+    }
+    for key in _regular_hf_norm_keys(hf_state):
+        # Include the magnitude observed in official Qwen3.5 norm tensors. BF16
+        # spacing grows with magnitude, so a constant epsilon is not a valid
+        # global bound for the add-one/subtract-one roundtrip.
+        hf_state[key] = torch.linspace(-0.75, 5.5, hf_state[key].numel(), dtype=dtype)
+
+    roundtrip = convert_qwen3_5_state_to_hf(
+        config,
+        convert_qwen3_5_state_from_hf(config, hf_state),
+    )
+
+    changed_norm_keys = set()
+    for key, expected in hf_state.items():
+        if key in _regular_hf_norm_keys(hf_state):
+            native_arithmetic = (expected + 1.0) - 1.0
+            torch.testing.assert_close(roundtrip[key], native_arithmetic, rtol=0, atol=0)
+            if not torch.equal(native_arithmetic, expected):
+                changed_norm_keys.add(key)
+        else:
+            torch.testing.assert_close(roundtrip[key], expected, rtol=0, atol=0)
+    # The existing importer stores the affine transform in the source dtype, so
+    # precision discarded by that intermediate representation cannot be recovered.
+    assert changed_norm_keys
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error", "message"),
+    [
+        ("missing", KeyError, "Missing required"),
+        ("extra", RuntimeError, "Some state keys were not converted"),
+        ("shape", ValueError, "Unexpected shape"),
+        ("value", TypeError, "to be a tensor"),
+        ("wrapper", ValueError, "canonical unwrapped"),
+    ],
+)
+def test_qwen3_5_rejects_malformed_state(mutation, error, message):
+    config = _text_config()
+    state = _olmo_state()
+    if mutation == "missing":
+        del state["blocks.0.attention.w_a.weight"]
+    elif mutation == "extra":
+        state["unexpected.weight"] = torch.ones(1)
+    elif mutation == "shape":
+        state["blocks.0.attention.w_a.weight"] = torch.ones(3, 8)
+    elif mutation == "value":
+        state["blocks.0.attention.w_a.weight"] = "not a tensor"  # type: ignore[assignment]
+    elif mutation == "wrapper":
+        state["module.unexpected.weight"] = torch.ones(1)
+
+    with pytest.raises(error, match=message):
+        convert_qwen3_5_state_to_hf(config, state)
+
+
+def test_qwen3_5_rejects_unknown_or_incomplete_layer_types():
+    config = _text_config()
+    config.layer_types[0] = "unknown"
+    with pytest.raises(ValueError, match="Unknown layer type"):
+        convert_qwen3_5_state_to_hf(config, _olmo_state())
+
+    config = _text_config()
+    config.layer_types.pop()
+    with pytest.raises(ValueError, match="one Qwen3.5 layer type per layer"):
+        convert_qwen3_5_state_to_hf(config, _olmo_state())
+
+
+def test_qwen3_5_tied_embeddings_must_agree():
+    config = _text_config(tie_word_embeddings=True)
+    state = _olmo_state(tied=True)
+    assert state["embeddings.weight"].data_ptr() != state["lm_head.w_out.weight"].data_ptr()
+    hf_state = convert_qwen3_5_state_to_hf(config, state)
+    torch.testing.assert_close(
+        hf_state["model.embed_tokens.weight"], hf_state["lm_head.weight"], rtol=0, atol=0
+    )
+
+    state["lm_head.w_out.weight"] = state["embeddings.weight"]
+    convert_qwen3_5_state_to_hf(config, state)
+
+    with pytest.raises(ValueError, match="ties word embeddings.*differ"):
+        convert_qwen3_5_state_to_hf(config, _olmo_state(tied=False))
+
+    state = _olmo_state(tied=True)
+    state["lm_head.w_out.weight"] = state["lm_head.w_out.weight"].double()
+    with pytest.raises(ValueError, match="different dtype or device"):
+        convert_qwen3_5_state_to_hf(config, state)
+
+
+def test_qwen3_5_does_not_implicitly_resize_vocabulary():
+    config = _text_config()
+    state = _olmo_state()
+    state["embeddings.weight"] = torch.ones(17, 8)
+    state["lm_head.w_out.weight"] = torch.ones(17, 8)
+
+    with pytest.raises(ValueError, match=r"expected \(16, 8\), found \(17, 8\)"):
+        convert_qwen3_5_state_to_hf(config, state)
+
+
+def test_qwen3_5_accepts_non_contiguous_query_and_gate_weights():
+    state = _olmo_state()
+    for key in ("blocks.1.attention.w_q.weight", "blocks.1.attention.w_g.weight"):
+        state[key] = state[key].T.contiguous().T
+        assert not state[key].is_contiguous()
+
+    hf_state = convert_qwen3_5_state_to_hf(_text_config(), state)
+
+    assert hf_state["model.layers.1.self_attn.q_proj.weight"].shape == (8, 8)

--- a/src/test/nn/hf/qwen3_5_convert_test.py
+++ b/src/test/nn/hf/qwen3_5_convert_test.py
@@ -417,6 +417,29 @@ def test_qwen3_5_tied_embeddings_must_agree():
         convert_qwen3_5_state_to_hf(config, state)
 
 
+def test_qwen3_5_tied_embeddings_support_meta_preflight():
+    config = _text_config(tie_word_embeddings=True)
+    expected = convert_state_to_hf(config, _olmo_state(tied=True))
+    meta_state = {key: tensor.to(device="meta") for key, tensor in _olmo_state(tied=True).items()}
+
+    actual = convert_state_to_hf(config, meta_state)
+
+    assert actual.keys() == expected.keys()
+    for key, tensor in actual.items():
+        assert tensor.is_meta
+        assert tensor.shape == expected[key].shape
+        assert tensor.dtype == expected[key].dtype
+
+
+def test_qwen3_5_tied_embeddings_reject_mixed_meta_state():
+    config = _text_config(tie_word_embeddings=True)
+    state = {key: tensor.to(device="meta") for key, tensor in _olmo_state(tied=True).items()}
+    state["lm_head.w_out.weight"] = torch.empty_like(state["lm_head.w_out.weight"], device="cpu")
+
+    with pytest.raises(ValueError, match="different dtype or device"):
+        convert_qwen3_5_state_to_hf(config, state)
+
+
 def test_qwen3_5_does_not_implicitly_resize_vocabulary():
     config = _text_config()
     state = _olmo_state()

--- a/src/test/nn/hf/qwen3_5_test.py
+++ b/src/test/nn/hf/qwen3_5_test.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from olmo_core.nn.attention import AttentionBackendName
-from olmo_core.nn.hf.convert import convert_state_from_hf
+from olmo_core.nn.hf.convert import convert_state_from_hf, convert_state_to_hf
 from olmo_core.nn.transformer import TransformerConfig
 from olmo_core.testing.utils import requires_fla, requires_gpu
 
@@ -88,3 +88,67 @@ def test_qwen3_5_matches_huggingface():
     print(f"Logits diff mean: {diff.mean().item():.2e}, max: {diff.max().item():.2e}")
 
     torch.testing.assert_close(hf_logits, olmo_logits, rtol=1e-3, atol=5e-3)
+
+
+@pytest.mark.skipif(not _has_qwen3_5_transformers(), reason="transformers lacks Qwen3.5 support")
+@requires_gpu
+@requires_fla
+def test_qwen3_5_state_export_matches_huggingface(tmp_path):
+    import transformers
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    hf_config = transformers.Qwen3_5TextConfig(
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_num_value_heads=2,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        layer_types=["linear_attention", "linear_attention", "linear_attention", "full_attention"],
+        tie_word_embeddings=True,
+    )
+    hf_model = transformers.Qwen3_5ForCausalLM(hf_config).eval().to(device)
+
+    olmo_config = _get_qwen3_5_config(hf_model.config)
+    olmo_model = olmo_config.build(init_device="cpu").eval().to(device)
+    converted_state = convert_state_from_hf(
+        hf_model.config,
+        hf_model.state_dict(),
+        model_type="qwen3_5_text",
+    )
+    olmo_model.load_state_dict(converted_state, strict=True)
+
+    exported_state = convert_state_to_hf(hf_model.config, olmo_model.state_dict())
+    reference_state = hf_model.state_dict()
+    assert exported_state.keys() == reference_state.keys()
+    for key, value in exported_state.items():
+        assert value.shape == reference_state[key].shape
+        assert value.dtype == reference_state[key].dtype
+
+    exported_hf_model = transformers.Qwen3_5ForCausalLM(hf_config).eval()
+    incompatible = exported_hf_model.load_state_dict(exported_state, strict=True)
+    assert incompatible.missing_keys == []
+    assert incompatible.unexpected_keys == []
+
+    exported_hf_model.save_pretrained(tmp_path)
+    reloaded_hf_model = transformers.Qwen3_5ForCausalLM.from_pretrained(tmp_path).eval()
+    exported_hf_model.to(device)
+    reloaded_hf_model.to(device)
+
+    input_ids = torch.randint(0, hf_config.vocab_size, (2, 8), device=device)
+
+    with torch.no_grad():
+        olmo_logits = olmo_model(input_ids)
+        exported_hf_logits = exported_hf_model(input_ids=input_ids).logits
+        reloaded_hf_logits = reloaded_hf_model(input_ids=input_ids).logits
+
+    torch.testing.assert_close(olmo_logits, exported_hf_logits, rtol=1e-3, atol=5e-3)
+    torch.testing.assert_close(exported_hf_logits, reloaded_hf_logits, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

- Add the inverse of the specialized Qwen3.5 HF importer for canonical, unsharded OLMo-core model state dictionaries.
- Reconstruct official `qwen3_5_text` GatedDeltaNet Q/K/V and convolution fusions, full-attention query/gate interleaving, and regular RMSNorm parameterization.
- Declare direct shared, common-layer, GatedDeltaNet, and full-attention key mappings, keeping custom tensor operations only for the fused and interleaved layouts.
- Preserve tied and untied embedding/LM-head semantics and dispatch text configs through `convert_state_to_hf`.
- Reject incomplete, malformed, or wrapped state before allocating converted tensors.
- Support tied-weight structural export preflight on meta tensors while retaining exact equality validation for materialized tied weights and rejecting mixed-device states.

This intentionally exports official dense text state for `Qwen3_5ForCausalLM`. It does not reconstruct the multimodal wrapper or vision/MTP weights, gather distributed checkpoints, implement Qwen3.5 tensor parallelism, or change the generic hybrid checkpoint writer.

## Validation

- `make checks`
- `python -m pytest -q src/test/nn/hf/qwen3_5_convert_test.py src/test/nn/hf/convert_test.py src/test/nn/hf/qwen3_5_test.py -k 'not logprobs_match_after_roundtrip'` (34 passed, 2 skipped, 2 deselected)
- Adjacent checkpoint suite (38 passed)
- Existing distributed-checkpoint unshard test on the available CPU/Gloo backend
  (1 passed, 1 skipped)
- Deterministic mixed GDN/full-attention HF → OLMo → HF roundtrip with zero FP32 tensor error, strict `Qwen3_5ForCausalLM` load, `save_pretrained`, and reload
- `python -m pytest -q src/test/nn/hf/qwen3_5_test.py::test_qwen3_5_state_export_matches_huggingface` on one NVIDIA A100-SXM-64GB (1 passed in 114.33s), covering strict HF load, save/reload, and OLMo/HF forward parity with the exact current commit
- Pinned `Qwen/Qwen3.5-0.8B-Base@dc7cdfe2ee4154fa7e30f5b51ca41bfa40174e68` validation: complete 321-key inventory, all 260 non-norm tensors bit-exact, all regular norms equal the exact native-BF16 affine oracle, and strict official text save/reload
- Tied-weight meta regression coverage: complete all-meta state succeeds while a
  mixed meta/materialized state is rejected.
- Complete Qwen3.5 converter suite: 23 passed.
- On one NVIDIA A100, all 26 Qwen3.5-related HF tests passed with zero skips, including meta preflight, strict load/save/reload, and OLMo/HF forward parity.

Regular low-precision norm conversion is intentionally checked against the exact native-dtype expression rather than a constant epsilon, since BF16 spacing grows with parameter magnitude. An HF-origin BF16 roundtrip can therefore change norm bits after the existing importer stores `HF weight + 1` in BF16; the outbound converter cannot recover precision already discarded by that representation change. Projection fusion, splitting, and interleaving remain bit-exact.