### PR TITLE
Release staged state before async checkpoint callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Raised the minimum supported PyTorch version to 2.10.0. Updated the stable Beaker images to PyTorch 2.10 with CUDA 12.8 and PyTorch 2.11 with CUDA 13.0, and expanded CI coverage to include PyTorch 2.10 and 2.11 with CUDA 12.8 and Docker builds through PyTorch 2.12 with CUDA 13.0.
 
+### Fixed
+
+- Released staged model and optimizer state before async checkpoint callbacks run, reducing peak host memory during callback execution.
+
 ## [v2.6.0](https://github.com/allenai/OLMo-core/releases/tag/v2.6.0) - 2026-08-11
 
 ### Added

--- a/src/olmo_core/train/checkpoint.py
+++ b/src/olmo_core/train/checkpoint.py
@@ -158,9 +158,10 @@ class Checkpointer:
 
         # Save model and optim state.
         train_module_dir = f"{dir}/model_and_optim"
+        state_dict = train_module.state_dict_to_save()
         future = async_save_state_dict(
             train_module_dir,
-            train_module.state_dict_to_save(),
+            state_dict,
             process_group=self.process_group,
             thread_count=self.save_thread_count,
             #  process_count=self.save_process_count,
@@ -173,6 +174,9 @@ class Checkpointer:
 
         def done_callback(fut: Future):
             del fut
+            # A ThreadPoolExecutor keeps its call arguments alive until all callbacks
+            # finish, so release the staged tensors before downstream callbacks run.
+            state_dict.clear()
             self._save_metadata(dir, CheckpointMetadata(ephemeral=ephemeral))
 
         # Upload metadata when everything else is done.

--- a/src/test/train/checkpoint_test.py
+++ b/src/test/train/checkpoint_test.py
@@ -1,10 +1,14 @@
 import os
 import time
+import weakref
+from concurrent.futures import Future
+from unittest.mock import Mock
 
 import pytest
 import torch
 import torch.distributed as dist
 
+import olmo_core.train.checkpoint as checkpoint_module
 from olmo_core.distributed.utils import barrier, get_rank
 from olmo_core.io import dir_is_empty, file_exists, is_url, normalize_path
 from olmo_core.testing import run_distributed_test
@@ -112,6 +116,44 @@ def test_async_checkpointer_with_local_dir(tmp_path, tiny_model_factory):
         func_args=(tmp_path / "checkpoint", tmp_path / "work_dir", tiny_model_factory),
         start_method="spawn",
     )
+
+
+def test_async_checkpointer_releases_staged_state_before_callbacks(tmp_path, monkeypatch):
+    checkpointer = Checkpointer(work_dir=tmp_path)
+    train_module = Mock()
+    staged_tensor = torch.empty(1)
+    staged_tensor_ref = weakref.ref(staged_tensor)
+    staged_state_dict = {"model": staged_tensor}
+    train_module.state_dict_to_save.return_value = staged_state_dict
+    del staged_tensor
+
+    save_future: Future[None] = Future()
+    observed_by_later_callback = []
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    def fake_async_save_state_dict(_dir, state_dict, **_kwargs):
+        assert state_dict is staged_state_dict
+        return save_future
+
+    monkeypatch.setattr(checkpoint_module, "async_save_state_dict", fake_async_save_state_dict)
+
+    future = checkpointer.save_async(tmp_path / "checkpoint", train_module, {})
+    future.add_done_callback(
+        lambda _future: observed_by_later_callback.append(
+            (dict(staged_state_dict), staged_tensor_ref() is None)
+        )
+    )
+
+    assert staged_state_dict
+    assert staged_tensor_ref() is not None
+    assert observed_by_later_callback == []
+
+    save_future.set_result(None)
+
+    assert staged_state_dict == {}
+    assert staged_tensor_ref() is None
+    assert observed_by_later_callback == [({}, True)]
 
 
 def test_async_checkpointer_with_remote_s3_dir(s3_checkpoint_dir, tmp_path, tiny_model_factory):


### PR DESCRIPTION
Fixes #856.

## Summary

- keep a reference to the staged model/optimizer state passed to `async_save_state_dict`
- clear that top-level mapping in the checkpointer's completion callback, before metadata writing and later Trainer/user callbacks
- add a deterministic CPU regression that tracks a staged tensor with a weak reference and verifies it is released before a subsequently registered callback runs
- document the fix in the changelog

## Rationale

PyTorch's async checkpoint executor retains the submitted call arguments while the future's callbacks run. The callbacks do not receive or use the staged state dict, but its tensor values can account for substantial host memory. Clearing the mapping in the first callback releases those values as soon as the checkpoint write is complete while preserving the mapping during the write itself.

`Checkpointer.save_async` registers this callback before returning the future, so callbacks registered by `Trainer.save_checkpoint_async` or callers run after the staged values have been released.

## Validation

- Regression test against `origin/main`: fails because the staged mapping still contains the tensor after future completion.
- Regression test with this patch: `1 passed`.
- Actual PyTorch async checkpoint harness: completed the save and observed the staged tensor collected before the later callback.
- `isort --check .`
- `black --check .` (`398 files would be left unchanged`)
- `ruff check .`
- `mypy src/` (`Success: no issues found in 397 source files`)

The focused pytest run used a Windows-only import shim for `bettermap`'s POSIX `fork` assumption; the test itself is CPU-only and requires no distributed or GPU resources.