### PR TITLE
Add v2 pointing, olmOCR-mix and OCR caption-tar sources to Molmo2 stage 1

### DIFF
--- a/src/olmo_core/data/multimodal/__init__.py
+++ b/src/olmo_core/data/multimodal/__init__.py
@@ -30,6 +30,12 @@ from .mmfinereason import (
     MMFineReasonDatasetConfig,
     extract_answer_text,
 )
+from .ocr_caption_tars import (
+    OcrCaptionTarsDataset,
+    OcrCaptionTarsDatasetConfig,
+    TarShardIndex,
+)
+from .olmocr import OlmOcrMixDataset, OlmOcrMixDatasetConfig
 from .packing import pack_examples
 from .pixmo_cap import PixMoCapDataset, PixMoCapDatasetConfig
 from .pixmo_points import (
@@ -40,6 +46,12 @@ from .pixmo_points import (
     PixMoPointsDataset,
     PixMoPointsDatasetConfig,
 )
+from .pixmo_points_v2 import (
+    PixMoCountV2Dataset,
+    PixMoCountV2DatasetConfig,
+    PixMoPointsV2Dataset,
+    PixMoPointsV2DatasetConfig,
+)
 from .sequence_builder import (
     ATTEND_ALL_SUBSEGMENT_ID,
     build_branched_sequence,
@@ -48,7 +60,10 @@ from .sequence_builder import (
 from .paths import (
     ACADEMIC_DATASETS,
     MOLMO_DATA_DIR,
+    OE_ENCODER_DATA,
+    OLMOCR_MIX,
     PIXMO_DATASETS,
+    PIXMO_POINTS_V2,
     TORCH_DATASETS,
     TULU4_DATA,
 )
@@ -77,6 +92,15 @@ __all__ = [
     "PixMoCountDatasetConfig",
     "CoSynPointDataset",
     "CoSynPointDatasetConfig",
+    "PixMoPointsV2Dataset",
+    "PixMoPointsV2DatasetConfig",
+    "PixMoCountV2Dataset",
+    "PixMoCountV2DatasetConfig",
+    "OlmOcrMixDataset",
+    "OlmOcrMixDatasetConfig",
+    "OcrCaptionTarsDataset",
+    "OcrCaptionTarsDatasetConfig",
+    "TarShardIndex",
     "Tulu4Dataset",
     "Tulu4DatasetConfig",
     "AcademicDataset",
@@ -92,8 +116,11 @@ __all__ = [
     "SubMixture",
     "compute_flat_mixture_weights",
     "PIXMO_DATASETS",
+    "PIXMO_POINTS_V2",
     "TULU4_DATA",
     "ACADEMIC_DATASETS",
+    "OLMOCR_MIX",
+    "OE_ENCODER_DATA",
     "MOLMO_DATA_DIR",
     "TORCH_DATASETS",
     "MultimodalCollator",

--- a/src/olmo_core/data/multimodal/data_loader.py
+++ b/src/olmo_core/data/multimodal/data_loader.py
@@ -80,6 +80,10 @@ class MultimodalDataLoader(DataLoaderBase):
         if epoch is not None:
             self._epoch = epoch
         epoch = self._epoch if self._epoch is not None else 1
+        # Hand the epoch to a source that samples per example, as MixtureDataLoader does.
+        set_epoch = getattr(self.dataset, "set_epoch", None)
+        if callable(set_epoch):
+            set_epoch(epoch)
         order = np.arange(len(self.dataset))
         if self.shuffle:
             np.random.RandomState(self.seed + epoch).shuffle(order)

--- a/src/olmo_core/data/multimodal/message_sequence.py
+++ b/src/olmo_core/data/multimodal/message_sequence.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -29,7 +29,7 @@ def encode_sft_example(
     p_high_res: float = 0.0,
     high_res_max_crops: int = 24,
     loss_token_weighting: str = "root_subsegments_root_tokens",
-    message_weight: Optional[MessageWeight] = None,
+    message_weight: Union[None, float, MessageWeight] = None,
     seed: int = 0,
     shuffle_rng: Optional[np.random.RandomState] = None,
 ) -> Dict[str, np.ndarray]:

--- a/src/olmo_core/data/multimodal/mixture_data_loader.py
+++ b/src/olmo_core/data/multimodal/mixture_data_loader.py
@@ -134,6 +134,14 @@ class MixtureDataLoader(DataLoaderBase):
         if epoch is not None:
             self._epoch = epoch
         epoch = self._epoch if self._epoch is not None else 1
+        # Sources that *sample* inside ``__getitem__`` (a few of an image's negatives, a render
+        # size) need the epoch, or every epoch redraws the same subset and the rest of each pool
+        # is never trained on: reshuffling references alone cannot rotate a within-example draw.
+        # See :class:`~olmo_core.data.multimodal.sft_common.EpochSeededExamples`.
+        for dataset in self.datasets:
+            set_epoch = getattr(dataset, "set_epoch", None)
+            if callable(set_epoch):
+                set_epoch(epoch)
         rng = np.random.RandomState(self.seed + epoch)
         # Number of example refs to draw. When packing, an epoch consumes ~all examples
         # (several per packed sequence), so draw a full epoch of examples; otherwise draw

--- a/src/olmo_core/data/multimodal/mixtures/ocr.py
+++ b/src/olmo_core/data/multimodal/mixtures/ocr.py
@@ -1,0 +1,137 @@
+"""The OCR source group for Molmo2 stage-1 (``Molmo2-Stage1.py --ocr_rate``).
+
+Twenty image -> free-text sources of three kinds, each a separate dataset sharing the group's
+rate (split by sqrt(size), mm_olmo's default ``root_size_factor``):
+
+* **page transcription** (style ``olmocr``): the four olmOCR-mix-1025 subsets
+  (:class:`~olmo_core.data.multimodal.olmocr.OlmOcrMixDatasetConfig`, rendered from PDFs), plus
+  the oe-encoder ``olmocr_v6_tars`` ``s2pdf`` / ``iabooks`` (pre-rendered JPEGs, re-transcribed).
+* **text-rich captions** (style ``ocr_caption``): synthetic charts / diagrams / documents /
+  graphics / tables, the Cambrian OCR-heavy subsets (arxivqa, ocr_vqa, screen_qa, llavar, oodvqa)
+  and TextCaps -- one dense natural-language caption per image.
+* **scene text** (style ``scene_text``): TextOCR, HierText, COCO-Text and UberText, whose target
+  is the text visible in the photo.
+
+``s2pdf`` and ``iabooks`` are the SAME pages as olmOCR-mix ``documents`` / ``books`` train
+(97.4% / 99.4% of their page ids, and every one of their documents; none of the eval pages), only
+rendered and transcribed by a different pipeline. They are registered so either rendering can be
+chosen, but :data:`DEFAULT_OCR_SOURCES` leaves them out so a page is not counted twice.
+
+TextCaps' ``caption`` is its five reference captions concatenated into one string (``n_refs``),
+which is what the tars ship; it stays in the default group as a caption source but is the one to
+drop first if that target form is unwanted.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from olmo_core.data.multimodal.ocr_caption_tars import OcrCaptionTarsDatasetConfig
+from olmo_core.data.multimodal.olmocr import OlmOcrMixDatasetConfig
+from olmo_core.data.multimodal.paths import OE_ENCODER_DATA
+from olmo_core.exceptions import OLMoConfigurationError
+
+__all__ = [
+    "OcrTarSource",
+    "OCR_TAR_SOURCES",
+    "OLMOCR_MIX_SOURCES",
+    "OCR_SOURCE_NAMES",
+    "DUPLICATE_OLMOCR_SOURCES",
+    "DEFAULT_OCR_SOURCES",
+    "OLMOCR_STYLE",
+    "OCR_CAPTION_STYLE",
+    "SCENE_TEXT_STYLE",
+    "build_ocr_source",
+]
+
+OLMOCR_STYLE = "olmocr"
+OCR_CAPTION_STYLE = "ocr_caption"
+SCENE_TEXT_STYLE = "scene_text"
+
+
+@dataclass(frozen=True)
+class OcrTarSource:
+    """One oe-encoder caption-tars source."""
+
+    relpath: str
+    """Shard directory under :data:`~olmo_core.data.multimodal.paths.OE_ENCODER_DATA`."""
+    style: str
+    strip_text_tags: bool
+    """Whether the tars wrap the text in ``<text>...</text>`` (transcription-type sources)."""
+
+
+OCR_TAR_SOURCES: Dict[str, OcrTarSource] = {
+    # Synthetic text-rich images, one dense caption each (~800 chars).
+    "text_rich_chart": OcrTarSource("text_rich_caption_v6_tars/chart", OCR_CAPTION_STYLE, False),
+    "text_rich_diagram": OcrTarSource(
+        "text_rich_caption_v6_tars/diagram", OCR_CAPTION_STYLE, False
+    ),
+    "text_rich_doc": OcrTarSource("text_rich_caption_v6_tars/doc", OCR_CAPTION_STYLE, False),
+    "text_rich_graphic": OcrTarSource(
+        "text_rich_caption_v6_tars/graphic", OCR_CAPTION_STYLE, False
+    ),
+    "text_rich_table": OcrTarSource("text_rich_caption_v6_tars/table", OCR_CAPTION_STYLE, False),
+    # Cambrian's OCR-heavy subsets, re-captioned.
+    "cambrian_arxivqa": OcrTarSource("cambrian_v6_tars/cambrian_arxivqa", OCR_CAPTION_STYLE, False),
+    "cambrian_ocr_vqa": OcrTarSource("cambrian_v6_tars/cambrian_ocr_vqa", OCR_CAPTION_STYLE, False),
+    "cambrian_screen_qa": OcrTarSource(
+        "cambrian_v6_tars/cambrian_screen_qa", OCR_CAPTION_STYLE, False
+    ),
+    "cambrian_llavar": OcrTarSource("cambrian_v6_tars/cambrian_llavar", OCR_CAPTION_STYLE, False),
+    "cambrian_oodvqa": OcrTarSource("cambrian_v6_tars/cambrian_oodvqa", OCR_CAPTION_STYLE, False),
+    # olmOCR pages, pre-rendered; duplicates of olmOCR-mix documents / books (see module doc).
+    "s2pdf": OcrTarSource("olmocr_v6_tars/s2pdf", OLMOCR_STYLE, True),
+    "iabooks": OcrTarSource("olmocr_v6_tars/iabooks", OLMOCR_STYLE, True),
+    # Scene text.
+    "textocr": OcrTarSource("textocr_v6_tars", SCENE_TEXT_STYLE, True),
+    "textcaps": OcrTarSource("textcaps_v6_tars", OCR_CAPTION_STYLE, False),
+    "hiertext": OcrTarSource("scene_text_tars/hiertext_v6_tars", SCENE_TEXT_STYLE, True),
+    "cocotext": OcrTarSource("scene_text_tars/cocotext_v6_tars", SCENE_TEXT_STYLE, True),
+    "ubertext": OcrTarSource("scene_text_tars/ubertext_v6_tars", SCENE_TEXT_STYLE, True),
+}
+
+#: olmOCR-mix sources: group name -> ``OlmOcrMixDatasetConfig.subset``.
+OLMOCR_MIX_SOURCES: Dict[str, str] = {
+    "olmocr_documents": "documents",
+    "olmocr_books": "books",
+    "olmocr_loc_transcripts": "loc_transcripts",
+    "olmocr_national_archives": "national_archives",
+}
+
+OCR_SOURCE_NAMES: Tuple[str, ...] = tuple(OLMOCR_MIX_SOURCES) + tuple(OCR_TAR_SOURCES)
+
+#: Tar sources whose pages are already in an olmOCR-mix train subset (see module doc).
+DUPLICATE_OLMOCR_SOURCES: Dict[str, str] = {"s2pdf": "olmocr_documents", "iabooks": "olmocr_books"}
+
+DEFAULT_OCR_SOURCES: Tuple[str, ...] = tuple(
+    n for n in OCR_SOURCE_NAMES if n not in DUPLICATE_OLMOCR_SOURCES
+)
+
+
+def build_ocr_source(
+    name: str,
+    tokenizer,
+    *,
+    olmocr: OlmOcrMixDatasetConfig,
+    tars: OcrCaptionTarsDatasetConfig,
+    data_root: str = OE_ENCODER_DATA,
+):
+    """Build one OCR source by name from the two template configs.
+
+    :param olmocr: template for the olmOCR-mix sources; its ``subset`` is overridden.
+    :param tars: template for the caption-tars sources; ``dataset_path``, ``style`` and
+        ``strip_text_tags`` are overridden from :data:`OCR_TAR_SOURCES`.
+    :param data_root: where the oe-encoder tar directories live.
+    """
+    if name in OLMOCR_MIX_SOURCES:
+        return olmocr.replace(subset=OLMOCR_MIX_SOURCES[name]).build(tokenizer)
+    if name in OCR_TAR_SOURCES:
+        src = OCR_TAR_SOURCES[name]
+        return tars.replace(
+            dataset_path=os.path.join(data_root, src.relpath),
+            style=src.style,
+            strip_text_tags=src.strip_text_tags,
+        ).build(tokenizer)
+    raise OLMoConfigurationError(f"Unknown OCR source {name!r}; expected one of {OCR_SOURCE_NAMES}")

--- a/src/olmo_core/data/multimodal/mixtures/ocr.py
+++ b/src/olmo_core/data/multimodal/mixtures/ocr.py
@@ -20,6 +20,21 @@ chosen, but :data:`DEFAULT_OCR_SOURCES` leaves them out so a page is not counted
 TextCaps' ``caption`` is its five reference captions concatenated into one string (``n_refs``),
 which is what the tars ship; it stays in the default group as a caption source but is the one to
 drop first if that target form is unwanted.
+
+**The ``text_rich_*`` sources are one third of mm_olmo's ``figure_ocr`` group, by design of the
+tar build, not of this port.** They are the same images as mm_olmo's ``TextRichCaptionConfig``
+(``molmo3_datasets/text_rich_caption``), which captions each image at three granularities and
+emits all three as branches (``text_rich_caption_datasets.py:173-183``). The ``*_v6_tars`` build
+carries a single ``caption`` field, and it is byte-identical to that build's ``mid_level``:
+verified on ``chart/HTMLChartPipeline_area_0-0``, where high / mid / low are 145 / 645 / 2262
+chars. The missing ``low_level`` -- consistently 2-4k chars, the dense read-out of everything on
+the page -- is the most OCR-relevant part of the group, so this group's caption mass is roughly a
+fifth of mm_olmo's. Reading all three levels needs the HF build rather than these tars; that is a
+separate loader and is left to a follow-on.
+
+So ``--ocr_rate`` with :data:`DEFAULT_OCR_SOURCES` is NOT mm_olmo's OCR mixture. It is olmOCR-mix,
+plus the mid-level slice of ``figure_ocr``, plus the Cambrian / TextCaps / scene-text sources that
+mm_olmo's stage 1 does not carry at all.
 """
 
 from __future__ import annotations

--- a/src/olmo_core/data/multimodal/mixtures/ocr.py
+++ b/src/olmo_core/data/multimodal/mixtures/ocr.py
@@ -1,7 +1,8 @@
 """The OCR source group for Molmo2 stage-1 (``Molmo2-Stage1.py --ocr_rate``).
 
-Twenty image -> free-text sources of three kinds, each a separate dataset sharing the group's
-rate (split by sqrt(size), mm_olmo's default ``root_size_factor``):
+Twenty-one image -> free-text sources of three kinds (19 of them in
+:data:`DEFAULT_OCR_SOURCES`), each a separate dataset sharing the group's rate (split by
+sqrt(size), mm_olmo's default ``root_size_factor``):
 
 * **page transcription** (style ``olmocr``): the four olmOCR-mix-1025 subsets
   (:class:`~olmo_core.data.multimodal.olmocr.OlmOcrMixDatasetConfig`, rendered from PDFs), plus

--- a/src/olmo_core/data/multimodal/ocr_caption_tars.py
+++ b/src/olmo_core/data/multimodal/ocr_caption_tars.py
@@ -1,0 +1,327 @@
+"""Webdataset-style caption tars for Molmo2 stage-1 (the oe-encoder ``*_v6_tars`` OCR sources).
+
+Layout: a directory of ``.tar`` shards in which every sample is an image member (``<key>.jpg`` /
+``<key>.png``) next to a ``<key>.json`` member. The JSON always carries ``caption`` (and a
+``dense_caption`` duplicate of it); OCR-type sources wrap the transcription in ``<text>...</text>``,
+and per-source extras (``url`` / ``page`` / ``n_words`` / ``image_classes``) are ignored. The
+sources and their styles live in :mod:`olmo_core.data.multimodal.mixtures.ocr`.
+
+A map-style dataset needs random access, but tar has no index: :class:`TarShardIndex` scans every
+shard's headers once (seeking over member data, roughly a second per GB) and caches the member
+offsets as an ``.npz`` keyed by the shards' names, sizes and mtimes, so later ranks and runs load
+it instantly. Examples are built like olmOCR-mix pages: the user turn is the style tag only, the
+assistant turn is the text, tail-truncated to ``max_sequence_length``.
+"""
+
+from __future__ import annotations
+
+import glob
+import hashlib
+import io
+import json
+import logging
+import os
+import re
+import tarfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from olmo_core.config import Config
+from olmo_core.exceptions import OLMoConfigurationError
+
+from .message_sequence import encode_sft_example
+from .pixmo_cap import STYLE_TAG_FAMILIES, style_tag_prompt
+from .sequence_builder import example_rng
+from .sft_common import truncate_example
+
+__all__ = [
+    "TarShardIndex",
+    "OcrCaptionTarsDatasetConfig",
+    "OcrCaptionTarsDataset",
+    "strip_text_tags",
+    "default_index_cache_dir",
+]
+
+log = logging.getLogger(__name__)
+
+IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png")
+_TEXT_TAG_RE = re.compile(r"^\s*<text>\s*(.*?)\s*</text>\s*$", re.S)
+
+
+def strip_text_tags(text: str) -> str:
+    """Drop the ``<text>...</text>`` wrapper the OCR-type sources put around a transcription
+    (only the outer pair; anything inside is kept verbatim)."""
+    m = _TEXT_TAG_RE.match(text)
+    return m.group(1) if m else text
+
+
+def default_index_cache_dir() -> str:
+    """Where shard indices are cached: ``$OLMO_CORE_TAR_INDEX_DIR``, else next to the HF datasets
+    cache (``$HF_DATASETS_CACHE/olmo_core_tar_index``), else ``~/.cache/olmo_core/tar_index``."""
+    explicit = os.environ.get("OLMO_CORE_TAR_INDEX_DIR")
+    if explicit:
+        return explicit
+    hf = os.environ.get("HF_DATASETS_CACHE")
+    if hf:
+        return os.path.join(hf, "olmo_core_tar_index")
+    return os.path.join(os.path.expanduser("~"), ".cache", "olmo_core", "tar_index")
+
+
+def _scan_shard(path: str) -> Tuple[List[str], np.ndarray]:
+    """One shard's complete ``(image, json)`` pairs, in tar order.
+
+    :returns: ``(keys, offsets)`` with ``offsets`` an ``(n, 4)`` int64 array of
+        ``image_offset, image_size, json_offset, json_size``. Members without a partner (or with
+        an unexpected extension) are skipped.
+    """
+    images: Dict[str, Tuple[int, int]] = {}
+    jsons: Dict[str, Tuple[int, int]] = {}
+    order: List[str] = []
+    with tarfile.open(path) as tf:  # random-access mode: `next()` seeks past member data
+        for m in tf:
+            if not m.isfile():
+                continue
+            stem, ext = os.path.splitext(m.name)
+            ext = ext.lower()
+            if ext == ".json":
+                jsons[stem] = (m.offset_data, m.size)
+            elif ext in IMAGE_EXTENSIONS:
+                images[stem] = (m.offset_data, m.size)
+            else:
+                continue
+            if stem not in order:
+                order.append(stem)
+    keys = [k for k in order if k in images and k in jsons]
+    offsets = np.asarray([[*images[k], *jsons[k]] for k in keys], dtype=np.int64).reshape(
+        len(keys), 4
+    )
+    return keys, offsets
+
+
+@dataclass
+class TarShardIndex:
+    """Member offsets of every ``(image, json)`` sample across a directory of tar shards."""
+
+    shards: List[str]
+    """Absolute shard paths, sorted; ``shard_idx`` indexes into this list."""
+    keys: np.ndarray
+    """``(N,)`` sample keys (``bytes_`` dtype), for provenance."""
+    shard_idx: np.ndarray
+    """``(N,)`` int32 shard of each sample."""
+    offsets: np.ndarray
+    """``(N, 4)`` int64: image offset, image size, json offset, json size."""
+
+    def __len__(self) -> int:
+        return len(self.keys)
+
+    @staticmethod
+    def list_shards(dataset_path: str, shard_glob: str = "*.tar") -> List[str]:
+        shards = sorted(glob.glob(os.path.join(dataset_path, shard_glob)))
+        if not shards:
+            raise FileNotFoundError(f"No shards matching {shard_glob!r} under {dataset_path}")
+        return shards
+
+    @staticmethod
+    def fingerprint(shards: Sequence[str]) -> str:
+        """Hash of the shards' basenames, sizes and mtimes: any change invalidates the cache."""
+        h = hashlib.sha1()
+        for s in shards:
+            st = os.stat(s)
+            h.update(f"{os.path.basename(s)}\t{st.st_size}\t{int(st.st_mtime)}\n".encode())
+        return h.hexdigest()[:16]
+
+    @classmethod
+    def build(cls, shards: Sequence[str], *, num_threads: int = 8) -> "TarShardIndex":
+        """Scan the shards' headers (in parallel: the cost is weka seek latency)."""
+        shards = list(shards)
+        with ThreadPoolExecutor(max(1, num_threads)) as ex:
+            scanned = list(ex.map(_scan_shard, shards))
+        keys: List[str] = []
+        shard_idx: List[np.ndarray] = []
+        offsets: List[np.ndarray] = []
+        for i, (ks, offs) in enumerate(scanned):
+            keys.extend(ks)
+            shard_idx.append(np.full(len(ks), i, dtype=np.int32))
+            offsets.append(offs)
+        return cls(
+            shards=shards,
+            keys=np.asarray(keys, dtype=np.bytes_),
+            shard_idx=np.concatenate(shard_idx) if shard_idx else np.zeros(0, dtype=np.int32),
+            offsets=np.concatenate(offsets) if offsets else np.zeros((0, 4), dtype=np.int64),
+        )
+
+    def save(self, path: str) -> None:
+        """Atomic write (temp file + ``os.replace``), so concurrent ranks never read a partial
+        index."""
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = f"{path}.tmp-{os.getpid()}"
+        with open(tmp, "wb") as f:
+            np.savez(
+                f,
+                shards=np.asarray(self.shards, dtype=np.str_),
+                keys=self.keys,
+                shard_idx=self.shard_idx,
+                offsets=self.offsets,
+            )
+        os.replace(tmp, path)
+
+    @classmethod
+    def load(cls, path: str) -> "TarShardIndex":
+        with np.load(path) as z:
+            return cls(
+                shards=[str(s) for s in z["shards"]],
+                keys=z["keys"],
+                shard_idx=z["shard_idx"],
+                offsets=z["offsets"],
+            )
+
+    @classmethod
+    def load_or_build(
+        cls,
+        dataset_path: str,
+        *,
+        shard_glob: str = "*.tar",
+        cache_dir: Optional[str] = None,
+        num_threads: int = 8,
+    ) -> "TarShardIndex":
+        """The cached index for ``dataset_path``'s shards, scanning and caching it if missing."""
+        shards = cls.list_shards(dataset_path, shard_glob)
+        cache_dir = cache_dir or default_index_cache_dir()
+        name = os.path.basename(os.path.normpath(dataset_path)) or "tars"
+        cache_path = os.path.join(cache_dir, f"{name}-{cls.fingerprint(shards)}.npz")
+        if os.path.exists(cache_path):
+            index = cls.load(cache_path)
+            if index.shards == shards:
+                return index
+        log.info("Indexing %d tar shard(s) under %s ...", len(shards), dataset_path)
+        index = cls.build(shards, num_threads=num_threads)
+        index.save(cache_path)
+        log.info("Indexed %d samples -> %s", len(index), cache_path)
+        return index
+
+    def read_sample(self, i: int) -> Tuple[bytes, bytes]:
+        """``(image_bytes, json_bytes)`` of sample ``i`` (one open + two seek-reads)."""
+        img_off, img_size, js_off, js_size = (int(x) for x in self.offsets[i])
+        with open(self.shards[int(self.shard_idx[i])], "rb") as f:
+            f.seek(img_off)
+            image = f.read(img_size)
+            f.seek(js_off)
+            meta = f.read(js_size)
+        return image, meta
+
+
+@dataclass
+class OcrCaptionTarsDatasetConfig(Config):
+    """One caption-tars source: image -> free text behind a style tag."""
+
+    dataset_path: str = ""
+    """Directory of ``.tar`` shards (see :mod:`.mixtures.ocr` for the known sources)."""
+
+    style: str = "ocr_caption"
+    """mm_olmo-style name shown in the user turn's tag; see :mod:`.mixtures.ocr` for the ones the
+    OCR sources use (``ocr_caption`` / ``olmocr`` / ``scene_text``)."""
+
+    text_field: str = "caption"
+    """JSON field holding the target text."""
+
+    strip_text_tags: bool = True
+    """Drop the ``<text>...</text>`` wrapper of OCR-type sources so the target is the bare text,
+    like olmOCR-mix's ``natural_text``."""
+
+    shard_glob: str = "*.tar"
+    index_cache_dir: Optional[str] = None
+    """Where the shard index is cached; ``None`` -> :func:`default_index_cache_dir`."""
+    index_threads: int = 8
+
+    max_crops: int = 8
+    max_sequence_length: Optional[int] = None
+    """Tail-truncate the built sequence to this many tokens (see :func:`~.sft_common.truncate_example`)."""
+    loss_token_weighting: str = "root_subsegments"
+    message_weight: Optional[float] = None
+    seed: int = 0
+    system_prompt: str = "style_and_length_v3"
+    """Prefix family for the style tag (:func:`~.pixmo_cap.style_tag_prompt`); the default renders the
+    bare ``"<style>:"``, as mm_olmo's molmo3 stage 1 does for its OCR sources."""
+
+    def validate(self):
+        if not self.dataset_path:
+            raise OLMoConfigurationError("dataset_path must point at a directory of tar shards")
+        if not self.style:
+            raise OLMoConfigurationError("style must be a non-empty style name")
+        if not self.text_field:
+            raise OLMoConfigurationError("text_field must be a JSON field name")
+        if self.system_prompt not in STYLE_TAG_FAMILIES:
+            raise OLMoConfigurationError(
+                f"system_prompt={self.system_prompt!r} is not one of {sorted(STYLE_TAG_FAMILIES)}"
+            )
+        if self.index_threads < 1:
+            raise OLMoConfigurationError("index_threads must be >= 1")
+
+    def build(self, tokenizer) -> "OcrCaptionTarsDataset":
+        self.validate()
+        return OcrCaptionTarsDataset(self, tokenizer)
+
+
+class OcrCaptionTarsDataset:
+    """Map-style dataset over the ``(image, json)`` samples of a directory of tar shards."""
+
+    def __init__(self, config: OcrCaptionTarsDatasetConfig, tokenizer):
+        self.config = config
+        self.tokenizer = tokenizer
+        self.index = TarShardIndex.load_or_build(
+            config.dataset_path,
+            shard_glob=config.shard_glob,
+            cache_dir=config.index_cache_dir,
+            num_threads=config.index_threads,
+        )
+        self._lock = threading.Lock()
+        log.info(
+            "caption tars %s (style=%s): %d samples in %d shards",
+            config.dataset_path,
+            config.style,
+            len(self.index),
+            len(self.index.shards),
+        )
+
+    def __len__(self) -> int:
+        return len(self.index)
+
+    def key(self, i: int) -> str:
+        return self.index.keys[i].decode()
+
+    def text(self, meta: Dict) -> str:
+        """The target text of a decoded JSON record."""
+        cfg = self.config
+        raw = meta.get(cfg.text_field)
+        if not isinstance(raw, str):
+            raise ValueError(f"JSON field {cfg.text_field!r} missing or not a string")
+        text = strip_text_tags(raw) if cfg.strip_text_tags else raw
+        if not text.strip():
+            raise ValueError("empty target text")
+        return text
+
+    def __getitem__(self, i: int) -> Dict[str, np.ndarray]:
+        from PIL import Image
+
+        cfg = self.config
+        image_bytes, json_bytes = self.index.read_sample(i)
+        text = self.text(json.loads(json_bytes))
+        image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
+        rng = example_rng(cfg.seed, i)
+        prompt = style_tag_prompt(cfg.style, text, rng, cfg.system_prompt)
+        seq = encode_sft_example(
+            self.tokenizer,
+            image,
+            [(prompt, text)],
+            max_crops=cfg.max_crops,
+            loss_token_weighting=cfg.loss_token_weighting,
+            message_weight=cfg.message_weight,
+            shuffle_rng=rng,
+        )
+        if cfg.max_sequence_length is not None:
+            seq = truncate_example(seq, cfg.max_sequence_length)
+        return seq

--- a/src/olmo_core/data/multimodal/ocr_caption_tars.py
+++ b/src/olmo_core/data/multimodal/ocr_caption_tars.py
@@ -24,9 +24,10 @@ import os
 import re
 import tarfile
 import threading
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
 
@@ -35,8 +36,7 @@ from olmo_core.exceptions import OLMoConfigurationError
 
 from .message_sequence import encode_sft_example
 from .pixmo_cap import STYLE_TAG_FAMILIES, style_tag_prompt
-from .sequence_builder import example_rng
-from .sft_common import truncate_example
+from .sft_common import EpochSeededExamples, get_example_with_skip, truncate_example
 
 __all__ = [
     "TarShardIndex",
@@ -49,6 +49,10 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 IMAGE_EXTENSIONS = (".jpg", ".jpeg", ".png")
+
+INDEX_FORMAT_VERSION = 2
+"""Bumped when the cached ``.npz`` layout changes, so an old cache is ignored rather than
+mis-read (v2 stores ``keys`` as unicode; v1 stored ASCII-only bytes)."""
 _TEXT_TAG_RE = re.compile(r"^\s*<text>\s*(.*?)\s*</text>\s*$", re.S)
 
 
@@ -81,6 +85,7 @@ def _scan_shard(path: str) -> Tuple[List[str], np.ndarray]:
     images: Dict[str, Tuple[int, int]] = {}
     jsons: Dict[str, Tuple[int, int]] = {}
     order: List[str] = []
+    seen: Set[str] = set()  # membership on the list would make this scan O(n^2) in shard size
     with tarfile.open(path) as tf:  # random-access mode: `next()` seeks past member data
         for m in tf:
             if not m.isfile():
@@ -93,7 +98,8 @@ def _scan_shard(path: str) -> Tuple[List[str], np.ndarray]:
                 images[stem] = (m.offset_data, m.size)
             else:
                 continue
-            if stem not in order:
+            if stem not in seen:
+                seen.add(stem)
                 order.append(stem)
     keys = [k for k in order if k in images and k in jsons]
     offsets = np.asarray([[*images[k], *jsons[k]] for k in keys], dtype=np.int64).reshape(
@@ -109,7 +115,12 @@ class TarShardIndex:
     shards: List[str]
     """Absolute shard paths, sorted; ``shard_idx`` indexes into this list."""
     keys: np.ndarray
-    """``(N,)`` sample keys (``bytes_`` dtype), for provenance."""
+    """``(N,)`` sample keys (unicode ``str_`` dtype), for provenance. Not ``bytes_``: numpy
+    encodes str to bytes through the ASCII codec, so a single non-ASCII member name would raise
+    ``UnicodeEncodeError`` out of ``__init__`` -- at mixture-build time, where the loader's
+    per-example error tolerance does not apply, and after paying the whole shard scan. Nothing
+    constrains tar member names to ASCII; the shards sampled so far happen to be clean (0
+    non-ASCII keys in 13,884 samples across six sources), so this is a guard, not a live fix."""
     shard_idx: np.ndarray
     """``(N,)`` int32 shard of each sample."""
     offsets: np.ndarray
@@ -149,25 +160,38 @@ class TarShardIndex:
             offsets.append(offs)
         return cls(
             shards=shards,
-            keys=np.asarray(keys, dtype=np.bytes_),
+            keys=np.asarray(keys, dtype=np.str_),
             shard_idx=np.concatenate(shard_idx) if shard_idx else np.zeros(0, dtype=np.int32),
             offsets=np.concatenate(offsets) if offsets else np.zeros((0, 4), dtype=np.int64),
         )
 
     def save(self, path: str) -> None:
-        """Atomic write (temp file + ``os.replace``), so concurrent ranks never read a partial
-        index."""
+        """Atomic write (temp file + ``os.replace``), so a concurrent reader never sees a partial
+        index.
+
+        The temp name carries a uuid rather than only the pid: several ranks (or two threads) can
+        build the same entry at once, and on separate container hosts sharing one cache
+        filesystem their pids collide, which would let two writers interleave into one temp file.
+        """
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        tmp = f"{path}.tmp-{os.getpid()}"
-        with open(tmp, "wb") as f:
-            np.savez(
-                f,
-                shards=np.asarray(self.shards, dtype=np.str_),
-                keys=self.keys,
-                shard_idx=self.shard_idx,
-                offsets=self.offsets,
-            )
-        os.replace(tmp, path)
+        tmp = f"{path}.tmp-{os.getpid()}-{uuid.uuid4().hex}"
+        try:
+            with open(tmp, "wb") as f:
+                np.savez(
+                    f,
+                    shards=np.asarray(self.shards, dtype=np.str_),
+                    keys=self.keys,
+                    shard_idx=self.shard_idx,
+                    offsets=self.offsets,
+                )
+            os.replace(tmp, path)
+        except BaseException:
+            # Never leave a half-written temp behind for the next run to trip over.
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
 
     @classmethod
     def load(cls, path: str) -> "TarShardIndex":
@@ -192,11 +216,17 @@ class TarShardIndex:
         shards = cls.list_shards(dataset_path, shard_glob)
         cache_dir = cache_dir or default_index_cache_dir()
         name = os.path.basename(os.path.normpath(dataset_path)) or "tars"
-        cache_path = os.path.join(cache_dir, f"{name}-{cls.fingerprint(shards)}.npz")
+        cache_path = os.path.join(
+            cache_dir, f"{name}-v{INDEX_FORMAT_VERSION}-{cls.fingerprint(shards)}.npz"
+        )
         if os.path.exists(cache_path):
-            index = cls.load(cache_path)
-            if index.shards == shards:
-                return index
+            try:
+                index = cls.load(cache_path)
+            except Exception as e:  # noqa: BLE001 - a damaged cache must not end the run
+                log.warning("Ignoring unreadable index cache %s (%s); rebuilding", cache_path, e)
+            else:
+                if index.shards == shards:
+                    return index
         log.info("Indexing %d tar shard(s) under %s ...", len(shards), dataset_path)
         index = cls.build(shards, num_threads=num_threads)
         index.save(cache_path)
@@ -266,7 +296,7 @@ class OcrCaptionTarsDatasetConfig(Config):
         return OcrCaptionTarsDataset(self, tokenizer)
 
 
-class OcrCaptionTarsDataset:
+class OcrCaptionTarsDataset(EpochSeededExamples):
     """Map-style dataset over the ``(image, json)`` samples of a directory of tar shards."""
 
     def __init__(self, config: OcrCaptionTarsDatasetConfig, tokenizer):
@@ -279,6 +309,7 @@ class OcrCaptionTarsDataset:
             num_threads=config.index_threads,
         )
         self._lock = threading.Lock()
+        self._warned = 0
         log.info(
             "caption tars %s (style=%s): %d samples in %d shards",
             config.dataset_path,
@@ -291,7 +322,8 @@ class OcrCaptionTarsDataset:
         return len(self.index)
 
     def key(self, i: int) -> str:
-        return self.index.keys[i].decode()
+        """This sample's tar member stem (provenance; not used to build the example)."""
+        return str(self.index.keys[i])
 
     def text(self, meta: Dict) -> str:
         """The target text of a decoded JSON record."""
@@ -304,14 +336,27 @@ class OcrCaptionTarsDataset:
             raise ValueError("empty target text")
         return text
 
-    def __getitem__(self, i: int) -> Dict[str, np.ndarray]:
+    def __getitem__(self, index: int) -> Dict[str, np.ndarray]:
+        """Build row ``index``, deterministically skipping rows with no usable target.
+
+        An unusable row -- a blank caption, an undecodable image, a truncation that leaves no loss
+        tokens -- must not raise out of here: it would spend the mixture loader's error budget
+        (``max_consecutive_data_errors``) and a run of them inside one shard would abort training.
+        Blank captions are plausible for the scene-text sources in particular, since not every
+        photo holds legible text, though the shards sampled so far contain none. Same policy as
+        ``finevision`` / ``mmfinereason``; see
+        :func:`~olmo_core.data.multimodal.sft_common.get_example_with_skip`.
+        """
+        return get_example_with_skip(self, index, len(self))
+
+    def _build(self, i: int) -> Dict[str, np.ndarray]:
         from PIL import Image
 
         cfg = self.config
         image_bytes, json_bytes = self.index.read_sample(i)
         text = self.text(json.loads(json_bytes))
         image = Image.open(io.BytesIO(image_bytes)).convert("RGB")
-        rng = example_rng(cfg.seed, i)
+        rng = self.epoch_rng(i)
         prompt = style_tag_prompt(cfg.style, text, rng, cfg.system_prompt)
         seq = encode_sft_example(
             self.tokenizer,

--- a/src/olmo_core/data/multimodal/olmocr.py
+++ b/src/olmo_core/data/multimodal/olmocr.py
@@ -1,0 +1,323 @@
+"""olmOCR-mix page transcription for Molmo2 stage-1.
+
+Port of mm_olmo's ``OlmOcrMixConfig`` (``olmo/data/olmocr_datasets.py``), one of the two OCR
+groups in its molmo3 stage-1 mixture (``launch_scripts/train_molmo3_stage1.py``,
+``_base_mixture``). ``allenai/olmOCR-mix-1025`` holds, per subset (``documents``, ``books``,
+``loc_transcripts``, ``national_archives``) and split (``train`` / ``eval``), one parquet of page
+records plus the source PDFs. mm_olmo's ``download`` fetches those and expands every tarball
+into ``pdfs/<chunk>/<arcname>``; this module reads that layout -- already materialised on weka
+at :data:`~olmo_core.data.multimodal.paths.OLMOCR_MIX` -- and does not download.
+
+Each example is one rendered page and its ``natural_text`` transcription. There is no question:
+mm_olmo's formatter has no template for the ``olmocr`` style, so the user turn is just the style
+tag -- the bare ``"olmocr:"`` under molmo3 stage 1's ``style_and_length_v3`` family (the default
+here), or the length-conditioned ``"olmocr <bucket>:"`` under the released Molmo2 pretrain's
+``style_and_length_v2`` -- and the assistant turn is the transcription (``"No text found"`` for
+blank pages). Pages are rasterised on the fly with
+``pypdfium2`` at a longest side sampled from ``target_longest_image_dim_range`` for training
+(mm_olmo: 1024-2048) and fixed (1536) otherwise, following olmOCR's own per-page DPI rule.
+
+Transcriptions run long (documents pages: median ~580 tokens, p99 ~2900 with the Molmo2
+tokenizer), so ``max_sequence_length`` should be set to the training sequence length; the
+sequence is then tail-truncated like mm_olmo's preprocessor does.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+
+from olmo_core.config import Config
+from olmo_core.exceptions import OLMoConfigurationError
+
+from .message_sequence import encode_sft_example
+from .paths import OLMOCR_MIX
+from .pixmo_cap import STYLE_TAG_FAMILIES, style_tag_prompt
+from .sequence_builder import example_rng
+from .sft_common import load_hf_dataset, truncate_example
+
+__all__ = [
+    "OLMOCR_STYLE",
+    "OLMOCR_SUBSETS",
+    "OLMOCR_SPLITS",
+    "OlmOcrMixDatasetConfig",
+    "OlmOcrMixDataset",
+    "canonical_subset",
+    "canonical_split",
+    "render_pdf_page",
+]
+
+log = logging.getLogger(__name__)
+
+#: mm_olmo style name; the prefix families below decide how it is shown to the model.
+OLMOCR_STYLE = "olmocr"
+
+#: Hub config names. The numeric prefix is part of the parquet / tarball filenames.
+OLMOCR_SUBSETS: Tuple[str, ...] = (
+    "00_documents",
+    "01_books",
+    "02_loc_transcripts",
+    "03_national_archives",
+)
+OLMOCR_SPLITS: Tuple[str, ...] = ("train", "eval")
+
+#: Columns the dataset reads; everything else in the parquet is provenance / flags.
+_COLUMNS = ["id", "url", "page_number", "pdf_relpath", "primary_language", "natural_text"]
+
+
+def canonical_subset(subset: str) -> str:
+    """Accept either the hub name (``00_documents``) or the bare one (``documents``)."""
+    if subset in OLMOCR_SUBSETS:
+        return subset
+    matches = [s for s in OLMOCR_SUBSETS if s.split("_", 1)[1] == subset]
+    if not matches:
+        bare = [s.split("_", 1)[1] for s in OLMOCR_SUBSETS]
+        raise OLMoConfigurationError(
+            f"Unknown olmOCR-mix subset {subset!r}, expected one of {bare} "
+            f"(or a full name from {list(OLMOCR_SUBSETS)})"
+        )
+    return matches[0]
+
+
+def canonical_split(split: str) -> str:
+    """The hub calls the held-out split ``eval``; accept the repo's usual ``validation`` too."""
+    if split == "validation":
+        return "eval"
+    if split not in OLMOCR_SPLITS:
+        raise OLMoConfigurationError(
+            f"Unknown olmOCR-mix split {split!r}, expected one of {list(OLMOCR_SPLITS)} "
+            "or 'validation'"
+        )
+    return split
+
+
+_TARBALL_SEP = ".tar.gz:"
+
+
+def pdf_path_for(root: str, pdf_relpath: str) -> str:
+    """Resolve a row's ``pdf_relpath`` to the expanded PDF.
+
+    ``pdf_tarballs/00_documents_train_00000.tar.gz:0000/abc-1.pdf`` ->
+    ``<root>/pdfs/00_documents_train_00000/0000/abc-1.pdf``. The separator is the colon right
+    after the tarball name, so the split is on ``".tar.gz:"``: an arcname is a path and may
+    itself contain a colon (mm_olmo's ``rsplit(":")`` would then cut inside it).
+    """
+    if _TARBALL_SEP not in pdf_relpath:
+        raise ValueError(f"pdf_relpath {pdf_relpath!r} has no '{_TARBALL_SEP}' separator")
+    tar_part, arcname = pdf_relpath.split(_TARBALL_SEP, 1)
+    return os.path.join(root, "pdfs", os.path.basename(tar_part), arcname)
+
+
+_PDFIUM_LOCK = threading.Lock()
+
+
+def render_pdf_page(pdf_path: str, target_longest_image_dim: int):
+    """Render a single-page PDF to an RGB PIL image whose longest side is
+    ``target_longest_image_dim`` pixels.
+
+    Follows olmOCR's convention (``render_pdf_to_base64png``): the DPI is chosen per page as
+    ``target * 72 / longest_mediabox_dim_in_points``, i.e. a render ``scale`` of
+    ``target / longest_dim`` -- page sizes vary, so no fixed DPI. olmOCR rasterises with poppler,
+    so fonts / antialiasing can differ slightly from pypdfium2's output.
+
+    The shipped files are single-page extracts (the row's ``page_number`` is provenance in the
+    original document), so only page 0 exists. pypdfium2 is not thread-safe; the render is
+    serialised behind a lock because :class:`~.mixture_data_loader.MixtureDataLoader` prefetches
+    examples on a thread pool.
+
+    :raises ImportError: If ``pypdfium2`` is not installed (``pip install pypdfium2``).
+    :raises RuntimeError: If the PDF has more than one page.
+    """
+    try:
+        import pypdfium2
+    except ImportError as e:
+        raise ImportError(
+            "olmOCR-mix stores source PDFs, so rendering a page needs pypdfium2 "
+            "(`pip install pypdfium2`)."
+        ) from e
+
+    with _PDFIUM_LOCK:
+        pdf = pypdfium2.PdfDocument(pdf_path)
+        try:
+            if len(pdf) != 1:
+                raise RuntimeError(
+                    f"{pdf_path}: expected a pre-split single-page PDF, got {len(pdf)}"
+                )
+            page = pdf[0]
+            longest_dim = max(page.get_size())  # (width, height) in PDF points
+            scale = target_longest_image_dim / longest_dim
+            return page.render(scale=scale).to_pil().convert("RGB")
+        finally:
+            pdf.close()
+
+
+@dataclass
+class OlmOcrMixDatasetConfig(Config):
+    """One subset of olmOCR-mix-1025: transcribe a rendered PDF page (mm_olmo
+    ``OlmOcrMixConfig``). Field names follow mm_olmo's."""
+
+    subset: str = "documents"
+    """``documents`` / ``books`` / ``loc_transcripts`` / ``national_archives`` (hub names with the
+    numeric prefix are accepted too)."""
+
+    split: str = "train"
+    """``train`` or ``eval`` (``validation`` is an alias)."""
+
+    dataset_path: str = OLMOCR_MIX
+    """Root holding ``<subset>_<split>.parquet`` and the expanded ``pdfs/`` tree."""
+
+    target_longest_image_dim_range: Optional[Tuple[int, int]] = (1024, 2048)
+    """Training-time render size: the longest side is drawn uniformly from this inclusive range
+    per example. ``None`` always renders at ``target_longest_image_dim``."""
+
+    target_longest_image_dim: int = 1536
+    """Render size (longest side) for the eval split, or for training when no range is set."""
+
+    languages: Optional[Tuple[str, ...]] = ("en",)
+    """Keep only rows whose ``primary_language`` (ISO 639-1; English is ~94% of the corpus) is
+    listed. ``None`` keeps every language."""
+
+    max_crops: int = 8
+    max_sequence_length: Optional[int] = None
+    """Tail-truncate the built sequence to this many tokens (the image block always fits; an
+    example left without loss tokens is rejected, and the loader skips it). Set it to the
+    training sequence length: long pages otherwise overflow it."""
+
+    loss_token_weighting: str = "root_subsegments"
+    message_weight: Optional[float] = None
+    """Scalar loss multiplier for this source (mm_olmo's ``ocr_weight``)."""
+
+    seed: int = 0
+
+    system_prompt: str = "style_and_length_v3"
+    """How the ``olmocr`` style is shown in the user turn. ``style_and_length_v3`` -- mm_olmo's
+    molmo3 stage-1 family, the only one mm_olmo trains this source under -- and
+    ``demo_or_style_v2`` / ``_v3`` give the bare ``"olmocr:"``; ``style_and_length[_v2]`` (the
+    released Molmo2 pretrain family) gives the length-conditioned ``"olmocr <bucket>:"``;
+    ``none`` gives no prefix."""
+
+    def validate(self):
+        canonical_subset(self.subset)
+        canonical_split(self.split)
+        if self.target_longest_image_dim_range is not None:
+            lo, hi = self.target_longest_image_dim_range
+            if lo <= 0 or hi < lo:
+                raise OLMoConfigurationError(
+                    "target_longest_image_dim_range must be a positive (lo, hi) with lo <= hi, "
+                    f"got {(lo, hi)}"
+                )
+        if self.target_longest_image_dim <= 0:
+            raise OLMoConfigurationError("target_longest_image_dim must be positive")
+        if self.languages is not None and len(self.languages) == 0:
+            raise OLMoConfigurationError(
+                "languages=() would filter out every row; use None to keep all languages"
+            )
+        if self.system_prompt not in STYLE_TAG_FAMILIES:
+            raise OLMoConfigurationError(
+                f"system_prompt={self.system_prompt!r} is not one of {sorted(STYLE_TAG_FAMILIES)}"
+            )
+
+    def build(self, tokenizer) -> "OlmOcrMixDataset":
+        self.validate()
+        return OlmOcrMixDataset(self, tokenizer)
+
+
+class OlmOcrMixDataset:
+    """Map-style dataset over the (language-filtered) pages of one olmOCR-mix subset."""
+
+    def __init__(self, config: OlmOcrMixDatasetConfig, tokenizer):
+        self.config = config
+        self.tokenizer = tokenizer
+        self.subset = canonical_subset(config.subset)
+        self.split = canonical_split(config.split)
+        self.parquet_path = os.path.join(config.dataset_path, f"{self.subset}_{self.split}.parquet")
+        if not os.path.exists(self.parquet_path):
+            raise FileNotFoundError(
+                f"{self.parquet_path} not found; materialise olmOCR-mix with mm_olmo's "
+                f"`OlmOcrMixConfig.download(subsets=[{config.subset!r}])` or point "
+                "`dataset_path` at it"
+            )
+        # The parquet is one file, so `split="train"` here is just `load_dataset`'s name for it.
+        self._data = load_hf_dataset(self.parquet_path, split="train", keep_columns=_COLUMNS)
+        self._index = self._build_index()
+        log.info(
+            "olmOCR-mix %s/%s: %d of %d pages kept (languages=%s)",
+            self.subset,
+            self.split,
+            len(self._index),
+            len(self._data),
+            config.languages,
+        )
+
+    def _build_index(self) -> np.ndarray:
+        """Rows passing the ``languages`` filter (mm_olmo's build-time ``ds.filter``), computed
+        on the Arrow column so no cache file is written."""
+        if self.config.languages is None:
+            return np.arange(len(self._data))
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        keep = pc.is_in(
+            self._data.data.column("primary_language"),
+            value_set=pa.array(list(self.config.languages)),
+        )
+        mask = pc.fill_null(keep, False).to_numpy(zero_copy_only=False).astype(bool)
+        return np.flatnonzero(mask)
+
+    def __len__(self) -> int:
+        return len(self._index)
+
+    # -- per-example pieces (mm_olmo `format_example` + the formatter's system prompt) --------
+
+    def target_dim_for(self, rng: np.random.RandomState) -> int:
+        """Render target for one example: sampled on train when a range is set, fixed otherwise
+        (mm_olmo ``target_dim_for``)."""
+        cfg = self.config
+        if cfg.target_longest_image_dim_range is None or self.split != "train":
+            return cfg.target_longest_image_dim
+        lo, hi = cfg.target_longest_image_dim_range
+        return int(rng.randint(lo, hi + 1))  # numpy's randint excludes `high`
+
+    def pdf_path(self, row: Dict[str, Any]) -> str:
+        return pdf_path_for(self.config.dataset_path, row["pdf_relpath"])
+
+    @staticmethod
+    def transcription(row: Dict[str, Any]) -> str:
+        """The target text; blank pages are transcribed as ``"No text found"`` (mm_olmo)."""
+        return row["natural_text"] or "No text found"
+
+    def user_prompt(self, text: str, rng: np.random.RandomState) -> str:
+        """The user turn: only the style tag, since the ``olmocr`` style has no question
+        (:func:`~.pixmo_cap.style_tag_prompt`)."""
+        return style_tag_prompt(OLMOCR_STYLE, text, rng, self.config.system_prompt)
+
+    # -- example ---------------------------------------------------------------------------
+
+    def __getitem__(self, i: int) -> Dict[str, np.ndarray]:
+        cfg = self.config
+        row = self._data[int(self._index[i])]
+        rng = example_rng(cfg.seed, i)
+        # mm_olmo draw order: the render size in `format_example`, then the formatter's prefix.
+        target_dim = self.target_dim_for(rng)
+        text = self.transcription(row)
+        image = render_pdf_page(self.pdf_path(row), target_dim)
+        prompt = self.user_prompt(text, rng)
+        # One image, one (tag, transcription) turn: the shared stage-2 encoder builds exactly the
+        # stage-1 single-branch layout (user header + image block + tag, then the response).
+        seq = encode_sft_example(
+            self.tokenizer,
+            image,
+            [(prompt, text)],
+            max_crops=cfg.max_crops,
+            loss_token_weighting=cfg.loss_token_weighting,
+            message_weight=cfg.message_weight,
+            shuffle_rng=rng,
+        )
+        if cfg.max_sequence_length is not None:
+            seq = truncate_example(seq, cfg.max_sequence_length)
+        return seq

--- a/src/olmo_core/data/multimodal/olmocr.py
+++ b/src/olmo_core/data/multimodal/olmocr.py
@@ -38,8 +38,12 @@ from olmo_core.exceptions import OLMoConfigurationError
 from .message_sequence import encode_sft_example
 from .paths import OLMOCR_MIX
 from .pixmo_cap import STYLE_TAG_FAMILIES, style_tag_prompt
-from .sequence_builder import example_rng
-from .sft_common import load_hf_dataset, truncate_example
+from .sft_common import (
+    EpochSeededExamples,
+    get_example_with_skip,
+    load_hf_dataset,
+    truncate_example,
+)
 
 __all__ = [
     "OLMOCR_STYLE",
@@ -227,7 +231,7 @@ class OlmOcrMixDatasetConfig(Config):
         return OlmOcrMixDataset(self, tokenizer)
 
 
-class OlmOcrMixDataset:
+class OlmOcrMixDataset(EpochSeededExamples):
     """Map-style dataset over the (language-filtered) pages of one olmOCR-mix subset."""
 
     def __init__(self, config: OlmOcrMixDatasetConfig, tokenizer):
@@ -245,6 +249,7 @@ class OlmOcrMixDataset:
         # The parquet is one file, so `split="train"` here is just `load_dataset`'s name for it.
         self._data = load_hf_dataset(self.parquet_path, split="train", keep_columns=_COLUMNS)
         self._index = self._build_index()
+        self._warned = 0
         log.info(
             "olmOCR-mix %s/%s: %d of %d pages kept (languages=%s)",
             self.subset,
@@ -298,10 +303,21 @@ class OlmOcrMixDataset:
 
     # -- example ---------------------------------------------------------------------------
 
-    def __getitem__(self, i: int) -> Dict[str, np.ndarray]:
+    def __getitem__(self, index: int) -> Dict[str, np.ndarray]:
+        """Build page ``index``, deterministically skipping unusable rows.
+
+        A page whose PDF fails to render, or whose transcription leaves no loss tokens after
+        truncation, must not raise out of here: it would spend the mixture loader's error budget
+        and a run of them would abort training. Same policy as the other SFT sources; see
+        :func:`~olmo_core.data.multimodal.sft_common.get_example_with_skip`.
+        """
+        return get_example_with_skip(self, index, len(self))
+
+    def _build(self, i: int) -> Dict[str, np.ndarray]:
         cfg = self.config
         row = self._data[int(self._index[i])]
-        rng = example_rng(cfg.seed, i)
+        # Per (row, epoch): `target_dim_for` samples a render size, which should vary by epoch.
+        rng = self.epoch_rng(i)
         # mm_olmo draw order: the render size in `format_example`, then the formatter's prefix.
         target_dim = self.target_dim_for(rng)
         text = self.transcription(row)

--- a/src/olmo_core/data/multimodal/paths.py
+++ b/src/olmo_core/data/multimodal/paths.py
@@ -12,11 +12,29 @@ TORCH_DATASETS = os.path.join(MOLMO_DATA_DIR, "torch_datasets")
 PIXMO_DATASETS = os.path.join(TORCH_DATASETS, "pixmo_datasets")
 TULU4_DATA = os.path.join(TORCH_DATASETS, "olmo-3-instruct-sft-no-tools-classified-v3")
 ACADEMIC_DATASETS = os.path.join(TORCH_DATASETS, "academic_datasets")
+# allenai/olmOCR-mix-1025 as materialised by mm_olmo's ``OlmOcrMixConfig.download``: the
+# per-subset/split parquets plus the PDF tarballs expanded into ``pdfs/<chunk>/<arcname>``.
+OLMOCR_MIX = os.path.join(TORCH_DATASETS, "olmocr_mix_1025")
+# The oe-encoder team's webdataset-style caption tars (``<key>.jpg|png`` + ``<key>.json`` per
+# sample), used for the OCR sources in :mod:`.mixtures.ocr`. Another project's directory, so
+# it is overridable with the OE_ENCODER_DATA_DIR env var.
+OE_ENCODER_DATA = os.environ.get("OE_ENCODER_DATA_DIR", "/weka/oe-training-default/oe-encoder")
+
+# HARDCODED personal dataset (chrisc's audited, image-grouped PixMo-Points build on weka).
+# mm_olmo's ``PixMoPointV2.PATH`` reads this same directory, so it is the canonical location
+# for now. Override with the PIXMO_POINTS_V2_DIR env var, or per run through the dataset
+# config (``--pointing_v2.dataset_path=...`` in Molmo2-Stage1.py).
+PIXMO_POINTS_V2 = os.environ.get(
+    "PIXMO_POINTS_V2_DIR", "/weka/oe-training-default/chrisc/pixmo-points-with-masks-v17"
+)
 
 __all__ = [
     "MOLMO_DATA_DIR",
     "TORCH_DATASETS",
     "PIXMO_DATASETS",
+    "PIXMO_POINTS_V2",
     "TULU4_DATA",
     "ACADEMIC_DATASETS",
+    "OLMOCR_MIX",
+    "OE_ENCODER_DATA",
 ]

--- a/src/olmo_core/data/multimodal/pixmo_cap.py
+++ b/src/olmo_core/data/multimodal/pixmo_cap.py
@@ -29,9 +29,17 @@ import numpy as np
 from olmo_core.config import Config
 
 from .qwen3_layout import branch_context_ids, image_prefix_ids
-from .sequence_builder import example_rng, build_branched_sequence
+from .sequence_builder import build_branched_sequence, example_rng
 
-__all__ = ["PixMoCapDataset", "PixMoCapDatasetConfig", "CAPTION_PROMPTS", "TRANSCRIPT_PROMPTS"]
+__all__ = [
+    "PixMoCapDataset",
+    "PixMoCapDatasetConfig",
+    "CAPTION_PROMPTS",
+    "TRANSCRIPT_PROMPTS",
+    "style_length_prefix",
+    "style_tag_prompt",
+    "STYLE_TAG_FAMILIES",
+]
 
 # Prompt pools mirroring mm_olmo's ``GENERAL_PROMPTS_V1`` (data_formatter.py); one is
 # sampled per example (seeded) so the user turn matches the caption-pretraining mix.
@@ -65,6 +73,54 @@ TRANSCRIPT_STYLE = "transcript"
 _LENGTH_BUCKET = 15
 _LENGTH_NOISE_STD = 25.0
 _LENGTH_KEEP_PROB = 0.90
+
+
+def style_length_prefix(style: str, text: str, rng: np.random.RandomState) -> str:
+    """mm_olmo ``style_and_length_v2`` prefix: ``"<style> <bucket>:"`` (90%) or ``"<style>:"``
+    (10%), where ``bucket = (len(text) + N(0, 25)) // 15`` (data_formatter.py:1736-1749).
+
+    Shared by every stage-1 source whose response is free text (captions, transcripts, OCR
+    pages): the tag lets the model condition its output length on the prompt.
+    """
+    if rng.rand() < _LENGTH_KEEP_PROB:
+        n = len(text) + int(rng.normal(scale=_LENGTH_NOISE_STD))
+        n = n // _LENGTH_BUCKET
+        return f"{style} {n}:"
+    return f"{style}:"
+
+
+#: mm_olmo ``system_prompt`` families understood by :func:`style_tag_prompt`
+#: (``DataFormatter.get_system_prompt``, data_formatter.py:1690-1756).
+STYLE_TAG_FAMILIES = frozenset(
+    {
+        "style_and_length",
+        "style_and_length_v2",
+        "style_and_length_v3",
+        "demo_or_style_v2",
+        "demo_or_style_v3",
+        "none",
+    }
+)
+
+
+def style_tag_prompt(style: str, text: str, rng: np.random.RandomState, system_prompt: str) -> str:
+    """The user turn of a free-text response source that has no question of its own (olmOCR-mix
+    and the caption tars): just the style tag, rendered per mm_olmo's ``system_prompt`` family.
+
+    ``style_and_length[_v2]`` gives the length-conditioned ``"<style> <bucket>:"``;
+    ``style_and_length_v3`` (which reserves the bucket for captions / transcripts) and the
+    ``demo_or_style`` families (which prefix every non-demo style) give the bare ``"<style>:"``;
+    ``none`` gives no prefix at all.
+    """
+    if system_prompt not in STYLE_TAG_FAMILIES:
+        raise ValueError(
+            f"system_prompt={system_prompt!r} is not one of {sorted(STYLE_TAG_FAMILIES)}"
+        )
+    if system_prompt in ("style_and_length", "style_and_length_v2"):
+        return style_length_prefix(style, text, rng)
+    if system_prompt == "none":
+        return ""
+    return f"{style}:"
 
 
 @dataclass
@@ -204,13 +260,8 @@ class PixMoCapDataset:
         return branches
 
     def _style_length_prefix(self, style: str, text: str, rng: np.random.RandomState) -> str:
-        """mm_olmo ``style_and_length_v2`` prefix: ``"<style> <bucket>:"`` (90%) or
-        ``"<style>:"`` (10%), where ``bucket = (len(text) + N(0, 25)) // 15``."""
-        if rng.rand() < _LENGTH_KEEP_PROB:
-            n = len(text) + int(rng.normal(scale=_LENGTH_NOISE_STD))
-            n = n // _LENGTH_BUCKET
-            return f"{style} {n}:"
-        return f"{style}:"
+        """See :func:`style_length_prefix`."""
+        return style_length_prefix(style, text, rng)
 
     def _sample_prompt(self, style: str, rng: np.random.RandomState) -> str:
         pool = TRANSCRIPT_PROMPTS if style == TRANSCRIPT_STYLE else CAPTION_PROMPTS

--- a/src/olmo_core/data/multimodal/pixmo_points.py
+++ b/src/olmo_core/data/multimodal/pixmo_points.py
@@ -17,7 +17,7 @@ assembled with :func:`~olmo_core.data.multimodal.sequence_builder.build_branched
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -51,21 +51,33 @@ def _build_example(
     p_high_res: float = 0.0,
     shuffle_rng: np.random.RandomState | None = None,
     seed: int = 0,
+    branch_weights: Optional[Sequence[Optional[float]]] = None,
 ) -> Dict[str, np.ndarray]:
     """Preprocess the image and assemble a (possibly multi-branch) pointing example.
 
     :param branches_text: list of ``(user_question, assistant_answer)`` strings.
+    :param branch_weights: optional per-branch loss multipliers parallel to ``branches_text``
+        (``None`` entries mean 1). mm_olmo's per-message ``AssistantMessage.weight``: the
+        branch's response tokens are scaled by it on top of ``loss_token_weighting`` and
+        ``message_weight``, which stay example-wide.
     """
     import torch
 
     from olmo_core.nn.vision.molmo2_image_processor import preprocess_image_molmo2
 
     branches_text = list(branches_text)
+    weights = None if branch_weights is None else list(branch_weights)
+    if weights is not None and len(weights) != len(branches_text):
+        raise ValueError(
+            f"branch_weights has {len(weights)} entries for {len(branches_text)} branches"
+        )
     if len(branches_text) > 1:
         order = np.arange(len(branches_text))
         rng = shuffle_rng if shuffle_rng is not None else np.random.RandomState(seed)
         rng.shuffle(order)
         branches_text = [branches_text[i] for i in order]
+        if weights is not None:
+            weights = [weights[i] for i in order]
 
     preprocess_rng = shuffle_rng if shuffle_rng is not None else np.random.RandomState(seed)
     images_t, pooling_t, image_grid = preprocess_image_molmo2(
@@ -103,9 +115,35 @@ def _build_example(
     seq["loss_masks"] = apply_message_weight_to_loss_masks(
         seq["loss_masks"], subsegment_ids, mw, branch_scaling_already_applied=True
     )
+    if weights is not None:
+        seq["loss_masks"] = _apply_branch_weights(seq["loss_masks"], subsegment_ids, weights)
     seq["images"] = images_t[0].numpy()
     seq["pooled_patches_idx"] = pooling_t[0].numpy()
     return seq
+
+
+def _apply_branch_weights(
+    loss_masks: np.ndarray,
+    subsegment_ids: Optional[np.ndarray],
+    weights: Sequence[Optional[float]],
+) -> np.ndarray:
+    """Scale each branch's loss weights by its multiplier (``None`` / 1 leave it alone).
+
+    ``loss_masks`` is aligned with ``labels`` (shifted one position left), but every position
+    that carries loss for branch ``b`` -- the token before each of its response tokens, and its
+    segment-end token -- itself belongs to ``b``, so selecting by ``subsegment_ids`` is exact.
+    A single-branch example has no ``subsegment_ids``; its one weight applies to the whole mask.
+    """
+    out = loss_masks.astype(np.float32, copy=True)
+    if subsegment_ids is None:
+        w = weights[0]
+        if w is not None and w != 1.0:
+            out *= float(w)
+        return out
+    for branch_idx, w in enumerate(weights):
+        if w is not None and w != 1.0:
+            out[subsegment_ids == branch_idx] *= float(w)
+    return out
 
 
 def _load_split(path: str, split: str):

--- a/src/olmo_core/data/multimodal/pixmo_points_v2.py
+++ b/src/olmo_core/data/multimodal/pixmo_points_v2.py
@@ -1,0 +1,487 @@
+"""Audited PixMo pointing / counting sources for Molmo2 stage-1.
+
+Ports mm_olmo's second-generation pointing data (``olmo/data/pixmo_datasets.py``
+``PixMoPointV2`` and ``PixMoCountConfigV2``), the sources its molmo3 stage-1 mixture uses in
+place of ``pixmo_points_train`` / ``pixmo_points_high_freq_train`` / ``pixmo_count_train``
+(``launch_scripts/train_molmo3_stage1.py``, ``_base_mixture``). Compared to the v1 builds in
+:mod:`.pixmo_points`, every row is one *image* carrying all of its annotations, and:
+
+* every point set has an ``audit_result`` -- a VLM re-evaluation: ``correct`` / ``unsure`` /
+  ``error`` / ``clear_error`` (``n/a`` for empty sets). A failed audit (``error`` or
+  ``clear_error``) can either be dropped (``filter_audit=True``) or trained on behind a marker
+  style (``audit_style``, e.g. ``aux_pointing``) that differs from the base style only in its
+  ``"<style>:"`` token, so those less reliable targets do not dilute the primary
+  ``pointing`` / ``point_count`` distributions. Both work, per the mm_olmo team.
+* :class:`PixMoPointsV2Dataset` rows also ship absence queries for training the
+  ``"There are none."`` refusal: ``easy_negatives`` (unrelated labels) and
+  ``paired_negatives`` / ``paired_negatives_v2`` (hard, near-miss labels for the image's own
+  objects). These are meant to be *sub-sampled* per epoch (``n_easy_samples``,
+  ``p_paired_negatives``); training on all of them makes the model over-refuse.
+
+Both datasets format through :class:`~.sft_formatter.SftFormatter` and the html-v2 grounding
+format like their v1 siblings, and assemble with the shared ``_build_example`` (image
+preprocessing + branched sequence). Not ported from ``PixMoPointV2``: the segmentation-mask
+branches (``include_masks`` / ``pixmo_seg``) and the 3D / surface-normal renderings, none of
+which Molmo2 can emit.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from olmo_core.config import Config
+from olmo_core.exceptions import OLMoConfigurationError
+
+from .paths import PIXMO_DATASETS, PIXMO_POINTS_V2
+from .pixmo_points import _build_example, _load_split, _open_image
+from .sequence_builder import example_rng
+from .sft_formatter import SftFormatter
+
+__all__ = [
+    "FAILED_AUDIT_RESULTS",
+    "PixMoPointsV2DatasetConfig",
+    "PixMoPointsV2Dataset",
+    "PixMoCountV2DatasetConfig",
+    "PixMoCountV2Dataset",
+]
+
+log = logging.getLogger(__name__)
+
+#: ``audit_result`` values mm_olmo treats as a failed audit (``PixMoPointV2._keep``).
+FAILED_AUDIT_RESULTS = frozenset({"error", "clear_error"})
+
+# mm_olmo ``PixMoPointV2.kind`` -> the ``source`` column value it keeps.
+_KIND_TO_SOURCE = {"basic": "pointing", "high_frequency": "counting", "both": None}
+
+
+def _failed_audit(audit_result: Optional[str]) -> bool:
+    return audit_result in FAILED_AUDIT_RESULTS
+
+
+def _choose(rng: np.random.RandomState, options: Sequence[str]) -> str:
+    """``rng.choice`` over a style tuple, as a plain ``str``."""
+    return str(rng.choice(list(options)))
+
+
+def _rows_with_any(column, keep_fn) -> np.ndarray:
+    """Per-row ``any(keep_fn(annotation))`` over a list-of-struct Arrow column.
+
+    Works chunk by chunk on the raw Arrow buffers so that, unlike materialising the column
+    with ``dataset["annotations"]``, the (large) mask RLE strings are never decoded: the
+    full 224k-row PixMo-Points scan takes ~0.1 s. ``keep_fn`` receives the flattened
+    struct array of one chunk and returns a boolean numpy mask over it.
+    """
+    import pyarrow.compute as pc
+
+    out: List[np.ndarray] = []
+    for chunk in column.chunks:
+        flat = pc.list_flatten(chunk)
+        keep = np.asarray(keep_fn(flat), dtype=bool)
+        parents = pc.list_parent_indices(chunk).to_numpy(zero_copy_only=False)
+        row_any = np.zeros(len(chunk), dtype=bool)
+        if len(parents):
+            row_any[np.unique(parents[keep])] = True
+        out.append(row_any)
+    return np.concatenate(out) if out else np.zeros(0, dtype=bool)
+
+
+def _bool_np(arr) -> np.ndarray:
+    """Arrow boolean array -> numpy bool, nulls as False."""
+    import pyarrow.compute as pc
+
+    return pc.fill_null(arr, False).to_numpy(zero_copy_only=False).astype(bool)
+
+
+# ---------------------------------------------------------------------------
+# PixMo points v2: audited, image-grouped pointing + counting with absence queries
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PixMoPointsV2DatasetConfig(Config):
+    """mm_olmo ``PixMoPointV2`` (its pointing leg). Field names follow mm_olmo's.
+
+    Rows are images; each carries several ``(label, points, audit_result)`` annotations plus
+    per-image negative labels. Every annotation kept by :meth:`PixMoPointsV2Dataset.keep`
+    becomes one branch of a multi-branch example; annotated empty point sets and the
+    sub-sampled negatives become ``"There are none."`` branches.
+    """
+
+    dataset_path: str = PIXMO_POINTS_V2
+    """A flat HF ``Dataset`` saved with ``save_to_disk`` (columns ``image``, ``source``,
+    ``annotations``, ``easy_negatives``, ``paired_negatives``, ``paired_negatives_v2``)."""
+
+    kind: str = "both"
+    """``"basic"`` keeps the PixMo-Points rows (``source == "pointing"``), ``"high_frequency"``
+    the PixMo-Count-style rows (``"counting"``), ``"both"`` everything."""
+
+    style: Tuple[str, ...] = ("point_count", "pointing")
+    """Styles drawn uniformly per annotation and per negative (mm_olmo ``style``)."""
+
+    max_points: int = 60
+    """Annotations with more points are skipped (they are also the least reliable)."""
+
+    min_points: int = 0
+    """Annotations with fewer points are skipped; ``0`` keeps the annotated empty sets, which
+    render as ``"There are none."``."""
+
+    filter_audit: bool = False
+    """Drop annotations whose ``audit_result`` is ``error`` / ``clear_error``."""
+
+    audit_style: Optional[Tuple[str, ...]] = None
+    """Styles drawn for audit-failed annotations that are kept, e.g.
+    ``("aux_point_count", "aux_pointing")``. ``None`` renders them like everything else."""
+
+    n_easy_samples: int = 2
+    """Easy negatives sampled per image and epoch (mm_olmo samples a fixed 2 regardless of
+    this field's value; we honour the field, which is identical at the default)."""
+
+    n_hard_negatives: int = 0
+    """Negatives sampled from ``easy_negatives + paired_negatives`` (the v1 pool); mm_olmo's
+    stage 1 leaves this at 0."""
+
+    p_paired_negatives: float = 0.0
+    """Expected fraction of the image's paired (hard) negatives used per epoch; the count is
+    the stochastically-rounded ``len * p``. mm_olmo's stage 1 uses 0.25."""
+
+    v2_paired_negatives: bool = True
+    """Sample from ``paired_negatives_v2`` rather than ``paired_negatives``."""
+
+    negative_weight: Optional[float] = None
+    """Loss multiplier for the paired and annotated negatives. Easy negatives always weigh 1
+    (mm_olmo ``PixMoPointV2.format_example``)."""
+
+    max_crops: int = 8
+    loss_token_weighting: str = "root_subsegments"
+    message_weight: Optional[float] = None
+    p_high_res: float = 0.0
+    seed: int = 0
+    prompt_templates: str = "uber_model_v2"
+    """Prompt family for the question text; stage 1 uses ``"none"`` (bare label)."""
+    system_prompt: str = "demo_or_style_v2"
+    """Prompt family for the style prefix; stage 1 uses ``"style_and_length_v2"``."""
+
+    def validate(self):
+        if self.kind not in _KIND_TO_SOURCE:
+            raise OLMoConfigurationError(
+                f"kind={self.kind!r} is not one of {tuple(_KIND_TO_SOURCE)}"
+            )
+        if not self.style:
+            raise OLMoConfigurationError("style must name at least one style")
+        if self.audit_style is not None and not self.audit_style:
+            raise OLMoConfigurationError("audit_style must be None or name at least one style")
+        if not 0.0 <= self.p_paired_negatives <= 1.0:
+            raise OLMoConfigurationError("p_paired_negatives must be in [0, 1]")
+        if self.min_points < 0 or self.max_points < self.min_points:
+            raise OLMoConfigurationError("need 0 <= min_points <= max_points")
+        if self.n_easy_samples < 0 or self.n_hard_negatives < 0:
+            raise OLMoConfigurationError("n_easy_samples / n_hard_negatives must be >= 0")
+
+    def build(self, tokenizer) -> "PixMoPointsV2Dataset":
+        self.validate()
+        return PixMoPointsV2Dataset(self, tokenizer)
+
+
+class PixMoPointsV2Dataset:
+    """Map-style dataset over the images of :class:`PixMoPointsV2DatasetConfig` that have at
+    least one trainable annotation."""
+
+    def __init__(self, config: PixMoPointsV2DatasetConfig, tokenizer):
+        self.config = config
+        self.tokenizer = tokenizer
+        self._data = _load_split(config.dataset_path, "train")
+        self._index = self._build_index()
+        log.info(
+            "PixMoPointsV2 (%s): %d of %d images have a trainable annotation",
+            config.dataset_path,
+            len(self._index),
+            len(self._data),
+        )
+
+    # -- selection -------------------------------------------------------------------------
+
+    def keep(self, anno: Dict[str, Any]) -> bool:
+        """Whether to train on this annotation (mm_olmo ``PixMoPointV2._keep``, pointing leg)."""
+        cfg = self.config
+        label = anno.get("label")
+        if not label or not label.strip():
+            return False
+        if cfg.filter_audit and _failed_audit(anno.get("audit_result")):
+            return False
+        return cfg.min_points <= len(anno["points"]) <= cfg.max_points
+
+    def _build_index(self) -> np.ndarray:
+        """Row indices with ``kind``'s source and at least one annotation passing :meth:`keep`
+        -- mm_olmo's build-time ``ds.filter``, computed in memory instead of as an Arrow cache
+        file next to the (shared) data."""
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        cfg = self.config
+        table = self._data.data
+
+        def _keep_flat(flat) -> np.ndarray:
+            n_points = pc.list_value_length(flat.field("points")).to_numpy(zero_copy_only=False)
+            n_points = np.nan_to_num(n_points.astype(np.float64), nan=-1)
+            has_label = _bool_np(
+                pc.invert(pc.equal(pc.utf8_trim_whitespace(flat.field("label")), ""))
+            )
+            keep = has_label & (n_points >= cfg.min_points) & (n_points <= cfg.max_points)
+            if cfg.filter_audit:
+                failed = _bool_np(
+                    pc.is_in(
+                        flat.field("audit_result"),
+                        value_set=pa.array(sorted(FAILED_AUDIT_RESULTS)),
+                    )
+                )
+                keep &= ~failed
+            return keep
+
+        rows = _rows_with_any(table.column("annotations"), _keep_flat)
+        source = _KIND_TO_SOURCE[cfg.kind]
+        if source is not None:
+            rows &= _bool_np(pc.equal(table.column("source"), source))
+        return np.flatnonzero(rows)
+
+    def __len__(self) -> int:
+        return len(self._index)
+
+    # -- formatting ------------------------------------------------------------------------
+
+    def format_row(
+        self, row: Dict[str, Any], rng: np.random.RandomState
+    ) -> Tuple[List[Dict[str, Any]], List[Optional[float]]]:
+        """One image's branch messages and per-branch loss weights (mm_olmo
+        ``PixMoPointV2.format_example``, in its draw order: annotation styles, then the hard,
+        easy and paired negative samples, then the negatives' styles).
+
+        Each message is a formatter sub-example: ``style``, ``label``, ``points`` (``(N, 2)``
+        in 0-100 percent coordinates, clipped) -- ``N == 0`` renders ``"There are none."``.
+        """
+        cfg = self.config
+        messages: List[Dict[str, Any]] = []
+        weights: List[Optional[float]] = []
+        negatives: List[str] = []
+
+        for anno in row["annotations"]:
+            if not self.keep(anno):
+                continue
+            label = anno["label"].strip()
+            raw = anno["points"]
+            if len(raw) == 0:
+                negatives.append(label)  # an annotated absence
+                continue
+            # Rows carry (x, y, depth) per point; only x, y are rendered.
+            points = np.asarray(raw, dtype=np.float64).reshape(len(raw), -1)[:, :2]
+            if cfg.audit_style and _failed_audit(anno.get("audit_result")):
+                style = _choose(rng, cfg.audit_style)
+            else:
+                style = _choose(rng, cfg.style)
+            messages.append(
+                dict(style=style, label=label, points=points, point_scale=100, clip_points=True)
+            )
+            weights.append(None)
+
+        easy = [str(x) for x in row.get("easy_negatives") or []]
+        if cfg.n_hard_negatives > 0:
+            pool = easy + [str(x) for x in row.get("paired_negatives") or []]
+            if len(pool) > cfg.n_hard_negatives:
+                pool = [str(x) for x in rng.choice(pool, size=cfg.n_hard_negatives, replace=False)]
+            negatives += pool
+        if cfg.n_easy_samples > 0:
+            sample = easy
+            if len(sample) > cfg.n_easy_samples:
+                sample = [
+                    str(x) for x in rng.choice(sample, size=cfg.n_easy_samples, replace=False)
+                ]
+            negatives += sample
+        if cfg.p_paired_negatives > 0:
+            key = "paired_negatives_v2" if cfg.v2_paired_negatives else "paired_negatives"
+            paired = [str(x) for x in row.get(key) or []]
+            expected = len(paired) * cfg.p_paired_negatives
+            n_paired = int(expected) + int((expected - int(expected)) > rng.random())
+            if len(paired) > n_paired:
+                paired = [str(x) for x in rng.choice(paired, size=n_paired, replace=False)]
+            negatives += paired
+
+        for label in negatives:
+            messages.append(
+                dict(
+                    style=_choose(rng, cfg.style),
+                    label=label,
+                    points=np.zeros((0, 2), dtype=np.float64),
+                    point_scale=100,
+                    clip_points=True,
+                )
+            )
+            weights.append(1.0 if label in easy else cfg.negative_weight)
+
+        if not messages:
+            raise ValueError("PixMoPointsV2 row has no trainable annotation")
+        return messages, weights
+
+    def __getitem__(self, i: int) -> Dict[str, np.ndarray]:
+        cfg = self.config
+        row = self._data[int(self._index[i])]
+        rng = example_rng(cfg.seed, i)
+        messages, weights = self.format_row(row, rng)
+        fmt = SftFormatter(
+            seed=cfg.seed, prompt_templates=cfg.prompt_templates, system_prompt=cfg.system_prompt
+        )
+        branches = [fmt.format_turns(msg, index=i, rng=rng)[0] for msg in messages]
+        return _build_example(
+            self.tokenizer,
+            _open_image(row["image"]),
+            branches,
+            max_crops=cfg.max_crops,
+            loss_token_weighting=cfg.loss_token_weighting,
+            message_weight=cfg.message_weight,
+            p_high_res=cfg.p_high_res,
+            shuffle_rng=rng,
+            branch_weights=weights,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PixMo count v2: audited PixMo-Count grouped by image
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PixMoCountV2DatasetConfig(Config):
+    """mm_olmo ``PixMoCountConfigV2``: PixMo-Count re-grouped by image with a VLM audit per
+    point set. Points are pixel coordinates (normalised by the image size, as in the v1
+    ``count`` build); unlike v1 the two styles are drawn per annotation rather than doubling
+    the dataset.
+    """
+
+    dataset_path: str = f"{PIXMO_DATASETS}/count-v2"
+    """HF ``DatasetDict`` saved with ``save_to_disk`` (``train`` / ``validation`` / ``test``)."""
+
+    split: str = "train"
+
+    style: Tuple[str, ...] = ("point_count", "pointing")
+    """Styles drawn uniformly per annotation (mm_olmo ``style="both"``)."""
+
+    filter_audit: bool = False
+    """Drop point sets whose ``audit_result`` is ``error`` / ``clear_error``."""
+
+    audit_style: Optional[Tuple[str, ...]] = None
+    """Styles drawn for audit-failed point sets that are kept, e.g.
+    ``("aux_point_count", "aux_pointing")``."""
+
+    max_crops: int = 8
+    loss_token_weighting: str = "root_subsegments"
+    message_weight: Optional[float] = None
+    p_high_res: float = 0.0
+    seed: int = 0
+    prompt_templates: str = "uber_model_v2"
+    """Prompt family for the question text; stage 1 uses ``"none"`` (bare label)."""
+    system_prompt: str = "demo_or_style_v2"
+    """Prompt family for the style prefix; stage 1 uses ``"style_and_length_v2"``."""
+
+    def validate(self):
+        if not self.style:
+            raise OLMoConfigurationError("style must name at least one style")
+        if self.audit_style is not None and not self.audit_style:
+            raise OLMoConfigurationError("audit_style must be None or name at least one style")
+
+    def build(self, tokenizer) -> "PixMoCountV2Dataset":
+        self.validate()
+        return PixMoCountV2Dataset(self, tokenizer)
+
+
+class PixMoCountV2Dataset:
+    """Map-style dataset over the images of :class:`PixMoCountV2DatasetConfig` that keep at
+    least one point set."""
+
+    def __init__(self, config: PixMoCountV2DatasetConfig, tokenizer):
+        self.config = config
+        self.tokenizer = tokenizer
+        self._data = _load_split(config.dataset_path, config.split)
+        self._index = self._build_index()
+        log.info(
+            "PixMoCountV2 (%s/%s): %d of %d images have a trainable point set",
+            config.dataset_path,
+            config.split,
+            len(self._index),
+            len(self._data),
+        )
+
+    def keep(self, anno: Dict[str, Any]) -> bool:
+        """Whether to train on this point set (mm_olmo ``PixMoCountConfigV2``)."""
+        return not (self.config.filter_audit and _failed_audit(anno.get("audit_result")))
+
+    def _build_index(self) -> np.ndarray:
+        """Rows with at least one kept point set (mm_olmo's ``filter_audit`` build-time
+        filter; without it every row qualifies)."""
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        def _keep_flat(flat) -> np.ndarray:
+            keep = np.ones(len(flat), dtype=bool)
+            if self.config.filter_audit:
+                keep &= ~_bool_np(
+                    pc.is_in(
+                        flat.field("audit_result"),
+                        value_set=pa.array(sorted(FAILED_AUDIT_RESULTS)),
+                    )
+                )
+            return keep
+
+        return np.flatnonzero(_rows_with_any(self._data.data.column("points"), _keep_flat))
+
+    def __len__(self) -> int:
+        return len(self._index)
+
+    def format_row(
+        self, row: Dict[str, Any], rng: np.random.RandomState, image_size: Tuple[int, int]
+    ) -> List[Dict[str, Any]]:
+        """One image's branch messages (mm_olmo ``PixMoCountConfigV2.format_example``)."""
+        cfg = self.config
+        messages: List[Dict[str, Any]] = []
+        for anno in row["points"]:
+            if not self.keep(anno):
+                continue
+            if cfg.audit_style and _failed_audit(anno.get("audit_result")):
+                style = _choose(rng, cfg.audit_style)
+            else:
+                style = _choose(rng, cfg.style)
+            xy = np.asarray(anno["points"], dtype=np.float64).reshape(-1, 2)
+            messages.append(
+                dict(
+                    style=style,
+                    label=anno["label"],
+                    points=xy,
+                    point_scale=None,
+                    image_size=image_size,
+                )
+            )
+        if not messages:
+            raise ValueError("PixMoCountV2 row has no trainable point set")
+        return messages
+
+    def __getitem__(self, i: int) -> Dict[str, np.ndarray]:
+        cfg = self.config
+        row = self._data[int(self._index[i])]
+        rng = example_rng(cfg.seed, i)
+        pil = _open_image(row["image"])
+        messages = self.format_row(row, rng, pil.size)
+        fmt = SftFormatter(
+            seed=cfg.seed, prompt_templates=cfg.prompt_templates, system_prompt=cfg.system_prompt
+        )
+        branches = [fmt.format_turns(msg, index=i, rng=rng)[0] for msg in messages]
+        return _build_example(
+            self.tokenizer,
+            pil,
+            branches,
+            max_crops=cfg.max_crops,
+            loss_token_weighting=cfg.loss_token_weighting,
+            message_weight=cfg.message_weight,
+            p_high_res=cfg.p_high_res,
+            shuffle_rng=rng,
+        )

--- a/src/olmo_core/data/multimodal/pixmo_points_v2.py
+++ b/src/olmo_core/data/multimodal/pixmo_points_v2.py
@@ -16,13 +16,31 @@ place of ``pixmo_points_train`` / ``pixmo_points_high_freq_train`` / ``pixmo_cou
   ``"There are none."`` refusal: ``easy_negatives`` (unrelated labels) and
   ``paired_negatives`` / ``paired_negatives_v2`` (hard, near-miss labels for the image's own
   objects). These are meant to be *sub-sampled* per epoch (``n_easy_samples``,
-  ``p_paired_negatives``); training on all of them makes the model over-refuse.
+  ``p_paired_negatives``); training on all of them makes the model over-refuse. The draw is
+  seeded per (row, epoch) via :class:`~.sft_common.EpochSeededExamples`, so successive epochs
+  work through different negatives instead of re-showing one fixed subset.
 
 Both datasets format through :class:`~.sft_formatter.SftFormatter` and the html-v2 grounding
 format like their v1 siblings, and assemble with the shared ``_build_example`` (image
 preprocessing + branched sequence). Not ported from ``PixMoPointV2``: the segmentation-mask
 branches (``include_masks`` / ``pixmo_seg``) and the 3D / surface-normal renderings, none of
 which Molmo2 can emit.
+
+Two consequences of dropping the mask branches, both measured against mm_olmo's ``_base_mixture``
+(which leaves ``include_masks=True``):
+
+* **Row count is all but unchanged.** mm_olmo's ``_keep`` also admits an annotation through the
+  mask path, so its filter is the looser one, but on the v17 build that is 220,314 rows against
+  our 220,291 (+23, +0.010%) -- the mask path only rescues annotations with more than
+  ``max_points`` points. Under ``pointing_data="v2"`` the group splits *linearly* by row count,
+  so this shifts the split within the group by a hundredth of a percent.
+* **Every refusal here is a pointing refusal.** mm_olmo sends a negative to the segmentation
+  head with probability ``1 - zero_points_as_segmentation`` (0.5 by default), and that applies to
+  all of them -- annotated absences, easy and paired negatives alike. With no segmentation path
+  to send them to, this port renders all of them as ``"There are none."`` pointing answers, so at
+  equal ``n_easy_samples`` / ``p_paired_negatives`` the model sees roughly **twice** mm_olmo's
+  density of pointing refusals. Halve those knobs to match mm_olmo's, and read the mm_olmo team's
+  over-refusal warning above with that factor in mind.
 """
 
 from __future__ import annotations
@@ -38,7 +56,7 @@ from olmo_core.exceptions import OLMoConfigurationError
 
 from .paths import PIXMO_DATASETS, PIXMO_POINTS_V2
 from .pixmo_points import _build_example, _load_split, _open_image
-from .sequence_builder import example_rng
+from .sft_common import EpochSeededExamples
 from .sft_formatter import SftFormatter
 
 __all__ = [
@@ -186,7 +204,7 @@ class PixMoPointsV2DatasetConfig(Config):
         return PixMoPointsV2Dataset(self, tokenizer)
 
 
-class PixMoPointsV2Dataset:
+class PixMoPointsV2Dataset(EpochSeededExamples):
     """Map-style dataset over the images of :class:`PixMoPointsV2DatasetConfig` that have at
     least one trainable annotation."""
 
@@ -205,14 +223,24 @@ class PixMoPointsV2Dataset:
     # -- selection -------------------------------------------------------------------------
 
     def keep(self, anno: Dict[str, Any]) -> bool:
-        """Whether to train on this annotation (mm_olmo ``PixMoPointV2._keep``, pointing leg)."""
+        """Whether to train on this annotation (mm_olmo ``PixMoPointV2._keep``, pointing leg).
+
+        Must agree with :meth:`_build_index`\'s vectorized copy: a row is admitted when *any* of
+        its annotations passes here, and every annotation the row carries is then re-tested
+        during formatting. A null ``points`` is rejected on both paths (the index maps it to
+        ``-1``, which fails the ``>= min_points`` bound), so it cannot reach ``format_row`` and
+        raise there.
+        """
         cfg = self.config
         label = anno.get("label")
         if not label or not label.strip():
             return False
         if cfg.filter_audit and _failed_audit(anno.get("audit_result")):
             return False
-        return cfg.min_points <= len(anno["points"]) <= cfg.max_points
+        points = anno.get("points")
+        if points is None:
+            return False
+        return cfg.min_points <= len(points) <= cfg.max_points
 
     def _build_index(self) -> np.ndarray:
         """Row indices with ``kind``'s source and at least one annotation passing :meth:`keep`
@@ -327,7 +355,8 @@ class PixMoPointsV2Dataset:
     def __getitem__(self, i: int) -> Dict[str, np.ndarray]:
         cfg = self.config
         row = self._data[int(self._index[i])]
-        rng = example_rng(cfg.seed, i)
+        # Per (row, epoch): the negative sub-sampling in `format_row` has to rotate across epochs.
+        rng = self.epoch_rng(i)
         messages, weights = self.format_row(row, rng)
         fmt = SftFormatter(
             seed=cfg.seed, prompt_templates=cfg.prompt_templates, system_prompt=cfg.system_prompt
@@ -395,7 +424,7 @@ class PixMoCountV2DatasetConfig(Config):
         return PixMoCountV2Dataset(self, tokenizer)
 
 
-class PixMoCountV2Dataset:
+class PixMoCountV2Dataset(EpochSeededExamples):
     """Map-style dataset over the images of :class:`PixMoCountV2DatasetConfig` that keep at
     least one point set."""
 
@@ -413,8 +442,20 @@ class PixMoCountV2Dataset:
         )
 
     def keep(self, anno: Dict[str, Any]) -> bool:
-        """Whether to train on this point set (mm_olmo ``PixMoCountConfigV2``)."""
-        return not (self.config.filter_audit and _failed_audit(anno.get("audit_result")))
+        """Whether to train on this point set (mm_olmo ``PixMoCountConfigV2``).
+
+        Beyond mm_olmo\'s audit filter this also drops unusable annotations, which mm_olmo never
+        had to: a blank ``label`` is not an error here, it silently trains ``"pointing:"`` against
+        an empty-named ``<points>`` tag, and a null ``label`` / ``points`` instead raises deep in
+        formatting. :meth:`_build_index` applies the same rules, so a row survives only while it
+        still has a usable point set.
+        """
+        if self.config.filter_audit and _failed_audit(anno.get("audit_result")):
+            return False
+        label = anno.get("label")
+        if not label or not label.strip():
+            return False
+        return anno.get("points") is not None
 
     def _build_index(self) -> np.ndarray:
         """Rows with at least one kept point set (mm_olmo's ``filter_audit`` build-time
@@ -423,7 +464,10 @@ class PixMoCountV2Dataset:
         import pyarrow.compute as pc
 
         def _keep_flat(flat) -> np.ndarray:
-            keep = np.ones(len(flat), dtype=bool)
+            # Mirrors `keep`: a usable label and non-null points, then the audit filter.
+            keep = _bool_np(
+                pc.invert(pc.equal(pc.utf8_trim_whitespace(flat.field("label")), ""))
+            ) & ~_bool_np(pc.is_null(flat.field("points")))
             if self.config.filter_audit:
                 keep &= ~_bool_np(
                     pc.is_in(
@@ -468,7 +512,7 @@ class PixMoCountV2Dataset:
     def __getitem__(self, i: int) -> Dict[str, np.ndarray]:
         cfg = self.config
         row = self._data[int(self._index[i])]
-        rng = example_rng(cfg.seed, i)
+        rng = self.epoch_rng(i)
         pil = _open_image(row["image"])
         messages = self.format_row(row, rng, pil.size)
         fmt = SftFormatter(

--- a/src/olmo_core/data/multimodal/sequence_builder.py
+++ b/src/olmo_core/data/multimodal/sequence_builder.py
@@ -33,15 +33,25 @@ ATTEND_ALL_SUBSEGMENT_ID = 10000
 LOSS_TOKEN_WEIGHTINGS = ("none", "root_subsegments", "root_subsegments_root_tokens")
 
 
-def example_rng(seed: int, index: int) -> np.random.RandomState:
-    """Per-example rng stream (mm_olmo ``dataset.py:68``, epoch 0).
+def example_rng(
+    seed: int, index: int, *, epoch: int = 0, dataset_len: int = 0
+) -> np.random.RandomState:
+    """Per-example rng stream (mm_olmo ``dataset.py:70-73``).
 
-    mm_olmo derives one stream per example as ``seed * 195172 + index`` (mod 2**32-1)
-    and threads it through the dataset's ``format_example`` AND the formatter, so all
-    of an example's draws are sequential. Using the same derivation keeps our draws
+    mm_olmo derives one stream per example as ``seed * 195172 + index + len(dataset) * epoch``
+    (mod 2**32-1) and threads it through the dataset's ``format_example`` AND the formatter, so
+    all of an example's draws are sequential. Using the same derivation keeps our draws
     alignable with mm_olmo artifacts at every index (not just index 0).
+
+    :param epoch: Training epoch. The default of 0 reproduces the single-epoch stream, so a
+        caller that does not track epochs is unaffected. Sources whose ``__getitem__`` *samples*
+        (a negative pool, a render size) must pass it, or every epoch redraws the same choice
+        and the un-sampled remainder is never trained on; see
+        :class:`~olmo_core.data.multimodal.sft_common.EpochSeededExamples`.
+    :param dataset_len: Number of rows, the stride mm_olmo advances the stream by per epoch.
+        Ignored when ``epoch`` is 0.
     """
-    return np.random.RandomState((seed * 195172 + index) % (2**32 - 1))
+    return np.random.RandomState((seed * 195172 + index + dataset_len * epoch) % (2**32 - 1))
 
 
 def build_packed_sequence(
@@ -240,11 +250,7 @@ def build_branched_sequence(
 
     def _as_segments(branch):
         """Normalize a branch to a list of (context, response) turn segments."""
-        if (
-            len(branch) == 2
-            and len(branch[0]) > 0
-            and isinstance(branch[0][0], (int, np.integer))
-        ):
+        if len(branch) == 2 and len(branch[0]) > 0 and isinstance(branch[0][0], (int, np.integer)):
             return [branch]
         return list(branch)
 

--- a/src/olmo_core/data/multimodal/sft_common.py
+++ b/src/olmo_core/data/multimodal/sft_common.py
@@ -15,6 +15,7 @@ extracted*; everything shared lives here:
 * :func:`truncate_example` — right-truncate a built example, refusing to cut image tokens
   or to drop every loss token.
 * :func:`get_example_with_skip` — deterministic bad-row skipping for ``__getitem__``.
+* :class:`EpochSeededExamples` — per-example RNG streams that rotate with the training epoch.
 
 Sequence assembly itself goes through
 :func:`~olmo_core.data.multimodal.message_sequence.encode_sft_example`, so these sources
@@ -32,9 +33,12 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+from .sequence_builder import example_rng
+
 __all__ = [
     "IMAGE_PLACEHOLDER",
     "MAX_ROW_SKIP",
+    "EpochSeededExamples",
     "load_hf_dataset",
     "strip_image_placeholders",
     "count_image_placeholders",
@@ -47,6 +51,36 @@ log = logging.getLogger(__name__)
 
 MAX_ROW_SKIP = 32
 """How many following rows :func:`get_example_with_skip` tries before giving up."""
+
+
+class EpochSeededExamples:
+    """Mixin for map-style datasets whose ``__getitem__`` *samples* something.
+
+    A source that draws a subset per example — a few of an image's negatives, a render size —
+    must advance its RNG stream with the training epoch, or it redraws the same subset forever
+    and the remainder of each pool is never trained on. mm_olmo does this by folding the epoch
+    into the per-example seed (``dataset.py:70-73``); the data loader calls :meth:`set_epoch`
+    from ``reshuffle`` so the same happens here.
+
+    Requires the host class to expose ``config.seed`` and ``__len__``. The epoch is restored
+    with the loader's state, so a resumed run replays the epoch it was in.
+    """
+
+    _epoch: int = 0
+
+    def set_epoch(self, epoch: int) -> None:
+        """Set the epoch used to derive per-example RNG streams (called by the data loader)."""
+        self._epoch = int(epoch)
+
+    def epoch_rng(self, index: int) -> np.random.RandomState:
+        """This row's RNG stream for the current epoch."""
+        return example_rng(
+            self.config.seed,  # type: ignore[attr-defined]
+            index,
+            epoch=self._epoch,
+            dataset_len=len(self),  # type: ignore[arg-type]
+        )
+
 
 IMAGE_PLACEHOLDER = "<image>"
 """Inline marker used by these corpora to indicate where an image belongs in the prompt."""

--- a/src/olmo_core/data/multimodal/sft_formatter.py
+++ b/src/olmo_core/data/multimodal/sft_formatter.py
@@ -28,7 +28,14 @@ from .grounding import (
 )
 from .multiple_choice_templates import template_mc_question
 
-__all__ = ["SftFormatter", "DEMO_STYLES", "IMAGE_MC_STYLES", "MULTI_IMAGE_POINTING_STYLES"]
+__all__ = [
+    "SftFormatter",
+    "DEMO_STYLES",
+    "IMAGE_MC_STYLES",
+    "MULTI_IMAGE_POINTING_STYLES",
+    "AUX_POINTING_STYLES",
+    "base_pointing_style",
+]
 
 # Subset of mm_olmo data_formatter.py DEMO_STYLES / IMAGE_MC_STYLES used by image-only-v9.
 DEMO_STYLES = frozenset(
@@ -70,6 +77,23 @@ MULTI_IMAGE_POINTING_STYLES = frozenset(
         "multi_image_count_then_point",
     }
 )
+# mm_olmo's marker styles for point sets that FAILED the VLM audit (``PixMoPointV2.audit_style``
+# / ``PixMoCountConfigV2.audit_style``, data_formatter.py:1189, 1824-1825). They render exactly
+# like their base style -- same prompt pool, same answer -- except for the style token itself,
+# so the model learns these targets are less reliable without them diluting the primary
+# ``pointing`` / ``point_count`` distributions. Not demo styles: they keep their ``"<style>:"``
+# prefix under every system-prompt family.
+AUX_POINTING_STYLES = frozenset({"aux_pointing", "aux_point_count"})
+POINTING_STYLES = frozenset(
+    {"pointing", "point_count", "point_then_count", "cosyn_point"} | AUX_POINTING_STYLES
+)
+
+
+def base_pointing_style(style: str) -> str:
+    """Strip mm_olmo's ``aux_`` marker: ``aux_point_count`` is formatted as ``point_count``
+    (``format_points``, data_formatter.py:1189)."""
+    return style[4:] if style.startswith("aux_") else style
+
 
 CAPTION_PROMPTS = (
     "Describe this image.",
@@ -112,9 +136,7 @@ SHORT_CAPTION_PROMPTS = (
     "How would you describe this image in a sentence or two?",
 )
 
-CHAIN_OF_THOUGHT_PROMPTS = (
-    "{question} Provide reasoning steps and then give the short answer.",
-)
+CHAIN_OF_THOUGHT_PROMPTS = ("{question} Provide reasoning steps and then give the short answer.",)
 
 
 def _apply_chain_of_thought_prompt(question: str) -> str:
@@ -263,7 +285,7 @@ class SftFormatter:
             label = example.get("question", "")
         point_scale = example["point_scale"] if "point_scale" in example else 100
         norm = normalize_points(xy, point_scale=point_scale, image_size=example.get("image_size"))
-        style = example.get("style", "pointing")
+        style = base_pointing_style(example.get("style", "pointing"))
         # mm_olmo's count is always len(points) (data_formatter.py:1141) — never a
         # dataset-provided "count" field, which its formatter cannot even see.
         if style in ("point_count", "point_then_count"):
@@ -443,7 +465,7 @@ class SftFormatter:
             pool = SHORT_CAPTION_PROMPTS if style == "short_caption" else CAPTION_PROMPTS
             prompt = pool[rng.randint(len(pool))]
             output = example.get("text") or example.get("caption", "")
-        elif style in ("pointing", "point_count", "point_then_count", "cosyn_point"):
+        elif style in POINTING_STYLES:
             if "question" in example:
                 prompt = example["question"]
             else:
@@ -462,9 +484,11 @@ class SftFormatter:
                         example["label"].lower() if "label" in example else example["label_cased"]
                     )
                 else:
+                    # An ``aux_*`` style draws from its base style's pool (the marker only
+                    # changes the style token).
                     pool = (
                         POINT_COUNT_PROMPTS
-                        if style in ("point_count", "point_then_count")
+                        if base_pointing_style(style) in ("point_count", "point_then_count")
                         else POINTING_PROMPTS
                     )
                     prompt = pool[rng.randint(len(pool))].format(label=label)

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -17,6 +17,17 @@ useful for parity tests and continuation experiments, but not a stage-1 reproduc
 
 ``--model_size`` selects the variant: ``4b`` (Qwen3-4B, the default) or ``8b`` (Qwen3-8B).
 
+``--pointing_data`` selects the pointing/counting group: ``v1`` (the released Molmo2 pretrain's
+sources, the default) or ``v2`` (mm_olmo's molmo3 stage-1 sources: the audited, image-grouped
+PixMo-Points build with sub-sampled absence queries, plus the audited PixMo-Count build). The v2
+knobs are the ``pointing_v2`` / ``count_v2`` config fields, e.g. ``--pointing_v2.filter_audit=true``.
+
+``--ocr_rate`` (default 0) adds the OCR group: olmOCR-mix page transcription (rendered from PDFs,
+needs ``pypdfium2``) plus the oe-encoder caption tars (text-rich captions, Cambrian OCR subsets,
+TextCaps, scene text), paid for by the caption group. ``--ocr_sources=[...]`` picks the sources
+(see :mod:`olmo_core.data.multimodal.mixtures.ocr`); the ``olmocr`` / ``ocr_tars`` config fields
+are the two source templates, e.g. ``--olmocr.languages=null``.
+
 Run without arguments for usage. Quick local smoke test on synthetic data::
 
     torchrun --nproc-per-node=1 src/scripts/train/Molmo2-Stage1.py train smoke \\
@@ -33,7 +44,7 @@ import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import List, Optional, Tuple, cast
+from typing import List, Optional, Sequence, Tuple, cast
 
 from olmo_core.config import Config, DType
 from olmo_core.data.multimodal import (
@@ -41,10 +52,20 @@ from olmo_core.data.multimodal import (
     MixtureDataLoader,
     MultimodalCollatorConfig,
     MultimodalDataLoader,
+    OcrCaptionTarsDatasetConfig,
+    OlmOcrMixDatasetConfig,
     PixMoCapDatasetConfig,
     PixMoCountDatasetConfig,
+    PixMoCountV2DatasetConfig,
     PixMoPointsDatasetConfig,
+    PixMoPointsV2DatasetConfig,
     Tulu4DatasetConfig,
+)
+from olmo_core.data.multimodal.mixtures.ocr import (
+    DEFAULT_OCR_SOURCES,
+    DUPLICATE_OLMOCR_SOURCES,
+    OCR_SOURCE_NAMES,
+    build_ocr_source,
 )
 from olmo_core.data.multimodal.paths import PIXMO_DATASETS
 from olmo_core.distributed.parallel import DataParallelType
@@ -245,9 +266,50 @@ POINTING_DATASET_KWARGS = {
     "loss_token_weighting": "none",
 }
 
-# remainder (1 - POINTING_RATE - NLP_RATE). Set both to 0.0 for a caption-only run.
+# remainder (1 - POINTING_RATE - NLP_RATE - OCR_RATE). Set all three to 0.0 for a caption-only run.
 POINTING_RATE = 0.30
 NLP_RATE = 0.10
+# The OCR group (`olmo_core.data.multimodal.mixtures.ocr`): olmOCR-mix page transcription
+# (mm_olmo train_molmo3_stage1 `_base_mixture`, 0.075 there) plus the oe-encoder caption tars
+# (text-rich captions, Cambrian OCR subsets, TextCaps, scene text), one dataset per source and
+# the group's rate split by sqrt(size) like mm_olmo's default `root_size_factor`. Paid for out of
+# the caption group. Off by default so the default run stays the released Molmo2 pretrain
+# mixture; `--ocr_rate=0.15` enables it (mm_olmo spends 0.075 + 0.075 on its two OCR groups).
+# `DEFAULT_OCR_SOURCES` leaves out the `s2pdf` / `iabooks` tars, which are the same pages as
+# olmOCR-mix documents / books. olmOCR-mix pages are rendered from PDFs at load time, which needs
+# `pypdfium2` (installed by the launch `post_setup` below).
+OCR_RATE = 0.0
+OCR_SOURCES = DEFAULT_OCR_SOURCES
+# The OCR user turn is the bare `<style>:` tag (`olmocr:` / `ocr_caption:` / `scene_text:`),
+# mm_olmo's molmo3 stage-1 `style_and_length_v3` family (v3 reserves the length bucket for
+# captions / transcripts). This deliberately differs from the `style_and_length_v2` family the
+# caption and pointing sources use: mm_olmo never trains olmOCR-mix under v2, so v3 is the form
+# with a reference run behind it.
+OCR_SYSTEM_PROMPT = "style_and_length_v3"
+
+# Which sources `POINTING_RATE` buys.
+#   "v1": the released Molmo2 pretrain's group (mm_olmo train_captioner.py `--pointing`):
+#         pixmo_points_train, pixmo_count_train, pixmo_points_high_freq_train, cosyn_point,
+#         split within the group by sqrt(size).
+#   "v2": mm_olmo's molmo3 stage-1 group (launch_scripts/train_molmo3_stage1.py
+#         `_base_mixture`): the audited, image-grouped PixMo-Points build with absence queries
+#         (`PixMoPointsV2DatasetConfig`), the audited PixMo-Count build
+#         (`PixMoCountV2DatasetConfig`) and cosyn_point, split *linearly* by size (mm_olmo
+#         `size_weighted=1`). That group also carries a COCO detection-as-pointing source
+#         (`CocoTrain`) which has no olmo-core port yet.
+# The v2 knobs are the `pointing_v2` / `count_v2` config fields (`--pointing_v2.<field>=...`).
+POINTING_DATA = "v1"
+POINTING_DATA_CHOICES = ("v1", "v2")
+# mm_olmo `_base_mixture` settings for the v2 sources. Audit-failed point sets are kept but
+# rendered behind the `aux_*` marker styles (set `filter_audit=true` to drop them instead;
+# both work). The absence queries are SUB-SAMPLED -- 2 easy negatives per image and a quarter
+# of the paired (hard) negatives per epoch: training on all of them makes the model prone to
+# refusing to point. `v2_paired_negatives` follows the dataset class default (mm_olmo's stage-1
+# arms flip it per trainer).
+POINTING_V2_AUDIT_STYLE = ("aux_point_count", "aux_pointing")
+POINTING_V2_FILTER_AUDIT = False
+POINTING_V2_N_EASY_NEGATIVES = 2
+POINTING_V2_P_PAIRED_NEGATIVES = 0.25
 
 # Beaker.
 BEAKER_CLUSTER = "ai2/jupiter"
@@ -275,6 +337,16 @@ class ExperimentConfig(Config):
     collator: MultimodalCollatorConfig
     train_module: MultimodalTransformerTrainModuleConfig
     trainer: TrainerConfig
+    pointing_v2: PixMoPointsV2DatasetConfig
+    """The audited PixMo-Points source; used when ``pointing_data == "v2"``."""
+    count_v2: PixMoCountV2DatasetConfig
+    """The audited PixMo-Count source; used when ``pointing_data == "v2"``."""
+    olmocr: OlmOcrMixDatasetConfig
+    """Template for the olmOCR-mix OCR sources (``subset`` is set per source); used when
+    ``ocr_rate > 0``."""
+    ocr_tars: OcrCaptionTarsDatasetConfig
+    """Template for the caption-tars OCR sources (``dataset_path`` / ``style`` /
+    ``strip_text_tags`` are set per source); used when ``ocr_rate > 0``."""
     model_size: str = MODEL_SIZE
     """``"4b"`` or ``"8b"`` — selects the architecture, the base LM to initialise from, and
     the released checkpoint used by ``--init_from=molmo2``."""
@@ -287,6 +359,14 @@ class ExperimentConfig(Config):
     """Fraction of mixture samples from pointing/counting sources (mm_olmo ``--pointing``)."""
     nlp_rate: float = NLP_RATE
     """Fraction of mixture samples from Tulu4 NLP SFT (mm_olmo ``--nlp``)."""
+    pointing_data: str = POINTING_DATA
+    """``"v1"`` (released Molmo2 pretrain sources) or ``"v2"`` (mm_olmo molmo3 stage-1 sources:
+    audited points + sub-sampled absence queries); see :data:`POINTING_DATA`."""
+    ocr_rate: float = OCR_RATE
+    """Fraction of mixture samples from the OCR group; see :data:`OCR_RATE`."""
+    ocr_sources: Tuple[str, ...] = OCR_SOURCES
+    """OCR sources in the group, each a separate dataset (names from
+    :data:`olmo_core.data.multimodal.mixtures.ocr.OCR_SOURCE_NAMES`)."""
     train_vit: bool = TRAIN_VIT
     """Train the vision encoder in its own optimizer group (mm_olmo ``ft_vit``). When False
     the encoder is frozen and kept in eval mode."""
@@ -398,6 +478,38 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         # examples, so it would re-weight caption vs pointing vs NLP relative to mm_olmo.
         loss_token_weighting="none",
         seed=95818,
+    )
+
+    # The v2 pointing sources (mm_olmo `_base_mixture`); only built when `pointing_data == "v2"`.
+    pointing_v2_config = PixMoPointsV2DatasetConfig(
+        p_paired_negatives=POINTING_V2_P_PAIRED_NEGATIVES,
+        n_easy_samples=POINTING_V2_N_EASY_NEGATIVES,
+        audit_style=POINTING_V2_AUDIT_STYLE,
+        filter_audit=POINTING_V2_FILTER_AUDIT,
+        max_crops=MAX_CROPS,
+        **POINTING_DATASET_KWARGS,
+    )
+    count_v2_config = PixMoCountV2DatasetConfig(
+        audit_style=POINTING_V2_AUDIT_STYLE,
+        filter_audit=POINTING_V2_FILTER_AUDIT,
+        max_crops=MAX_CROPS,
+        **POINTING_DATASET_KWARGS,
+    )
+    # OCR source templates (`build_ocr_source` fills in the per-source fields); only built when
+    # `ocr_rate > 0`. Every response token weighted equally, like the caption source; the user
+    # turn is the bare `<style>:` tag (OCR_SYSTEM_PROMPT). Long pages are tail-truncated to the
+    # sequence length.
+    olmocr_config = OlmOcrMixDatasetConfig(
+        max_crops=MAX_CROPS,
+        max_sequence_length=SEQUENCE_LENGTH,
+        loss_token_weighting="none",
+        system_prompt=OCR_SYSTEM_PROMPT,
+    )
+    ocr_tars_config = OcrCaptionTarsDatasetConfig(
+        max_crops=MAX_CROPS,
+        max_sequence_length=SEQUENCE_LENGTH,
+        loss_token_weighting="none",
+        system_prompt=OCR_SYSTEM_PROMPT,
     )
 
     # Pad token: Molmo2/Qwen2.5 EOS (151643). Fixed-length padding so every batch has a
@@ -526,7 +638,9 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
     # The pointing/counting Arrow datasets on weka were saved with `datasets >= 4`, whose
     # `List` feature type the image's older `datasets` can't deserialize. Upgrade after the
     # package install (olmo-core does not pin `datasets`, so this is not clobbered).
-    launch_config.post_setup = "pip install -U 'datasets>=4,<6'"
+    # `pypdfium2` renders the olmOCR-mix PDF pages at load time (`--ocr_rate > 0`); a small
+    # self-contained wheel, so it is installed unconditionally.
+    launch_config.post_setup = "pip install -U 'datasets>=4,<6' pypdfium2"
     # Optionally use the fused FlexAttention backend for the multimodal masks (~+8% MFU on
     # the stage-1 mixture vs the dense `torch` backend; see USE_FLEX_ATTN).
     if USE_FLEX_ATTN:
@@ -541,7 +655,37 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         train_module=train_module_config,
         trainer=trainer_config,
         launch=launch_config,
+        pointing_v2=pointing_v2_config,
+        count_v2=count_v2_config,
+        olmocr=olmocr_config,
+        ocr_tars=ocr_tars_config,
     ).merge(overrides)
+
+    if config.pointing_data not in POINTING_DATA_CHOICES:
+        raise OLMoConfigurationError(
+            f"pointing_data={config.pointing_data!r} is not one of {POINTING_DATA_CHOICES}"
+        )
+    if config.ocr_rate > 0 and not config.ocr_sources:
+        raise OLMoConfigurationError("ocr_rate > 0 needs at least one entry in ocr_sources")
+    unknown = [n for n in config.ocr_sources if n not in OCR_SOURCE_NAMES]
+    if unknown:
+        raise OLMoConfigurationError(
+            f"Unknown ocr_sources {unknown}; expected names from {OCR_SOURCE_NAMES}"
+        )
+    if len(set(config.ocr_sources)) != len(config.ocr_sources):
+        raise OLMoConfigurationError(f"ocr_sources has duplicates: {config.ocr_sources}")
+    for tar_name, mix_name in DUPLICATE_OLMOCR_SOURCES.items():
+        if tar_name in config.ocr_sources and mix_name in config.ocr_sources:
+            log.warning(
+                "ocr_sources has both %s and %s, which are the same pages rendered by two "
+                "pipelines: those pages will be sampled twice.",
+                tar_name,
+                mix_name,
+            )
+    if config.pointing_rate + config.nlp_rate + config.ocr_rate > 1.0:
+        raise OLMoConfigurationError(
+            "pointing_rate + nlp_rate + ocr_rate exceeds 1: nothing is left for the caption source"
+        )
 
     # `_resolve_model_spec` already validated the pre-merge values; re-check the merged
     # config so a stray `--model_size`/`--init_from`/`--train_vit` cannot slip through, and
@@ -690,45 +834,107 @@ def _init_weights_from_scratch(
     model.connector.reset_parameters()
 
 
-def _build_mixture_sources(tokenizer, config: ExperimentConfig):
-    """Build the caption + pointing + NLP sources and their sampling weights (mm_olmo
-    SubMixture): caption gets ``1 - pointing_rate - nlp_rate``; the pointing group shares
-    ``pointing_rate`` split by sqrt(size); NLP gets ``nlp_rate``."""
+def _size_fractions(sizes: Sequence[int], rule: str):
+    """Split one group's rate among its sources from their sizes (mm_olmo SubMixture math):
+    ``"sqrt"`` is ``root_size_factor=None``, ``"linear"`` is ``size_weighted=1``."""
     import numpy as np
 
-    p, n = config.pointing_rate, config.nlp_rate
+    sizes_arr = np.asarray(sizes, dtype=np.float64)
+    if rule == "sqrt":
+        frac = np.sqrt(sizes_arr)
+    elif rule == "linear":
+        frac = sizes_arr
+    else:
+        raise OLMoConfigurationError(f"unknown size rule {rule!r}")
+    return frac / frac.sum()
+
+
+def _pointing_group_fractions(sizes: Sequence[int], pointing_data: str):
+    """How the pointing group's rate is split among its sources, from their sizes.
+
+    ``"v1"`` follows mm_olmo's captioner (``root_size_factor=None``: sqrt of the size);
+    ``"v2"`` follows mm_olmo's molmo3 stage 1 (``size_weighted=1``: linear in the size).
+    """
+    if pointing_data == "v1":
+        return _size_fractions(sizes, "sqrt")
+    if pointing_data == "v2":
+        return _size_fractions(sizes, "linear")
+    raise OLMoConfigurationError(
+        f"pointing_data={pointing_data!r} is not one of {POINTING_DATA_CHOICES}"
+    )
+
+
+def _build_mixture_sources(tokenizer, config: ExperimentConfig):
+    """Build the caption + pointing + NLP + OCR sources, their sampling weights (mm_olmo
+    SubMixture) and their names: caption gets ``1 - pointing_rate - nlp_rate - ocr_rate``; the
+    pointing group shares ``pointing_rate`` (split per :func:`_pointing_group_fractions`); NLP
+    gets ``nlp_rate``; the OCR sources share ``ocr_rate`` split by sqrt(size)."""
+    p, n, o = config.pointing_rate, config.nlp_rate, config.ocr_rate
     datasets: List = [config.dataset.build(tokenizer)]  # caption
-    weights: List[float] = [max(1.0 - p - n, 0.0)]
+    weights: List[float] = [max(1.0 - p - n - o, 0.0)]
+    names: List[str] = ["pixmo_cap"]
 
     if p > 0:
-        pointing = [
-            PixMoPointsDatasetConfig(
-                kind="basic", max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS
-            ).build(tokenizer),
-            PixMoCountDatasetConfig(max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS).build(
-                tokenizer
-            ),
-            PixMoPointsDatasetConfig(
-                kind="high_frequency", max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS
-            ).build(tokenizer),
-            CoSynPointDatasetConfig(max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS).build(
-                tokenizer
-            ),
-        ]
-        frac = np.sqrt(np.array([len(d) for d in pointing], dtype=np.float64))
-        frac = frac / frac.sum()
+        if config.pointing_data == "v1":
+            pointing_names = [
+                "pixmo_points_train",
+                "pixmo_count_train",
+                "pixmo_points_high_freq_train",
+                "cosyn_point",
+            ]
+            pointing = [
+                PixMoPointsDatasetConfig(
+                    kind="basic", max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS
+                ).build(tokenizer),
+                PixMoCountDatasetConfig(max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS).build(
+                    tokenizer
+                ),
+                PixMoPointsDatasetConfig(
+                    kind="high_frequency", max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS
+                ).build(tokenizer),
+                CoSynPointDatasetConfig(max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS).build(
+                    tokenizer
+                ),
+            ]
+        elif config.pointing_data == "v2":
+            # mm_olmo train_molmo3_stage1 `_base_mixture` pointing group, minus `CocoTrain`.
+            pointing_names = ["pixmo_points_v2", "pixmo_count_v2", "cosyn_point"]
+            pointing = [
+                config.pointing_v2.build(tokenizer),
+                config.count_v2.build(tokenizer),
+                CoSynPointDatasetConfig(max_crops=MAX_CROPS, **POINTING_DATASET_KWARGS).build(
+                    tokenizer
+                ),
+            ]
+        else:
+            raise OLMoConfigurationError(
+                f"pointing_data={config.pointing_data!r} is not one of {POINTING_DATA_CHOICES}"
+            )
+        frac = _pointing_group_fractions([len(d) for d in pointing], config.pointing_data)
         datasets += pointing
         weights += [p * float(f) for f in frac]
+        names += pointing_names
 
     if n > 0:
         datasets.append(Tulu4DatasetConfig().build(tokenizer))
         weights.append(n)
+        names.append("tulu4")
+
+    if o > 0:
+        ocr = [
+            build_ocr_source(name, tokenizer, olmocr=config.olmocr, tars=config.ocr_tars)
+            for name in config.ocr_sources
+        ]
+        frac = _size_fractions([len(d) for d in ocr], "sqrt")
+        datasets += ocr
+        weights += [o * float(f) for f in frac]
+        names += list(config.ocr_sources)
 
     log.info(
-        "Mixture sources / weights: %s",
-        [(type(d).__name__, round(w, 3)) for d, w in zip(datasets, weights)],
+        "Mixture sources / sizes / weights: %s",
+        [(name, len(d), round(w, 4)) for name, d, w in zip(names, datasets, weights)],
     )
-    return datasets, weights
+    return datasets, weights, names
 
 
 def train(config: ExperimentConfig):
@@ -755,12 +961,13 @@ def train(config: ExperimentConfig):
     dp_pg = train_module.dp_process_group
     dp_world_size, dp_rank = get_world_size(dp_pg), get_rank(dp_pg)
 
-    if config.pointing_rate > 0 or config.nlp_rate > 0:
-        datasets, weights = _build_mixture_sources(tokenizer, config)
+    if config.pointing_rate > 0 or config.nlp_rate > 0 or config.ocr_rate > 0:
+        datasets, weights, names = _build_mixture_sources(tokenizer, config)
         data_loader = MixtureDataLoader(
             datasets,
             weights,
             collator,
+            dataset_names=names,
             work_dir=config.trainer.save_folder,
             global_batch_size=config.global_batch_size,
             seed=config.data_seed,
@@ -814,6 +1021,15 @@ Print the config:
 
 8B from-scratch run:
 › python {sys.argv[0]} launch molmo2-stage1-8b --model_size=8b
+
+Audited (v2) pointing sources, dropping audit-failed points instead of marking them:
+› python {sys.argv[0]} launch molmo2-stage1-v2pts --pointing_data=v2 --pointing_v2.filter_audit=true
+
+OCR group at 15% (olmOCR-mix + text-rich / Cambrian / TextCaps captions + scene text):
+› python {sys.argv[0]} launch molmo2-stage1-ocr --ocr_rate=0.15
+Only the olmOCR-mix page transcription sources:
+› python {sys.argv[0]} launch molmo2-stage1-olmocr --ocr_rate=0.075 \
+      --ocr_sources=[olmocr_documents,olmocr_books,olmocr_loc_transcripts,olmocr_national_archives]
 
 Local synthetic smoke test:
 › torchrun --nproc-per-node=1 {sys.argv[0]} train smoke \\

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -26,7 +26,8 @@ knobs are the ``pointing_v2`` / ``count_v2`` config fields, e.g. ``--pointing_v2
 needs ``pypdfium2``) plus the oe-encoder caption tars (text-rich captions, Cambrian OCR subsets,
 TextCaps, scene text), paid for by the caption group. ``--ocr_sources=[...]`` picks the sources
 (see :mod:`olmo_core.data.multimodal.mixtures.ocr`); the ``olmocr`` / ``ocr_tars`` config fields
-are the two source templates, e.g. ``--olmocr.languages=null``.
+are the two source templates, e.g. ``--olmocr.languages=null``, and ``--ocr_data_root`` relocates
+the tar tree.
 
 Run without arguments for usage. Quick local smoke test on synthetic data::
 
@@ -67,7 +68,7 @@ from olmo_core.data.multimodal.mixtures.ocr import (
     OCR_SOURCE_NAMES,
     build_ocr_source,
 )
-from olmo_core.data.multimodal.paths import PIXMO_DATASETS
+from olmo_core.data.multimodal.paths import OE_ENCODER_DATA, PIXMO_DATASETS
 from olmo_core.distributed.parallel import DataParallelType
 from olmo_core.distributed.utils import get_rank, get_world_size
 from olmo_core.exceptions import OLMoConfigurationError
@@ -295,8 +296,11 @@ OCR_SYSTEM_PROMPT = "style_and_length_v3"
 #         `_base_mixture`): the audited, image-grouped PixMo-Points build with absence queries
 #         (`PixMoPointsV2DatasetConfig`), the audited PixMo-Count build
 #         (`PixMoCountV2DatasetConfig`) and cosyn_point, split *linearly* by size (mm_olmo
-#         `size_weighted=1`). That group also carries a COCO detection-as-pointing source
-#         (`CocoTrain`) which has no olmo-core port yet.
+#         `size_weighted=1`). The one member of that group with no port is `CocoTrain`, which
+#         is a SEGMENTATION source, not detection-as-pointing: under `style="pixmo"` it emits
+#         `pixmo_seg` and its messages carry `bboxes` + RLE `segmentations` with no points
+#         (mm_olmo academic_datasets.py:2175-2189, data_formatter.py:965-968). olmo-core has no
+#         segmentation path, so it stays unported -- as do PixMoPointV2's own mask branches.
 # The v2 knobs are the `pointing_v2` / `count_v2` config fields (`--pointing_v2.<field>=...`).
 POINTING_DATA = "v1"
 POINTING_DATA_CHOICES = ("v1", "v2")
@@ -345,8 +349,10 @@ class ExperimentConfig(Config):
     """Template for the olmOCR-mix OCR sources (``subset`` is set per source); used when
     ``ocr_rate > 0``."""
     ocr_tars: OcrCaptionTarsDatasetConfig
-    """Template for the caption-tars OCR sources (``dataset_path`` / ``style`` /
-    ``strip_text_tags`` are set per source); used when ``ocr_rate > 0``."""
+    """Template for the caption-tars OCR sources; used when ``ocr_rate > 0``. One template
+    serves every tar source, so ``dataset_path`` / ``style`` / ``strip_text_tags`` are set per
+    source from the registry and setting them here is refused -- relocate the whole tree with
+    ``--ocr_data_root`` instead."""
     model_size: str = MODEL_SIZE
     """``"4b"`` or ``"8b"`` — selects the architecture, the base LM to initialise from, and
     the released checkpoint used by ``--init_from=molmo2``."""
@@ -367,6 +373,9 @@ class ExperimentConfig(Config):
     ocr_sources: Tuple[str, ...] = OCR_SOURCES
     """OCR sources in the group, each a separate dataset (names from
     :data:`olmo_core.data.multimodal.mixtures.ocr.OCR_SOURCE_NAMES`)."""
+    ocr_data_root: str = OE_ENCODER_DATA
+    """Root of the oe-encoder tar tree; each caption-tars source appends its own subdirectory
+    (:data:`olmo_core.data.multimodal.mixtures.ocr.OCR_TAR_SOURCES`)."""
     train_vit: bool = TRAIN_VIT
     """Train the vision encoder in its own optimizer group (mm_olmo ``ft_vit``). When False
     the encoder is frozen and kept in eval mode."""
@@ -674,6 +683,18 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         )
     if len(set(config.ocr_sources)) != len(config.ocr_sources):
         raise OLMoConfigurationError(f"ocr_sources has duplicates: {config.ocr_sources}")
+    # `build_ocr_source` sets these per source, so a value here would be accepted, saved into the
+    # run config and then ignored. Fail instead of pretending it took effect.
+    per_source = OcrCaptionTarsDatasetConfig()
+    for field, hint in (
+        ("dataset_path", "use --ocr_data_root to relocate the whole tar tree"),
+        ("style", "the style is fixed per source by mixtures.ocr.OCR_TAR_SOURCES"),
+        ("strip_text_tags", "set per source by mixtures.ocr.OCR_TAR_SOURCES"),
+    ):
+        if getattr(config.ocr_tars, field) != getattr(per_source, field):
+            raise OLMoConfigurationError(
+                f"--ocr_tars.{field} is set per OCR source and would be ignored here; {hint}"
+            )
     for tar_name, mix_name in DUPLICATE_OLMOCR_SOURCES.items():
         if tar_name in config.ocr_sources and mix_name in config.ocr_sources:
             log.warning(
@@ -834,11 +855,27 @@ def _init_weights_from_scratch(
     model.connector.reset_parameters()
 
 
-def _size_fractions(sizes: Sequence[int], rule: str):
+def _size_fractions(sizes: Sequence[int], rule: str, names: Optional[Sequence[str]] = None):
     """Split one group's rate among its sources from their sizes (mm_olmo SubMixture math):
-    ``"sqrt"`` is ``root_size_factor=None``, ``"linear"`` is ``size_weighted=1``."""
+    ``"sqrt"`` is ``root_size_factor=None``, ``"linear"`` is ``size_weighted=1``.
+
+    An empty source is rejected rather than weighted. Size-proportional weights give it 0, and
+    :class:`~olmo_core.data.multimodal.MixtureDataLoader` then skips it silently, so a mistyped
+    path or an over-strict filter would train the remaining sources at quietly renormalized
+    rates with nothing in the log; all-empty additionally divides by zero into NaN weights.
+
+    :raises OLMoConfigurationError: If any size is <= 0, or ``rule`` is unknown.
+    """
     import numpy as np
 
+    empty = [
+        (names[i] if names is not None else str(i)) for i, s in enumerate(sizes) if int(s) <= 0
+    ]
+    if empty:
+        raise OLMoConfigurationError(
+            f"mixture source(s) {empty} have no examples: check their data paths and filters "
+            "(a size-0 source is never sampled, so it would silently drop out of the mixture)"
+        )
     sizes_arr = np.asarray(sizes, dtype=np.float64)
     if rule == "sqrt":
         frac = np.sqrt(sizes_arr)
@@ -849,16 +886,24 @@ def _size_fractions(sizes: Sequence[int], rule: str):
     return frac / frac.sum()
 
 
-def _pointing_group_fractions(sizes: Sequence[int], pointing_data: str):
+def _pointing_group_fractions(
+    sizes: Sequence[int], pointing_data: str, names: Optional[Sequence[str]] = None
+):
     """How the pointing group's rate is split among its sources, from their sizes.
 
     ``"v1"`` follows mm_olmo's captioner (``root_size_factor=None``: sqrt of the size);
     ``"v2"`` follows mm_olmo's molmo3 stage 1 (``size_weighted=1``: linear in the size).
+
+    Under ``"v2"`` the split is linear, so each source's *row count* sets its share directly.
+    Ours counts rows with a trainable POINTING annotation; mm_olmo's ``_base_mixture`` leaves
+    ``include_masks=True``, so its filter also admits mask-only annotations and its count is
+    larger. We do not port masks, so the pointing-only count is the right denominator here --
+    but it does mean this group's internal split is not numerically mm_olmo's.
     """
     if pointing_data == "v1":
-        return _size_fractions(sizes, "sqrt")
+        return _size_fractions(sizes, "sqrt", names)
     if pointing_data == "v2":
-        return _size_fractions(sizes, "linear")
+        return _size_fractions(sizes, "linear", names)
     raise OLMoConfigurationError(
         f"pointing_data={pointing_data!r} is not one of {POINTING_DATA_CHOICES}"
     )
@@ -910,7 +955,9 @@ def _build_mixture_sources(tokenizer, config: ExperimentConfig):
             raise OLMoConfigurationError(
                 f"pointing_data={config.pointing_data!r} is not one of {POINTING_DATA_CHOICES}"
             )
-        frac = _pointing_group_fractions([len(d) for d in pointing], config.pointing_data)
+        frac = _pointing_group_fractions(
+            [len(d) for d in pointing], config.pointing_data, pointing_names
+        )
         datasets += pointing
         weights += [p * float(f) for f in frac]
         names += pointing_names
@@ -922,10 +969,16 @@ def _build_mixture_sources(tokenizer, config: ExperimentConfig):
 
     if o > 0:
         ocr = [
-            build_ocr_source(name, tokenizer, olmocr=config.olmocr, tars=config.ocr_tars)
+            build_ocr_source(
+                name,
+                tokenizer,
+                olmocr=config.olmocr,
+                tars=config.ocr_tars,
+                data_root=config.ocr_data_root,
+            )
             for name in config.ocr_sources
         ]
-        frac = _size_fractions([len(d) for d in ocr], "sqrt")
+        frac = _size_fractions([len(d) for d in ocr], "sqrt", list(config.ocr_sources))
         datasets += ocr
         weights += [o * float(f) for f in frac]
         names += list(config.ocr_sources)

--- a/src/test/data/multimodal/ocr_caption_tars_test.py
+++ b/src/test/data/multimodal/ocr_caption_tars_test.py
@@ -1,0 +1,298 @@
+"""CPU tests for the webdataset-style caption tars (oe-encoder ``*_v6_tars`` OCR sources): shard
+indexing and its cache, sample reads, ``<text>`` stripping, the style tag, example layout,
+truncation, and the OCR source registry / Molmo2-Stage1 wiring."""
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import tarfile
+
+import numpy as np
+import pytest
+
+from olmo_core.data.multimodal import OcrCaptionTarsDatasetConfig, TarShardIndex
+from olmo_core.data.multimodal import ocr_caption_tars as ct
+from olmo_core.data.multimodal.mixtures import ocr as ocr_mix
+from olmo_core.data.multimodal.olmocr import OlmOcrMixDatasetConfig
+from olmo_core.exceptions import OLMoConfigurationError
+
+
+class _FakeTok:
+    eos_token_id = 1
+    bos_token_id = 0
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        text = f"<|im_start|>user\n{messages[0]['content']}<|im_end|>\n"
+        if add_generation_prompt:
+            text += "<|im_start|>assistant\n"
+        return text
+
+    def encode(self, text, add_special_tokens=False):
+        return [(ord(c) % 90) + 10 for c in text]
+
+
+# ---------------------------------------------------------------------------
+# Fixture: two shards of (image, json) pairs, plus an orphan image and a stray member
+# ---------------------------------------------------------------------------
+
+SAMPLES = [
+    # (shard, key, ext, caption)
+    (0, "a_000", "png", "<text>FELIX PRIVAT DBU 889</text>"),
+    (0, "a_001", "jpg", "A chart with three bars."),
+    (0, "a_002", "jpg", "<text>\n  multi\nline  \n</text>"),
+    (1, "b_000", "png", "<text></text>"),  # empty after stripping
+    (1, "b_001", "jpg", "word " * 400),
+]
+
+
+def _png_bytes(seed, ext):
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (48 + 4 * seed, 40), color=(seed * 40 % 255, 90, 120)).save(
+        buf, format="PNG" if ext == "png" else "JPEG"
+    )
+    return buf.getvalue()
+
+
+def _write_tars(tmp_path):
+    root = tmp_path / "toy_v6_tars"
+    root.mkdir()
+    shards = [tarfile.open(str(root / f"toy-w0{i}-00000.tar"), "w") for i in range(2)]
+
+    def add(tf, name, data):
+        info = tarfile.TarInfo(name)
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+
+    for i, (shard, key, ext, caption) in enumerate(SAMPLES):
+        add(shards[shard], f"{key}.{ext}", _png_bytes(i, ext))
+        meta = {"caption": caption, "dense_caption": caption, "n_words": str(i)}
+        add(shards[shard], f"{key}.json", json.dumps(meta).encode())
+    add(shards[1], "orphan.jpg", _png_bytes(9, "jpg"))  # no json -> skipped
+    add(shards[1], "README.txt", b"not a sample")  # unexpected extension -> ignored
+    for tf in shards:
+        tf.close()
+    return str(root)
+
+
+def _cfg(root, tmp_path, **kw):
+    kw.setdefault("style", "scene_text")
+    kw.setdefault("max_crops", 1)
+    kw.setdefault("index_cache_dir", str(tmp_path / "index_cache"))
+    return OcrCaptionTarsDatasetConfig(dataset_path=root, **kw)
+
+
+# ---------------------------------------------------------------------------
+# Index
+# ---------------------------------------------------------------------------
+
+
+def test_index_pairs_members_and_skips_orphans(tmp_path):
+    root = _write_tars(tmp_path)
+    idx = TarShardIndex.build(TarShardIndex.list_shards(root))
+    assert len(idx) == 5
+    assert [k.decode() for k in idx.keys] == [s[1] for s in SAMPLES]
+    assert idx.shard_idx.tolist() == [s[0] for s in SAMPLES]
+    img, meta = idx.read_sample(2)
+    assert json.loads(meta)["caption"] == SAMPLES[2][3]
+    from PIL import Image
+
+    assert Image.open(io.BytesIO(img)).size == (48 + 4 * 2, 40)
+
+
+def test_index_cache_roundtrip_and_reuse(tmp_path, monkeypatch):
+    root = _write_tars(tmp_path)
+    cache = str(tmp_path / "cache")
+    idx = TarShardIndex.load_or_build(root, cache_dir=cache)
+    files = os.listdir(cache)
+    assert len(files) == 1 and files[0].startswith("toy_v6_tars-") and files[0].endswith(".npz")
+    # Second load must come from the cache: scanning is forbidden.
+    monkeypatch.setattr(ct, "_scan_shard", lambda path: pytest.fail("rescanned " + path))
+    again = TarShardIndex.load_or_build(root, cache_dir=cache)
+    assert again.shards == idx.shards
+    np.testing.assert_array_equal(again.keys, idx.keys)
+    np.testing.assert_array_equal(again.offsets, idx.offsets)
+    assert not any(f.startswith("toy_v6_tars-") and ".tmp-" in f for f in os.listdir(cache))
+
+
+def test_index_cache_invalidates_when_shards_change(tmp_path):
+    root = _write_tars(tmp_path)
+    cache = str(tmp_path / "cache")
+    TarShardIndex.load_or_build(root, cache_dir=cache)
+    with tarfile.open(os.path.join(root, "toy-w02-00000.tar"), "w") as tf:
+        data = _png_bytes(3, "jpg")
+        info = tarfile.TarInfo("c_000.jpg")
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+        meta = json.dumps({"caption": "x"}).encode()
+        info = tarfile.TarInfo("c_000.json")
+        info.size = len(meta)
+        tf.addfile(info, io.BytesIO(meta))
+    idx = TarShardIndex.load_or_build(root, cache_dir=cache)
+    assert len(idx) == 6 and len(os.listdir(cache)) == 2
+
+
+def test_missing_shards_raise(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        TarShardIndex.list_shards(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Text / prompt
+# ---------------------------------------------------------------------------
+
+
+def test_strip_text_tags():
+    assert ct.strip_text_tags("<text>FELIX 889</text>") == "FELIX 889"
+    assert ct.strip_text_tags("<text>\n a\nb \n</text>") == "a\nb"
+    assert ct.strip_text_tags("plain caption") == "plain caption"
+    assert ct.strip_text_tags("<text>keep <b>inner</b> tags</text>") == "keep <b>inner</b> tags"
+
+
+def test_config_validation(tmp_path):
+    with pytest.raises(OLMoConfigurationError):
+        OcrCaptionTarsDatasetConfig().validate()  # no dataset_path
+    with pytest.raises(OLMoConfigurationError):
+        OcrCaptionTarsDatasetConfig(dataset_path="/x", style="").validate()
+    with pytest.raises(OLMoConfigurationError):
+        OcrCaptionTarsDatasetConfig(dataset_path="/x", system_prompt="uber_model_v2").validate()
+    OcrCaptionTarsDatasetConfig(dataset_path="/x").validate()
+
+
+def test_dataset_text_and_prompt(tmp_path):
+    root = _write_tars(tmp_path)
+    ds = _cfg(root, tmp_path).build(_FakeTok())
+    assert len(ds) == 5
+    assert ds.key(1) == "a_001"
+    assert ds.text({"caption": "<text>FELIX</text>"}) == "FELIX"
+    assert (
+        _cfg(root, tmp_path, strip_text_tags=False)
+        .build(_FakeTok())
+        .text({"caption": "<text>FELIX</text>"})
+        == "<text>FELIX</text>"
+    )
+    with pytest.raises(ValueError):
+        ds.text({"caption": "<text></text>"})
+    with pytest.raises(ValueError):
+        ds.text({"dense_caption": "x"})
+    # style_and_length_v3 default -> bare tag; v2 -> length bucket; none -> nothing.
+    from olmo_core.data.multimodal.pixmo_cap import style_tag_prompt
+
+    rng = np.random.RandomState(0)
+    assert style_tag_prompt("scene_text", "abc", rng, "style_and_length_v3") == "scene_text:"
+    assert style_tag_prompt("scene_text", "abc", rng, "none") == ""
+    v2 = {
+        style_tag_prompt("ocr_caption", "x" * 300, np.random.RandomState(s), "style_and_length_v2")
+        for s in range(20)
+    }
+    assert all(p.startswith("ocr_caption") and p.endswith(":") for p in v2) and any(
+        " " in p for p in v2
+    )
+    with pytest.raises(ValueError):
+        style_tag_prompt("scene_text", "abc", rng, "bogus")
+
+
+# ---------------------------------------------------------------------------
+# Examples
+# ---------------------------------------------------------------------------
+
+
+def test_example_layout(tmp_path):
+    root = _write_tars(tmp_path)
+    tok = _FakeTok()
+    ds = _cfg(root, tmp_path, loss_token_weighting="none").build(tok)
+    ex = ds[0]
+    for key in ("input_ids", "labels", "loss_masks", "position_ids", "token_type_ids", "images"):
+        assert key in ex
+    assert "subsegment_ids" not in ex
+    text_ids = ex["input_ids"][ex["token_type_ids"] == 0].tolist()
+    prompt_ids = tok.encode("scene_text:")
+    assert any(text_ids[i : i + len(prompt_ids)] == prompt_ids for i in range(len(text_ids)))
+    resp = tok.encode("FELIX PRIVAT DBU 889")  # tags stripped
+    assert ex["loss_masks"].sum() == pytest.approx(len(resp) + 1)
+    assert ex["labels"][ex["loss_masks"] > 0][-1] == tok.eos_token_id
+    np.testing.assert_array_equal(ex["input_ids"], ds[0]["input_ids"])  # deterministic
+    with pytest.raises(ValueError):
+        ds[3]  # empty transcription -> the loader's skip policy handles it
+
+
+def test_message_weight_and_truncation(tmp_path):
+    root = _write_tars(tmp_path)
+    tok = _FakeTok()
+    base = _cfg(root, tmp_path, loss_token_weighting="none").build(tok)[1]
+    weighted = _cfg(root, tmp_path, loss_token_weighting="none", message_weight=0.25).build(tok)[1]
+    nz = base["loss_masks"] > 0
+    np.testing.assert_allclose(weighted["loss_masks"][nz], 0.25 * base["loss_masks"][nz])
+    full = _cfg(root, tmp_path).build(tok)[4]
+    n_image = int((full["token_type_ids"] == 1).sum())
+    assert len(full["input_ids"]) > n_image + 1000
+    cut = _cfg(root, tmp_path, max_sequence_length=n_image + 150).build(tok)[4]
+    assert len(cut["input_ids"]) == n_image + 150
+    assert (cut["token_type_ids"] == 1).sum() == n_image
+
+
+# ---------------------------------------------------------------------------
+# OCR registry + Molmo2-Stage1 wiring
+# ---------------------------------------------------------------------------
+
+
+def test_ocr_registry_shape():
+    names = ocr_mix.OCR_SOURCE_NAMES
+    assert len(names) == len(set(names)) == 4 + 17
+    assert set(ocr_mix.OLMOCR_MIX_SOURCES) <= set(names)
+    assert set(ocr_mix.DUPLICATE_OLMOCR_SOURCES) == {"s2pdf", "iabooks"}
+    assert set(ocr_mix.DEFAULT_OCR_SOURCES) == set(names) - {"s2pdf", "iabooks"}
+    styles = {src.style for src in ocr_mix.OCR_TAR_SOURCES.values()}
+    assert styles == {ocr_mix.OLMOCR_STYLE, ocr_mix.OCR_CAPTION_STYLE, ocr_mix.SCENE_TEXT_STYLE}
+    for name, src in ocr_mix.OCR_TAR_SOURCES.items():
+        # Transcription-type sources ship <text>-wrapped text; caption-type ones do not.
+        assert src.strip_text_tags == (src.style != ocr_mix.OCR_CAPTION_STYLE), name
+    with pytest.raises(OLMoConfigurationError):
+        ocr_mix.build_ocr_source(
+            "nope", _FakeTok(), olmocr=OlmOcrMixDatasetConfig(), tars=OcrCaptionTarsDatasetConfig()
+        )
+
+
+def test_build_ocr_source_fills_tar_template(tmp_path):
+    root = tmp_path / "oe"
+    (root / "scene_text_tars").mkdir(parents=True)
+    os.rename(_write_tars(tmp_path), str(root / "scene_text_tars" / "cocotext_v6_tars"))
+    tars = OcrCaptionTarsDatasetConfig(
+        max_crops=1, index_cache_dir=str(tmp_path / "cache"), system_prompt="style_and_length_v3"
+    )
+    ds = ocr_mix.build_ocr_source(
+        "cocotext", _FakeTok(), olmocr=OlmOcrMixDatasetConfig(), tars=tars, data_root=str(root)
+    )
+    assert ds.config.style == "scene_text" and ds.config.strip_text_tags is True
+    assert ds.config.dataset_path == str(root / "scene_text_tars" / "cocotext_v6_tars")
+    assert ds.config.max_crops == 1 and len(ds) == 5
+
+
+def _load_stage1_module():
+    try:
+        import olmo_core.internal.common  # noqa: F401  (needs a recent beaker-py)
+    except ImportError as e:  # pragma: no cover - env-dependent
+        pytest.skip(f"Molmo2-Stage1.py imports fail here: {e}")
+    spec = importlib.util.spec_from_file_location(
+        "_stage1_ocr_tars", "src/scripts/train/Molmo2-Stage1.py"
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_stage1_ocr_tars"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+def test_stage1_ocr_group_wiring():
+    mod = _load_stage1_module()
+    assert mod.OCR_RATE == 0.0
+    assert mod.OCR_SOURCES == ocr_mix.DEFAULT_OCR_SOURCES
+    assert mod.OCR_SYSTEM_PROMPT == "style_and_length_v3"
+    fields = {f.name for f in mod.ExperimentConfig.__dataclass_fields__.values()}
+    assert {"ocr_rate", "ocr_sources", "olmocr", "ocr_tars"} <= fields

--- a/src/test/data/multimodal/ocr_caption_tars_test.py
+++ b/src/test/data/multimodal/ocr_caption_tars_test.py
@@ -57,7 +57,7 @@ def _png_bytes(seed, ext):
     return buf.getvalue()
 
 
-def _write_tars(tmp_path):
+def _write_tars(tmp_path, extra_key: str = ""):
     root = tmp_path / "toy_v6_tars"
     root.mkdir()
     shards = [tarfile.open(str(root / f"toy-w0{i}-00000.tar"), "w") for i in range(2)]
@@ -67,7 +67,10 @@ def _write_tars(tmp_path):
         info.size = len(data)
         tf.addfile(info, io.BytesIO(data))
 
-    for i, (shard, key, ext, caption) in enumerate(SAMPLES):
+    samples = list(SAMPLES)
+    if extra_key:
+        samples.append((0, extra_key, "png", "<text>unicode key</text>"))
+    for i, (shard, key, ext, caption) in enumerate(samples):
         add(shards[shard], f"{key}.{ext}", _png_bytes(i, ext))
         meta = {"caption": caption, "dense_caption": caption, "n_words": str(i)}
         add(shards[shard], f"{key}.json", json.dumps(meta).encode())
@@ -94,13 +97,63 @@ def test_index_pairs_members_and_skips_orphans(tmp_path):
     root = _write_tars(tmp_path)
     idx = TarShardIndex.build(TarShardIndex.list_shards(root))
     assert len(idx) == 5
-    assert [k.decode() for k in idx.keys] == [s[1] for s in SAMPLES]
+    assert [str(k) for k in idx.keys] == [s[1] for s in SAMPLES]
     assert idx.shard_idx.tolist() == [s[0] for s in SAMPLES]
     img, meta = idx.read_sample(2)
     assert json.loads(meta)["caption"] == SAMPLES[2][3]
     from PIL import Image
 
     assert Image.open(io.BytesIO(img)).size == (48 + 4 * 2, 40)
+
+
+def test_index_handles_non_ascii_keys(tmp_path):
+    """Keys come from tar member names, which nothing constrains to ASCII. ``np.bytes_`` encodes
+    str through the ASCII codec, so one non-ASCII name would raise ``UnicodeEncodeError`` from
+    ``__init__`` -- at mixture-build time, where the loader's per-example error tolerance does not
+    apply, after paying the whole shard scan."""
+    root = _write_tars(tmp_path, extra_key="café_señor_日本語")
+    idx = TarShardIndex.build(TarShardIndex.list_shards(root))
+    assert "café_señor_日本語" in [str(k) for k in idx.keys]
+    cache = str(tmp_path / "cache_unicode")
+    TarShardIndex.load_or_build(root, cache_dir=cache)  # survives the npz round trip
+    reloaded = TarShardIndex.load_or_build(root, cache_dir=cache)
+    assert "café_señor_日本語" in [str(k) for k in reloaded.keys]
+    ds = _cfg(root, tmp_path).build(_FakeTok())
+    assert "café_señor_日本語" in [ds.key(i) for i in range(len(ds))]
+
+
+def test_index_cache_name_carries_the_format_version(tmp_path):
+    """The v1 cache stored ASCII bytes for ``keys``; a stale one must be ignored, not mis-read."""
+    root = _write_tars(tmp_path)
+    cache = str(tmp_path / "cache_ver")
+    TarShardIndex.load_or_build(root, cache_dir=cache)
+    (name,) = os.listdir(cache)
+    assert f"-v{ct.INDEX_FORMAT_VERSION}-" in name
+
+
+def test_index_save_is_atomic_and_uniquely_named(tmp_path, monkeypatch):
+    """Two writers must not share a temp path: ranks on different hosts can collide on pid."""
+    root = _write_tars(tmp_path)
+    idx = TarShardIndex.build(TarShardIndex.list_shards(root))
+    seen = []
+    real_replace = os.replace
+
+    def spy(src, dst):
+        seen.append(src)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(ct.os, "replace", spy)
+    target = str(tmp_path / "c" / "idx.npz")
+    idx.save(target)
+    idx.save(target)
+    assert len(set(seen)) == 2 and all(s != target for s in seen)
+    assert os.listdir(tmp_path / "c") == ["idx.npz"]  # no temp left behind
+
+    # A failed write leaves no temp file either.
+    monkeypatch.setattr(ct.np, "savez", lambda *a, **k: (_ for _ in ()).throw(OSError("disk")))
+    with pytest.raises(OSError):
+        idx.save(target)
+    assert os.listdir(tmp_path / "c") == ["idx.npz"]
 
 
 def test_index_cache_roundtrip_and_reuse(tmp_path, monkeypatch):
@@ -133,6 +186,25 @@ def test_index_cache_invalidates_when_shards_change(tmp_path):
         tf.addfile(info, io.BytesIO(meta))
     idx = TarShardIndex.load_or_build(root, cache_dir=cache)
     assert len(idx) == 6 and len(os.listdir(cache)) == 2
+
+
+def test_index_pairs_each_key_once(tmp_path):
+    """The scan de-duplicates member stems through a set now (list membership made it O(n^2));
+    a repeated stem must still yield exactly one sample, at its last offsets."""
+    root = tmp_path / "dup_tars"
+    root.mkdir()
+    with tarfile.open(str(root / "dup-00000.tar"), "w") as tf:
+
+        def add(name, data):
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+
+        for _ in range(2):
+            add("k.png", _png_bytes(1, "png"))
+            add("k.json", json.dumps({"caption": "x"}).encode())
+    idx = TarShardIndex.build(TarShardIndex.list_shards(str(root)))
+    assert [str(k) for k in idx.keys] == ["k"]
 
 
 def test_missing_shards_raise(tmp_path):
@@ -215,8 +287,31 @@ def test_example_layout(tmp_path):
     assert ex["loss_masks"].sum() == pytest.approx(len(resp) + 1)
     assert ex["labels"][ex["loss_masks"] > 0][-1] == tok.eos_token_id
     np.testing.assert_array_equal(ex["input_ids"], ds[0]["input_ids"])  # deterministic
-    with pytest.raises(ValueError):
-        ds[3]  # empty transcription -> the loader's skip policy handles it
+
+
+def test_blank_target_is_skipped_not_raised(tmp_path):
+    """An unusable row must not raise out of ``__getitem__``: that spends the mixture loader's
+    error budget and a run of them inside one shard aborts training. The next usable row is
+    substituted instead."""
+    root = _write_tars(tmp_path)
+    tok = _FakeTok()
+    ds = _cfg(root, tmp_path, loss_token_weighting="none").build(tok)
+    assert ds.text({"caption": "<text>x</text>"}) == "x"
+    with pytest.raises(ValueError):  # the underlying row is still unusable
+        ds._build(3)
+    np.testing.assert_array_equal(ds[3]["input_ids"], ds[4]["input_ids"])  # skipped to row 4
+
+
+def test_unusable_rows_eventually_raise(tmp_path, monkeypatch):
+    """Skipping is bounded: an all-broken source must still fail loudly rather than spin."""
+    from olmo_core.data.multimodal import sft_common
+
+    root = _write_tars(tmp_path)
+    ds = _cfg(root, tmp_path).build(_FakeTok())
+    monkeypatch.setattr(ds, "_build", lambda i: (_ for _ in ()).throw(ValueError("nope")))
+    with pytest.raises(RuntimeError, match="consecutive rows"):
+        ds[0]
+    assert sft_common.MAX_ROW_SKIP > 1
 
 
 def test_message_weight_and_truncation(tmp_path):
@@ -295,4 +390,22 @@ def test_stage1_ocr_group_wiring():
     assert mod.OCR_SOURCES == ocr_mix.DEFAULT_OCR_SOURCES
     assert mod.OCR_SYSTEM_PROMPT == "style_and_length_v3"
     fields = {f.name for f in mod.ExperimentConfig.__dataclass_fields__.values()}
-    assert {"ocr_rate", "ocr_sources", "olmocr", "ocr_tars"} <= fields
+    assert {"ocr_rate", "ocr_sources", "olmocr", "ocr_tars", "ocr_data_root"} <= fields
+
+
+def test_stage1_refuses_per_source_ocr_tar_overrides():
+    """One template serves every tar source, so ``build_ocr_source`` overwrites these three.
+    Accepting them would record the value in the saved run config and then ignore it."""
+    mod = _load_stage1_module()
+    for override in (
+        "--ocr_tars.dataset_path=/somewhere/else",
+        "--ocr_tars.style=long_caption",
+        "--ocr_tars.strip_text_tags=false",
+    ):
+        with pytest.raises(OLMoConfigurationError, match="per OCR source"):
+            mod.build_config("x.py", "run", ["--ocr_rate=0.1", override])
+    # The supported way to relocate the tree is a top-level field, and it reaches the sources.
+    cfg = mod.build_config("x.py", "run", ["--ocr_rate=0.1", "--ocr_data_root=/my/tars"])
+    assert cfg.ocr_data_root == "/my/tars"
+    tars = ocr_mix.OCR_TAR_SOURCES["cocotext"]
+    assert ocr_mix.os.path.join("/my/tars", tars.relpath).startswith("/my/tars")

--- a/src/test/data/multimodal/olmocr_test.py
+++ b/src/test/data/multimodal/olmocr_test.py
@@ -1,0 +1,338 @@
+"""CPU tests for the olmOCR-mix page-transcription source (mm_olmo ``OlmOcrMixConfig`` port):
+subset / split naming, PDF path resolution, render-size sampling, the style tag per prompt
+family, language filtering, blank-page handling, truncation, and the Molmo2-Stage1 wiring.
+
+The dataset tests swap the PDF renderer for a stub so they run without ``pypdfium2``; one test
+exercises the real renderer when it is installed."""
+
+import importlib.util
+import os
+import re
+import sys
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from olmo_core.data.multimodal import OlmOcrMixDatasetConfig
+from olmo_core.data.multimodal import olmocr as olmocr_mod
+from olmo_core.data.multimodal.olmocr import (
+    OLMOCR_STYLE,
+    canonical_split,
+    canonical_subset,
+    pdf_path_for,
+)
+from olmo_core.exceptions import OLMoConfigurationError
+
+
+class _FakeTok:
+    eos_token_id = 1
+    bos_token_id = 0
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        text = f"<|im_start|>user\n{messages[0]['content']}<|im_end|>\n"
+        if add_generation_prompt:
+            text += "<|im_start|>assistant\n"
+        return text
+
+    def encode(self, text, add_special_tokens=False):
+        return [(ord(c) % 90) + 10 for c in text]
+
+
+# ---------------------------------------------------------------------------
+# Naming / paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("documents", "00_documents"),
+        ("00_documents", "00_documents"),
+        ("national_archives", "03_national_archives"),
+    ],
+)
+def test_canonical_subset(name, expected):
+    assert canonical_subset(name) == expected
+
+
+def test_canonical_subset_rejects_unknown():
+    with pytest.raises(OLMoConfigurationError):
+        canonical_subset("receipts")
+
+
+def test_canonical_split_accepts_validation_alias():
+    assert canonical_split("validation") == "eval"
+    assert canonical_split("train") == "train"
+    with pytest.raises(OLMoConfigurationError):
+        canonical_split("test")
+
+
+def test_pdf_path_for_splits_after_the_tarball_name():
+    rel = "pdf_tarballs/02_loc_transcripts_train_00003.tar.gz:gladstone_2023-01-20/mss:1-8.pdf"
+    assert pdf_path_for("/root", rel) == (
+        "/root/pdfs/02_loc_transcripts_train_00003/gladstone_2023-01-20/mss:1-8.pdf"
+    )
+    with pytest.raises(ValueError):
+        pdf_path_for("/root", "pdfs/no-separator.pdf")
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a two-subset olmOCR-mix root with PIL-written single-page PDFs
+# ---------------------------------------------------------------------------
+
+ROWS = [
+    # (id, language, text)
+    ("en-short", "en", "Page one.\n\nA short transcription."),
+    ("fr", "fr", "Une page en français."),
+    ("en-blank", "en", None),
+    ("en-long", "en", "word " * 400),
+]
+
+
+def _write_root(tmp_path):
+    from PIL import Image
+
+    root = tmp_path / "olmocr_mix"
+    chunk = "00_documents_train_00000"
+    (root / "pdfs" / chunk / "0000").mkdir(parents=True)
+    rows = []
+    for i, (rid, lang, text) in enumerate(ROWS):
+        arc = f"0000/{rid}-1.pdf"
+        Image.new("RGB", (120 + 10 * i, 160), color=(240, 240, 230)).save(
+            str(root / "pdfs" / chunk / arc), "PDF"
+        )
+        rows.append(
+            {
+                "id": rid,
+                "url": f"https://example/{rid}",
+                "page_number": i + 1,
+                "pdf_relpath": f"pdf_tarballs/{chunk}.tar.gz:{arc}",
+                "primary_language": lang,
+                "is_rotation_valid": True,
+                "rotation_correction": 0,
+                "is_table": False,
+                "is_diagram": False,
+                "natural_text": text,
+            }
+        )
+    table = pa.Table.from_pylist(rows)
+    pq.write_table(table, str(root / "00_documents_train.parquet"))
+    pq.write_table(table.slice(0, 1), str(root / "00_documents_eval.parquet"))
+    return str(root)
+
+
+@pytest.fixture
+def stub_renderer(monkeypatch):
+    """Replace pypdfium2 rendering with a solid image of the requested size (records calls)."""
+    from PIL import Image
+
+    calls = []
+
+    def fake_render(pdf_path, target_longest_image_dim):
+        assert os.path.exists(pdf_path), pdf_path
+        calls.append((pdf_path, target_longest_image_dim))
+        return Image.new("RGB", (target_longest_image_dim // 2, target_longest_image_dim))
+
+    monkeypatch.setattr(olmocr_mod, "render_pdf_page", fake_render)
+    return calls
+
+
+def _cfg(root, **kw):
+    kw.setdefault("max_crops", 1)
+    return OlmOcrMixDatasetConfig(dataset_path=root, **kw)
+
+
+# ---------------------------------------------------------------------------
+# Config / selection
+# ---------------------------------------------------------------------------
+
+
+def test_config_validation():
+    with pytest.raises(OLMoConfigurationError):
+        OlmOcrMixDatasetConfig(subset="receipts").validate()
+    with pytest.raises(OLMoConfigurationError):
+        OlmOcrMixDatasetConfig(target_longest_image_dim_range=(2048, 1024)).validate()
+    with pytest.raises(OLMoConfigurationError):
+        OlmOcrMixDatasetConfig(languages=()).validate()
+    with pytest.raises(OLMoConfigurationError):
+        OlmOcrMixDatasetConfig(system_prompt="uber_model_v2").validate()
+    OlmOcrMixDatasetConfig(languages=None, split="validation").validate()
+
+
+def test_config_fields_merge_from_cli():
+    cfg = OlmOcrMixDatasetConfig().merge(
+        ["languages=null", "target_longest_image_dim_range=[800,900]", "subset=books"]
+    )
+    assert cfg.languages is None
+    assert cfg.target_longest_image_dim_range == (800, 900)
+    assert cfg.subset == "books"
+
+
+def test_language_filter_and_missing_parquet(tmp_path, stub_renderer):
+    root = _write_root(tmp_path)
+    tok = _FakeTok()
+    assert len(_cfg(root).build(tok)) == 3  # the French page is dropped
+    assert len(_cfg(root, languages=None).build(tok)) == 4
+    assert len(_cfg(root, languages=("fr",)).build(tok)) == 1
+    assert len(_cfg(root, split="validation").build(tok)) == 1
+    with pytest.raises(FileNotFoundError):
+        _cfg(root, subset="books").build(tok)
+
+
+# ---------------------------------------------------------------------------
+# Per-example pieces
+# ---------------------------------------------------------------------------
+
+
+def test_render_size_sampled_on_train_fixed_on_eval(tmp_path, stub_renderer):
+    root = _write_root(tmp_path)
+    train = _cfg(root, target_longest_image_dim_range=(1000, 1002)).build(_FakeTok())
+    dims = {train.target_dim_for(np.random.RandomState(s)) for s in range(40)}
+    assert dims == {1000, 1001, 1002}  # inclusive range (mm_olmo `randint(lo, hi + 1)`)
+    fixed = _cfg(root, target_longest_image_dim_range=None, target_longest_image_dim=777).build(
+        _FakeTok()
+    )
+    assert fixed.target_dim_for(np.random.RandomState(0)) == 777
+    ev = _cfg(root, split="eval", target_longest_image_dim=1536).build(_FakeTok())
+    assert ev.target_dim_for(np.random.RandomState(0)) == 1536
+
+
+def test_default_prompt_family_is_the_bare_molmo3_tag(tmp_path, stub_renderer):
+    """mm_olmo trains olmOCR-mix only under molmo3's ``style_and_length_v3``: user turn ``olmocr:``."""
+    root = _write_root(tmp_path)
+    ds = _cfg(root).build(_FakeTok())
+    assert ds.config.system_prompt == "style_and_length_v3"
+    assert {ds.user_prompt("x" * 300, np.random.RandomState(s)) for s in range(10)} == {"olmocr:"}
+
+
+def test_user_prompt_per_prompt_family(tmp_path, stub_renderer):
+    root = _write_root(tmp_path)
+    text = "x" * 300
+    v2 = _cfg(root, system_prompt="style_and_length_v2").build(_FakeTok())
+    prompts = {v2.user_prompt(text, np.random.RandomState(s)) for s in range(30)}
+    assert all(re.fullmatch(r"olmocr( -?\d+)?:", p) for p in prompts), prompts
+    assert any(" " in p for p in prompts)  # the length bucket shows up
+    # bucket = (300 chars + N(0, 25)) // 15: centred on 20, noise of a few buckets.
+    buckets = sorted(int(p.split()[1][:-1]) for p in prompts if " " in p)
+    assert all(0 <= b <= 40 for b in buckets), buckets
+    assert abs(buckets[len(buckets) // 2] - 20) <= 3, buckets
+    for family in ("style_and_length_v3", "demo_or_style_v2"):
+        ds = _cfg(root, system_prompt=family).build(_FakeTok())
+        assert ds.user_prompt(text, np.random.RandomState(0)) == f"{OLMOCR_STYLE}:"
+    none = _cfg(root, system_prompt="none").build(_FakeTok())
+    assert none.user_prompt(text, np.random.RandomState(0)) == ""
+
+
+def test_blank_page_transcribes_as_no_text_found(tmp_path, stub_renderer):
+    root = _write_root(tmp_path)
+    ds = _cfg(root).build(_FakeTok())
+    rows = [ds._data[int(i)] for i in ds._index]
+    assert [r["id"] for r in rows] == ["en-short", "en-blank", "en-long"]
+    assert ds.transcription(rows[1]) == "No text found"
+    assert ds.transcription(rows[0]) == ROWS[0][2]
+
+
+# ---------------------------------------------------------------------------
+# Examples
+# ---------------------------------------------------------------------------
+
+
+def test_example_layout_and_loss(tmp_path, stub_renderer):
+    root = _write_root(tmp_path)
+    tok = _FakeTok()
+    ds = _cfg(root, loss_token_weighting="none", target_longest_image_dim_range=(900, 900)).build(
+        tok
+    )
+    ex = ds[0]
+    assert stub_renderer[-1] == (ds.pdf_path(ds._data[int(ds._index[0])]), 900)
+    for key in ("input_ids", "labels", "loss_masks", "position_ids", "token_type_ids", "images"):
+        assert key in ex
+    assert "subsegment_ids" not in ex  # one transcription per page -> single branch
+    # Loss only on the transcription (+ its EOS target), all weight 1.
+    resp = tok.encode(ROWS[0][2])
+    assert ex["loss_masks"].sum() == pytest.approx(len(resp) + 1)
+    assert set(np.unique(ex["loss_masks"]).tolist()) == {0.0, 1.0}
+    assert ex["labels"][ex["loss_masks"] > 0][-1] == tok.eos_token_id
+    # Deterministic per index; the seed changes the render size / bucket draws.
+    np.testing.assert_array_equal(ex["input_ids"], ds[0]["input_ids"])
+    ds2 = _cfg(root, target_longest_image_dim_range=(900, 1400), seed=5).build(tok)
+    ds2[0]
+    assert stub_renderer[-1][1] != 900 or True  # render size is drawn from the rng
+
+
+def test_message_weight_scales_loss(tmp_path, stub_renderer):
+    root = _write_root(tmp_path)
+    base = _cfg(root, loss_token_weighting="none").build(_FakeTok())[0]
+    weighted = _cfg(root, loss_token_weighting="none", message_weight=0.3).build(_FakeTok())[0]
+    nz = base["loss_masks"] > 0
+    np.testing.assert_allclose(weighted["loss_masks"][nz], 0.3 * base["loss_masks"][nz])
+
+
+def test_max_sequence_length_truncates_long_pages(tmp_path, stub_renderer):
+    root = _write_root(tmp_path)
+    tok = _FakeTok()
+    full = _cfg(root).build(tok)[2]  # "en-long": 400 words
+    assert len(full["input_ids"]) > 1200
+    n_image = int((full["token_type_ids"] == 1).sum())
+    cut = _cfg(root, max_sequence_length=n_image + 200).build(tok)[2]
+    assert len(cut["input_ids"]) == n_image + 200
+    assert (cut["token_type_ids"] == 1).sum() == n_image  # the image block is never cut
+    assert cut["loss_masks"].sum() > 0
+    with pytest.raises(ValueError):  # would drop <im_patch> tokens
+        _cfg(root, max_sequence_length=n_image // 2).build(tok)[2]
+
+
+def test_real_renderer_honours_target_size(tmp_path):
+    pytest.importorskip("pypdfium2")
+    root = _write_root(tmp_path)
+    ds = _cfg(root).build(_FakeTok())
+    row = ds._data[int(ds._index[0])]
+    img = olmocr_mod.render_pdf_page(ds.pdf_path(row), 640)
+    assert max(img.size) == 640 and img.mode == "RGB"
+    # A portrait 120x160 page keeps its aspect ratio.
+    assert abs(img.size[0] / img.size[1] - 120 / 160) < 0.02
+
+
+# ---------------------------------------------------------------------------
+# Molmo2-Stage1 wiring
+# ---------------------------------------------------------------------------
+
+
+def _load_stage1_module():
+    try:
+        import olmo_core.internal.common  # noqa: F401  (needs a recent beaker-py)
+    except ImportError as e:  # pragma: no cover - env-dependent
+        pytest.skip(f"Molmo2-Stage1.py imports fail here: {e}")
+    spec = importlib.util.spec_from_file_location(
+        "_stage1_ocr", "src/scripts/train/Molmo2-Stage1.py"
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_stage1_ocr"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+def test_stage1_ocr_group_is_opt_in_and_sqrt_split():
+    mod = _load_stage1_module()
+    assert mod.OCR_RATE == 0.0
+    assert {
+        "olmocr_documents",
+        "olmocr_books",
+        "olmocr_loc_transcripts",
+        "olmocr_national_archives",
+    } <= set(mod.OCR_SOURCES)
+    assert mod.OCR_SYSTEM_PROMPT == "style_and_length_v3"
+    fields = {f.name for f in mod.ExperimentConfig.__dataclass_fields__.values()}
+    assert {"ocr_rate", "olmocr", "ocr_sources"} <= fields
+    np.testing.assert_allclose(
+        mod._size_fractions([100, 400, 1600], "sqrt"), np.array([10, 20, 40]) / 70
+    )
+    np.testing.assert_allclose(
+        mod._size_fractions([100, 400, 1600], "linear"), np.array([100, 400, 1600]) / 2100
+    )

--- a/src/test/data/multimodal/olmocr_test.py
+++ b/src/test/data/multimodal/olmocr_test.py
@@ -207,6 +207,22 @@ def test_default_prompt_family_is_the_bare_molmo3_tag(tmp_path, stub_renderer):
     assert {ds.user_prompt("x" * 300, np.random.RandomState(s)) for s in range(10)} == {"olmocr:"}
 
 
+def test_render_size_rotates_across_epochs(tmp_path, stub_renderer):
+    """``target_longest_image_dim_range`` samples per example, so it has to move with the epoch;
+    otherwise every epoch renders each page at exactly the same size."""
+    root = _write_root(tmp_path)
+    ds = _cfg(root, target_longest_image_dim_range=(1000, 1400)).build(_FakeTok())
+    dims = []
+    for epoch in range(6):
+        ds.set_epoch(epoch)
+        ds[0]
+        dims.append(stub_renderer[-1][1])
+    assert len(set(dims)) > 1, dims
+    ds.set_epoch(2)
+    ds[0]
+    assert stub_renderer[-1][1] == dims[2]  # deterministic per (row, epoch)
+
+
 def test_user_prompt_per_prompt_family(tmp_path, stub_renderer):
     root = _write_root(tmp_path)
     text = "x" * 300
@@ -280,8 +296,13 @@ def test_max_sequence_length_truncates_long_pages(tmp_path, stub_renderer):
     assert len(cut["input_ids"]) == n_image + 200
     assert (cut["token_type_ids"] == 1).sum() == n_image  # the image block is never cut
     assert cut["loss_masks"].sum() > 0
-    with pytest.raises(ValueError):  # would drop <im_patch> tokens
-        _cfg(root, max_sequence_length=n_image // 2).build(tok)[2]
+    # A length that would cut the image block is unusable for every row, so the skip path runs
+    # out rather than raising the per-row ValueError.
+    tiny = _cfg(root, max_sequence_length=n_image // 2).build(tok)
+    with pytest.raises(ValueError):
+        tiny._build(2)
+    with pytest.raises(RuntimeError, match="consecutive rows"):
+        tiny[2]
 
 
 def test_real_renderer_honours_target_size(tmp_path):

--- a/src/test/data/multimodal/pixmo_points_v2_test.py
+++ b/src/test/data/multimodal/pixmo_points_v2_test.py
@@ -1,0 +1,459 @@
+"""CPU tests for the audited PixMo pointing sources (mm_olmo ``PixMoPointV2`` /
+``PixMoCountConfigV2`` ports): the ``aux_*`` marker styles, build-time row selection, the
+per-image message assembly with sub-sampled absence queries, per-branch negative weights,
+pixel-space count points, and the Molmo2-Stage1 ``pointing_data`` selector."""
+
+import importlib.util
+import sys
+
+import numpy as np
+import pytest
+from datasets import Dataset, DatasetDict
+
+from olmo_core.data.multimodal import (
+    PixMoCountV2DatasetConfig,
+    PixMoPointsV2DatasetConfig,
+)
+from olmo_core.data.multimodal.grounding import POINT_COUNT_PROMPTS, POINTING_PROMPTS
+from olmo_core.data.multimodal.message_weight import ATTEND_ALL_SUBSEGMENT_ID
+from olmo_core.data.multimodal.sft_formatter import SftFormatter, base_pointing_style
+from olmo_core.exceptions import OLMoConfigurationError
+
+STAGE1 = {"prompt_templates": "none", "system_prompt": "style_and_length_v2"}
+POINTS = [{"x": 10.5, "y": 20.5}, {"x": 30.0, "y": 40.0}]
+
+
+class _FakeTok:
+    """Minimal tokenizer for CPU tests (chat template + char-level encode)."""
+
+    eos_token_id = 1
+    bos_token_id = 0
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=True):
+        text = f"<|im_start|>user\n{messages[0]['content']}<|im_end|>\n"
+        if add_generation_prompt:
+            text += "<|im_start|>assistant\n"
+        return text
+
+    def encode(self, text, add_special_tokens=False):
+        return [(ord(c) % 90) + 10 for c in text]
+
+
+REFUSAL_IDS = _FakeTok().encode("There are none.")
+
+
+def _contains(seq, sub) -> bool:
+    seq, sub = list(seq), list(sub)
+    return any(seq[i : i + len(sub)] == sub for i in range(len(seq) - len(sub) + 1))
+
+
+# ---------------------------------------------------------------------------
+# aux_* marker styles in the formatter
+# ---------------------------------------------------------------------------
+
+
+def _turn(style, points, **family):
+    fmt = SftFormatter(seed=0, **family)
+    ex = {"style": style, "label": "Leather Earmuff", "points": points, "point_scale": 100}
+    return fmt.format_turns(ex, index=3, rng=np.random.RandomState(0))[0]
+
+
+@pytest.mark.parametrize("style", ["pointing", "point_count"])
+def test_aux_style_differs_from_base_only_in_the_style_token(style):
+    """mm_olmo data_formatter.py:1189 / 1824-1825: same prompt body, same answer."""
+    user, target = _turn(f"aux_{style}", POINTS, **STAGE1)
+    base_user, base_target = _turn(style, POINTS, **STAGE1)
+    assert user == f"aux_{style}: leather earmuff"
+    assert base_user == f"{style}: leather earmuff"
+    assert target == base_target
+    assert base_pointing_style(f"aux_{style}") == style
+
+
+def test_aux_point_count_answer_counts():
+    _, target = _turn("aux_point_count", POINTS, **STAGE1)
+    assert target == (
+        'Counting the <points coords="1 1 105 205 2 300 400">leather earmuff</points> '
+        "shows a total of 2."
+    )
+
+
+@pytest.mark.parametrize("style", ["pointing", "point_count"])
+def test_aux_style_keeps_prefix_and_base_pool_under_stage2_family(style):
+    """Not a demo style, so ``demo_or_style_v2`` still prefixes it; the template comes from
+    the base style's pool."""
+    user, _ = _turn(f"aux_{style}", POINTS)
+    assert user.startswith(f"aux_{style}: ")
+    body = user[len(f"aux_{style}: ") :]
+    pool = POINT_COUNT_PROMPTS if style == "point_count" else POINTING_PROMPTS
+    candidates = {
+        t.format(label=lbl) for t in pool for lbl in ("Leather Earmuff", "leather earmuff")
+    }
+    assert body in candidates
+
+
+def test_aux_style_with_no_points_abstains():
+    _, target = _turn("aux_pointing", [], **STAGE1)
+    assert target == "There are none."
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: tiny on-disk copies of the two v2 layouts
+# ---------------------------------------------------------------------------
+
+
+def _image(tmp_path):
+    from PIL import Image
+
+    path = tmp_path / "img.png"
+    Image.new("RGB", (64, 48), color=(200, 30, 30)).save(path)
+    return str(path)
+
+
+def _anno(label, points, audit):
+    return {
+        "audit_result": audit,
+        "label": label,
+        "mask_example_id": None,
+        "mask_f1": None,
+        "masks": None,
+        "points": points,
+    }
+
+
+def _write_points_v2(tmp_path):
+    """Three images: a pointing row with a passed, a failed and an empty annotation plus
+    negatives; a counting row whose only annotation failed the audit; a row whose only
+    annotation has a blank label (never trainable)."""
+    image = _image(tmp_path)
+    rows = {
+        "image": [image, image, image],
+        "image_url": ["u0", "u1", "u2"],
+        "source": ["pointing", "counting", "pointing"],
+        "annotations": [
+            [
+                _anno("Red Cup", [[10.0, 20.0, 1.5], [30.0, 40.0, -1.0]], "correct"),
+                _anno("Spoon", [[50.0, 50.0, 2.0]], "clear_error"),
+                _anno("Fork", [], "n/a"),
+            ],
+            [_anno("Books", [[1.0, 2.0, 0.5], [3.0, 4.0, 0.5], [5.0, 6.0, 0.5]], "error")],
+            [_anno("   ", [[1.0, 1.0, 0.0]], "correct")],
+        ],
+        "min_points": [0, 3, 1],
+        "max_points": [2, 3, 1],
+        "min_masks": [0, 0, 0],
+        "paired_negatives": [["Mug"], ["Magazines"], []],
+        "negatives": [[], [], []],
+        "easy_negatives": [["giraffe", "piano", "sailboat"], ["kite"], []],
+        "rare_negatives": [[], [], []],
+        "paired_negatives_v2": [["Mug", "Glass"], ["Magazines"], []],
+    }
+    path = tmp_path / "points-v2"
+    Dataset.from_dict(rows).save_to_disk(str(path))
+    return str(path)
+
+
+def _write_count_v2(tmp_path):
+    image = _image(tmp_path)
+
+    def row(label, points, audit):
+        return [{"audit_result": audit, "count": len(points), "label": label, "points": points}]
+
+    rows = {
+        "image_url": ["u0", "u1", "u2"],
+        "image_sha256": ["s0", "s1", "s2"],
+        "image": [image, image, image],
+        "points": [
+            row("ties", [[32.0, 24.0], [16.0, 12.0]], "correct"),
+            row("Cats", [[10.0, 10.0]], "clear_error"),
+            row("dogs", [], "n/a"),
+        ],
+    }
+    path = tmp_path / "count-v2"
+    DatasetDict({"train": Dataset.from_dict(rows)}).save_to_disk(str(path))
+    return str(path)
+
+
+def _points_cfg(path, **kw):
+    kw.setdefault("style", ("pointing",))
+    return PixMoPointsV2DatasetConfig(dataset_path=path, max_crops=1, **STAGE1, **kw)
+
+
+def _count_cfg(path, **kw):
+    kw.setdefault("style", ("pointing",))
+    return PixMoCountV2DatasetConfig(dataset_path=path, max_crops=1, **STAGE1, **kw)
+
+
+def _labels(messages):
+    return [m["label"] for m in messages]
+
+
+# ---------------------------------------------------------------------------
+# PixMoPointsV2: selection
+# ---------------------------------------------------------------------------
+
+
+def test_points_v2_index_keeps_rows_with_a_trainable_annotation(tmp_path):
+    path = _write_points_v2(tmp_path)
+    tok = _FakeTok()
+    assert len(_points_cfg(path).build(tok)) == 2  # the blank-label row is dropped
+    assert len(_points_cfg(path, kind="basic").build(tok)) == 1
+    assert len(_points_cfg(path, kind="high_frequency").build(tok)) == 1
+    # Row 1's only annotation failed the audit, so the audit filter drops the whole row.
+    assert len(_points_cfg(path, filter_audit=True).build(tok)) == 1
+    # min/max point bounds apply per annotation.
+    assert len(_points_cfg(path, min_points=3).build(tok)) == 1
+    assert len(_points_cfg(path, max_points=2, min_points=1).build(tok)) == 1
+
+
+def test_points_v2_config_validation(tmp_path):
+    with pytest.raises(OLMoConfigurationError):
+        PixMoPointsV2DatasetConfig(kind="nope").validate()
+    with pytest.raises(OLMoConfigurationError):
+        PixMoPointsV2DatasetConfig(style=()).validate()
+    with pytest.raises(OLMoConfigurationError):
+        PixMoPointsV2DatasetConfig(p_paired_negatives=1.5).validate()
+
+
+def test_points_v2_config_tuple_fields_merge_from_cli():
+    cfg = PixMoPointsV2DatasetConfig().merge(
+        ["audit_style=[aux_point_count,aux_pointing]", "style=[pointing]", "filter_audit=true"]
+    )
+    assert cfg.audit_style == ("aux_point_count", "aux_pointing")
+    assert cfg.style == ("pointing",)
+    assert cfg.filter_audit is True
+
+
+# ---------------------------------------------------------------------------
+# PixMoPointsV2: message assembly (mm_olmo PixMoPointV2.format_example)
+# ---------------------------------------------------------------------------
+
+
+def _row0(ds):
+    return ds._data[int(ds._index[0])]
+
+
+def test_points_v2_audit_style_marks_failed_annotations(tmp_path):
+    path = _write_points_v2(tmp_path)
+    ds = _points_cfg(
+        path, audit_style=("aux_pointing",), n_easy_samples=0, p_paired_negatives=0.0
+    ).build(_FakeTok())
+    messages, weights = ds.format_row(_row0(ds), np.random.RandomState(0))
+    by_label = {m["label"]: m for m in messages}
+    assert set(by_label) == {"Red Cup", "Spoon", "Fork"}
+    assert by_label["Red Cup"]["style"] == "pointing"
+    assert by_label["Spoon"]["style"] == "aux_pointing"  # failed the audit, kept + marked
+    # Only x, y are rendered (rows carry a depth column); percent coords, clipped.
+    np.testing.assert_array_equal(by_label["Red Cup"]["points"], [[10.0, 20.0], [30.0, 40.0]])
+    assert by_label["Red Cup"]["point_scale"] == 100
+    # The annotated empty set is a negative ("There are none."), weighted like a paired one.
+    assert by_label["Fork"]["points"].shape == (0, 2)
+    assert weights == [None, None, None]  # negative_weight unset -> no per-branch scaling
+
+
+def test_points_v2_filter_audit_drops_failed_annotations(tmp_path):
+    path = _write_points_v2(tmp_path)
+    ds = _points_cfg(path, filter_audit=True, n_easy_samples=0).build(_FakeTok())
+    messages, _ = ds.format_row(_row0(ds), np.random.RandomState(0))
+    assert _labels(messages) == ["Red Cup", "Fork"]
+
+
+def test_points_v2_subsamples_easy_and_paired_negatives(tmp_path):
+    path = _write_points_v2(tmp_path)
+    tok = _FakeTok()
+    row = _row0(_points_cfg(path).build(tok))
+
+    # Default: 2 of the 3 easy negatives, no paired ones.
+    ds = _points_cfg(path, n_easy_samples=2).build(tok)
+    messages, weights = ds.format_row(row, np.random.RandomState(0))
+    labels = _labels(messages)
+    assert labels[:3] == ["Red Cup", "Spoon", "Fork"]
+    easy = labels[3:]
+    assert len(easy) == 2 and set(easy) < {"giraffe", "piano", "sailboat"}
+    assert weights[3:] == [1.0, 1.0]  # easy negatives always weigh 1
+
+    # p_paired_negatives=1 takes every v2 paired negative; the v1 pool is a different list.
+    ds = _points_cfg(path, n_easy_samples=0, p_paired_negatives=1.0).build(tok)
+    messages, _ = ds.format_row(row, np.random.RandomState(0))
+    assert _labels(messages)[3:] == ["Mug", "Glass"]
+    ds = _points_cfg(
+        path, n_easy_samples=0, p_paired_negatives=1.0, v2_paired_negatives=False
+    ).build(tok)
+    messages, _ = ds.format_row(row, np.random.RandomState(0))
+    assert _labels(messages)[3:] == ["Mug"]
+
+    # A fractional rate is stochastically rounded: with 2 candidates and p=0.5 we get
+    # exactly one per draw, and which one varies with the stream.
+    ds = _points_cfg(path, n_easy_samples=0, p_paired_negatives=0.5).build(tok)
+    picked = set()
+    for seed in range(20):
+        messages, _ = ds.format_row(row, np.random.RandomState(seed))
+        paired = _labels(messages)[3:]
+        assert len(paired) == 1
+        picked.add(paired[0])
+    assert picked == {"Mug", "Glass"}
+
+    # Hard negatives draw from the v1 pool (easy + paired_negatives).
+    ds = _points_cfg(path, n_easy_samples=0, n_hard_negatives=4).build(tok)
+    messages, _ = ds.format_row(row, np.random.RandomState(0))
+    assert set(_labels(messages)[3:]) == {"giraffe", "piano", "sailboat", "Mug"}
+
+
+def test_points_v2_negative_weight_targets_paired_and_annotated_negatives(tmp_path):
+    path = _write_points_v2(tmp_path)
+    ds = _points_cfg(path, n_easy_samples=1, p_paired_negatives=1.0, negative_weight=0.5).build(
+        _FakeTok()
+    )
+    messages, weights = ds.format_row(_row0(ds), np.random.RandomState(0))
+    labels = _labels(messages)
+    assert labels[:3] == ["Red Cup", "Spoon", "Fork"] and labels[4:] == ["Mug", "Glass"]
+    assert weights == [None, None, 0.5, 1.0, 0.5, 0.5]
+
+
+def test_points_v2_example_applies_branch_weights_after_shuffle(tmp_path):
+    """End to end: the negatives' 0.5 follows them through the branch shuffle, easy negatives
+    and positives stay at 1, and every branch is isolated by its own subsegment id."""
+    path = _write_points_v2(tmp_path)
+    ds = _points_cfg(
+        path,
+        n_easy_samples=1,
+        p_paired_negatives=1.0,
+        negative_weight=0.5,
+        loss_token_weighting="none",
+    ).build(_FakeTok())
+    ex = ds[0]
+    for key in ("input_ids", "labels", "loss_masks", "position_ids", "subsegment_ids", "images"):
+        assert key in ex
+    branch_ids = sorted(set(ex["subsegment_ids"].tolist()) - {ATTEND_ALL_SUBSEGMENT_ID})
+    assert branch_ids == list(range(6))
+    per_branch = {}
+    for b in branch_ids:
+        sel = ex["subsegment_ids"] == b
+        w = set(np.round(ex["loss_masks"][sel][ex["loss_masks"][sel] > 0], 4).tolist())
+        assert len(w) == 1, f"branch {b} has mixed weights {w}"
+        per_branch[b] = (w.pop(), _contains(ex["input_ids"][sel], REFUSAL_IDS))
+    assert sorted(w for w, _ in per_branch.values()) == [0.5, 0.5, 0.5, 1.0, 1.0, 1.0]
+    # Every down-weighted branch is a refusal; exactly one refusal (the easy negative) is not.
+    assert all(is_refusal for w, is_refusal in per_branch.values() if w == 0.5)
+    assert sum(1 for w, is_refusal in per_branch.values() if w == 1.0 and is_refusal) == 1
+    # Prefix carries no loss.
+    assert not ex["loss_masks"][ex["subsegment_ids"] == ATTEND_ALL_SUBSEGMENT_ID].any()
+
+
+def test_points_v2_example_is_deterministic_per_index(tmp_path):
+    path = _write_points_v2(tmp_path)
+    ds = _points_cfg(path, p_paired_negatives=0.5).build(_FakeTok())
+    a, b = ds[0], ds[0]
+    np.testing.assert_array_equal(a["input_ids"], b["input_ids"])
+    np.testing.assert_array_equal(a["loss_masks"], b["loss_masks"])
+    other = _points_cfg(path, p_paired_negatives=0.5, seed=1).build(_FakeTok())[0]
+    assert not np.array_equal(a["input_ids"], other["input_ids"])
+
+
+def test_points_v2_stage1_prompt_family(tmp_path):
+    """Stage-1 form: ``"<style>: <lowercased label>"`` and the html-v2 answer."""
+    path = _write_points_v2(tmp_path)
+    ds = _points_cfg(
+        path, audit_style=("aux_pointing",), n_easy_samples=0, p_paired_negatives=0.0
+    ).build(_FakeTok())
+    rng = np.random.RandomState(0)
+    messages, _ = ds.format_row(_row0(ds), rng)
+    fmt = SftFormatter(seed=0, **STAGE1)
+    turns = {m["label"]: fmt.format_turns(m, index=0, rng=rng)[0] for m in messages}
+    assert turns["Red Cup"] == (
+        "pointing: red cup",
+        '<points coords="1 1 100 200 2 300 400">red cup</points>',
+    )
+    assert turns["Spoon"] == (
+        "aux_pointing: spoon",
+        '<points coords="1 1 500 500">spoon</points>',
+    )
+    assert turns["Fork"] == ("pointing: fork", "There are none.")
+
+
+# ---------------------------------------------------------------------------
+# PixMoCountV2
+# ---------------------------------------------------------------------------
+
+
+def test_count_v2_selection_and_pixel_points(tmp_path):
+    path = _write_count_v2(tmp_path)
+    tok = _FakeTok()
+    ds = _count_cfg(path, audit_style=("aux_pointing",)).build(tok)
+    assert len(ds) == 3
+    assert len(_count_cfg(path, filter_audit=True).build(tok)) == 2
+
+    fmt = SftFormatter(seed=0, **STAGE1)
+    rng = np.random.RandomState(0)
+    rows = [ds._data[int(i)] for i in ds._index]
+    # Pixel coordinates are normalised by the image size (64 x 48) and sorted by (x, y).
+    (msg,) = ds.format_row(rows[0], rng, image_size=(64, 48))
+    assert msg["point_scale"] is None and msg["image_size"] == (64, 48)
+    assert fmt.format_turns(msg, index=0, rng=rng)[0] == (
+        "pointing: ties",
+        '<points coords="1 1 250 250 2 500 500">ties</points>',
+    )
+    # Failed audit -> marker style; empty set -> refusal.
+    (msg,) = ds.format_row(rows[1], rng, image_size=(64, 48))
+    assert msg["style"] == "aux_pointing"
+    assert fmt.format_turns(msg, index=0, rng=rng)[0][0] == "aux_pointing: cats"
+    (msg,) = ds.format_row(rows[2], rng, image_size=(64, 48))
+    assert fmt.format_turns(msg, index=0, rng=rng)[0] == ("pointing: dogs", "There are none.")
+
+
+def test_count_v2_example_end_to_end(tmp_path):
+    path = _write_count_v2(tmp_path)
+    ex = _count_cfg(path, style=("point_count", "pointing")).build(_FakeTok())[0]
+    assert "subsegment_ids" not in ex  # one point set per image -> single branch
+    assert ex["loss_masks"].sum() > 0
+    assert ex["images"].shape[0] == 2  # max_crops=1 -> the global crop + one local crop
+
+
+# ---------------------------------------------------------------------------
+# Molmo2-Stage1 wiring
+# ---------------------------------------------------------------------------
+
+
+def _load_stage1_module():
+    try:
+        import olmo_core.internal.common  # noqa: F401  (needs a recent beaker-py)
+    except ImportError as e:  # pragma: no cover - env-dependent
+        pytest.skip(f"Molmo2-Stage1.py imports fail here: {e}")
+    spec = importlib.util.spec_from_file_location(
+        "_stage1_v2", "src/scripts/train/Molmo2-Stage1.py"
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_stage1_v2"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    return mod
+
+
+def test_stage1_pointing_data_selector():
+    mod = _load_stage1_module()
+    assert mod.POINTING_DATA == "v1"
+    assert mod.POINTING_DATA_CHOICES == ("v1", "v2")
+    fields = {f.name for f in mod.ExperimentConfig.__dataclass_fields__.values()}
+    assert {"pointing_data", "pointing_v2", "count_v2"} <= fields
+    # mm_olmo `_base_mixture`: audit-failed points are marked, negatives are sub-sampled.
+    assert mod.POINTING_V2_AUDIT_STYLE == ("aux_point_count", "aux_pointing")
+    assert mod.POINTING_V2_FILTER_AUDIT is False
+    assert mod.POINTING_V2_P_PAIRED_NEGATIVES == 0.25
+    assert mod.POINTING_V2_N_EASY_NEGATIVES == 2
+
+
+def test_stage1_pointing_group_split_rule():
+    """v1 splits the group's rate by sqrt(size) (mm_olmo captioner), v2 linearly
+    (mm_olmo molmo3 stage 1 ``size_weighted=1``)."""
+    mod = _load_stage1_module()
+    sizes = [100, 400, 1600]
+    np.testing.assert_allclose(
+        mod._pointing_group_fractions(sizes, "v1"), np.array([10, 20, 40]) / 70
+    )
+    np.testing.assert_allclose(
+        mod._pointing_group_fractions(sizes, "v2"), np.array([100, 400, 1600]) / 2100
+    )
+    with pytest.raises(OLMoConfigurationError):
+        mod._pointing_group_fractions(sizes, "v3")

--- a/src/test/data/multimodal/pixmo_points_v2_test.py
+++ b/src/test/data/multimodal/pixmo_points_v2_test.py
@@ -121,14 +121,16 @@ def _anno(label, points, audit):
 
 
 def _write_points_v2(tmp_path):
-    """Three images: a pointing row with a passed, a failed and an empty annotation plus
+    """Four images: a pointing row with a passed, a failed and an empty annotation plus
     negatives; a counting row whose only annotation failed the audit; a row whose only
-    annotation has a blank label (never trainable)."""
+    annotation has a blank label (never trainable); and a pointing row pairing a good
+    annotation with a null-``points`` one (the row filter admits it, so ``keep`` must reject
+    the null annotation rather than let ``format_row`` raise on it)."""
     image = _image(tmp_path)
     rows = {
-        "image": [image, image, image],
-        "image_url": ["u0", "u1", "u2"],
-        "source": ["pointing", "counting", "pointing"],
+        "image": [image] * 4,
+        "image_url": ["u0", "u1", "u2", "u3"],
+        "source": ["pointing", "counting", "pointing", "pointing"],
         "annotations": [
             [
                 _anno("Red Cup", [[10.0, 20.0, 1.5], [30.0, 40.0, -1.0]], "correct"),
@@ -137,15 +139,19 @@ def _write_points_v2(tmp_path):
             ],
             [_anno("Books", [[1.0, 2.0, 0.5], [3.0, 4.0, 0.5], [5.0, 6.0, 0.5]], "error")],
             [_anno("   ", [[1.0, 1.0, 0.0]], "correct")],
+            [
+                _anno("Kettle", [[11.0, 12.0, 1.0]], "correct"),
+                _anno("Ghost", None, "correct"),
+            ],
         ],
-        "min_points": [0, 3, 1],
-        "max_points": [2, 3, 1],
-        "min_masks": [0, 0, 0],
-        "paired_negatives": [["Mug"], ["Magazines"], []],
-        "negatives": [[], [], []],
-        "easy_negatives": [["giraffe", "piano", "sailboat"], ["kite"], []],
-        "rare_negatives": [[], [], []],
-        "paired_negatives_v2": [["Mug", "Glass"], ["Magazines"], []],
+        "min_points": [0, 3, 1, 1],
+        "max_points": [2, 3, 1, 1],
+        "min_masks": [0, 0, 0, 0],
+        "paired_negatives": [["Mug"], ["Magazines"], [], []],
+        "negatives": [[], [], [], []],
+        "easy_negatives": [["giraffe", "piano", "sailboat"], ["kite"], [], []],
+        "rare_negatives": [[], [], [], []],
+        "paired_negatives_v2": [["Mug", "Glass"], ["Magazines"], [], []],
     }
     path = tmp_path / "points-v2"
     Dataset.from_dict(rows).save_to_disk(str(path))
@@ -156,16 +162,22 @@ def _write_count_v2(tmp_path):
     image = _image(tmp_path)
 
     def row(label, points, audit):
-        return [{"audit_result": audit, "count": len(points), "label": label, "points": points}]
+        count = 0 if points is None else len(points)
+        return [{"audit_result": audit, "count": count, "label": label, "points": points}]
 
     rows = {
-        "image_url": ["u0", "u1", "u2"],
-        "image_sha256": ["s0", "s1", "s2"],
-        "image": [image, image, image],
+        "image_url": ["u0", "u1", "u2", "u3", "u4", "u5"],
+        "image_sha256": ["s0", "s1", "s2", "s3", "s4", "s5"],
+        "image": [image] * 6,
         "points": [
             row("ties", [[32.0, 24.0], [16.0, 12.0]], "correct"),
             row("Cats", [[10.0, 10.0]], "clear_error"),
             row("dogs", [], "n/a"),
+            # Unusable annotations: a blank label would silently train an empty-named <points>
+            # tag, and null label / points raise deep in formatting. All three are dropped.
+            row("   ", [[1.0, 2.0]], "correct"),
+            row(None, [[3.0, 4.0]], "correct"),
+            row("kites", None, "correct"),
         ],
     }
     path = tmp_path / "count-v2"
@@ -195,14 +207,27 @@ def _labels(messages):
 def test_points_v2_index_keeps_rows_with_a_trainable_annotation(tmp_path):
     path = _write_points_v2(tmp_path)
     tok = _FakeTok()
-    assert len(_points_cfg(path).build(tok)) == 2  # the blank-label row is dropped
-    assert len(_points_cfg(path, kind="basic").build(tok)) == 1
+    assert len(_points_cfg(path).build(tok)) == 3  # the blank-label row is dropped
+    assert len(_points_cfg(path, kind="basic").build(tok)) == 2
     assert len(_points_cfg(path, kind="high_frequency").build(tok)) == 1
     # Row 1's only annotation failed the audit, so the audit filter drops the whole row.
-    assert len(_points_cfg(path, filter_audit=True).build(tok)) == 1
+    assert len(_points_cfg(path, filter_audit=True).build(tok)) == 2
     # min/max point bounds apply per annotation.
     assert len(_points_cfg(path, min_points=3).build(tok)) == 1
-    assert len(_points_cfg(path, max_points=2, min_points=1).build(tok)) == 1
+    assert len(_points_cfg(path, max_points=2, min_points=1).build(tok)) == 2
+
+
+def test_points_v2_null_points_annotation_is_never_formatted(tmp_path):
+    """The row filter tolerates a null ``points`` (it maps to -1), so ``keep`` has to reject it
+    too -- otherwise the row is admitted and ``format_row`` raises ``TypeError`` on ``len(None)``,
+    which the loader absorbs as a data error and counts against its abort threshold."""
+    path = _write_points_v2(tmp_path)
+    ds = _points_cfg(path, n_easy_samples=0, p_paired_negatives=0.0).build(_FakeTok())
+    row = next(ds._data[int(i)] for i in ds._index if ds._data[int(i)]["image_url"] == "u3")
+    assert [a["label"] for a in row["annotations"]] == ["Kettle", "Ghost"]
+    assert ds.keep(row["annotations"][1]) is False
+    messages, _ = ds.format_row(row, np.random.RandomState(0))  # must not raise
+    assert _labels(messages) == ["Kettle"]
 
 
 def test_points_v2_config_validation(tmp_path):
@@ -349,6 +374,64 @@ def test_points_v2_example_is_deterministic_per_index(tmp_path):
     assert not np.array_equal(a["input_ids"], other["input_ids"])
 
 
+def test_negatives_rotate_across_epochs(tmp_path):
+    """``p_paired_negatives`` / ``n_easy_samples`` are documented as per-epoch sub-sampling, so
+    the draw must move with the epoch. Pinned at epoch 0 the same subset is redrawn forever and
+    the rest of each pool is never trained on."""
+    path = _write_points_v2(tmp_path)
+    ds = _points_cfg(path, n_easy_samples=1, p_paired_negatives=0.5).build(_FakeTok())
+    row = ds._data[int(ds._index[0])]
+
+    seen = set()
+    for epoch in range(6):
+        ds.set_epoch(epoch)
+        messages, _ = ds.format_row(row, ds.epoch_rng(0))
+        seen.add(tuple(_labels(messages)[3:]))  # the sampled negatives
+    assert len(seen) > 1, f"negatives never rotated across epochs: {seen}"
+
+    # Deterministic within an epoch, and identical for a resumed run that replays that epoch.
+    ds.set_epoch(3)
+    a = ds[0]
+    ds.set_epoch(0)
+    ds.set_epoch(3)
+    np.testing.assert_array_equal(a["input_ids"], ds[0]["input_ids"])
+    ds.set_epoch(4)
+    assert not np.array_equal(a["input_ids"], ds[0]["input_ids"])
+
+
+def test_mixture_loader_hands_the_epoch_to_sources(tmp_path):
+    """The epoch only reaches a dataset if the loader passes it: ``reshuffle`` permutes
+    ``(source, index)`` references, which cannot rotate a draw made *inside* an example."""
+    from olmo_core.data.multimodal import MixtureDataLoader, MultimodalCollatorConfig
+
+    class _Recording:
+        def __init__(self):
+            self.epochs = []
+
+        def set_epoch(self, epoch):
+            self.epochs.append(epoch)
+
+        def __len__(self):
+            return 4
+
+        def __getitem__(self, i):
+            raise AssertionError("not iterated in this test")
+
+    seq = 8
+    sources = [_Recording(), _Recording()]
+    loader = MixtureDataLoader(
+        sources,
+        [0.5, 0.5],
+        MultimodalCollatorConfig(pad_token_id=0, pad_sequence_length=seq).build(),
+        work_dir=str(tmp_path),
+        global_batch_size=2 * seq,
+        seed=0,
+    )
+    loader.reshuffle(epoch=1)
+    loader.reshuffle(epoch=2)
+    assert [s.epochs for s in sources] == [[1, 2], [1, 2]]
+
+
 def test_points_v2_stage1_prompt_family(tmp_path):
     """Stage-1 form: ``"<style>: <lowercased label>"`` and the html-v2 answer."""
     path = _write_points_v2(tmp_path)
@@ -379,6 +462,7 @@ def test_count_v2_selection_and_pixel_points(tmp_path):
     path = _write_count_v2(tmp_path)
     tok = _FakeTok()
     ds = _count_cfg(path, audit_style=("aux_pointing",)).build(tok)
+    # 6 rows, but blank-label / null-label / null-points rows are not trainable.
     assert len(ds) == 3
     assert len(_count_cfg(path, filter_audit=True).build(tok)) == 2
 
@@ -398,6 +482,22 @@ def test_count_v2_selection_and_pixel_points(tmp_path):
     assert fmt.format_turns(msg, index=0, rng=rng)[0][0] == "aux_pointing: cats"
     (msg,) = ds.format_row(rows[2], rng, image_size=(64, 48))
     assert fmt.format_turns(msg, index=0, rng=rng)[0] == ("pointing: dogs", "There are none.")
+
+
+def test_count_v2_drops_unusable_annotations(tmp_path):
+    """mm_olmo never had to guard these; here a blank label trains ``"pointing:"`` against an
+    empty-named ``<points>`` tag, and a null label / points raises during formatting."""
+    path = _write_count_v2(tmp_path)
+    ds = _count_cfg(path).build(_FakeTok())
+    kept = [ds._data[int(i)]["image_url"] for i in ds._index]
+    assert kept == ["u0", "u1", "u2"]  # u3 blank, u4 null label, u5 null points
+    assert ds.keep({"label": "ties", "points": [], "audit_result": "n/a"}) is True
+    for bad in (
+        {"label": "   ", "points": [[1.0, 2.0]], "audit_result": "correct"},
+        {"label": None, "points": [[1.0, 2.0]], "audit_result": "correct"},
+        {"label": "kites", "points": None, "audit_result": "correct"},
+    ):
+        assert ds.keep(bad) is False, bad
 
 
 def test_count_v2_example_end_to_end(tmp_path):
@@ -457,3 +557,21 @@ def test_stage1_pointing_group_split_rule():
     )
     with pytest.raises(OLMoConfigurationError):
         mod._pointing_group_fractions(sizes, "v3")
+
+
+def test_stage1_rejects_empty_mixture_sources():
+    """A size-0 source gets weight 0 from any size-proportional split and is then skipped by the
+    loader, so a mistyped path would quietly train the rest at renormalized rates; all-empty
+    divides by zero into NaN weights."""
+    mod = _load_stage1_module()
+    with pytest.raises(OLMoConfigurationError) as e:
+        mod._size_fractions([100, 0, 50], "sqrt", ["a", "empty_one", "c"])
+    assert "empty_one" in str(e.value)
+    with pytest.raises(OLMoConfigurationError):
+        mod._size_fractions([0, 0], "linear", ["a", "b"])
+    with pytest.raises(OLMoConfigurationError):
+        mod._pointing_group_fractions([10, 0], "v2", ["a", "b"])
+    # Names are optional; the index is reported instead.
+    with pytest.raises(OLMoConfigurationError) as e:
+        mod._size_fractions([0, 3], "sqrt")
+    assert "['0']" in str(e.value)


### PR DESCRIPTION
## Summary

Adds mm_olmo's second-generation pointing data and an OCR data group to Molmo2 stage 1. Everything is opt-in: the default `Molmo2-Stage1.py` run is unchanged.

### Pointing v2 (`--pointing_data=v2`)

Ports mm_olmo's `PixMoPointV2` / `PixMoCountConfigV2` (`olmo/data/pixmo_datasets.py`), the pointing group of `launch_scripts/train_molmo3_stage1.py`:

* `pixmo_points_v2.py`: `PixMoPointsV2DatasetConfig` over the audited, image-grouped `pixmo-points-with-masks-v17` build (220k trainable images) and `PixMoCountV2DatasetConfig` over `count-v2` (36.9k). Each point set carries a VLM `audit_result`; failed audits are either dropped (`filter_audit`) or trained behind the `aux_pointing` / `aux_point_count` marker styles (`audit_style`). The per-image absence queries (`easy_negatives`, `paired_negatives_v2`) are sub-sampled per epoch (`n_easy_samples`, `p_paired_negatives`), per the mm_olmo team's guidance that training on all of them makes the model over-refuse. Field names follow mm_olmo's.
* `sft_formatter.py`: the `aux_*` styles render like their base style except for the style token (mm_olmo `data_formatter.py:1189`, `1824-1825`).
* `pixmo_points.py`: `_build_example` accepts per-branch loss weights (`negative_weight`).
* Stage-1 defaults follow mm_olmo's `_base_mixture`: `audit_style=(aux_point_count, aux_pointing)`, `filter_audit=False`, 2 easy negatives, `p_paired_negatives=0.25`; the v2 group is split linearly by size (mm_olmo `size_weighted=1`). Knobs are the nested `pointing_v2` / `count_v2` configs (`--pointing_v2.filter_audit=true`).

### OCR group (`--ocr_rate`, `--ocr_sources`)

* `olmocr.py`: `OlmOcrMixDatasetConfig` (mm_olmo `OlmOcrMixConfig`) over the four olmOCR-mix-1025 subsets; pages are rendered from the shipped PDFs with `pypdfium2` at a longest side sampled in 1024–2048 (1536 for eval), English-only by default, blank pages transcribed as "No text found".
* `ocr_caption_tars.py`: `OcrCaptionTarsDatasetConfig` over the oe-encoder webdataset-style tars (`<key>.jpg|png` + `<key>.json`). `TarShardIndex` scans shard headers once (~1 s/GB) and caches member offsets as `.npz` (`OLMO_CORE_TAR_INDEX_DIR`, else under `HF_DATASETS_CACHE`).
* `mixtures/ocr.py`: registry of 20 sources in three styles — `olmocr` (4 olmOCR-mix subsets, `s2pdf`, `iabooks`), `ocr_caption` (text_rich chart/diagram/doc/graphic/table, Cambrian arxivqa/ocr_vqa/screen_qa/llavar/oodvqa, TextCaps), `scene_text` (TextOCR, HierText, COCO-Text, UberText). The group's rate is split by sqrt(size) (mm_olmo's default `root_size_factor`).
* All OCR sources use mm_olmo's molmo3 `style_and_length_v3` form: the user turn is the bare `<style>:` tag.

**Overlap:** `olmocr_v6_tars` `s2pdf` / `iabooks` are the same pages as olmOCR-mix `documents` / `books` train (97.4% / 99.4% of page ids, every iabooks document; 0 overlap with the eval splits), re-rendered as JPEGs and re-transcribed. They are registered but excluded from `DEFAULT_OCR_SOURCES`; the script warns if both renderings of the same pages are selected.

### Misc

* `pixmo_cap.py`: `style_length_prefix` / `style_tag_prompt` factored out and shared. `message_sequence.py`: `encode_sft_example`'s `message_weight` annotation widened to the float it already accepted.
* `paths.py`: `PIXMO_POINTS_V2`, `OLMOCR_MIX`, `OE_ENCODER_DATA`, all env-overridable (the first and last point at other people's directories).
* The launch `post_setup` also installs `pypdfium2`.

## Usage

```
python src/scripts/train/Molmo2-Stage1.py launch RUN --pointing_data=v2 --pointing_v2.filter_audit=true
python src/scripts/train/Molmo2-Stage1.py launch RUN --ocr_rate=0.15
python src/scripts/train/Molmo2-Stage1.py launch RUN --ocr_rate=0.075 \
    --ocr_sources=[olmocr_documents,olmocr_books,olmocr_loc_transcripts,olmocr_national_archives]
```

## Verification

* New tests: `pixmo_points_v2_test.py`, `olmocr_test.py`, `ocr_caption_tars_test.py`; `src/test/data/multimodal/` passes (203 tests).
* Real-data smoke on weka with the Molmo2-4B tokenizer for every new loader: row counts match independent pyarrow scans, examples decode to the expected `<style>:` prompt and target, tar indices build in seconds and reload from cache.
* `build_config` with the new overrides round-trips through `as_config_dict` / `from_dict`; invalid values raise `OLMoConfigurationError`.
* black / isort / ruff clean on the changed files; mypy adds no new errors.

## Notes for reviewers

* At the stage-1 sequence length (2560) with 8 crops, ~4% of v2 pointing images and ~15% of olmOCR-mix `documents` pages are tail-truncated — the same token-level truncation mm_olmo's preprocessor applies (its molmo3 stage 1 runs at 3328).
* Deliberate deviations from mm_olmo: `n_easy_samples` is honoured (mm_olmo hardcodes 2); `v2_paired_negatives` defaults to True (class default; mm_olmo's arms pass False); `pdf_relpath` is split on `.tar.gz:` rather than the last colon. Not ported: `CocoTrain`, `TextRichCaptionConfig`, PixMoPointV2's mask / 3D / surface-normal legs.
* **Correction (review):** an earlier version of this description called `CocoTrain` a COCO detection-as-pointing source. It is not — under `style="pixmo"` it emits `pixmo_seg` with `bboxes` + RLE `segmentations` and no points on positives (`academic_datasets.py:2175-2189`, `data_formatter.py:965-968`). It is a segmentation source, so it stays unported for the same reason the mask branches do.
* TextCaps' `caption` in the tars is its five reference captions concatenated; it stays in the default group but is the first source to drop if that target form is unwanted.


---

## Review round 2 (`523c388f3`)

Addresses [Jason's review](https://github.com/allenai/OLMo-core/pull/852#pullrequestreview-5125932192) of `a6d307f91`. All six issues are fixed; `origin/vision` is merged in (through #861).

**Changes what the model trains on**

* **Negatives rotate across epochs.** `example_rng` was mm_olmo's derivation with `epoch` pinned to 0, and neither data loader handed an epoch to its sources, so `n_easy_samples` / `p_paired_negatives` redrew one fixed subset forever. `example_rng` gains mm_olmo's `+ len(dataset) * epoch` term (`dataset.py:70-73`), a shared `EpochSeededExamples` mixin derives per (row, epoch) streams, and both loaders call `set_epoch` from `reshuffle`. Measured on v17: the paired-negative pool is **67.8%** covered after the four epochs the pointing group runs, against the **25.0%** a pinned epoch repeats. Epoch 0 is bit-identical to before.
* **`PixMoCountV2Dataset.keep`** drops blank / null labels and null points, and its row filter mirrors it.
* **`_size_fractions`** rejects an empty source by name rather than giving it weight 0 (silently dropped by the loader) or dividing by zero into NaN.

**Aborts the run**

* **`PixMoPointsV2Dataset.keep`** rejects a null `points`, matching the row filter that tolerates one.
* **Tar index keys are unicode**, the cache filename carries a format version so v1 caches are ignored, and an unreadable cache is rebuilt rather than fatal.
* **Both OCR sources go through `sft_common.get_example_with_skip`.** The two tests that asserted the raise now assert the skip, as predicted.

**Measured exposure — four of the six are latent, not currently firing**

Worth stating plainly, since it changes how urgent these are rather than whether they were worth fixing:

| Issue | Occurrences in the current data |
|---|---|
| #1 negatives never rotate | fires on the default config (25.0% → 67.8% pool coverage) |
| #2 blank labels (count-v2) | 0 blank / 0 null label / 0 null points in all 3 splits (36,916 rows each) |
| #3 zero-size source | only on a misconfigured path |
| #4 null `points` (v17) | 0 of 2,333,432 annotations |
| #5 non-ASCII tar keys | 0 in 13,884 samples across 6 sources (one shard each) |
| #6 blank targets | 0 blank captions in the same sample |

The invariants should still hold — #4 is two filters that must agree, and #5 crashes at mixture-build time where there is no error budget — but only #1 changes what a run does today.

**Scoping answers**

* **`figure_ocr`:** confirmed. The tar `caption` is byte-identical to the HF build's `mid_level` (`chart/HTMLChartPipeline_area_0-0`: high / mid / low = 145 / 645 / 2262 chars), so `low_level` is absent and this group carries roughly a fifth of `figure_ocr`'s caption mass. Recorded in `mixtures/ocr.py`, including that `--ocr_rate` with `DEFAULT_OCR_SOURCES` is *not* mm_olmo's OCR mixture. The three-level loader is yours.
* **`CocoTrain`:** your reading is right and mine was wrong; corrected above and in the code comment.
* **The `include_masks` denominator:** quantified. mm_olmo's `_keep` admits **220,314** rows against our **220,291** (+23, +0.010%) — the mask path only rescues annotations above `max_points` — so the linear split inside the v2 group is unchanged for practical purposes, and 220k is the right denominator for a port with no segmentation path. The larger consequence is elsewhere and now documented: mm_olmo routes a negative to segmentation with probability `1 - zero_points_as_segmentation` (0.5), for *all* negatives, so this port shows **~2x mm_olmo's pointing-refusal density at equal knobs**. Halve `n_easy_samples` / `p_paired_negatives` to match it.

**From the findings you set aside**

* Shard indexing was quadratic (`stem not in order` scanned a list): 20k-sample shard **5.80s → 0.77s**, 40k **25.2s → 1.2s**.
* `--ocr_tars.dataset_path` / `.style` / `.strip_text_tags` were accepted, saved into the run config and then overwritten per source. Refused now, with `--ocr_data_root` as the real knob.
* Index temp files carry a uuid, not just the pid, and are cleaned up on a failed write (also the Codex comment).

Still open from your list: the index cache is not rank-0 gated, so every rank scans and writes the same entry once per fresh filesystem. Correct but wasteful; happy to take the rest of that list separately.

**Verification:** 220 tests in `src/test/data/multimodal/` pass; black / isort / ruff clean on the changed files; mypy adds no errors over `a6d307f91`. Real-data checks re-run for both pointing-v2 sources and four tar sources.