### PR TITLE
per-head QK norm

### DIFF
--- a/src/olmo_core/nn/attention/__init__.py
+++ b/src/olmo_core/nn/attention/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from torch.distributed import DeviceMesh
-from torch.distributed.tensor import Placement, Replicate, Shard
+from torch.distributed.tensor import DTensor, Placement, Replicate, Shard, distribute_tensor
 from torch.distributed.tensor.parallel import parallelize_module
 
 from olmo_core.config import Config, DType, StrEnum
@@ -201,6 +201,7 @@ class AttentionConfig(SequenceMixerConfig["SequenceMixer"]):
     dtype: DType = DType.float32
     sliding_window: Optional[SlidingWindowAttentionConfig] = None
     use_head_qk_norm: Optional[bool] = None
+    scalable_softmax: bool = False
 
     def num_params(self, d_model: int) -> int:
         """
@@ -254,6 +255,9 @@ class AttentionConfig(SequenceMixerConfig["SequenceMixer"]):
             params += n_heads * head_dim
             params += n_kv_heads * head_dim
 
+        if self.scalable_softmax:
+            params += n_heads
+
         return params
 
     def build(
@@ -280,6 +284,10 @@ class AttentionConfig(SequenceMixerConfig["SequenceMixer"]):
         if sliding_window_config is not None and sliding_window_config.should_use_swa(
             layer_idx, n_layers
         ):
+            if self.scalable_softmax:
+                raise OLMoConfigurationError(
+                    "'scalable_softmax' is not supported with sliding window attention"
+                )
             kwargs["window_size"] = sliding_window_config.get_window_size(layer_idx, n_layers)
         else:  # global (non-SWA) layer
             rope_config: Optional[RoPEConfig] = kwargs.get("rope")
@@ -340,6 +348,7 @@ class Attention(SequenceMixer):
     :param dropout: Dropout probability.
     :param use_flash: Deprecated, use ``backend="flash_2"`` instead.
     :param backend: The attention backend to use. If not set, it will be chosen automatically.
+    :param scalable_softmax: Use Scalable-Softmax with a learned scale for each query head.
     :param dtype: The default data type to use for parameters.
     :param init_device: The device to initialize weights on.
     """
@@ -365,6 +374,7 @@ class Attention(SequenceMixer):
         init_device: str = "cpu",
         cache: Optional[BufferCache] = None,
         use_head_qk_norm: bool = False,
+        scalable_softmax: bool = False,
     ):
         super().__init__()
 
@@ -407,6 +417,14 @@ class Attention(SequenceMixer):
 
         self.clip_qkv = clip_qkv
         self.use_head_qk_norm = use_head_qk_norm
+        self.scalable_softmax = scalable_softmax
+        self.ssmax_scale: Optional[nn.Parameter] = None
+        if scalable_softmax:
+            if window_size is not None:
+                raise OLMoConfigurationError(
+                    "'scalable_softmax' is not supported with sliding window attention"
+                )
+            self.ssmax_scale = nn.Parameter(torch.ones(n_heads, dtype=dtype, device=init_device))
 
         self.q_norm: Optional[LayerNorm] = None
         self.k_norm: Optional[LayerNorm] = None
@@ -516,6 +534,38 @@ class Attention(SequenceMixer):
             self.kv_cache_manager.update_seqlen(q.shape[1])
         return att
 
+    def _apply_scalable_softmax(
+        self,
+        q: torch.Tensor,
+        cu_doc_lens: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if not self.scalable_softmax:
+            return q
+        if self.cp_enabled:
+            raise NotImplementedError("Scalable-Softmax is not supported with context parallelism")
+        if self.kv_cache_manager is not None:
+            raise NotImplementedError("Scalable-Softmax is not supported with KV caching")
+
+        if cu_doc_lens is None:
+            visible_lengths = torch.arange(1, q.shape[1] + 1, device=q.device)
+            visible_lengths = visible_lengths.unsqueeze(0).expand(q.shape[0], -1)
+        else:
+            boundaries = cu_doc_lens.to(device=q.device)
+            token_indices = torch.arange(
+                q.shape[0] * q.shape[1], device=q.device, dtype=boundaries.dtype
+            )
+            document_indices = torch.searchsorted(boundaries[1:], token_indices, right=True)
+            document_starts = boundaries[document_indices]
+            visible_lengths = (token_indices - document_starts + 1).view(q.shape[0], q.shape[1])
+
+        assert self.ssmax_scale is not None
+        ssmax_scale = self.ssmax_scale
+        if isinstance(ssmax_scale, DTensor):
+            ssmax_scale = ssmax_scale.to_local()
+        scale = visible_lengths.log().to(q.dtype).unsqueeze(-1)
+        scale = scale * ssmax_scale.to(q.dtype).view(1, 1, -1)
+        return q * scale.unsqueeze(-1)
+
     def _apply_rope(
         self,
         q: torch.Tensor,
@@ -618,6 +668,8 @@ class Attention(SequenceMixer):
             start_pos = self.kv_cache_manager.current_position() if self.kv_cache_manager else None
             q, k = self._apply_rope(q, k, start_pos, pos_sin, pos_cos, freqs_cis, cu_doc_lens)
 
+        q = self._apply_scalable_softmax(q, cu_doc_lens)
+
         # shape: (batch_size, seq_len, n_heads, head_dim)
         att = self.sdpa(
             q,
@@ -697,6 +749,12 @@ class Attention(SequenceMixer):
             #    which will be reshaped into (B, T, H [sharded], D)
             # if head-wise norm: output is sharded on the head dimension (B, T, H [sharded], D)
             plan["q_norm"] = SequenceParallel(use_local_output=True, output_layouts=Shard(2))
+
+        if self.ssmax_scale is not None:
+            self.register_parameter(
+                "ssmax_scale",
+                nn.Parameter(distribute_tensor(self.ssmax_scale, tp_mesh, [Shard(0)])),
+            )
         if self.k_norm is not None:
             plan["k_norm"] = SequenceParallel(use_local_output=True, output_layouts=Shard(2))
 
@@ -735,6 +793,9 @@ class Attention(SequenceMixer):
         generator: Optional[torch.Generator] = None,
     ) -> None:
         from olmo_core.nn.transformer.init import InitMethod, init_linear
+
+        if self.ssmax_scale is not None:
+            nn.init.ones_(self.ssmax_scale)
 
         # Compute std for Q/K/V initialization
         if init_method == InitMethod.fan_in:

--- a/src/olmo_core/nn/attention/__init__.py
+++ b/src/olmo_core/nn/attention/__init__.py
@@ -202,6 +202,7 @@ class AttentionConfig(SequenceMixerConfig["SequenceMixer"]):
     sliding_window: Optional[SlidingWindowAttentionConfig] = None
     use_head_qk_norm: Optional[bool] = None
     scalable_softmax: bool = False
+    qk_norm_per_head_gains: Optional[bool] = None
 
     def num_params(self, d_model: int) -> int:
         """
@@ -228,7 +229,7 @@ class AttentionConfig(SequenceMixerConfig["SequenceMixer"]):
 
         # Block attention QK norm.
         if self.qk_norm is not None:
-            if self.use_head_qk_norm:
+            if self.use_head_qk_norm and not self.qk_norm_per_head_gains:
                 params += 2 * self.qk_norm.num_params(head_dim)
             else:
                 params += self.qk_norm.num_params(n_heads * head_dim)  # q_norm
@@ -345,6 +346,10 @@ class Attention(SequenceMixer):
     :param rope: The config for RoPE, if RoPE should be used.
     :param clip_qkv: Clip QKV to this value, if set.
     :param qk_norm: Configuration a layer norm for queries and keys.
+    :param use_head_qk_norm: Apply the QK norm head-wise, i.e. to each head separately with
+        normalization statistics computed over ``head_dim`` instead of the full hidden dimension.
+    :param qk_norm_per_head_gains: Give each head its own norm gain (and bias) parameters instead
+        of sharing them across heads. Requires ``use_head_qk_norm=True``.
     :param dropout: Dropout probability.
     :param use_flash: Deprecated, use ``backend="flash_2"`` instead.
     :param backend: The attention backend to use. If not set, it will be chosen automatically.
@@ -375,8 +380,14 @@ class Attention(SequenceMixer):
         cache: Optional[BufferCache] = None,
         use_head_qk_norm: bool = False,
         scalable_softmax: bool = False,
+        qk_norm_per_head_gains: bool = False,
     ):
         super().__init__()
+
+        if qk_norm_per_head_gains and not use_head_qk_norm:
+            raise OLMoConfigurationError(
+                "'qk_norm_per_head_gains' requires 'use_head_qk_norm=True'"
+            )
 
         self.n_heads = n_heads
         self.n_kv_heads = n_kv_heads or n_heads
@@ -430,8 +441,17 @@ class Attention(SequenceMixer):
         self.k_norm: Optional[LayerNorm] = None
         if qk_norm is not None:
             if use_head_qk_norm:
-                self.q_norm = qk_norm.build(size=self.head_dim, init_device=init_device)
-                self.k_norm = qk_norm.build(size=self.head_dim, init_device=init_device)
+                q_weight_shape: Optional[Tuple[int, ...]] = None
+                k_weight_shape: Optional[Tuple[int, ...]] = None
+                if qk_norm_per_head_gains:
+                    q_weight_shape = (n_heads, self.head_dim)
+                    k_weight_shape = (self.n_kv_heads, self.head_dim)
+                self.q_norm = qk_norm.build(
+                    size=self.head_dim, init_device=init_device, weight_shape=q_weight_shape
+                )
+                self.k_norm = qk_norm.build(
+                    size=self.head_dim, init_device=init_device, weight_shape=k_weight_shape
+                )
             else:
                 self.q_norm = qk_norm.build(size=n_heads * self.head_dim, init_device=init_device)
                 self.k_norm = qk_norm.build(
@@ -652,6 +672,11 @@ class Attention(SequenceMixer):
         v = v.view(B, T, -1, self.head_dim)
 
         if self.use_head_qk_norm:
+            # NOTE: with per-head gains ('qk_norm_per_head_gains=True') the norm weight has shape
+            # (n_heads, head_dim), and correctness relies on applying the norm *after* the
+            # head-wise view above so that head 'h' broadcasts against gain row 'h'. Under tensor
+            # parallelism this still holds: the norm runs in the sequence-sharded region where all
+            # heads are present locally and the weight is replicated.
             if self.q_norm is not None:
                 q = self.q_norm(q)
             if self.k_norm is not None:

--- a/src/olmo_core/nn/layer_norm.py
+++ b/src/olmo_core/nn/layer_norm.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -90,17 +90,30 @@ class LayerNormConfig(ModuleConfig):
                 ln_params += size
         return ln_params
 
-    def build(self, size: int, init_device: str = "cpu") -> "LayerNorm":
+    def build(
+        self,
+        size: int,
+        init_device: str = "cpu",
+        weight_shape: Optional[Tuple[int, ...]] = None,
+    ) -> "LayerNorm":
         """
         Construct the corresponding LayerNorm class.
 
         :param size: The size of the input along the dimension to be normalized.
         :param init_device: The device initialize the parameters on, e.g. "cpu", "meta".
+        :param weight_shape: An optional shape for the element-wise weight/bias parameters, if it
+            should differ from ``(size,)``. Normalization statistics are always computed over the
+            last ``size`` elements of the input regardless of this value; see :class:`LayerNorm`
+            for a detailed explanation. Not supported by the kernel-backed implementations
+            (:class:`FusedRMSNorm`, :class:`CuTeRMSNorm`), which require the weight shape to
+            match ``(size,)``.
         """
         kwargs = self.as_dict(exclude_none=True)
         kwargs.pop("name")
         if (dtype := kwargs.pop("dtype", None)) is not None:
             kwargs.update(dtype=dtype.as_pt())
+        if weight_shape is not None:
+            kwargs.update(weight_shape=weight_shape)
 
         try:
             if self.name == LayerNormType.default:
@@ -127,6 +140,27 @@ class LayerNorm(nn.Module):
     """
     Layer normalization.
 
+    This module (and its subclasses) distinguishes between two shapes that coincide in a
+    conventional layer norm but can be configured independently here:
+
+    - ``normalized_shape``: always ``(size,)``. This determines which elements the normalization
+      *statistics* (mean/variance, or RMS) are computed over — namely the last ``size`` elements
+      of the input. Every window of ``size`` elements along the last dimension is normalized
+      using only its own statistics.
+    - ``weight_shape``: the shape of the learnable element-wise weight (gain) and bias
+      parameters. By default this is also ``(size,)``, in which case the same gains are applied
+      to every normalized window. Passing an explicit ``weight_shape`` decouples the two: the
+      statistics are still computed over the last dimension only, but the affine transform is
+      applied by broadcasting the weight/bias against the (normalized) input, so different
+      windows can receive different gains.
+
+    For example, for per-head QK-norm with per-head gains on an input of shape
+    ``(batch, seq_len, n_heads, head_dim)``, use ``size=head_dim`` together with
+    ``weight_shape=(n_heads, head_dim)``. Each head is normalized with its own statistics
+    (from ``normalized_shape=(head_dim,)``), and the ``(n_heads, head_dim)`` weight broadcasts
+    over the batch and sequence dimensions to give each head its own gains. With the default
+    ``weight_shape=(head_dim,)`` instead, all heads would share a single gain vector.
+
     :param size: The size of the input along the dimension to be normalized.
     :param eps: The epsilon used for numerical stability.
     :param elementwise_affine: Whether to include an element-wise affine transform.
@@ -138,6 +172,12 @@ class LayerNorm(nn.Module):
         If ``full_precision=False`` it can be useful to set this to the expected input data type.
         Ignored if ``elementwise_affine=False``.
     :param init_device: The device used when initializing the element-wise weight/bias.
+    :param weight_shape: An optional shape for the element-wise weight/bias parameters, if it
+        should differ from ``(size,)``. This only affects the affine transform, never the
+        normalization statistics, which are always computed over the last ``size`` elements of
+        the input. The shape must broadcast against the input, e.g. ``(n_heads, size)`` for a
+        per-head affine on input of shape ``(batch, seq_len, n_heads, size)``.
+        Ignored if ``elementwise_affine=False``.
     """
 
     def __init__(
@@ -150,18 +190,20 @@ class LayerNorm(nn.Module):
         full_precision: bool = True,
         dtype: torch.dtype = torch.float32,
         init_device: str = "cpu",
+        weight_shape: Optional[Tuple[int, ...]] = None,
     ):
         super().__init__()
         self.normalized_shape = (size,)
+        self.weight_shape = tuple(weight_shape) if weight_shape is not None else (size,)
         self.eps = eps
         self.full_precision = full_precision
         if elementwise_affine:
             self.weight = nn.Parameter(
-                torch.ones(self.normalized_shape, dtype=dtype, device=init_device)
+                torch.ones(self.weight_shape, dtype=dtype, device=init_device)
             )
             if bias:
                 self.bias = nn.Parameter(
-                    torch.zeros(self.normalized_shape, dtype=dtype, device=init_device)
+                    torch.zeros(self.weight_shape, dtype=dtype, device=init_device)
                 )
             else:
                 self.register_parameter("bias", None)
@@ -196,13 +238,21 @@ class LayerNorm(nn.Module):
             if self.full_precision:
                 x = x.float()
 
-            x = F.layer_norm(
-                x,
-                self.normalized_shape,
-                weight=None if self.weight is None else self.weight.type_as(x),
-                bias=None if self.bias is None else self.bias.type_as(x),
-                eps=self.eps,
-            )
+            if self.weight is not None and self.weight_shape != self.normalized_shape:
+                # 'F.layer_norm' requires the weight/bias to match 'normalized_shape', so apply
+                # the element-wise affine manually (via broadcasting) after normalizing.
+                x = F.layer_norm(x, self.normalized_shape, eps=self.eps)
+                x = self.weight.type_as(x) * x
+                if self.bias is not None:
+                    x = x + self.bias.type_as(x)
+            else:
+                x = F.layer_norm(
+                    x,
+                    self.normalized_shape,
+                    weight=None if self.weight is None else self.weight.type_as(x),
+                    bias=None if self.bias is None else self.bias.type_as(x),
+                    eps=self.eps,
+                )
 
             return x.to(og_dtype)
 
@@ -281,6 +331,7 @@ class CuTeRMSNorm(RMSNorm):
         full_precision: bool = True,
         init_device: str = "cpu",
         dtype: torch.dtype = torch.float32,
+        weight_shape: Optional[Tuple[int, ...]] = None,
     ):
         from quack import rmsnorm as rms_norm_fn  # type: ignore
 
@@ -288,6 +339,11 @@ class CuTeRMSNorm(RMSNorm):
             # the CUTE kernel always casts to full precision internally
             raise NotImplementedError(
                 f"Currently only 'full_precision=True' is supported with '{self.__class__.__name__}'"
+            )
+        if weight_shape is not None and tuple(weight_shape) != (size,):
+            # the CUTE kernel only supports a 1D weight matching the normalized dimension
+            raise NotImplementedError(
+                f"Custom 'weight_shape' is not supported with '{self.__class__.__name__}'"
             )
 
         super().__init__(
@@ -331,6 +387,7 @@ class FusedRMSNorm(RMSNorm):
         full_precision: bool = True,
         init_device: str = "cpu",
         dtype: torch.dtype = torch.float32,
+        weight_shape: Optional[Tuple[int, ...]] = None,
     ):
         from flash_attn.ops.triton.layer_norm import rms_norm_fn  # type: ignore
 
@@ -342,6 +399,11 @@ class FusedRMSNorm(RMSNorm):
             # the triton kernel always casts to full precision internally
             raise NotImplementedError(
                 f"Currently only 'full_precision=True' is supported with '{self.__class__.__name__}'"
+            )
+        if weight_shape is not None and tuple(weight_shape) != (size,):
+            # the triton kernel only supports a 1D weight matching the normalized dimension
+            raise NotImplementedError(
+                f"Custom 'weight_shape' is not supported with '{self.__class__.__name__}'"
             )
 
         super().__init__(

--- a/src/test/nn/attention/attention_test.py
+++ b/src/test/nn/attention/attention_test.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import pytest
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributed.tensor import Shard, init_device_mesh
 
@@ -30,6 +31,7 @@ from olmo_core.nn.attention.ring import (
 )
 from olmo_core.nn.layer_norm import LayerNormConfig
 from olmo_core.nn.rope import RoPEConfig, RoPEType
+from olmo_core.nn.transformer.init import InitMethod
 from olmo_core.testing import (
     BACKENDS,
     DEVICES,
@@ -882,6 +884,15 @@ def test_attention_leftpad_shift_equivalence(use_rope):
             ),
             id="headwise-gating",
         ),
+        pytest.param(
+            AttentionConfig(
+                name=AttentionType.default,
+                n_heads=8,
+                bias=False,
+                scalable_softmax=True,
+            ),
+            id="scalable-softmax",
+        ),
     ],
 )
 def test_attention_builder_config(attn_config: AttentionConfig):
@@ -893,6 +904,141 @@ def test_attention_builder_config(attn_config: AttentionConfig):
     # Make sure the estimated number of params matches the actual number of params.
     n_params = sum(p.numel() for p in attn.parameters())
     assert attn_config.num_params(d_model) == n_params
+
+
+@pytest.mark.parametrize(
+    "cu_doc_lens,expected_lengths",
+    [
+        pytest.param(None, [[1, 2, 3, 4], [1, 2, 3, 4]], id="causal"),
+        pytest.param(
+            torch.tensor([0, 2, 4, 7, 8], dtype=torch.int32),
+            [[1, 2, 1, 2], [1, 2, 3, 1]],
+            id="packed-documents",
+        ),
+    ],
+)
+def test_scalable_softmax_query_scaling(cu_doc_lens, expected_lengths):
+    attention = Attention(
+        d_model=8,
+        n_heads=2,
+        head_dim=4,
+        bias=False,
+        scalable_softmax=True,
+    )
+    assert attention.ssmax_scale is not None
+    with torch.no_grad():
+        attention.ssmax_scale.copy_(torch.tensor([0.5, 2.0]))
+
+    q = torch.ones(2, 4, 2, 4)
+    scaled_q = attention._apply_scalable_softmax(q, cu_doc_lens)
+    expected = torch.tensor(expected_lengths, dtype=q.dtype).log()
+    expected = expected[:, :, None, None] * torch.tensor([0.5, 2.0])[None, None, :, None]
+
+    torch.testing.assert_close(scaled_q, expected.expand_as(q))
+    scaled_q.sum().backward()
+    assert attention.ssmax_scale.grad is not None
+    assert torch.all(attention.ssmax_scale.grad > 0)
+
+
+def test_scalable_softmax_disabled_is_identity():
+    attention = Attention(d_model=8, n_heads=2, head_dim=4, bias=False)
+    q = torch.randn(2, 4, 2, 4)
+
+    assert attention.ssmax_scale is None
+    assert attention._apply_scalable_softmax(q, None) is q
+
+
+def test_scalable_softmax_scale_is_initialized_to_one():
+    attention = Attention(
+        d_model=8,
+        n_heads=2,
+        head_dim=4,
+        bias=False,
+        scalable_softmax=True,
+    )
+    assert attention.ssmax_scale is not None
+    with torch.no_grad():
+        attention.ssmax_scale.fill_(float("nan"))
+
+    attention.init_weights(
+        init_method=InitMethod.normal,
+        d_model=8,
+        block_idx=0,
+        num_blocks=1,
+    )
+
+    torch.testing.assert_close(attention.ssmax_scale, torch.ones(2))
+
+
+def test_scalable_softmax_is_applied_after_qk_norm():
+    class ConstantNorm(nn.Module):
+        def forward(self, x):
+            return torch.full_like(x, 3.0)
+
+    attention = Attention(
+        d_model=8,
+        n_heads=2,
+        head_dim=4,
+        bias=False,
+        qk_norm=LayerNormConfig(),
+        use_head_qk_norm=True,
+        scalable_softmax=True,
+    )
+    attention.q_norm = ConstantNorm()
+    attention.k_norm = ConstantNorm()
+    assert attention.ssmax_scale is not None
+    with torch.no_grad():
+        attention.ssmax_scale.fill_(2.0)
+
+    captured_q = None
+
+    def capture_sdpa(q, k, v, **kwargs):
+        nonlocal captured_q
+        captured_q = q
+        return torch.zeros_like(q)
+
+    attention.sdpa = capture_sdpa
+    attention(torch.randn(1, 3, 8))
+
+    assert captured_q is not None
+    expected = 6.0 * torch.arange(1, 4, dtype=captured_q.dtype).log()
+    expected = expected.view(1, 3, 1, 1).expand_as(captured_q)
+    torch.testing.assert_close(captured_q, expected)
+
+
+@pytest.mark.parametrize("unsupported_mode", ["kv-cache", "context-parallel"])
+def test_scalable_softmax_rejects_unsupported_runtime_modes(unsupported_mode):
+    attention = Attention(
+        d_model=8,
+        n_heads=2,
+        head_dim=4,
+        bias=False,
+        scalable_softmax=True,
+    )
+    if unsupported_mode == "kv-cache":
+        attention.kv_cache_manager = nn.Identity()
+        match = "KV caching"
+    else:
+        attention.backend.cp_enabled = True
+        match = "context parallelism"
+
+    with pytest.raises(NotImplementedError, match=match):
+        attention._apply_scalable_softmax(torch.ones(1, 2, 2, 4), None)
+
+
+def test_scalable_softmax_rejects_sliding_window_attention():
+    config = AttentionConfig(
+        n_heads=2,
+        scalable_softmax=True,
+        sliding_window=SlidingWindowAttentionConfig(
+            pattern=[128],
+            force_full_attention_on_first_layer=False,
+            force_full_attention_on_last_layer=False,
+        ),
+    )
+
+    with pytest.raises(OLMoConfigurationError, match="scalable_softmax"):
+        config.build(d_model=8, layer_idx=0, n_layers=2)
 
 
 @pytest.mark.parametrize(
@@ -1108,6 +1254,14 @@ def _run_tensor_parallel_attention(
         pytest.param(
             {"gate": GateConfig(granularity=GateGranularity.headwise)},
             id="headwise-gating",
+        ),
+        pytest.param(
+            {
+                "qk_norm": LayerNormConfig(),
+                "use_head_qk_norm": True,
+                "scalable_softmax": True,
+            },
+            id="scalable-softmax",
         ),
     ],
 )

--- a/src/test/nn/attention/attention_test.py
+++ b/src/test/nn/attention/attention_test.py
@@ -134,6 +134,14 @@ def test_attention_backend(
         pytest.param({"rope": RoPEConfig(name=RoPEType.complex)}, id="complex-rope"),
         pytest.param({"qk_norm": LayerNormConfig()}, id="qk-norm"),
         pytest.param({"qk_norm": LayerNormConfig(), "use_head_qk_norm": True}, id="head-qk-norm"),
+        pytest.param(
+            {
+                "qk_norm": LayerNormConfig(),
+                "use_head_qk_norm": True,
+                "qk_norm_per_head_gains": True,
+            },
+            id="head-qk-norm-per-head-gains",
+        ),
     ],
 )
 def test_attention(
@@ -893,6 +901,29 @@ def test_attention_leftpad_shift_equivalence(use_rope):
             ),
             id="scalable-softmax",
         ),
+        pytest.param(
+            AttentionConfig(
+                name=AttentionType.default,
+                n_heads=8,
+                n_kv_heads=2,
+                bias=False,
+                qk_norm=LayerNormConfig(),
+                use_head_qk_norm=True,
+            ),
+            id="GQA-head-qk-norm",
+        ),
+        pytest.param(
+            AttentionConfig(
+                name=AttentionType.default,
+                n_heads=8,
+                n_kv_heads=2,
+                bias=False,
+                qk_norm=LayerNormConfig(),
+                use_head_qk_norm=True,
+                qk_norm_per_head_gains=True,
+            ),
+            id="GQA-head-qk-norm-per-head-gains",
+        ),
     ],
 )
 def test_attention_builder_config(attn_config: AttentionConfig):
@@ -904,6 +935,34 @@ def test_attention_builder_config(attn_config: AttentionConfig):
     # Make sure the estimated number of params matches the actual number of params.
     n_params = sum(p.numel() for p in attn.parameters())
     assert attn_config.num_params(d_model) == n_params
+
+
+def test_qk_norm_per_head_gains():
+    d_model, n_heads, n_kv_heads = 128, 8, 2
+    head_dim = d_model // n_heads
+
+    attn = Attention(
+        d_model=d_model,
+        n_heads=n_heads,
+        n_kv_heads=n_kv_heads,
+        qk_norm=LayerNormConfig(),
+        use_head_qk_norm=True,
+        qk_norm_per_head_gains=True,
+    )
+    assert attn.q_norm is not None and attn.k_norm is not None
+    assert attn.q_norm.weight.shape == (n_heads, head_dim)
+    assert attn.k_norm.weight.shape == (n_kv_heads, head_dim)
+    # Statistics should still be computed per-head over 'head_dim'.
+    assert attn.q_norm.normalized_shape == (head_dim,)
+    assert attn.k_norm.normalized_shape == (head_dim,)
+
+    with pytest.raises(OLMoConfigurationError, match="use_head_qk_norm"):
+        Attention(
+            d_model=d_model,
+            n_heads=n_heads,
+            qk_norm=LayerNormConfig(),
+            qk_norm_per_head_gains=True,
+        )
 
 
 @pytest.mark.parametrize(
@@ -1250,6 +1309,14 @@ def _run_tensor_parallel_attention(
         pytest.param(
             {"qk_norm": LayerNormConfig(), "use_head_qk_norm": True, "rope": RoPEConfig()},
             id="headwise-qk-layernorm-rope",
+        ),
+        pytest.param(
+            {
+                "qk_norm": LayerNormConfig(),
+                "use_head_qk_norm": True,
+                "qk_norm_per_head_gains": True,
+            },
+            id="headwise-qk-layernorm-per-head-gains",
         ),
         pytest.param(
             {"gate": GateConfig(granularity=GateGranularity.headwise)},


### PR DESCRIPTION
Following Qwen and Gemma, our code has so far used a shared gain vector across all heads.

This PR enables each head to have its own gain vector via `the qk_norm_per_head_gains` flag.

We ran this intervention through our ladder and so no significant change in performance.

---

To clarify, there are now two flags that specify how QK Norm is implemented:

- the existing `use_head_qk_norm` flag manages whether the **statistics** are computed per-head or shared across all heads
- the new `qk_norm_per_head_gains` flag manages whether the **gains** are learned per-head or shared across all heads