### PR TITLE
Fix Beaker callback import without optional dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Raised the minimum supported PyTorch version to 2.10.0. Updated the stable Beaker images to PyTorch 2.10 with CUDA 12.8 and PyTorch 2.11 with CUDA 13.0, and expanded CI coverage to include PyTorch 2.10 and 2.11 with CUDA 12.8 and Docker builds through PyTorch 2.12 with CUDA 13.0.
 
+### Fixed
+
+- `BeakerCallback` no longer imports the optional Beaker and Gantry dependencies when auto-detecting whether it is running in a Beaker batch job.
+
 ## [v2.6.0](https://github.com/allenai/OLMo-core/releases/tag/v2.6.0) - 2026-08-11
 
 ### Added

--- a/src/olmo_core/launch/beaker.py
+++ b/src/olmo_core/launch/beaker.py
@@ -42,6 +42,7 @@ from ..utils import (
     prepare_cli_environment,
 )
 from ..version import VERSION
+from .utils import is_running_in_beaker, is_running_in_beaker_batch_job
 
 log = logging.getLogger(__name__)
 
@@ -61,23 +62,6 @@ __all__ = [
 _LOCAL = threading.local()
 _DEFAULT_TORCH = "2.10.0".replace(".", "")
 _DEFAULT_CUDA = "12.8".replace(".", "")
-
-
-def is_running_in_beaker() -> bool:
-    """
-    Check if the current process is running inside of a Beaker job (batch or session).
-    """
-    # There's a number of different environment variables set by the Beaker executor.
-    # Checking any one of these would suffice, but we check a couple to reduce the
-    # risk of false positives.
-    return "BEAKER_JOB_ID" in os.environ and "BEAKER_NODE_ID" in os.environ
-
-
-def is_running_in_beaker_batch_job() -> bool:
-    """
-    Check if the current process is running inside a Beaker batch job (as opposed to a session).
-    """
-    return is_running_in_beaker() and os.environ.get("BEAKER_JOB_KIND") == "batch"
 
 
 def get_beaker_experiment_id() -> str | None:

--- a/src/olmo_core/launch/utils.py
+++ b/src/olmo_core/launch/utils.py
@@ -11,6 +11,23 @@ GIT_REF_ENV_VAR = "GIT_REF"
 GIT_BRANCH_ENV_VAR = "GIT_BRANCH"
 
 
+def is_running_in_beaker() -> bool:
+    """
+    Check if the current process is running inside of a Beaker job (batch or session).
+    """
+    # There's a number of different environment variables set by the Beaker executor.
+    # Checking any one of these would suffice, but we check a couple to reduce the
+    # risk of false positives.
+    return "BEAKER_JOB_ID" in os.environ and "BEAKER_NODE_ID" in os.environ
+
+
+def is_running_in_beaker_batch_job() -> bool:
+    """
+    Check if the current process is running inside a Beaker batch job (as opposed to a session).
+    """
+    return is_running_in_beaker() and os.environ.get("BEAKER_JOB_KIND") == "batch"
+
+
 def parse_git_remote_url(url: str) -> Tuple[str, str]:
     """
     Parse a git remote URL into a GitHub (account, repo) pair.

--- a/src/olmo_core/train/callbacks/beaker.py
+++ b/src/olmo_core/train/callbacks/beaker.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Dict, Optional
 
 from olmo_core.distributed.utils import get_rank
+from olmo_core.launch.utils import is_running_in_beaker_batch_job
 
 from .callback import Callback
 from .comet import CometCallback
@@ -46,8 +47,6 @@ class BeakerCallback(Callback):
 
     def post_attach(self):
         if self.enabled is None:
-            from olmo_core.launch.beaker import is_running_in_beaker_batch_job
-
             self.enabled = is_running_in_beaker_batch_job()
 
     def pre_train(self):

--- a/src/test/launch/utils_test.py
+++ b/src/test/launch/utils_test.py
@@ -1,4 +1,37 @@
-from olmo_core.launch.utils import parse_git_remote_url
+import pytest
+
+from olmo_core.launch.utils import (
+    is_running_in_beaker,
+    is_running_in_beaker_batch_job,
+    parse_git_remote_url,
+)
+
+
+@pytest.mark.parametrize(
+    ("env", "in_beaker", "in_batch_job"),
+    [
+        ({}, False, False),
+        ({"BEAKER_JOB_ID": "job"}, False, False),
+        ({"BEAKER_JOB_ID": "job", "BEAKER_NODE_ID": "node"}, True, False),
+        (
+            {
+                "BEAKER_JOB_ID": "job",
+                "BEAKER_NODE_ID": "node",
+                "BEAKER_JOB_KIND": "batch",
+            },
+            True,
+            True,
+        ),
+    ],
+)
+def test_beaker_environment_detection(monkeypatch, env, in_beaker, in_batch_job):
+    for name in ("BEAKER_JOB_ID", "BEAKER_NODE_ID", "BEAKER_JOB_KIND"):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    assert is_running_in_beaker() is in_beaker
+    assert is_running_in_beaker_batch_job() is in_batch_job
 
 
 def test_parse_git_remote_url():

--- a/src/test/train/callbacks/beaker_test.py
+++ b/src/test/train/callbacks/beaker_test.py
@@ -1,0 +1,34 @@
+import sys
+
+import pytest
+
+from olmo_core.train.callbacks.beaker import BeakerCallback
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({}, False),
+        (
+            {
+                "BEAKER_JOB_ID": "job",
+                "BEAKER_NODE_ID": "node",
+                "BEAKER_JOB_KIND": "batch",
+            },
+            True,
+        ),
+    ],
+)
+def test_post_attach_does_not_import_optional_beaker_dependencies(monkeypatch, env, expected):
+    for name in ("BEAKER_JOB_ID", "BEAKER_NODE_ID", "BEAKER_JOB_KIND"):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    # Importing olmo_core.launch.beaker would load the optional beaker and gantry packages.
+    monkeypatch.setitem(sys.modules, "olmo_core.launch.beaker", None)
+
+    callback = BeakerCallback()
+    callback.post_attach()
+
+    assert callback.enabled is expected


### PR DESCRIPTION
## Summary

- move Beaker environment detection into the dependency-light `olmo_core.launch.utils` module
- keep the existing `olmo_core.launch.beaker` import path available for compatibility
- let `BeakerCallback.post_attach()` auto-detect batch jobs without importing the optional `beaker` or `gantry` packages
- add environment-matrix and callback regression coverage, plus an Unreleased changelog entry

Closes #850.

## Why

`BeakerCallback.post_attach()` only needs three environment variables, but importing the helpers from `olmo_core.launch.beaker` eagerly imports the optional Beaker/Gantry stack. That makes an otherwise auto-disabled callback fail during attachment when `ai2-olmo-core` is installed without the `[beaker]` extra.

The callback regression test explicitly blocks `olmo_core.launch.beaker` in `sys.modules`, so both the outside-Beaker and batch-job detection paths prove that attachment no longer reaches the optional module.

## Validation

- `pytest -q src/test/launch/utils_test.py` — 5 passed
- `pytest -q src/test/train/callbacks/beaker_test.py` — 2 passed
- Ruff, Black, and isort checks passed for all changed Python files
- mypy passed for the changed production modules
- compileall and `git diff --check` passed

The callback test was collected on Windows with a local-only spawn compatibility shim because the repository's `bettermap` dependency requires a `fork` multiprocessing context. No compatibility shim is included in this change.