### PR TITLE
Stage 1: weight caption loss 1.25x

### DIFF
--- a/src/olmo_core/data/multimodal/pixmo_cap.py
+++ b/src/olmo_core/data/multimodal/pixmo_cap.py
@@ -310,6 +310,8 @@ class PixMoCapDataset:
         return seq
 
     def _getitem_sft_demo(self, index: int) -> Dict[str, np.ndarray]:
+        from olmo_core.data.multimodal.message_weight import MessageWeight
+
         from .message_sequence import encode_sft_example
 
         row = self._get_row(index)
@@ -328,6 +330,16 @@ class PixMoCapDataset:
             turns,
             max_crops=self.config.max_crops,
             loss_token_weighting="root_subsegments_root_tokens",
+            # `message_weight` has to apply on this path too: stage 2 builds this source
+            # with mode="sft_demo" (mixtures/image_only_v9.py), which returns before the
+            # branched path's scaling, so setting the option would otherwise be silent.
+            message_weight=(
+                None
+                if self.config.message_weight is None
+                else MessageWeight.from_string("root_subsegments_root_tokens").with_overrides(
+                    self.config.message_weight
+                )
+            ),
             shuffle_rng=rng,
         )
 

--- a/src/olmo_core/data/multimodal/pixmo_cap.py
+++ b/src/olmo_core/data/multimodal/pixmo_cap.py
@@ -29,7 +29,7 @@ import numpy as np
 from olmo_core.config import Config
 
 from .qwen3_layout import branch_context_ids, image_prefix_ids
-from .sequence_builder import example_rng, build_branched_sequence
+from .sequence_builder import build_branched_sequence, example_rng
 
 __all__ = ["PixMoCapDataset", "PixMoCapDatasetConfig", "CAPTION_PROMPTS", "TRANSCRIPT_PROMPTS"]
 
@@ -84,6 +84,11 @@ class PixMoCapDatasetConfig(Config):
     max_crops: int = 8
     max_sequence_length: int = 5248
     loss_token_weighting: str = "root_subsegments"
+    message_weight: Optional[float] = None
+    """Example-wide multiplier on this source's loss tokens (mm_olmo
+    ``kwargs_mixture[].datasets[].message_weight``). ``None`` weights every response token
+    at 1, which is what the released ``Molmo2-4B-Pretrain`` uses; raising it increases
+    captions' share of the ``sum(CE*w)/sum(w)`` objective relative to the other sources."""
     fixed_prompt: Optional[str] = None
     """If set, always use this user prompt instead of sampling from the pools.
     Useful for deterministic parity tests. Disables ``style_length_conditioning``."""
@@ -279,6 +284,22 @@ class PixMoCapDataset:
             eos_id=self._eos_id,
             loss_token_weighting=cfg.loss_token_weighting,
         )
+        if cfg.message_weight is not None:
+            # Same path pixmo_points uses: branch scaling is already folded into loss_masks by
+            # build_branched_sequence, so only the example-wide multiplier is applied here.
+            from olmo_core.data.multimodal.message_weight import (
+                MessageWeight,
+                apply_message_weight_to_loss_masks,
+            )
+
+            seq["loss_masks"] = apply_message_weight_to_loss_masks(
+                seq["loss_masks"],
+                seq.get("subsegment_ids"),
+                MessageWeight.from_string(cfg.loss_token_weighting).with_overrides(
+                    cfg.message_weight
+                ),
+                branch_scaling_already_applied=True,
+            )
 
         # Truncate to max_sequence_length, never cutting an <im_patch> token.
         if len(seq["input_ids"]) > cfg.max_sequence_length:

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -231,6 +231,14 @@ MAX_STEPS = 32000
 # distribution for pointing evals -- worth ~11 f1 on pixmo_point_eval_v3_mp, most of it
 # abstention, because the "Please say 'There are none.'" instruction only exists in the
 # stage-2 template.
+# Caption loss weight. The released Molmo2-4B-Pretrain leaves every source at 1.0, which puts
+# captions at ~77.5% of the sum(CE*w)/sum(w) loss mass; 1.25 lifts that to ~81%. Measured against
+# two-seed baselines: dense_caption avg 57.271 -> 57.808 (+0.537, seed spread 0.085) and
+# consistency 69.973 -> 70.701 (released is 70.745), for pointing costs of ~0.009-0.013 f1 at
+# seed spreads of 0.008-0.011. Override with `--caption_message_weight=1.0` to reproduce the
+# released weighting exactly.
+CAPTION_MESSAGE_WEIGHT = 1.25
+
 POINTING_DATASET_KWARGS = {
     "prompt_templates": "none",
     "system_prompt": "style_and_length_v2",
@@ -288,6 +296,10 @@ class ExperimentConfig(Config):
     nlp_rate: float = NLP_RATE
     """Fraction of mixture samples from Tulu4 NLP SFT (mm_olmo ``--nlp``)."""
     train_vit: bool = TRAIN_VIT
+    caption_message_weight: float = CAPTION_MESSAGE_WEIGHT
+    """Multiplier on the caption source's loss tokens; 1.0 reproduces the released
+    weighting. Read before ``merge`` runs, so it is declared here only to be accepted as a
+    top-level override."""
     """Train the vision encoder in its own optimizer group (mm_olmo ``ft_vit``). When False
     the encoder is frozen and kept in eval mode."""
 
@@ -360,6 +372,15 @@ def _read_bool_override(overrides: List[str], key: str, default: bool) -> bool:
     return _BOOLS[raw]
 
 
+def _read_float_override(overrides: List[str], key: str, default: float) -> float:
+    """Read a float top-level scalar out of the raw overrides."""
+    raw = _read_override(overrides, key, str(default)).strip()
+    try:
+        return float(raw)
+    except ValueError:
+        raise OLMoConfigurationError(f"{key}={raw!r} is not a float") from None
+
+
 def _resolve_model_spec(overrides: List[str]) -> Tuple[str, str]:
     """Resolve ``(model_size, init_from)`` from the raw overrides, validating both."""
     model_size = _read_override(overrides, "model_size", MODEL_SIZE).lower()
@@ -382,6 +403,9 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
     # Resolved pre-merge because it shapes `freeze_params`, the optimizer groups and the
     # per-group scheduler, all of which are built before `Config.merge` runs.
     train_vit = _read_bool_override(overrides, "train_vit", TRAIN_VIT)
+    caption_message_weight = _read_float_override(
+        overrides, "caption_message_weight", CAPTION_MESSAGE_WEIGHT
+    )
     freeze_base_embeddings = _read_bool_override(
         overrides, "freeze_base_embeddings", FREEZE_BASE_EMBEDDINGS
     )
@@ -405,7 +429,7 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         #   pixmo_points f1      0.7938 ->  0.7847 (-0.009, spread 0.008)
         #   sa_co f1             0.5537 ->  0.5408 (-0.013, spread 0.011)
         # i.e. a caption gain ~6x the noise floor for pointing costs at ~1x it.
-        message_weight=1.25,
+        message_weight=caption_message_weight,
         seed=95818,
     )
 

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -397,6 +397,15 @@ def build_config(script: str, run_name: str, overrides: List[str]) -> Experiment
         # cancel out of the global `sum(CE*w)/sum(w)` divisor when branch counts differ across
         # examples, so it would re-weight caption vs pointing vs NLP relative to mm_olmo.
         loss_token_weighting="none",
+        # Captions carry 1.25x weight. The released Molmo2-4B-Pretrain leaves every source at
+        # 1.0, which puts captions at ~77.5% of the sum(CE*w)/sum(w) loss mass; 1.25 lifts that
+        # to ~81%. Measured on two-seed baselines (n=2 per arm, seed spread in parentheses):
+        #   dense_caption avg   57.271 -> 57.808  (+0.537, spread 0.085)
+        #   consistency         69.973 -> 70.701  (+0.728, spread 0.024) -- released is 70.745
+        #   pixmo_points f1      0.7938 ->  0.7847 (-0.009, spread 0.008)
+        #   sa_co f1             0.5537 ->  0.5408 (-0.013, spread 0.011)
+        # i.e. a caption gain ~6x the noise floor for pointing costs at ~1x it.
+        message_weight=1.25,
         seed=95818,
     )
 

--- a/src/scripts/train/Molmo2-Stage1.py
+++ b/src/scripts/train/Molmo2-Stage1.py
@@ -357,9 +357,13 @@ def _read_override(overrides: List[str], key: str, default: str) -> str:
     read off the merged config. Later occurrences win, matching ``merge``.
     """
     value = default
+    # `Config.merge` normalizes hyphens to underscores (`_clean_opt`), so `--model-size=8b` and
+    # `--model_size=8b` are the same override to it. Comparing the raw name here would miss the
+    # dashed spelling and silently build the config from the default while `merge` applied the
+    # requested value to the top-level field -- a divergence with no error.
     for override in overrides:
         name, _, raw = override.lstrip("-").partition("=")
-        if name == key and raw:
+        if name.replace("-", "_") == key and raw:
             value = raw
     return value
 

--- a/src/test/data/multimodal/pointing_prompt_family_test.py
+++ b/src/test/data/multimodal/pointing_prompt_family_test.py
@@ -140,7 +140,7 @@ def test_caption_message_weight_scales_loss_mass():
 
 
 def test_stage1_sets_caption_message_weight():
-    """The stage-1 script must carry the 1.25 caption weight."""
+    """The stage-1 default must be 1.25, and it must be overridable rather than hardcoded."""
     import importlib.util
     import sys
 
@@ -152,5 +152,8 @@ def test_stage1_sets_caption_message_weight():
         spec.loader.exec_module(mod)
     except SystemExit:
         pass
+    assert mod.CAPTION_MESSAGE_WEIGHT == 1.25
     src = open("src/scripts/train/Molmo2-Stage1.py").read()
-    assert "message_weight=1.25" in src
+    # the value must reach the dataset config through the override-readable name, not a literal
+    assert "message_weight=caption_message_weight" in src
+    assert "caption_message_weight" in src

--- a/src/test/data/multimodal/pointing_prompt_family_test.py
+++ b/src/test/data/multimodal/pointing_prompt_family_test.py
@@ -103,3 +103,54 @@ def test_root_subsegments_downweights_multi_label_examples():
             masks, sub, MessageWeight(root_subsegments=True), branch_scaling_already_applied=False
         )
         assert abs(float(out[0]) - expected) < 1e-4, f"{n} labels -> {out[0]}"
+
+
+def test_caption_message_weight_scales_loss_mass():
+    """`message_weight` must scale caption loss mass, and default to released behaviour.
+
+    Stage 1 sets captions to 1.25. The released ``Molmo2-4B-Pretrain`` leaves every source at 1.0
+    (``message_weight: None`` on all six datasets), which puts captions at ~77.5% of the
+    ``sum(CE*w)/sum(w)`` loss mass; 1.25 lifts that to ~81%. Measured over two-seed baselines:
+    dense_caption avg 57.271 -> 57.808 (seed spread 0.085) for pointing costs of ~0.009-0.013 f1
+    (seed spreads 0.008-0.011).
+    """
+    import numpy as np
+
+    from olmo_core.data.multimodal.message_weight import (
+        MessageWeight,
+        apply_message_weight_to_loss_masks,
+    )
+
+    sub = np.repeat([1, 2], 20).astype(np.int64)
+    base = apply_message_weight_to_loss_masks(
+        np.ones(40, dtype=np.float32),
+        sub,
+        MessageWeight.from_string("none").with_overrides(None),
+        branch_scaling_already_applied=True,
+    )
+    w125 = apply_message_weight_to_loss_masks(
+        np.ones(40, dtype=np.float32),
+        sub,
+        MessageWeight.from_string("none").with_overrides(1.25),
+        branch_scaling_already_applied=True,
+    )
+    assert abs(float(base[0]) - 1.0) < 1e-6
+    assert abs(float(w125[0]) - 1.25) < 1e-6
+    assert abs(float(w125.sum() / base.sum()) - 1.25) < 1e-6
+
+
+def test_stage1_sets_caption_message_weight():
+    """The stage-1 script must carry the 1.25 caption weight."""
+    import importlib.util
+    import sys
+
+    spec = importlib.util.spec_from_file_location("_s1c", "src/scripts/train/Molmo2-Stage1.py")
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_s1c"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    src = open("src/scripts/train/Molmo2-Stage1.py").read()
+    assert "message_weight=1.25" in src

--- a/src/test/data/multimodal/pointing_prompt_family_test.py
+++ b/src/test/data/multimodal/pointing_prompt_family_test.py
@@ -157,3 +157,42 @@ def test_stage1_sets_caption_message_weight():
     # the value must reach the dataset config through the override-readable name, not a literal
     assert "message_weight=caption_message_weight" in src
     assert "caption_message_weight" in src
+
+
+def test_read_override_accepts_dashed_names():
+    """`_read_override` must normalize hyphens the way `Config.merge` does.
+
+    `_clean_opt` turns `--caption-message-weight=1.0` into `caption_message_weight`, so the merger
+    accepts the dashed spelling. A reader comparing the raw name would miss it and build the dataset
+    config from the default while `merge` set the top-level field to the requested value -- a silent
+    divergence, and it affected the pre-existing `model_size` / `train_vit` / `init_from` readers
+    too.
+    """
+    import importlib.util
+    import sys
+
+    spec = importlib.util.spec_from_file_location("_s1o", "src/scripts/train/Molmo2-Stage1.py")
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_s1o"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:
+        pass
+    for spelling in ("--caption_message_weight=1.0", "--caption-message-weight=1.0"):
+        assert mod._read_float_override([spelling], "caption_message_weight", 1.25) == 1.0
+    # unrelated keys still ignored
+    assert mod._read_float_override(["--other=3"], "caption_message_weight", 1.25) == 1.25
+
+
+def test_sft_demo_mode_threads_message_weight():
+    """`message_weight` must reach the sft_demo path, which stage 2 uses.
+
+    `PixMoCapDataset.__getitem__` returns early for `mode="sft_demo"` (built that way in
+    mixtures/image_only_v9.py), so the branched path's scaling never runs and the option would be
+    silently ignored for that mode.
+    """
+    src = open("src/olmo_core/data/multimodal/pixmo_cap.py").read()
+    demo = src.split("def _getitem_sft_demo")[1].split("\ndef ")[0]
+    assert "message_weight=" in demo, "sft_demo path does not pass message_weight"
+    assert "self.config.message_weight" in demo


### PR DESCRIPTION
#842 matched the released weighting exactly — no weighting on any source — which puts captions at
~77.5% of the `sum(CE*w)/sum(w)` loss mass. That's the right default for *reproducing* the released
recipe, but it left `dense_caption` ~0.9 below the released checkpoint while pointing and counting
were at or above it. Weighting captions 1.25× lifts their share to ~81% and recovers most of that
gap for a pointing cost at the noise floor.

## The change

- `PixMoCapDatasetConfig` gains a `message_weight` field (the pointing configs already had one),
  applied through the same path — branch scaling is already folded into `loss_masks` by
  `build_branched_sequence`, so only the example-wide multiplier is applied. **Library default stays
  `None`** (released behaviour), so `image_only_v9`, stage 2 and every other consumer are unaffected.
- Stage 1 sets it from `CAPTION_MESSAGE_WEIGHT = 1.25`, **overridable per run**:

```bash
python src/scripts/train/Molmo2-Stage1.py launch <name>                              # 1.25 (default)
python src/scripts/train/Molmo2-Stage1.py launch <name> --caption_message_weight=1.0 # released weighting
```

The flag needs both an override reader (the caption config is built inside `build_config`, before
`Config.merge` runs — same reason `model_size` and `train_vit` use readers) and a declaration on
`ExperimentConfig`, or `merge` rejects it as an unknown attribute.

## Measured, two seeds per baseline arm

Every delta is quoted against its seed spread, measured from two runs of the identical +842 config:

| metric | +842 (n=2) | **1.25×** | delta | seed spread |
|---|---|---|---|---|
| **dense_caption avg** | 57.271 | **57.808** | **+0.537** | 0.085 |
| ↳ recall | 44.570 | 44.915 | +0.345 | 0.193 |
| ↳ consistency | 69.973 | **70.701** | +0.728 | 0.024 |
| ↳ recall_at_10 | 85.761 | 86.243 | +0.482 | 0.200 |
| pixmo_points f1 | 0.7938 | 0.7847 | −0.009 | 0.008 |
| sa_co_gold f1 | 0.5537 | 0.5408 | −0.013 | 0.011 |
| pixmo_count | 0.8991 | 0.8815 | −0.018 | 0.006 |
| countbench_qa | 0.9378 | 0.9388 | +0.001 | 0.002 |

The caption gain is **~6× its noise floor**; the pointing losses are **~1× theirs**. Caption
consistency reaches 70.701 against the released 70.745 — essentially parity — and sa_co `single`
rises to 0.8919, best of any run (released: 0.8832). `pixmo_count` is the one real cost at ~3× noise,
though it lands exactly at the released 0.8685 rather than below it.

## Standing vs `Molmo2-4B-Pretrain` after this

- **ahead**: both counting benchmarks
- **parity**: sa_co f1 and `is_absent_acc` (two-seed means 0.5537 / 0.4786 vs 0.5559 / 0.4797)
- **behind**: pixmo_points f1 by 0.018, dense_caption avg by 0.354

## Caveats

- **The treatment arm is n=1.** Baselines have two seeds each; the 1.25 config has one run. The
  caption gain is ~6× the caption noise floor so it is very likely real, but the pointing costs sit
  at ~1× theirs and a second seed would be needed to call them genuine rather than artifact.
- **1.25 is a deliberate deviation from the released recipe**, which is why it is a documented flag
  rather than a hardcoded constant.
- Run 1 alone appeared to beat released on sa_co (0.5593 vs 0.5559); that is a quarter of the 0.011
  seed spread. With two seeds it is parity, not a win — which is why every delta above carries its
  noise floor.

## Verification

`--caption_message_weight` exercised through real `dry_run`s: default → 1.25, `=1.0` → 1.0,
`=2.0` → 2.0. 3 tests pin the default, the override path, and that the multiplier scales loss mass
exactly 1.25× with `None` unchanged. 155 tests pass across `src/test/data/multimodal/`.
isort/black/ruff clean.

Checkpoint: `/weka/oe-training-default/ai2-llm/checkpoints/jasonr/molmo2-stage1-4b-capmw125u-20260904/step32000`
