### PR TITLE
Stage 1: stop down-weighting the pointing and counting loss

### DIFF
--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -231,9 +231,18 @@ MAX_STEPS = 32000
 # distribution for pointing evals -- worth ~11 f1 on pixmo_point_eval_v3_mp, most of it
 # abstention, because the "Please say 'There are none.'" instruction only exists in the
 # stage-2 template.
-POINTING_PROMPT_FAMILY = {
+POINTING_DATASET_KWARGS = {
     "prompt_templates": "none",
     "system_prompt": "style_and_length_v2",
+    # The pointing/counting dataset classes default to `root_subsegments`, which scales an
+    # example's loss by 1/sqrt(n_labels). The released run leaves this unset for every dataset
+    # (`mm_preprocessor.loss_token_weighting: None`, `message_weight: None` on all four pointing
+    # entries), so it weights every response token equally. Our pointing rows carry ~12.5 labels
+    # per example and counting ~2.8, so the default silently gave that data ~3.5x / ~1.7x less
+    # gradient weight per token than captions -- for exactly the reason the caption dataset's
+    # own comment gives: the factor does not cancel out of the global sum(CE*w)/sum(w) divisor
+    # when branch counts differ across examples.
+    "loss_token_weighting": "none",
 }
 
 # remainder (1 - POINTING_RATE - NLP_RATE). Set both to 0.0 for a caption-only run.
@@ -694,13 +703,17 @@ def _build_mixture_sources(tokenizer, config: ExperimentConfig):
     if p > 0:
         pointing = [
             PixMoPointsDatasetConfig(
-                kind="basic", max_crops=MAX_CROPS, **POINTING_PROMPT_FAMILY
+                kind="basic", max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS
             ).build(tokenizer),
-            PixMoCountDatasetConfig(max_crops=MAX_CROPS, **POINTING_PROMPT_FAMILY).build(tokenizer),
+            PixMoCountDatasetConfig(max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS).build(
+                tokenizer
+            ),
             PixMoPointsDatasetConfig(
-                kind="high_frequency", max_crops=MAX_CROPS, **POINTING_PROMPT_FAMILY
+                kind="high_frequency", max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS
             ).build(tokenizer),
-            CoSynPointDatasetConfig(max_crops=MAX_CROPS, **POINTING_PROMPT_FAMILY).build(tokenizer),
+            CoSynPointDatasetConfig(max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS).build(
+                tokenizer
+            ),
         ]
         frac = np.sqrt(np.array([len(d) for d in pointing], dtype=np.float64))
         frac = frac / frac.sum()

--- a/src/test/data/multimodal/pointing_prompt_family_test.py
+++ b/src/test/data/multimodal/pointing_prompt_family_test.py
@@ -58,3 +58,48 @@ def test_absent_label_abstains_in_both_families():
     for family in ({}, STAGE1):
         _, target = _turn("pointing", [], **family)
         assert target == "There are none."
+
+
+def test_stage1_weights_pointing_tokens_like_the_released_run():
+    """Stage 1 must not leave the pointing datasets on `root_subsegments`.
+
+    The dataset classes default to `root_subsegments`, which scales an example's loss by
+    1/sqrt(n_labels). The released ``Molmo2-4B-Pretrain`` sets no weighting anywhere
+    (``mm_preprocessor.loss_token_weighting: None``, ``message_weight: None`` on all four
+    pointing entries), so every response token counts equally. Our pointing rows average ~12.5
+    labels and counting ~2.8, so the default gave that data ~3.5x / ~1.7x less gradient weight
+    per token than captions -- and the factor does not cancel out of the global
+    ``sum(CE*w)/sum(w)`` divisor when branch counts differ across examples.
+    """
+    import importlib.util
+    import sys
+
+    spec = importlib.util.spec_from_file_location("_s1", "src/scripts/train/Molmo2-Stage1.py")
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_s1"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    assert mod.POINTING_DATASET_KWARGS["loss_token_weighting"] == "none"
+    assert mod.POINTING_DATASET_KWARGS["prompt_templates"] == "none"
+    assert mod.POINTING_DATASET_KWARGS["system_prompt"] == "style_and_length_v2"
+
+
+def test_root_subsegments_downweights_multi_label_examples():
+    """Pin the mechanism: 1/sqrt(n) per token, so a 12-label example is weighted ~0.29."""
+    import numpy as np
+
+    from olmo_core.data.multimodal.message_weight import (
+        MessageWeight,
+        apply_message_weight_to_loss_masks,
+    )
+
+    for n, expected in ((1, 1.0), (4, 0.5), (12, 1 / 12**0.5)):
+        sub = np.repeat(np.arange(1, n + 1), 10).astype(np.int64)
+        masks = np.ones(10 * n, dtype=np.float32)
+        out = apply_message_weight_to_loss_masks(
+            masks, sub, MessageWeight(root_subsegments=True), branch_scaling_already_applied=False
+        )
+        assert abs(float(out[0]) - expected) < 1e-4, f"{n} labels -> {out[0]}"


### PR DESCRIPTION
The pointing/counting dataset classes default `loss_token_weighting` to `root_subsegments`, which
scales an example's loss by `1/√(n_labels)`. The caption dataset is explicitly set to `"none"`, with
a comment explaining exactly why that factor is wrong here — it *"does not cancel out of the global
`sum(CE*w)/sum(w)` divisor when branch counts differ across examples"* — but the four pointing
entries were left on the default.

The released `Molmo2-4B-Pretrain` weights every response token equally:
`mm_preprocessor.loss_token_weighting: None`, and `message_weight: None` on all of
`pixmo_points_train`, `pixmo_count_train`, `pixmo_points_high_freq_train`, `cosyn_point`.

Measured over 15k source rows under our `max_points=60` filter:

| dataset | labels/example | our per-token weight | released |
|---|---|---|---|
| points-pointing | 12.5 | **0.28** | 1.00 |
| points-counting | 2.8 | **0.60** | 1.00 |

So pointing data got ~3.5× and counting ~1.7× less gradient weight per token than captions, for a
full 32k-step run.

## Verified by a full run

Three 4B stage-1 checkpoints, 32k steps each, same recipe and `data.seed=95818`, differing only in
these fixes. Every eval below was run with the checkpoint's own prompt family
(`-o prompt_templates=none -o system_prompt_style=style_and_length_v2`) and completed with zero
scoring failures.

| checkpoint | contents |
|---|---|
| `molmo2-stage1-4b-full-20260814` | baseline: neither fix |
| `molmo2-stage1-4b-ptfix-unalloc-20260819` | #836 only (stage-1 pointing prompt family) |
| `molmo2-stage1-4b-lossw-20260828` | #836 + this PR |

All at `/weka/oe-training-default/ai2-llm/checkpoints/jasonr/<name>/step32000`; released reference at
`/weka/oe-training-default/mm-olmo/released-models-molmo2-1225/Molmo2-4B-Pretrain/step32000`.

### pixmo_point_eval_v3_mp:test (1215 instances)

| metric | baseline | #836 only | **+#842** | Δ vs #836 | Δ vs baseline | released | gap left |
|---|---|---|---|---|---|---|---|
| **f1** | 0.7062 | 0.7053 | **0.7977** | **+0.0924** | +0.0915 | 0.8152 | 0.0175 |
| precision | 0.7231 | 0.7226 | 0.8164 | +0.0938 | +0.0933 | 0.8342 | 0.0178 |
| recall | 0.7232 | 0.7209 | 0.8037 | +0.0828 | +0.0805 | 0.8232 | 0.0195 |
| **single** | 0.7647 | 0.7338 | **0.8465** | **+0.1127** | +0.0818 | 0.8570 | 0.0105 |
| zero (absent) | 0.7181 | 0.8389 | 0.8658 | +0.0269 | +0.1477 | 0.9128 | 0.0470 |
| low_freq | 0.7233 | 0.7240 | 0.8205 | +0.0965 | +0.0972 | 0.8387 | 0.0182 |
| med_freq | 0.5795 | 0.5889 | 0.6774 | +0.0885 | +0.0979 | 0.6895 | 0.0121 |
| high_freq | 0.6739 | 0.6640 | 0.7366 | +0.0726 | +0.0627 | 0.7624 | 0.0258 |

### sa_co_gold_point_4k_mp:test (28,672 instances, unweighted primaries)

| metric | baseline | #836 only | **+#842** | Δ vs #836 | Δ vs baseline |
|---|---|---|---|---|---|
| **f1** | 0.3314 | 0.5502 | **0.5593** | +0.0091 | **+0.2279** |
| precision | 0.3463 | 0.5639 | 0.5741 | +0.0102 | +0.2278 |
| recall | 0.3394 | 0.5571 | 0.5640 | +0.0069 | +0.2246 |
| single | 0.8363 | 0.8541 | **0.8842** | +0.0301 | +0.0479 |
| low_freq | 0.3135 | 0.5476 | 0.5527 | +0.0051 | +0.2392 |
| med_freq | 0.6343 | 0.6417 | **0.7011** | +0.0594 | +0.0668 |
| high_freq | 0.5352 | 0.5423 | **0.6039** | +0.0616 | +0.0687 |
| is_absent_acc | 0.2053 | 0.4871 | 0.4859 | −0.0012 | +0.2806 |
| is_present_acc | 0.9969 | 0.9925 | 0.9912 | −0.0013 | −0.0057 |

### Counting and captions

| benchmark / metric | baseline | #836 only | **+#842** | Δ vs #836 | Δ vs baseline |
|---|---|---|---|---|---|
| `pixmo_count` correct | 0.8815 | 0.8685 | **0.8963** | **+0.0278** | +0.0148 |
| `countbench_qa` correct | 0.9612 | 0.9510 | 0.9388 | −0.0122 | **−0.0224** |
| `dense_caption` avg | 57.983 | 57.721 | 57.314 | −0.407 | **−0.669** |
| ↳ recall | 45.275 | 44.879 | 44.666 | −0.213 | −0.609 |
| ↳ consistency | 70.691 | 70.564 | 69.961 | −0.603 | −0.730 |
| ↳ recall_at_10 | 86.727 | 86.231 | 85.861 | −0.370 | −0.866 |
| ↳ num_statements | 21.655 | 21.763 | 21.739 | −0.024 | +0.084 |

## Reading it

The two fixes are cleanly separable, which is what makes the attribution credible:

* **#836 fixed abstention.** It moved `is_absent_acc` 0.205 → 0.487 and SA-Co f1 0.331 → 0.550, while
  leaving pixmo_points f1 flat (0.7062 → 0.7053) — the terse eval prompt lacks the "Please say
  'There are none.'" instruction that only existed in the stage-2 template.
* **This PR fixed localisation.** On top of that it moved pixmo_points `single` +0.113 and overall f1
  +0.092, and SA-Co's non-absent buckets (`med_freq` +0.059, `high_freq` +0.062, `single` +0.030),
  while `is_absent_acc` held flat (−0.001) — i.e. the reweighting did not spend #836's gain.

Net: the pointing gap against the released Pretrain checkpoint went from **11.0 points to 1.8**.

## Costs, stated plainly

Two benchmarks moved the wrong way and are **not** explained by the mechanism:

* `countbench_qa` declines monotonically across all three checkpoints (0.9612 → 0.9510 → 0.9388).
  It is the only benchmark that benefited from neither fix, and it is out-of-domain academic data,
  unlike in-distribution `pixmo_count`, which gained +0.028.
* every `dense_caption` sub-metric except `num_statements` declines monotonically (avg −0.67 from
  baseline). A plausible mechanism exists — raising the pointing/counting weight reduces captions'
  relative share of the normalised `sum(CE*w)/sum(w)` objective — but it is unconfirmed.

Both are small per step, and the trade (+9.2 f1 pointing, +2.8 counting, for ~0.7 caption avg) is
strongly favourable, but a second seed would be needed to separate the ~0.7 from run-to-run
variance. Filed as a follow-up rather than a blocker.

## Tests

2 new tests pin the stage-1 setting and the `1/√n` mechanism (1 label → 1.000, 4 → 0.500,
12 → 0.289); the stage-1 assertion fails when the value is restored to `root_subsegments`. 8 tests
pass in the file. isort/black/ruff clean.
